### PR TITLE
Implemented undo/redo-feature for MicrobeEditor

### DIFF
--- a/scripts/main_menu/main_menu_hud.lua
+++ b/scripts/main_menu/main_menu_hud.lua
@@ -10,11 +10,11 @@ function MainMenuHudSystem:init(gameState)
     local root = gameState:rootGUIWindow()
     local microbeButton = root:getChild("Background"):getChild("MicrobeButton")
     local microbeEditorButton = root:getChild("Background"):getChild("MicrobeEditorButton")
-    local mitochondriaButton = root:getChild("Background"):getChild("QuitButton")
+    local quitButton = root:getChild("Background"):getChild("QuitButton")
     
-    root:getChild("Background"):getChild("MicrobeButton"):registerEventHandler("Clicked", mainMenuMicrobeStageButtonClicked)
-    root:getChild("Background"):getChild("MicrobeEditorButton"):registerEventHandler("Clicked", mainMenuMicrobeEditorButtonClicked)
-    root:getChild("Background"):getChild("QuitButton"):registerEventHandler("Clicked", quitButtonClicked)
+    microbeButton:registerEventHandler("Clicked", mainMenuMicrobeStageButtonClicked)
+    microbeEditorButton:registerEventHandler("Clicked", mainMenuMicrobeEditorButtonClicked)
+    quitButton:registerEventHandler("Clicked", quitButtonClicked)
 end
 
 function MainMenuHudSystem:update(milliseconds)
@@ -27,3 +27,5 @@ end
 function mainMenuMicrobeEditorButtonClicked()
     Engine:setCurrentGameState(GameState.MICROBE_EDITOR)
 end
+
+-- quitButtonClicked is already defined in microbe_stage_hud.lua

--- a/scripts/microbe_editor/microbe_editor.lua
+++ b/scripts/microbe_editor/microbe_editor.lua
@@ -18,13 +18,15 @@ function MicrobeEditor:__init(hudSystem)
     self.mutationPoints = 100
     self.placementFunctions = {["nucleus"] = MicrobeEditor.createNewMicrobe,
                                ["flagelium"] = MicrobeEditor.addMovementOrganelle,
-                               ["mitochondria"] = MicrobeEditor.addProcessOrganelle,
+                               ["mitochondrion"] = MicrobeEditor.addProcessOrganelle,
                                ["chloroplast"] = MicrobeEditor.addProcessOrganelle,
                                ["toxin"] = MicrobeEditor.addAgentVacuole,
                                
                                ["vacuole"] = MicrobeEditor.addStorageOrganelle,
                              --  ["aminosynthesizer"] = MicrobeEditor.addProcessOrganelle,
                                ["remove"] = MicrobeEditor.removeOrganelle}
+    self.actionHistory = nil
+    self.actionIndex = 0
 end
 
 function MicrobeEditor:activate()
@@ -37,6 +39,8 @@ function MicrobeEditor:activate()
         Engine:playerData():setActiveCreature(self.nextMicrobeEntity.id, GameState.MICROBE_EDITOR)
     end
     self.mutationPoints = 100
+    self.actionHistory = {} -- where all user actions will  be registered
+    self.actionIndex = 0 -- marks the last action that has been done (not undone, but possibly redone), is 0 if there is none
 end
 
 function MicrobeEditor:update(milliseconds)
@@ -80,6 +84,42 @@ function MicrobeEditor:setActiveAction(actionName)
     self.activeActionName = actionName
 end
 
