### PR TITLE
Scrolling pane for organelle icons

### DIFF
--- a/scripts/examples/input.lua
+++ b/scripts/examples/input.lua
@@ -1,4 +1,4 @@
 local mousePosition = Engine.mouse:normalizedPosition() 
 local leftMouseButtonPressed = Engine.mouse.isButtonDown(MouseSystem.MB_Left)
 
-local shiftPressed = Engine:isKeyDown(KeyboardSystem.KC_SHIFT)
+local shiftPressed = Engine:isKeyDown(KeyboardSystem.KC_LSHIFT)

--- a/scripts/microbe_editor/microbe_editor_hud.lua
+++ b/scripts/microbe_editor/microbe_editor_hud.lua
@@ -12,6 +12,7 @@ function MicrobeEditorHudSystem:__init()
     self.creationFileMap = {} -- Map from player creation name to filepath
     self.activeButton = nil -- stores button, not name
     self.helpPanelOpen = false
+    self.organelleScrollPane = nil
 end
 
 
@@ -30,14 +31,14 @@ function MicrobeEditorHudSystem:init(gameState)
     self.nameTextbox = root:getChild("SpeciesNamePanel"):getChild("NameTextbox")
     root:getChild("SpeciesNamePanel"):registerEventHandler("Clicked", 
         function() global_activeMicrobeEditorHudSystem:nameClicked() end)
-
     -- self.mpProgressBar = root:getChild("BottomSection"):getChild("MutationPoints"):getChild("MPBar")
+    self.organelleScrollPane = root:getChild("scrollablepane");
     local nucleusButton = root:getChild("NewMicrobe")
-    local flageliumButton = root:getChild("AddFlagellum")
-    local mitochondriaButton = root:getChild("AddMitochondria")
-    local vacuoleButton = root:getChild("AddVacuole")
-    local toxinButton = root:getChild("AddToxinVacuole")
-    local chloroplastButton = root:getChild("AddChloroplast")
+    local flageliumButton = root:getChild("scrollablepane"):getChild("AddFlagellum")
+    local mitochondriaButton = root:getChild("scrollablepane"):getChild("AddMitochondria")
+    local vacuoleButton = root:getChild("scrollablepane"):getChild("AddVacuole")
+    local toxinButton = root:getChild("scrollablepane"):getChild("AddToxinVacuole")
+    local chloroplastButton = root:getChild("scrollablepane"):getChild("AddChloroplast")
     self.organelleButtons["nucleus"] = nucleusButton
     self.organelleButtons["flagelium"] = flageliumButton
     self.organelleButtons["mitochondrion"] = mitochondriaButton
@@ -161,15 +162,27 @@ function MicrobeEditorHudSystem:update(renderTime, logicTime)
     elseif Engine.keyboard:wasKeyPressed(Keyboard.KC_F12) then
         self:updateMicrobeName()
     end
-    properties = Entity(CAMERA_NAME .. 3):getComponent(OgreCameraComponent.TYPE_ID).properties
-    newFovY = properties.fovY + Degree(Engine.mouse:scrollChange()/10)
-    if newFovY < Degree(10) then
-        newFovY = Degree(10)
-    elseif newFovY > Degree(120) then
-        newFovY = Degree(120)
+
+    if Engine.keyboard:isKeyDown(Keyboard.KC_LSHIFT) then 
+        properties = Entity(CAMERA_NAME .. 3):getComponent(OgreCameraComponent.TYPE_ID).properties
+        newFovY = properties.fovY + Degree(Engine.mouse:scrollChange()/10)
+        if newFovY < Degree(10) then
+            newFovY = Degree(10)
+        elseif newFovY > Degree(120) then
+            newFovY = Degree(120)
+        end
+        properties.fovY = newFovY
+        properties:touch()
+    else
+        local organelleScrollVal = self.organelleScrollPane:scrollingpaneGetVerticalPosition() + Engine.mouse:scrollChange()/1000
+        if organelleScrollVal < 0 then
+            organelleScrollVal = 0
+        elseif organelleScrollVal > 1.0 then
+            organelleScrollVal = 1.0
+        end
+        self.organelleScrollPane:scrollingpaneSetVerticalPosition(organelleScrollVal)
+        
     end
-    properties.fovY = newFovY
-    properties:touch()
 end
 
 function MicrobeEditorHudSystem:updateMutationPoints() 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -110,7 +110,7 @@ struct Engine::Implementation : public Ogre::WindowEventListener {
         m_currentGameState = gameState;
         if (gameState) {
             gameState->activate();
-            gameState->rootGUIWindow().addChild(*m_consoleGUIWindow);
+            gameState->rootGUIWindow().addChild(m_consoleGUIWindow);
             luabind::call_member<void>(m_console, "registerEvents", gameState);
         }
     }

