### PR TITLE
Added top level symbolic link 'build' to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ $tf*/
 [Bb]uild/
 build-win/
 build*/
+/build
 # CMake cache
 CMakeCache.txt
 CMakeFiles


### PR DESCRIPTION
The current .gitignore file doesn't ignore symbolic links in the top level directory with the name "build"
(but it does ignore folders with the name build)