### PR TITLE
Quoted CMake arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,7 +567,7 @@ endif()
 ###############################################################################
 
 configure_file("${CMAKE_SOURCE_DIR}/cpack/zip.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/cpack/zip.cmake" @ONLY
+    "${CMAKE_CURRENT_BINARY_DIR}/cpack/zip.cmake" @ONLY
 )
 
 add_custom_target(zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,11 @@ SET(OGRE_SDK ""
     CACHE STRING "Path to the Ogre SDK"
 )
 
-set(ASSET_DIRECTORY ${CMAKE_SOURCE_DIR}/assets
+set(ASSET_DIRECTORY "${CMAKE_SOURCE_DIR}/assets"
     CACHE PATH "Path to assets"
 )
 
-if(NOT IS_DIRECTORY ${ASSET_DIRECTORY}/models)
+if(NOT IS_DIRECTORY "${ASSET_DIRECTORY}/models")
     message(FATAL_ERROR 
 "Could not find assets in ${ASSET_DIRECTORY}.  
 Please use Subversion to download the assets:
@@ -38,7 +38,7 @@ endif()
 
 # Configure search path for cmake modules
 list(APPEND CMAKE_MODULE_PATH
-    ${CMAKE_SOURCE_DIR}/cmake_modules
+    "${CMAKE_SOURCE_DIR}/cmake_modules"
 )
 
 # Import utility functions
@@ -52,7 +52,7 @@ set(CMAKE_INSTALL_RPATH ".")
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE
       "Debug"
-      CACHE STRING "Choose the type of build, options are: None (CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release."
+      CACHE STRING "Choose the type of build, options are: None (CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo."
       FORCE
     )
 endif ()
@@ -106,12 +106,12 @@ find_package(Boost COMPONENTS ${BOOST_COMPONENTS} REQUIRED QUIET)
 ###############
 
 add_subdirectory(
-    ${CMAKE_CURRENT_SOURCE_DIR}/contrib/googletest
+    "${CMAKE_CURRENT_SOURCE_DIR}/contrib/googletest"
 )
 
 include_directories(
     SYSTEM
-    ${CMAKE_CURRENT_SOURCE_DIR}/contrib/googletest/include
+    "${CMAKE_CURRENT_SOURCE_DIR}/contrib/googletest/include"
 )
 
 ##########
@@ -134,8 +134,8 @@ find_package(TinyXML REQUIRED QUIET)
 
 include_directories(
     SYSTEM
-    ${CMAKE_CURRENT_SOURCE_DIR}/contrib/lua/lua/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/contrib/luabind/
+    "${CMAKE_CURRENT_SOURCE_DIR}/contrib/lua/lua/src"
+    "${CMAKE_CURRENT_SOURCE_DIR}/contrib/luabind/"
 )
 
 #######
@@ -159,11 +159,11 @@ if(WIN32)
 endif()
 
 add_subdirectory(
-    ${CMAKE_CURRENT_SOURCE_DIR}/contrib/lua/
+    "${CMAKE_CURRENT_SOURCE_DIR}/contrib/lua/"
 )
 
 set(LUA_FOUND TRUE)
-set(LUA_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/contrib/lua/lua/src)
+set(LUA_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/contrib/lua/lua/src")
 set(LUA_LIBRARIES lua)
 #set(BUILD_SHARED_LUABIND ON)
 #set(INSTALL_LUABIND ON)
@@ -171,7 +171,7 @@ set(LIB_DIR bin)
 add_definitions(-DLUABIND_CPLUSPLUS_LUA)
 
 add_subdirectory(
-    ${CMAKE_CURRENT_SOURCE_DIR}/contrib/luabind/
+    "${CMAKE_CURRENT_SOURCE_DIR}/contrib/luabind/"
 )
 
 ################
@@ -185,12 +185,12 @@ find_package(Vorbis REQUIRED)
 add_definitions(-DHAVE_EFX=0)
 
 add_subdirectory(
-    ${CMAKE_CURRENT_SOURCE_DIR}/contrib/ogre_ogg_sound
+    "${CMAKE_CURRENT_SOURCE_DIR}/contrib/ogre_ogg_sound"
 )
 
 include_directories(
     SYSTEM
-    ${CMAKE_CURRENT_SOURCE_DIR}/contrib/ogre_ogg_sound/include
+    "${CMAKE_CURRENT_SOURCE_DIR}/contrib/ogre_ogg_sound/include"
     ${OpenAL_INCLUDE_DIRS}
     ${OGG_INCLUDE_DIRS}
     ${VORBIS_INCLUDE_DIRS}
@@ -207,7 +207,7 @@ include_directories(SYSTEM
 )
 
 include_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    "${CMAKE_CURRENT_SOURCE_DIR}/src"
 )
 
 # Compile using c++11
@@ -283,20 +283,20 @@ target_link_libraries(RunTests ThriveLib gtest_main)
 # Documentation #
 #################
 
-set(DOC_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/doc CACHE PATH "Documentation output directory.")
+set(DOC_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/doc" CACHE PATH "Documentation output directory.")
 set(DOC_INPUT "${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/doc")
 
 set( DOXYGEN_CONFIG_FILE
-    ${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen.cfg.in
+    "${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen.cfg.in"
 )
 
 find_package(Doxygen)
 
 if(DOXYGEN_FOUND)
-    configure_file(${DOXYGEN_CONFIG_FILE} ${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg @ONLY)
+    configure_file(${DOXYGEN_CONFIG_FILE} "${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg" @ONLY)
     add_custom_target(doc
-        ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doc
+        ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/doc"
         COMMENT "Generating API documentation with Doxygen" VERBATIM
         SOURCES ${DOXYGEN_CONFIG_FILE}
     )
@@ -320,31 +320,31 @@ install(EXPORT lua
 # Version file
 
 install(FILES
-    ${CMAKE_SOURCE_DIR}/thriveversion.ver
+    "${CMAKE_SOURCE_DIR}/thriveversion.ver"
     DESTINATION bin
 )
 
 # OGRE config and media
 
 install(FILES
-    ${CMAKE_SOURCE_DIR}/ogre_cfg/resources.cfg
+    "${CMAKE_SOURCE_DIR}/ogre_cfg/resources.cfg"
     DESTINATION bin
 )
 
 install(FILES
-    ${CMAKE_SOURCE_DIR}/ogre_cfg/plugins.cfg
+    "${CMAKE_SOURCE_DIR}/ogre_cfg/plugins.cfg"
     DESTINATION bin
     CONFIGURATIONS Release
 )
 
 install(FILES
-    ${CMAKE_SOURCE_DIR}/ogre_cfg/plugins_d.cfg
+    "${CMAKE_SOURCE_DIR}/ogre_cfg/plugins_d.cfg"
     DESTINATION bin
     CONFIGURATIONS Debug
     RENAME plugins.cfg
 )
 
-install(DIRECTORY ${ASSET_DIRECTORY}/models
+install(DIRECTORY "${ASSET_DIRECTORY}/models"
     DESTINATION ./
     CONFIGURATIONS Release  Debug
     FILES_MATCHING
@@ -354,7 +354,7 @@ install(DIRECTORY ${ASSET_DIRECTORY}/models
         PATTERN "*.skeleton.xml"
 )
 
-install(DIRECTORY ${ASSET_DIRECTORY}/materials
+install(DIRECTORY "${ASSET_DIRECTORY}/materials"
     DESTINATION ./
     CONFIGURATIONS Release  Debug
     FILES_MATCHING
@@ -365,7 +365,7 @@ install(DIRECTORY ${ASSET_DIRECTORY}/materials
 )
 
 install(DIRECTORY
-    ${ASSET_DIRECTORY}/fonts
+    "${ASSET_DIRECTORY}/fonts"
     DESTINATION ./
     CONFIGURATIONS Release  Debug
     FILES_MATCHING
@@ -375,19 +375,19 @@ install(DIRECTORY
 )
 
 install(DIRECTORY
-    ${CMAKE_SOURCE_DIR}/scripts
+    "${CMAKE_SOURCE_DIR}/scripts"
     DESTINATION ./
     CONFIGURATIONS Release  Debug
 )
 install(DIRECTORY
-    ${ASSET_DIRECTORY}/gui/animations
+   " ${ASSET_DIRECTORY}/gui/animations"
     DESTINATION ./gui/
     CONFIGURATIONS Release  Debug
     FILES_MATCHING
         PATTERN "*.anims"
 )
 install(DIRECTORY
-    ${ASSET_DIRECTORY}/gui/imagesets
+    "${ASSET_DIRECTORY}/gui/imagesets"
     DESTINATION ./gui/
     CONFIGURATIONS Release  Debug
     FILES_MATCHING
@@ -396,7 +396,7 @@ install(DIRECTORY
         PATTERN "*.png"
 )
 install(DIRECTORY
-    ${ASSET_DIRECTORY}/gui/layouts
+    "${ASSET_DIRECTORY}/gui/layouts"
     DESTINATION ./gui/
     CONFIGURATIONS Release  Debug
     FILES_MATCHING
@@ -404,14 +404,14 @@ install(DIRECTORY
         PATTERN "*.wnd"
 )
 install(DIRECTORY
-    ${ASSET_DIRECTORY}/gui/looknfeel
+    "${ASSET_DIRECTORY}/gui/looknfeel"
     DESTINATION ./gui/
     CONFIGURATIONS Release  Debug
     FILES_MATCHING
         PATTERN "*.looknfeel"
 )
 install(DIRECTORY
-    ${ASSET_DIRECTORY}/gui/schemes
+    "${ASSET_DIRECTORY}/gui/schemes"
     DESTINATION ./gui/
     CONFIGURATIONS Release  Debug
     FILES_MATCHING
@@ -419,7 +419,7 @@ install(DIRECTORY
 )
 
 install(DIRECTORY
-    ${ASSET_DIRECTORY}/sounds
+    "${ASSET_DIRECTORY}/sounds"
     DESTINATION ./
     CONFIGURATIONS Release  Debug
     FILES_MATCHING
@@ -428,7 +428,7 @@ install(DIRECTORY
 )
 
 install(DIRECTORY
-    ${ASSET_DIRECTORY}/definitions
+    "${ASSET_DIRECTORY}/definitions"
     DESTINATION ./
     CONFIGURATIONS Release  Debug
     FILES_MATCHING
@@ -458,62 +458,62 @@ if(WIN32)
     foreach(OGRE_PLUGIN ${OGRE_PLUGINS})
         # Release
         install(FILES
-            ${OGRE_PLUGIN_DIR_REL}/${OGRE_PLUGIN}.dll
+            "${OGRE_PLUGIN_DIR_REL}/${OGRE_PLUGIN}.dll"
             DESTINATION bin
             CONFIGURATIONS Release
         )
         # Debug
         install(FILES
-            ${OGRE_PLUGIN_DIR_DBG}/${OGRE_PLUGIN}_d.dll
+            "${OGRE_PLUGIN_DIR_DBG}/${OGRE_PLUGIN}_d.dll"
             DESTINATION bin
             CONFIGURATIONS Debug
         )
     endforeach()
 
     install(FILES
-        ${OGRE_PLUGIN_DIR_REL}/OgreMain.dll
-		${OGRE_PLUGIN_DIR_REL}/RenderSystem_GL.dll
-		${OGRE_PLUGIN_DIR_REL}/OIS.dll
-        #${OGRE_PLUGIN_DIR_REL}/cg.dll
+        "${OGRE_PLUGIN_DIR_REL}/OgreMain.dll"
+		"${OGRE_PLUGIN_DIR_REL}/RenderSystem_GL.dll"
+		"${OGRE_PLUGIN_DIR_REL}/OIS.dll"
+        #"${OGRE_PLUGIN_DIR_REL}/cg.dll"
 		DESTINATION bin
 		CONFIGURATIONS Release
 	)
     
 	install(FILES
-        ${OGRE_PLUGIN_DIR_DBG}/OgreMain_d.dll
-		${OGRE_PLUGIN_DIR_DBG}/RenderSystem_GL_d.dll
-		${OGRE_PLUGIN_DIR_DBG}/OIS_d.dll
-        #${OGRE_PLUGIN_DIR_DBG}/cg.dll
+        "${OGRE_PLUGIN_DIR_DBG}/OgreMain_d.dll"
+		"${OGRE_PLUGIN_DIR_DBG}/RenderSystem_GL_d.dll"
+		"${OGRE_PLUGIN_DIR_DBG}/OIS_d.dll"
+        #"${OGRE_PLUGIN_DIR_DBG}/cg.dll"
 		DESTINATION bin
 		CONFIGURATIONS Debug
 	)
     
     install(FILES
-        ${MINGW_ENV}/install/bin/libCEGUIBase-0_d.dll
-        ${MINGW_ENV}/install/bin/libCEGUIOgreRenderer-0_d.dll
-        ${MINGW_ENV}/install/bin/libCEGUITinyXMLParser_d.dll
-        ${MINGW_ENV}/install/bin/libCEGUICoreWindowRendererSet_d.dll
-        ${MINGW_ENV}/install/bin/Debug/libfreetype_d.dll
-        ${MINGW_ENV}/install/bin/Debug/libjpeg_d.dll
-        ${MINGW_ENV}/install/bin/Debug/liblibpng_d.dll
-        ${MINGW_ENV}/install/bin/Debug/libSILLY_d.dll
-        ${MINGW_ENV}/install/bin/Debug/libzlib_d.dll
-        ${MINGW_ENV}/install/bin/OpenAL32.dll
+        "${MINGW_ENV}/install/bin/libCEGUIBase-0_d.dll"
+        "${MINGW_ENV}/install/bin/libCEGUIOgreRenderer-0_d.dll"
+        "${MINGW_ENV}/install/bin/libCEGUITinyXMLParser_d.dll"
+        "${MINGW_ENV}/install/bin/libCEGUICoreWindowRendererSet_d.dll"
+        "${MINGW_ENV}/install/bin/Debug/libfreetype_d.dll"
+        "${MINGW_ENV}/install/bin/Debug/libjpeg_d.dll"
+        "${MINGW_ENV}/install/bin/Debug/liblibpng_d.dll"
+        "${MINGW_ENV}/install/bin/Debug/libSILLY_d.dll"
+        "${MINGW_ENV}/install/bin/Debug/libzlib_d.dll"
+        "${MINGW_ENV}/install/bin/OpenAL32.dll"
         DESTINATION bin
 		CONFIGURATIONS Debug
     )
     
     install(FILES
-        ${MINGW_ENV}/install/bin/libCEGUIBase-0.dll
-        ${MINGW_ENV}/install/bin/libCEGUIOgreRenderer-0.dll
-        ${MINGW_ENV}/install/bin/libCEGUITinyXMLParser.dll
-        ${MINGW_ENV}/install/bin/libCEGUICoreWindowRendererSet.dll
-        ${MINGW_ENV}/install/bin/Release/libfreetype.dll
-        ${MINGW_ENV}/install/bin/Release/libjpeg.dll
-        ${MINGW_ENV}/install/bin/Release/liblibpng.dll
-        ${MINGW_ENV}/install/bin/Release/libSILLY.dll
-        ${MINGW_ENV}/install/bin/Release/libzlib.dll
-        ${MINGW_ENV}/install/bin/OpenAL32.dll
+        "${MINGW_ENV}/install/bin/libCEGUIBase-0.dll"
+        "${MINGW_ENV}/install/bin/libCEGUIOgreRenderer-0.dll"
+        "${MINGW_ENV}/install/bin/libCEGUITinyXMLParser.dll"
+        "${MINGW_ENV}/install/bin/libCEGUICoreWindowRendererSet.dll"
+        "${MINGW_ENV}/install/bin/Release/libfreetype.dll"
+        "${MINGW_ENV}/install/bin/Release/libjpeg.dll"
+        "${MINGW_ENV}/install/bin/Release/liblibpng.dll"
+        "${MINGW_ENV}/install/bin/Release/libSILLY.dll"
+        "${MINGW_ENV}/install/bin/Release/libzlib.dll"
+        "${MINGW_ENV}/install/bin/OpenAL32.dll"
         DESTINATION bin
 		CONFIGURATIONS Release
     )
@@ -566,7 +566,7 @@ endif()
 # CPack
 ###############################################################################
 
-configure_file(${CMAKE_SOURCE_DIR}/cpack/zip.cmake.in
+configure_file("${CMAKE_SOURCE_DIR}/cpack/zip.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/cpack/zip.cmake" @ONLY
 )
 

--- a/doc/doxygen.cfg.in
+++ b/doc/doxygen.cfg.in
@@ -728,7 +728,7 @@ EXCLUDE_SYMBOLS        = *::Implementation thrive::detail::*
 # directories that contain example code fragments that are included (see
 # the \include command).
 
-EXAMPLE_PATH           = @CMAKE_CURRENT_SOURCE_DIR@/res/scripts/examples
+EXAMPLE_PATH           = "@CMAKE_CURRENT_SOURCE_DIR@/res/scripts/examples"
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_sources(
-    ${CMAKE_CURRENT_SOURCE_DIR}/game.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/game.h
+    "${CMAKE_CURRENT_SOURCE_DIR}/game.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/game.h"
 )
 
 add_subdirectory(bullet)

--- a/src/bullet/CMakeLists.txt
+++ b/src/bullet/CMakeLists.txt
@@ -1,20 +1,20 @@
 add_sources(
-    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_ogre_conversion.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_to_ogre_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_to_ogre_system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/collision_shape.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/collision_shape.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/debug_drawing.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/debug_drawing.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/rigid_body_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/rigid_body_system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/update_physics_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/update_physics_system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/collision_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/collision_system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/collision_filter.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/collision_filter.h
+    "${CMAKE_CURRENT_SOURCE_DIR}/bullet_ogre_conversion.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/bullet_to_ogre_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/bullet_to_ogre_system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/collision_shape.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/collision_shape.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/debug_drawing.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/debug_drawing.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/rigid_body_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/rigid_body_system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/update_physics_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/update_physics_system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/collision_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/collision_system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/collision_filter.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/collision_filter.h"
 )
 

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -1,41 +1,41 @@
 
 add_sources(
-    ${CMAKE_CURRENT_SOURCE_DIR}/component.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/component.h 
-    ${CMAKE_CURRENT_SOURCE_DIR}/component_collection.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/component_collection.h 
-    ${CMAKE_CURRENT_SOURCE_DIR}/component_factory.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/component_factory.h 
-    ${CMAKE_CURRENT_SOURCE_DIR}/engine.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/engine.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/entity.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/entity.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/entity_filter.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/entity_manager.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/entity_manager.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/game_state.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/game_state.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/player_data.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/player_data.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/rng.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/rng.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/rolling_grid.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/rolling_grid.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/serialization.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/serialization.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/touchable.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/touchable.h
+    "${CMAKE_CURRENT_SOURCE_DIR}/component.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/component.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/component_collection.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/component_collection.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/component_factory.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/component_factory.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/engine.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/engine.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/entity.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/entity.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/entity_filter.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/entity_manager.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/entity_manager.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/game_state.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/game_state.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/player_data.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/player_data.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/rng.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/rng.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/rolling_grid.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/rolling_grid.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/serialization.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/serialization.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/touchable.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/touchable.h"
 )
 
 add_test_sources(
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/entity.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/entity_filter.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/serialization.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/rng.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/rolling_grid.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_component.h
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/entity.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/entity_filter.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/serialization.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/rng.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/rolling_grid.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_component.h"
 )

--- a/src/general/CMakeLists.txt
+++ b/src/general/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_sources(
-    ${CMAKE_CURRENT_SOURCE_DIR}/timed_life_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/timed_life_system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/locked_map.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/locked_map.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/powerup_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/powerup_system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h
+    "${CMAKE_CURRENT_SOURCE_DIR}/timed_life_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/timed_life_system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/locked_map.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/locked_map.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/powerup_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/powerup_system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h"
 )
 
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_sources(
-    ${CMAKE_CURRENT_SOURCE_DIR}/CEGUIWindow.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/CEGUIWindow.h
-	${CMAKE_CURRENT_SOURCE_DIR}/AlphaHitWindow.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/AlphaHitWindow.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h
+    "${CMAKE_CURRENT_SOURCE_DIR}/CEGUIWindow.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/CEGUIWindow.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/AlphaHitWindow.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/AlphaHitWindow.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h"
 )
 
 

--- a/src/microbe_stage/CMakeLists.txt
+++ b/src/microbe_stage/CMakeLists.txt
@@ -1,18 +1,18 @@
 add_sources(
-    ${CMAKE_CURRENT_SOURCE_DIR}/compound.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/compound.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/compound_registry.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/compound_registry.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/compound_absorber_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/compound_absorber_system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/compound_emitter_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/compound_emitter_system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/bio_process_registry.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/bio_process_registry.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/species_registry.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/species_registry.h
+    "${CMAKE_CURRENT_SOURCE_DIR}/compound.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/compound.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/compound_registry.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/compound_registry.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/compound_absorber_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/compound_absorber_system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/compound_emitter_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/compound_emitter_system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/bio_process_registry.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/bio_process_registry.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/species_registry.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/species_registry.h"
 )
 
 

--- a/src/ogre/CMakeLists.txt
+++ b/src/ogre/CMakeLists.txt
@@ -1,29 +1,29 @@
 add_sources(
-    ${CMAKE_CURRENT_SOURCE_DIR}/camera_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/camera_system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/colour_material.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/colour_material.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/keyboard.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/keyboard.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/light_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/light_system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/mouse.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/mouse.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/render_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/render_system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/scene_node_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/scene_node_system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/sky_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/sky_system.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/text_overlay.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/text_overlay.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/viewport_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/viewport_system.h
+    "${CMAKE_CURRENT_SOURCE_DIR}/camera_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/camera_system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/colour_material.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/colour_material.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/keyboard.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/keyboard.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/light_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/light_system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/mouse.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/mouse.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/render_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/render_system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/scene_node_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/scene_node_system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sky_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sky_system.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/text_overlay.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/text_overlay.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/viewport_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/viewport_system.h"
 )
 
 add_test_sources(
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/script_bindings.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/sky_system.cpp
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/script_bindings.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/sky_system.cpp"
 )

--- a/src/scripting/CMakeLists.txt
+++ b/src/scripting/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_sources(
-    ${CMAKE_CURRENT_SOURCE_DIR}/lua_state.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/lua_state.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/luabind.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_entity_filter.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_entity_filter.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_initializer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_initializer.h
+    "${CMAKE_CURRENT_SOURCE_DIR}/lua_state.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/lua_state.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/luabind.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_entity_filter.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_entity_filter.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_initializer.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_initializer.h"
 )
 
 add_test_sources(

--- a/src/sound/CMakeLists.txt
+++ b/src/sound/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_sources(
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/sound_source_system.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/sound_source_system.h
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/script_bindings.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sound_source_system.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sound_source_system.h"
 )
 
 add_test_sources(

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 add_sources(
-    ${CMAKE_CURRENT_SOURCE_DIR}/make_unique.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/pair_hash.h
+    "${CMAKE_CURRENT_SOURCE_DIR}/make_unique.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/pair_hash.h"
 )


### PR DESCRIPTION
Issue https://github.com/Revolutionary-Games/Thrive/issues/298 suggests quoting CMake arguments that could include spaces.
I went around and quoted arguments that contained variables that might have been paths.
There is still at least one that might need to be quoted in `contrib/googletest/cmake/internal_utils.cmake:224`:      ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/${name}.py

I just noticed that I had also added RelWithDebInfo to the list of CMake build types... hopefully that is fine
