### PR TITLE
Lua will now always print a stacktrace when an error occurs

### DIFF
--- a/src/scripting/script_initializer.cpp
+++ b/src/scripting/script_initializer.cpp
@@ -42,6 +42,7 @@ constructTraceback(
        traceback << std::endl;
     }
     lua_pushstring(L, traceback.str().c_str());
+    std::cout << traceback.str().c_str() << std::endl;
     return 1;
 }
 


### PR DESCRIPTION
This is a fix to #164

This apparently works...
Please verify!

Also simply adding a cout like i did, I would expect it to print stack traces twice in the cases where it would have printed stacktrace anyway, but this doesn't occur for some reason. 
Magic? I dare say so...
I dont want to mess with it now that it apparently works.
yo