### PR TITLE
Updated CEGUI required version

### DIFF
--- a/SetupThrive.sh
+++ b/SetupThrive.sh
@@ -186,7 +186,9 @@ function prepare_CEGUI() {
 		cd cegui
 	fi
 
-	hg update default
+    # Let's use this commit for now
+    hg update 869014de5669
+	#hg update default
 
 	mkdir build
 	cd build

--- a/src/gui/CEGUIWindow.cpp
+++ b/src/gui/CEGUIWindow.cpp
@@ -482,7 +482,7 @@ CEGUIWindow::registerKeyEventHandler(
         {
             luabind::call_function<void>(callback, CEGUIWindow(static_cast<
                     const CEGUI::WindowEventArgs&>(args).window, false),
-                static_cast<int>(static_cast<const CEGUI::TextEventArgs&>(args).character));
+                static_cast<int>(static_cast<const CEGUI::TextEventArgs&>(args).d_character));
             return 0;
         };
 


### PR DESCRIPTION
For the latest CEGUI version a small fix was required.

I also set the current CEGUI commit to be the one the setup script uses so that it's easy to upgrade to that version.

Also I think we should stick with this version for this thrive release cycle (is that a thing?)
and only update if something is broken.