### PR TITLE
Fix behavior of SetupThrive.sh when assets directory exists

### DIFF
--- a/SetupThrive.sh
+++ b/SetupThrive.sh
@@ -324,7 +324,7 @@ function setup_Thrive() {
 	if [ -d assets ]; then
 			cd assets
 			svn up
-
+			cd ..
 	else
 		svn checkout http://assets.revolutionarygamesstudio.com/ assets
 	fi


### PR DESCRIPTION
Minor change to SetupThrive.sh to fix behavior if assets directory already exists.