### PR TITLE
Update linux_setup/readme.md removed redundancy

### DIFF
--- a/linux_setup/readme.md
+++ b/linux_setup/readme.md
@@ -84,7 +84,6 @@ to get the link for clone. And replace the url in this command with it:
 
 Then go to the directory and run the setup script.
 
-    cd thrive
     ./SetupThrive.rb
     
 If you installed ruby correctly you should now be prompted for your


### PR DESCRIPTION
Previous command in clone section already required `cd thrive`