### PR TITLE
Added some basic console commands

### DIFF
--- a/scripts/console_commands.lua
+++ b/scripts/console_commands.lua
@@ -1,0 +1,78 @@
+----------------------
+-- A number of useful functions to be called from the console
+----------------------
+
+global_consoleEmitter = nil
+
+function help()
+    commands()
+end
+
+function commands()
+    print("Extra console commands are: \n - spawnCompounds(name, amount) \n - reproduce() \n - suicide() \n - unlockAll() \n - mutationPoints()")
+end
+
+function spawnCompounds(name, amount)
+    if Engine:currentGameState():name() ~= GameState.MICROBE:name() then
+        print("Must be in microbe stage to spawn compounds")
+        return
+    end
+    if global_consoleEmitter == nil then
+        global_consoleEmitter = Entity()
+        local emitterComponent = CompoundEmitterComponent()
+        emitterComponent.emissionRadius = 0
+        emitterComponent.maxInitialSpeed = 0
+        emitterComponent.minInitialSpeed = 0
+        emitterComponent.particleLifetime = 100000
+        global_consoleEmitter:addComponent(emitterComponent)
+        local sceneNode = OgreSceneNodeComponent()
+        global_consoleEmitter:addComponent(sceneNode)
+    end
+    local playerCreature = Microbe(Entity(Engine:playerData():activeCreature()))
+    local compoundId = CompoundRegistry.getCompoundId(name)
+    local emitterSceneNode = global_consoleEmitter:getComponent(OgreSceneNodeComponent.TYPE_ID)
+    emitterSceneNode.transform.position = playerCreature.microbe.facingTargetPoint
+    emitterSceneNode.transform:touch()
+    local remainingAmount = amount
+    while remainingAmount > 0 do
+        local compoundEmitterComponent = global_consoleEmitter:getComponent(CompoundEmitterComponent.TYPE_ID)
+        compoundAmount = math.min(3, remainingAmount)
+        compoundEmitterComponent:emitCompound(compoundId, compoundAmount, 0, 0)  
+        remainingAmount = remainingAmount - compoundAmount
+    end
+end
+
+
+function reproduce()
+    if Engine:currentGameState():name() ~= GameState.MICROBE:name() then
+        print("Must be in microbe stage to reproduce")
+        return
+    end
+    playerCreature = Microbe(Entity(Engine:playerData():activeCreature()))
+    playerCreature:reproduce()
+end
+
+function suicide()
+    if Engine:currentGameState():name() ~= GameState.MICROBE:name() then
+        print("Must be in microbe stage to suicide")
+        return
+    end
+    playerCreature = Microbe(Entity(Engine:playerData():activeCreature()))
+    playerCreature:kill()
+end
+
+function unlockAll()
+    lockMap = Engine:playerData():lockedMap()
+    for lock in lockMap:locksList() do 
+        lockMap:unlock(lock)
+    end
+
+end
+
+function mutationPoints()
+    if Engine:currentGameState():name() ~= GameState.MICROBE_EDITOR:name() then
+        print("Must be in microbe editor to add mutation points")
+        return
+    end
+    global_activeMicrobeEditorHudSystem.editor.mutationPoints = 9999
+end

--- a/scripts/manifest.txt
+++ b/scripts/manifest.txt
@@ -9,4 +9,5 @@ microbe_editor
 //sandbox
 
 console.lua
+console_commands.lua
 


### PR DESCRIPTION
This is a solution to #188

TODO:
~~Complete help command~~
~~Check for and add some safeties to prevent crashes doing commands in wrong gamestates/situations~~
~~Make it so spawned compounds don't float away too fast, this can be done in 3 ways:~~
~~\- Make the players emitted compounds move away slower~~
~~\- Find an ugly workaround to stop compounds from moving in this case~~
~~\- Create the compounds without using the player emitter (this will make getting a safe distance annoying)~~
