### PR TITLE
Fixed videoplayer for latest ffmpeg 3.2 

### DIFF
--- a/src/gui/VideoPlayer.cpp
+++ b/src/gui/VideoPlayer.cpp
@@ -599,7 +599,12 @@ public:
             // so we access that through pkt_pts
             //CurrentlyDecodedTimeStamp = DecodedFrame->pkt_pts * VideoTimeBase;
             //VideoTimeBase = VideoCodec->time_base.num / VideoCodec->time_base.den;
-            CurrentlyDecodedTimeStamp = DecodedFrame->pkt_pts * VideoTimeBase;
+            //CurrentlyDecodedTimeStamp = DecodedFrame->pkt_pts * VideoTimeBase;
+
+            // Seems that the latest FFMPEG version has fixed this.
+            // I would put this in a #IF macro block if ffmpeg provided a way to check the
+            // version at compile time
+            CurrentlyDecodedTimeStamp = DecodedFrame->pts * VideoTimeBase;
             return true;
         }
 


### PR DESCRIPTION
But it is now broken for lots of earlier versions. And it seems that there's no compile time way to check ffmpeg version.