### PR TITLE
Working mutation points

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,11 +435,6 @@ install(DIRECTORY
         PATTERN "*.xml"
 )
 
-# Create directory tree that thrive requires
-file(MAKE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin/creations)
-file(MAKE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin/creations/microbe)
-file(MAKE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin/creations/multicellular)
-
 # Install Runtime Libraries
 if(WIN32)
 

--- a/assets/definitions/processes.xml
+++ b/assets/definitions/processes.xml
@@ -10,7 +10,7 @@
             <Output compound="atp" amount="36"/>
         </Outputs>
 	</Process>
-    <Process name="ReproductaseSynthesis" speedFactor="0.2" energyCost="6">
+    <Process name="ReproductaseSynthesis" speedFactor="0.3" energyCost="6">
         <Inputs>
             <Input compound="aminoacids" amount="6"/>
             <Input compound="glucose" amount="6"/>

--- a/scripts/microbe_editor/microbe_editor_hud.lua
+++ b/scripts/microbe_editor/microbe_editor_hud.lua
@@ -23,6 +23,8 @@ function MicrobeEditorHudSystem:init(gameState)
     sceneNode.meshName = "hex.mesh"
     self.hoverHex:addComponent(sceneNode)
     local root = gameState:rootGUIWindow()
+    self.mpLabel = root:getChild("BottomSection"):getChild("MutationPoints"):getChild("MPBar"):getChild("NumberLabel")
+    self.mpProgressBar = root:getChild("BottomSection"):getChild("MutationPoints"):getChild("MPBar")
     local nucleusButton = root:getChild("EditorTools"):getChild("NucleusItem")
     local flageliumButton = root:getChild("EditorTools"):getChild("FlageliumItem")
     local mitochondriaButton = root:getChild("EditorTools"):getChild("MitochondriaItem")
@@ -136,6 +138,12 @@ function MicrobeEditorHudSystem:update(milliseconds)
     end
     properties.fovY = newFovY
     properties:touch()
+end
+
+
+function MicrobeEditorHudSystem:updateMutationPoints()
+    self.mpProgressBar:progressbarSetProgress(self.editor.mutationPoints/100)
+    self.mpLabel:setText("" .. self.editor.mutationPoints)
 end
 
 

--- a/scripts/microbe_stage/agent_vacuole.lua
+++ b/scripts/microbe_stage/agent_vacuole.lua
@@ -80,6 +80,8 @@ function AgentVacuole:load(storage)
     self.process = process
 end
 
+Organelle.mpCosts["oxytoxy"] = 40
+
 -- factory functions
 function OrganelleFactory.make_oxytoxy(data)
     local agentVacuole = AgentVacuole(CompoundRegistry.getCompoundId("oxytoxy"), global_processMap["OxyToxySynthesis"])

--- a/scripts/microbe_stage/camera.lua
+++ b/scripts/microbe_stage/camera.lua
@@ -3,6 +3,7 @@ class 'MicrobeCameraSystem' (System)
 
 function MicrobeCameraSystem:__init()
     System.__init(self)
+    -- The offset from player microbe to camera
     self.camera = nil
     self.cameraScenenode = nil
 end
@@ -10,7 +11,6 @@ end
 function MicrobeCameraSystem:activate()
     local camera = Entity(CAMERA_NAME)
     self.camera = camera:getComponent(OgreCameraComponent.TYPE_ID)
-    -- The offset from player microbe to camera
     self.camera.properties.offset = Vector3(0, 0, 30)
     self.camera.properties:touch()
     self.cameraScenenode = camera:getComponent(OgreSceneNodeComponent.TYPE_ID)

--- a/scripts/microbe_stage/microbe.lua
+++ b/scripts/microbe_stage/microbe.lua
@@ -719,7 +719,6 @@ end
 
 -- Copies this microbe. The new microbe will not have the stored compounds of this one. 
 function Microbe:reproduce()
-
     copy = Microbe.createMicrobeEntity(nil, true)
     for _, organelle in pairs(self.microbe.organelles) do
         local organelleStorage = organelle:storage()
@@ -731,6 +730,9 @@ function Microbe:reproduce()
     copy.microbe:updateSafeAngles()
     copy.microbe:_resetCompoundPriorities()  
     copy.entity:addComponent(SpawnedComponent())
+    if self.microbe.isPlayerMicrobe then
+        showReproductionDialog()
+    end
 end
 
 

--- a/scripts/microbe_stage/microbe_stage_hud.lua
+++ b/scripts/microbe_stage/microbe_stage_hud.lua
@@ -14,6 +14,7 @@ end
 global_if_already_displayed = false
 
 function HudSystem:activate()
+    global_activeMicrobeStageHudSystem = self -- Global reference for event handlers
     lockedMap = Engine:playerData():lockedMap()
     if lockedMap ~= nil and not lockedMap:isLocked("Toxin") and not ss and not global_if_already_displayed then
         showMessage("'E' Releases Toxin")
@@ -30,16 +31,20 @@ function HudSystem:init(gameState)
     local menuButton = self.rootGuiWindow:getChild("BottomSection"):getChild("MenuButton")
     local helpButton = self.rootGuiWindow:getChild("BottomSection"):getChild("HelpButton")
     local editorButton = self.rootGuiWindow:getChild("MenuPanel"):getChild("EditorButton")
