### PR TITLE
Simplify SharedData when updating a new working copy

### DIFF
--- a/src/engine/shared_data.h
+++ b/src/engine/shared_data.h
@@ -560,6 +560,7 @@ private:
     ) {
         State& state = State::instance();
         short bufferIndex = state.getBufferIndex(buffer);
+        assert(0 <= bufferIndex && bufferIndex <=2 && "Invalid buffer index. Did you forget to lock the state?");
         return m_buffers[bufferIndex];
     }
 
@@ -569,6 +570,7 @@ private:
     ) const {
         State& state = State::instance();
         short bufferIndex = state.getBufferIndex(buffer);
+        assert(0 <= bufferIndex && bufferIndex <=2 && "Invalid buffer index. Did you forget to lock the state?");
         return m_buffers[bufferIndex];
     }
 

--- a/src/engine/tests/shared_data.cpp
+++ b/src/engine/tests/shared_data.cpp
@@ -18,6 +18,30 @@ TEST(SharedStateDeathTest, DoubleLockStable) {
 }
 
 
+TEST(SharedStateDeathTest, ForgotToLockStable) {
+    State& state = State::instance();
+    state.reset();
+    RenderData<int> data(1);
+    EXPECT_DEATH(
+        {data.stable();}, 
+        "Invalid buffer index"
+    );
+    state.reset();
+}
+
+
+TEST(SharedStateDeathTest, ForgotToLockWorkingCopy) {
+    State& state = State::instance();
+    state.reset();
+    RenderData<int> data(1);
+    EXPECT_DEATH(
+        {data.workingCopy();}, 
+        "Invalid buffer index"
+    );
+    state.reset();
+}
+
+
 TEST(SharedStateDeathTest, DoubleLockWorkingCopy) {
     State& state = State::instance();
     state.reset();


### PR DESCRIPTION
This removes the callback mechanism and replaces it with a
version check each time SharedData::workingCopy() is called.