--- a/src/engine/game_state.cpp
+++ b/src/engine/game_state.cpp
@@ -119,7 +119,7 @@ GameState::~GameState() {}
 
 void
 GameState::activate() {
-    CEGUIWindow::getRootWindow().addChild(m_impl->m_guiWindow);
+    CEGUIWindow::getRootWindow().addChild(&m_impl->m_guiWindow);
     for (const auto& system : m_impl->m_systems) {
         system->activate();
     }
@@ -131,7 +131,7 @@ GameState::deactivate() {
     for (const auto& system : m_impl->m_systems) {
         system->deactivate();
     }
-    CEGUIWindow::getRootWindow().removeChild(m_impl->m_guiWindow);
+    CEGUIWindow::getRootWindow().removeChild(&m_impl->m_guiWindow);
 }
 
 

--- a/src/gui/CEGUIWindow.h
+++ b/src/gui/CEGUIWindow.h
@@ -87,6 +87,9 @@ public:
     * - CEGUIWindow::itemListboxHandleUpdatedItemData
     * - CEGUIWindow::itemListboxGetLastSelectedItem
     *
+    * - CEGUIWindow::scrollingpaneGetVerticalPosition
+    * - CEGUIWindow::scrollingpaneSetVerticalPosition
+    *
     * - CEGUIWindow::progressbarSetProgress
     *
     * - CEGUIWindow.getWindowUnderMouse
@@ -136,7 +139,7 @@ public:
     */
     void
     addChild(
-        CEGUIWindow& window
+        CEGUIWindow* window
     );
 
     /**
@@ -147,7 +150,7 @@ public:
     */
     void
     removeChild(
-        CEGUIWindow& window
+        CEGUIWindow* window
     );
 
     /**
@@ -185,6 +188,17 @@ public:
     void
     appendText(
         const std::string& text
+    );
+
+    /**
+    * @brief Sets the underlying windows image property
+    *
+    * @param text
+    *  The image to use
+    */
+    void
+    setImage(
+        const std::string& image
     );
 
     /**
@@ -245,7 +259,38 @@ public:
     *  Float between 0.0 and 1.0
     */
     void
-    progressbarSetProgress(float progress);
+    progressbarSetProgress(
+       float progress
+   );
+
+    /**
+    * @brief Gets the vertical scroll position
+    *
+    * @return
+    */
+    float
+    scrollingpaneGetVerticalPosition();
+
+    /**
+    * @brief Sets the vertical scroll position
+    *
+    * @param position
+    *   float between 0.0 - 1.0
+    */
+    void
+    scrollingpaneSetVerticalPosition(
+         float position
+     );
+
+    /**
+    * @brief Adds an icon vertically to the scrollable pane
+    *
+    * @param Window to add
+    */
+    void
+    scrollingpaneAddIcon(
+        CEGUIWindow* icon
+    );
 
     /**
     * @brief Gets the underlying cegui windows parent, wrapped as a CEGUIWindow*
@@ -377,12 +422,39 @@ public:
     * The positional system uses Falagard coordinate system.
     * The position is offset from one of the corners and edges of this Element's parent element (depending on alignments)
     *
-    * @param position
-    *  The new position to use
+    * @param x
+    *
+    * @param x
     **/
     void
-    setPosition(
-        Ogre::Vector2 position
+    setPositionAbs(
+        float x,
+        float y
+    );
+    void
+    setPositionRel(
+        float x,
+        float y
+    );
+
+    /**
+    * @brief Sets the windows size
+    *
+    * The positional system uses Falagard coordinate system.
+    *
+    * @param width
+    *
+    * @param height
+    **/
+    void
+    setSizeAbs(
+        float width,
+        float height
+    );
+    void
+    setSizeRel(
+        float width,
+        float height
     );
 
     /**

--- a/src/ogre/mouse.cpp
+++ b/src/ogre/mouse.cpp
@@ -18,6 +18,7 @@ struct Mouse::Implementation : public OIS::MouseListener {
 
     bool mouseMoved (const OIS::MouseEvent& e){
         CEGUI::System::getSingleton().getDefaultGUIContext().injectMousePosition(e.state.X.abs, e.state.Y.abs );
+        CEGUI::System::getSingleton().getDefaultGUIContext().injectMouseWheelChange(e.state.Z.rel/100);
         return true;
     }
     bool mousePressed (const OIS::MouseEvent&, OIS::MouseButtonID id){


### PR DESCRIPTION
This is a fix for #247
Added scrollable panes to the GUI
- Functionality is there to dynamically add buttons, but not currently used

Microbe editor scroll behavior changed:
- Shift-scroll (old normal scroll) for zooming
- Scroll to scroll the new scrolling list of organelles

Other minor fixes.

layout, looknfeel and scheme files have changed, get the needed files here: https://drive.google.com/file/d/0B6VFIx02kBIeU08zWmJsbTJ5TVk/view?usp=sharing
I have not commited these to SVN to avoid breaking master branch.