+-- Instead of executing a command, put it in a table with a redo() and undo() function to make it use the Undo-/Redo-Feature.
+-- Enqueuing it will execute it automatically, so you don't have to write things twice.
+-- The cost of the action can also be incorporated into this by making it a member of the parameter table. It will be used automatically.
+function MicrobeEditor:enqueueAction(action)
+    if not action.cost or self:takeMutationPoints(action.cost) then
+        while #self.actionHistory > self.actionIndex do
+            table.remove(self.actionHistory)
+        end
+        action.redo()
+        table.insert(self.actionHistory, action)
+        self.actionIndex = self.actionIndex + 1
+    end
+end
+
+function MicrobeEditor:undo()
+    if self.actionIndex > 0 then
+        local action = self.actionHistory[self.actionIndex]
+        action.undo()
+        if action.cost then
+            self.mutationPoints = self.mutationPoints + action.cost
+        end
+        self.actionIndex = self.actionIndex - 1
+    end
+end
+
+function MicrobeEditor:redo()
+    if self.actionIndex < #self.actionHistory then
+        self.actionIndex = self.actionIndex + 1
+        local action = self.actionHistory[self.actionIndex]
+        action.redo()
+        if action.cost then
+            self.mutationPoints = self.mutationPoints - action.cost
+        end
+    end
+end
+
 function MicrobeEditor:getMouseHex()
     local mousePosition = Engine.mouse:normalizedPosition() 
     -- Get the position of the cursor in the plane that the microbes is floating in
@@ -94,10 +134,20 @@ function MicrobeEditor:removeOrganelle()
     local q, r = self:getMouseHex()
     if not (q == 0 and r == 0) then -- Don't remove nucleus
         local organelle = self.currentMicrobe:getOrganelleAt(q,r)
-        if organelle and self:takeMutationPoints(10) then
-            self.currentMicrobe:removeOrganelle(organelle.position.q ,organelle.position.r )
-            self.currentMicrobe.sceneNode.transform:touch()
-            self.organelleCount = self.organelleCount - 1
+        if organelle then
+            local storage = organelle:storage()
+            self:enqueueAction{
+                cost = 10,
+                redo = function()
+                    self.currentMicrobe:removeOrganelle(q, r)
+                    self.currentMicrobe.sceneNode.transform:touch()
+                    self.organelleCount = self.organelleCount - 1
+                end,
+                undo = function()
+                    self.currentMicrobe:addOrganelle(q, r, Organelle.loadOrganelle(storage))
+                    self.organelleCount = self.organelleCount + 1
+                end
+            }
         end
     end
 end
@@ -106,44 +156,80 @@ end
 function MicrobeEditor:addStorageOrganelle(organelleType)
    -- self.currentMicrobe = Microbe(Entity("working_microbe", GameState.MICROBE))
     local q, r = self:getMouseHex()
-    if self.currentMicrobe:getOrganelleAt(q, r) == nil and self:takeMutationPoints(Organelle.mpCosts["vacuole"]) then
-        self.currentMicrobe:addOrganelle(q, r, OrganelleFactory.make_vacuole({}))
-        self.organelleCount = self.organelleCount + 1
+    if self.currentMicrobe:getOrganelleAt(q, r) == nil then
+        self:enqueueAction{
+            cost = Organelle.mpCosts["vacuole"],
+            redo = function()
+                self.currentMicrobe:addOrganelle(q, r, OrganelleFactory.make_vacuole({}))
+                self.organelleCount = self.organelleCount + 1
+            end,
+            undo = function()
+                self.currentMicrobe:removeOrganelle(q, r)
+                self.currentMicrobe.sceneNode.transform:touch()
+                self.organelleCount = self.organelleCount - 1
+            end
+        }
     end
 end
 
 
 function MicrobeEditor:addMovementOrganelle(organelleType)
     local q, r = self:getMouseHex()
-    local data = {["q"]=q, ["r"]=r}
-    if self.currentMicrobe:getOrganelleAt(q, r) == nil and self:takeMutationPoints(Organelle.mpCosts["flagellum"]) then
-        self.currentMicrobe:addOrganelle(q,r, OrganelleFactory.make_flagellum(data))
-        self.organelleCount = self.organelleCount + 1
+    if self.currentMicrobe:getOrganelleAt(q, r) == nil then
+        self:enqueueAction{
+            cost = Organelle.mpCosts["flagellum"],
+            redo = function()
+                self.currentMicrobe:addOrganelle(q,r, OrganelleFactory.make_flagellum{["q"]=q, ["r"]=r})
+                self.organelleCount = self.organelleCount + 1
+            end,
+            undo = function()
+                self.currentMicrobe:removeOrganelle(q, r)
+                self.currentMicrobe.sceneNode.transform:touch()
+                self.organelleCount = self.organelleCount - 1
+            end
+        }
     end
 end
 
 function MicrobeEditor:addProcessOrganelle(organelleType)
     local q, r = self:getMouseHex()