+    local editorButton2 = self.rootGuiWindow:getChild("ReproductionPanel"):getChild("EditorButton")
     local returnButton = self.rootGuiWindow:getChild("MenuPanel"):getChild("ReturnButton")
     local returnButton2 = self.rootGuiWindow:getChild("HelpPanel"):getChild("ReturnButton")
     local returnButton3 = self.rootGuiWindow:getChild("MessagePanel"):getChild("ReturnButton")
+    local returnButton4 = self.rootGuiWindow:getChild("ReproductionPanel"):getChild("ReturnButton")
     local quitButton = self.rootGuiWindow:getChild("MenuPanel"):getChild("QuitButton")
     menuButton:registerEventHandler("Clicked", menuButtonClicked)
     helpButton:registerEventHandler("Clicked", helpButtonClicked)
     editorButton:registerEventHandler("Clicked", editorButtonClicked)
+    editorButton2:registerEventHandler("Clicked", editorButtonClicked)
     returnButton:registerEventHandler("Clicked", returnButtonClicked)
     returnButton2:registerEventHandler("Clicked", returnButtonClicked)
     returnButton3:registerEventHandler("Clicked", returnButtonClicked)
+    returnButton4:registerEventHandler("Clicked", returnButtonClicked)
     quitButton:registerEventHandler("Clicked", quitButtonClicked)
     self.rootGuiWindow:getChild("MenuPanel"):getChild("MainMenuButton"):registerEventHandler("Clicked", menuMainMenuClicked)
 end
@@ -83,6 +88,10 @@ function HudSystem:update(milliseconds)
     offset.z = newZVal
 end
 
+function showReproductionDialog()
+    global_activeMicrobeStageHudSystem.rootGuiWindow:getChild("ReproductionPanel"):show()
+end
+
 function showMessage(msg)
     local messagePanel = Engine:currentGameState():rootGUIWindow():getChild("MessagePanel")
     messagePanel:getChild("MessageLabel"):setText(msg)
@@ -115,6 +124,7 @@ function returnButtonClicked()
     if Engine:currentGameState():name() == "microbe" then
         Engine:currentGameState():rootGUIWindow():getChild("HelpPanel"):hide()
         Engine:currentGameState():rootGUIWindow():getChild("MessagePanel"):hide()
+        Engine:currentGameState():rootGUIWindow():getChild("ReproductionPanel"):hide()
     elseif Engine:currentGameState():name() == "microbe_editor" then
         Engine:currentGameState():rootGUIWindow():getChild("SaveLoadPanel"):hide()
     end

--- a/scripts/microbe_stage/movement_organelle.lua
+++ b/scripts/microbe_stage/movement_organelle.lua
@@ -131,6 +131,8 @@ function MovementOrganelle:update(microbe, milliseconds)
     self:_moveMicrobe(microbe, milliseconds)
 end
 
+Organelle.mpCosts["flagellum"] = 25
+
 -- factory functions
 function OrganelleFactory.make_flagellum(data)
     -- Calculate the momentum of the movement organelle based on angle towards nucleus

--- a/scripts/microbe_stage/organelle.lua
+++ b/scripts/microbe_stage/organelle.lua
@@ -1,6 +1,8 @@
 -- Base class for microbe organelles
 class 'Organelle'
 
+Organelle.mpCosts = {}
+
 -- Factory function for organelles
 function Organelle.loadOrganelle(storage)
     local className = storage:get("className", "")

--- a/scripts/microbe_stage/process_organelle.lua
+++ b/scripts/microbe_stage/process_organelle.lua
@@ -290,6 +290,9 @@ end
 -------------------------------------------
 -- factory functions for process organelles
 
+Organelle.mpCosts["chloroplast"] = 20
+Organelle.mpCosts["mitochondrion"] = 20
+
 function OrganelleFactory.make_mitochondrion(data)
     local mito = ProcessOrganelle()
     mito:addProcess(global_processMap["Respiration"])

--- a/scripts/microbe_stage/setup.lua
+++ b/scripts/microbe_stage/setup.lua
@@ -4,7 +4,6 @@ local function setupBackground()
     local skyplane = SkyPlaneComponent()
     skyplane.properties.plane.normal = Vector3(0, 0, 2000)
     skyplane.properties.materialName = "background/blue_01"
-    skyplane.properties.tiling = 7
     skyplane.properties:touch()
     
     entity:addComponent(skyplane)

--- a/scripts/microbe_stage/storage_organelle.lua
+++ b/scripts/microbe_stage/storage_organelle.lua
@@ -36,6 +36,7 @@ function StorageOrganelle:onRemovedFromMicrobe(microbe, q, r)
     microbe:removeStorageOrganelle(self)
 end
 
+Organelle.mpCosts["vacuole"] = 15
 
 function OrganelleFactory.make_vacuole(data)
     local vacuole = StorageOrganelle(100.0)


### PR DESCRIPTION
This is a solution to #159 

I have not limited when you can go into the editor, so you can easily get as many MP as you want by exiting and entering the editor, but I have added a dialog that lets you enter the editor after reproduction, so the only thing missing for restricted access is to restrict access from main menu and microbe stage menu dialog.

GUI changes for mutation points has been pushed to SVN. 

Loading a microbe resets your MP to 0 such that save&load will not be a way to exploit infinite MP when mutation becomes limited.
