### PR TITLE
Game loading now initializes microbe-stage state before loading to overwrite changed data.

### DIFF
--- a/scripts/main_menu/main_menu_hud.lua
+++ b/scripts/main_menu/main_menu_hud.lua
@@ -37,6 +37,7 @@ end
 function mainMenuLoadButtonClicked()
     local guiSoundEntity = Entity("gui_sounds")
     guiSoundEntity:getComponent(SoundSourceComponent.TYPE_ID):playSound("button-hover-click")
+    Engine:setCurrentGameState(GameState.MICROBE)
     Engine:load("quick.sav")
     print("Game loaded");
 end


### PR DESCRIPTION
Fixes #285