### PR TITLE
Everything renders outside viewing rectangle.

### DIFF
--- a/scripts/microbe_stage/setup.lua
+++ b/scripts/microbe_stage/setup.lua
@@ -219,18 +219,19 @@ local function createSpawnSystem()
 
     --Spawn one emitter on average once in every square of sidelength 10
     -- (square dekaunit?)
-    spawnSystem:addSpawnType(spawnOxygenEmitter, 1/500, 30)
-    spawnSystem:addSpawnType(spawnCO2Emitter, 1/500, 30)
-    spawnSystem:addSpawnType(spawnGlucoseEmitter, 1/500, 30)
-    spawnSystem:addSpawnType(spawnAmmoniaEmitter, 1/1250, 30)
-    spawnSystem:addSpawnType(toxinOrganelleSpawnFunction, 1/17000, 30)
+	-- Spawn radius should depend on view rectangle
+    spawnSystem:addSpawnType(spawnOxygenEmitter, 1/500, 50)
+    spawnSystem:addSpawnType(spawnCO2Emitter, 1/500, 50)
+    spawnSystem:addSpawnType(spawnGlucoseEmitter, 1/500, 50)
+    spawnSystem:addSpawnType(spawnAmmoniaEmitter, 1/1250, 50)
+    spawnSystem:addSpawnType(toxinOrganelleSpawnFunction, 1/17000, 50)
 
     for name, species in pairs(starter_microbes) do
         spawnSystem:addSpawnType(
             function(pos) 
                 return microbeSpawnFunctionGeneric(pos, name, true, nil)
             end, 
-            species.spawnDensity, 40)
+            species.spawnDensity, 60)
     end
     return spawnSystem
 end


### PR DESCRIPTION
Change a couple things so that microbes and emmiters spawn outside of the viewing rectangle. This, however, is not ideal as the frame rate on my laptop dropped in half. I'm hoping this will be fixed by the compound clouds, but if it isn't, we will have to do some optimization.