-    if self.currentMicrobe:getOrganelleAt(q, r) == nil then
+    
+    if organelleType and self.currentMicrobe:getOrganelleAt(q, r) == nil then
+        local data = { ["name"] = organelleType }
         
-        if organelleType == "mitochondria" and self:takeMutationPoints(Organelle.mpCosts["mitochondrion"]) then
-            self.currentMicrobe:addOrganelle(q,r, OrganelleFactory.make_mitochondrion({}))
-        elseif organelleType == "chloroplast" and self:takeMutationPoints(Organelle.mpCosts["chloroplast"]) then
-            self.currentMicrobe:addOrganelle(q,r, OrganelleFactory.make_chloroplast({}))
-        end
+        self:enqueueAction{
+            cost = Organelle.mpCosts[data.name],
+            redo = function()
+                self.currentMicrobe:addOrganelle(q, r, OrganelleFactory.makeOrganelle(data))
+                self.organelleCount = self.organelleCount + 1
+            end,
+            undo = function()
+                self.currentMicrobe:removeOrganelle(q, r)
+                self.currentMicrobe.sceneNode.transform:touch()
+                self.organelleCount = self.organelleCount - 1
+            end
+        }
     end
-    self.organelleCount = self.organelleCount + 1
 end
 
 function MicrobeEditor:addAgentVacuole(organelleType)
     if organelleType == "toxin" then         
         local q, r = self:getMouseHex()
-        if self.currentMicrobe:getOrganelleAt(q, r) == nil and self:takeMutationPoints(Organelle.mpCosts["oxytoxy"]) then
-            self.currentMicrobe:addOrganelle(q, r, OrganelleFactory.make_oxytoxy({}))
-            self.organelleCount = self.organelleCount + 1
+        if self.currentMicrobe:getOrganelleAt(q, r) == nil then
+            self:enqueueAction{
+                cost = Organelle.mpCosts["oxytoxy"],
+                redo = function()
+                    self.currentMicrobe:addOrganelle(q, r, OrganelleFactory.make_oxytoxy({}))
+                    self.organelleCount = self.organelleCount + 1
+                end,
+                undo = function()
+                    self.currentMicrobe:removeOrganelle(q, r)
+                    self.currentMicrobe.sceneNode.transform:touch()
+                    self.organelleCount = self.organelleCount - 1
+                end
+            }
         end
     end
-    self.organelleCount = self.organelleCount + 1
 end
 
 function MicrobeEditor:addNucleus()
@@ -163,19 +249,56 @@ function MicrobeEditor:loadMicrobe(entityId)
     self.currentMicrobe.collisionHandler:addCollisionGroup("powerupable")
     Engine:playerData():setActiveCreature(entityId, GameState.MICROBE_EDITOR)
     self.mutationPoints = 0
+    -- resetting the action history - it should not become entangled with the local file system
+    self.actionHistory = {}
+    self.actionIndex = 0
 end
 
 function MicrobeEditor:createNewMicrobe()
-    self.organelleCount = 0
+    local action = {
+        redo = function()
+            self.organelleCount = 0
+            if self.currentMicrobe ~= nil then
+                self.currentMicrobe.entity:destroy()
+            end
+            self.currentMicrobe = Microbe.createMicrobeEntity(nil, false)
+            self.currentMicrobe.entity:stealName("working_microbe")
+            self.currentMicrobe.sceneNode.transform.orientation = Quaternion(Radian(Degree(180)), Vector3(0, 0, 1))-- Orientation
+            self.currentMicrobe.sceneNode.transform:touch()
+            self.currentMicrobe.collisionHandler:addCollisionGroup("powerupable")
+            self:addNucleus()
+            self.mutationPoints = 100
+            Engine:playerData():setActiveCreature(self.currentMicrobe.entity.id, GameState.MICROBE_EDITOR)
+        end
+    }
+    
     if self.currentMicrobe ~= nil then
