### PR TITLE
Update SVN assets domain

### DIFF
--- a/mingw_setup/readme.txt
+++ b/mingw_setup/readme.txt
@@ -138,14 +138,14 @@ file in the next step.
 * If you Installed tortoise SVN
 
     Right click somewhere in the git repository and click SVN Checkout.
-    Under URL enter: http://crovea.net/svn/thrive_assets
-    Edit the last part of Checkout directory to "/assets" instead of "/trive_assets"
+    Under URL enter: http://assets.revolutionarygamesstudio.com
+    Edit the last part of Checkout directory to "/assets" instead of "/assets.revolutionarygamesstudio.com"
     Click checkout and it will prompt you for a user
     For password and username simply enter 'thrive' and 'thrive'
 
 * If you are instead using commandline SVN
 
-    svn co http://crovea.net/svn/thrive_assets/ ./assets
+    svn co http://assets.revolutionarygamesstudio.com ./assets
     
 8. Invoke CMake
 ---------------


### PR DESCRIPTION
The old assets domain at http://crovea.net/svn/thrive_assets is no longer operating, so references to it have been changed to the new assets domain at http://assets.revolutionarygamesstudio.com

I confirmed that it works with tortoise SVN, and I think I got the commandline instructions right but someone may want to check that the syntax is correct.