-        self.currentMicrobe.entity:destroy()
+         -- that there has already been a microbe in the editor suggests that it was a player action, so it's prepared and filed in for un/redo
+        local organelleStorage = {} -- self.currentMicrobe.microbe.organelles
+        local previousOrganelleCount = self.organelleCount
+        local previousMP = self.mutationPoints
+        for position,organelle in pairs(self.currentMicrobe.microbe.organelles) do
+            organelleStorage[position] = organelle:storage()
+        end
+        action.undo = function()
+            self.currentMicrobe.entity:destroy() -- remove the "new" entity that has replaced the previous one
+            self.currentMicrobe = Microbe.createMicrobeEntity(nil, false)
+            self.currentMicrobe.entity:stealName("working_microbe")
+            self.currentMicrobe.sceneNode.transform.orientation = Quaternion(Radian(Degree(180)), Vector3(0, 0, 1))-- Orientation
+            self.currentMicrobe.sceneNode.transform:touch()
+            self.currentMicrobe.collisionHandler:addCollisionGroup("powerupable")
+            for position,storage in pairs(organelleStorage) do
+                local q, r = decodeAxial(position)
+                self.currentMicrobe:addOrganelle(q, r, Organelle.loadOrganelle(storage))
+            end
+            -- no need to add the nucleus manually - it's alreary included in the organelleStorage
+            self.mutationPoints = previousMP
+            self.organelleCount = previousOrganelleCount
+            Engine:playerData():setActiveCreature(self.currentMicrobe.entity.id, GameState.MICROBE_EDITOR)
+        end
+        self:enqueueAction(action)
+    else
+        -- if there's no microbe yet, it can be safely assumed that this is a generated default microbe when opening the editor for the first time, so it's not an action that should be put into the un/redo-feature
+        action.redo()
     end
-    self.currentMicrobe = Microbe.createMicrobeEntity(nil, false)
-    self.currentMicrobe.entity:stealName("working_microbe")
-    self.currentMicrobe.sceneNode.transform.orientation = Quaternion(Radian(Degree(180)), Vector3(0, 0, 1))-- Orientation
-    self.currentMicrobe.sceneNode.transform:touch()
-    self.currentMicrobe.collisionHandler:addCollisionGroup("powerupable")
-    self:addNucleus()
-    self.mutationPoints = 100
-    Engine:playerData():setActiveCreature(self.currentMicrobe.entity.id, GameState.MICROBE_EDITOR)
 end

--- a/scripts/microbe_editor/microbe_editor_hud.lua
+++ b/scripts/microbe_editor/microbe_editor_hud.lua
@@ -102,26 +102,34 @@ function MicrobeEditorHudSystem:update(milliseconds)
         -- These global event handlers are defined in microbe_editor_hud.lua
         nucleusClicked()
     elseif  Engine.keyboard:wasKeyPressed(Keyboard.KC_R) then
-        self.editor:setActiveAction("remove")
-        self.editor:performLocationAction()
-    elseif  Engine.keyboard:wasKeyPressed(Keyboard.KC_S) and self.editor.currentMicrobe ~= nil then
+        if Engine.keyboard:isKeyDown(Keyboard.KC_LCONTROL) then
+            self.editor:redo()
+        else
+            self.editor:setActiveAction("remove")
+            self.editor:performLocationAction()
+        end
+    elseif Engine.keyboard:wasKeyPressed(Keyboard.KC_U) then
+        if Engine.keyboard:isKeyDown(Keyboard.KC_LCONTROL) then
+            self.editor:undo()
+        end
+    elseif  Engine.keyboard:wasKeyPressed(Keyboard.KC_S) then
         vacuoleClicked()
         self.editor:performLocationAction()
-    elseif  Engine.keyboard:wasKeyPressed(Keyboard.KC_T) and self.editor.currentMicrobe ~= nil then
+    elseif  Engine.keyboard:wasKeyPressed(Keyboard.KC_T) then
         if not Engine:playerData():lockedMap():isLocked("Toxin") then
             toxinClicked()
             self.editor:performLocationAction()
         end
-    elseif  Engine.keyboard:wasKeyPressed(Keyboard.KC_F) and self.editor.currentMicrobe ~= nil then
+    elseif  Engine.keyboard:wasKeyPressed(Keyboard.KC_F) then
         flageliumClicked()
         self.editor:performLocationAction()
-    elseif  Engine.keyboard:wasKeyPressed(Keyboard.KC_M) and self.editor.currentMicrobe ~= nil then
+    elseif  Engine.keyboard:wasKeyPressed(Keyboard.KC_M) then
         mitochondriaClicked()  
         self.editor:performLocationAction()
     --elseif  Engine.keyboard:wasKeyPressed(Keyboard.KC_A) and self.editor.currentMicrobe ~= nil then
     --    aminoSynthesizerClicked()
     --    self.editor:performLocationAction()
-    elseif Engine.keyboard:wasKeyPressed(Keyboard.KC_P) and self.editor.currentMicrobe ~= nil then
+    elseif Engine.keyboard:wasKeyPressed(Keyboard.KC_P) then
        chloroplastClicked()
        self.editor:performLocationAction()
     elseif  Engine.keyboard:wasKeyPressed(Keyboard.KC_ESCAPE) then
@@ -129,6 +137,7 @@ function MicrobeEditorHudSystem:update(milliseconds)
     elseif  Engine.keyboard:wasKeyPressed(Keyboard.KC_F2) then
         playClicked()
     end
+	
     properties = Entity(CAMERA_NAME .. 3):getComponent(OgreCameraComponent.TYPE_ID).properties
     newFovY = properties.fovY + Degree(Engine.mouse:scrollChange()/10)
     if newFovY < Degree(10) then
@@ -171,7 +180,7 @@ function mitochondriaClicked()
     global_activeMicrobeEditorHudSystem.activeButton = 
         global_activeMicrobeEditorHudSystem.organelleButtons["Mitochondria"]
     global_activeMicrobeEditorHudSystem.activeButton:disable()
-    global_activeMicrobeEditorHudSystem:setActiveAction("mitochondria")
+    global_activeMicrobeEditorHudSystem:setActiveAction("mitochondrion")
 end
 
 function chloroplastClicked()

--- a/scripts/microbe_stage/hex.lua
+++ b/scripts/microbe_stage/hex.lua
@@ -162,7 +162,7 @@ function cubeHexRound(x, y, z)
 end
 
 -- Maximum hex coordinate value that can be encoded with encodeAxial()
-local OFFSET = 100
+local OFFSET = 256
 
 -- Multiplier for the q coordinate used in encodeAxial()
 local SHIFT = OFFSET * 10


### PR DESCRIPTION
Using a closure-based action-command pattern, the MicrobeEditor now internally maintains a list of all changes that can be un- and redone if possible. (Practically closes issue #207 )
- every organelle action as well as creating a new microbe can be un- and redone
- entering the microbe editor and loading a microbe reset the action history
- Since the GUI is being overhauled atm, the implementation is purely code-based and can be used with Ctrl+U for undo and Ctrl+R for redo (because Z and Y are swapped between general European and other keyboard standards, using them has been avoided to prevent confusion until a more compatible solution is implemented)
- To perform an action with undo/redo-support, use the enqueueAction() function and provide it with a table that has an undo() and a redo() function (and optionally, a (MP) cost member).

Other notes:
- fixed a bug that would cause the organelleCount to be incremented always in addProcessOrganelle() and addAgentVacuole(), no matter the actual validity of the user action. This caused some stat calculations to become corrupt if the user had tried to place corresponding organelles on hexes that were already occupied.
- tinily improved the variable usage in main_menu_hud.lua
- removed some checks for currentMicrobe to be ~= nil in the input processing of the MicrobeEditorHUD, as I could not gather any sign for it to be relevant.
