### PR TITLE
AlphaHit windows now use an image that is dedicated to them

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -22,6 +22,7 @@
 #include <CEGUI/InputAggregator.h>
 #include "CEGUI/RendererModules/Ogre/Renderer.h"
 #include "gui/AlphaHitWindow.h"
+#include "gui/gui_texture_helper.h"
 
 // Ogre
 #include "ogre/camera_system.h"
@@ -334,11 +335,9 @@ struct Engine::Implementation : public Ogre::WindowEventListener {
     void
     setupGUI(){
 
-        // Start loading gui Images needed by AlphaHitWindow //
-        // TODO: see if we can use the same Texture that CEGUI loads for itself
-        Ogre::ResourceBackgroundQueue::getSingleton().load(
-            Ogre::Root::getSingleton().getTextureManager()->getResourceType(),
-            "ThriveGeneric.png", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+        // Load gui Images needed by AlphaHitWindow //
+        // This loads this image before continuing. Could be in a background thread
+        m_guiHelper.getTexture("ThriveGeneric.png");
         
         CEGUI::WindowFactoryManager::addFactory<CEGUI::TplWindowFactory<AlphaHitWindow> >();
 
@@ -517,6 +516,8 @@ struct Engine::Implementation : public Ogre::WindowEventListener {
     luabind::object m_console;
     std::unique_ptr<SoundManager> m_soundManager;
     std::unique_ptr<CEGUI::InputAggregator> m_aggregator;
+
+    GUITextureHelper m_guiHelper;
 };
 
 
@@ -733,6 +734,12 @@ Engine::mouse() const {
 Ogre::Root*
 Engine::ogreRoot() const {
     return m_impl->m_graphics.root.get();
+}
+
+GUITextureHelper&
+Engine::guiTextureHelper() const{
+    
+    return m_impl->m_guiHelper;
 }
 
 

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -43,7 +43,7 @@ class OgreViewportSystem;
 class CollisionSystem;
 class System;
 class RNG;
-
+class GUITextureHelper;
 
 /**
 * @brief The heart of the game
@@ -234,6 +234,13 @@ public:
     */
     Ogre::Root*
     ogreRoot() const;
+
+    /**
+    * @brief GUI image loader helper
+    */
+    GUITextureHelper&
+    guiTextureHelper() const;
+        
 
     /**
     * @brief Creates a savegame

--- a/src/gui/AlphaHitWindow.cpp
+++ b/src/gui/AlphaHitWindow.cpp
@@ -2,52 +2,32 @@
 
 #include <CEGUI/CoordConverter.h>
 
-#include <OgreRoot.h>
-#include <OgreTextureManager.h>
-#include <OgreHardwarePixelBuffer.h>
+#include "game.h"
+#include "engine/engine.h"
+#include "gui_texture_helper.h"
+
+#include <OgreImage.h>
+#include <OgreColourValue.h>
 
 //----------------------------------------------------------------------------//
 class TextureAlphaCheckArea{
 public:
 
-    TextureAlphaCheckArea(const Ogre::TexturePtr &texture,
+    TextureAlphaCheckArea(const std::shared_ptr<Ogre::Image> &texture,
         uint32_t x, uint32_t y,
         uint32_t width, uint32_t height) :
-        m_texture(texture), m_x(x), m_y(y), m_width(width), m_height(height),
-        m_readPixel(1, 1, 1, Ogre::PixelFormat::PF_A8R8G8B8)
+        m_texture(texture), m_x(x), m_y(y), m_width(width), m_height(height)
     {
-        if(m_texture.isNull()){
+        if(!m_texture){
 
             throw std::runtime_error("TextureAlphaCheckArea given null texture");
         }
-    }
-
-    //! Starts loading m_texture if it isn't loading already
-    //! \todo Actual background loading. Now this just loads it in the primary thread
-    void
-        makeSureIsLoading()
-    {
-        if(!isReady())
-            m_texture->load();
-    }
-
-    //! \returns True if the texture is ready for use
-    bool
-        isReady() const
-    {
-        return m_texture->isLoaded();
     }
 
     //! \returns Pixel at position
     Ogre::ColourValue
         getPixel(uint32_t x, uint32_t y)
     {
-        assert(isReady());
-        
-        auto buffer = m_texture->getBuffer();
-    
-        assert(buffer != nullptr);
-
         const auto offsetX = x + m_x;
         const auto offsetY = y + m_y;
 
@@ -60,33 +40,14 @@ public:
         }
         
         // Single pixel from texture
-        uint32_t pixelDataHolder;
-        m_readPixel.data = &pixelDataHolder;
-
-        try{
-            buffer->blitToMemory(Ogre::Box(offsetX, offsetY, offsetX + 1, offsetY + 1),
-            m_readPixel);
-        
-        } catch(const Ogre::Exception &e){
-
-            // This seems to sometimes trigger completely randomly //
-            // std::cout << "Error: AlphaHitWindow failed to read pixel data: " <<
-            //     e.what() << std::endl;
-            
-            return Ogre::ColourValue::ZERO;
-        }
-
-        // We could also bit shift the alpha out of pixelDataHolder
-        return m_readPixel.getColourAt(0, 0, 0);
+        return m_texture->getColourAt(offsetX, offsetY, 0);
     }
 
-    const Ogre::TexturePtr m_texture;
+    const std::shared_ptr<Ogre::Image> m_texture;
     const uint32_t m_x;
     const uint32_t m_y;
     const uint32_t m_width;
     const uint32_t m_height;
-
-    Ogre::PixelBox m_readPixel;
 };
 
 
@@ -140,14 +101,6 @@ AlphaHitWindow::isHit(
 
     assert(m_hitTestTexture);
 
-    m_hitTestTexture->makeSureIsLoading();
-
-    if(!m_hitTestTexture->isReady()){
-
-        // Not ready yet, don't let user click //
-        return false;
-    }
-
     // Read the pixel under mouse pos //
     const CEGUIVector2 relativePos = CEGUI::CoordConverter::screenToWindow(*this, position); 
 
@@ -195,13 +148,11 @@ std::unique_ptr<TextureAlphaCheckArea>
 
     const std::string setName = schemaPart.c_str();
 
-    auto texture = std::get<0>(Ogre::Root::getSingleton().getTextureManager()->
-        createOrRetrieve(setName + ".png",
-            Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME)).
-        dynamicCast<Ogre::Texture>();
+    auto img = thrive::Game::instance().engine().guiTextureHelper().
+        getTexture(setName + ".png");
 
-    if(texture.isNull())
-        throw std::runtime_error("AlphaHitWindow: didn't find texture file for image");
+    if(!img)
+        throw std::runtime_error("AlphaHitWindow: didn't find texture file for image");    
     
     // Find the offset into the file //
     std::ifstream imageset("../gui/imagesets/" + setName + ".imageset");
@@ -272,5 +223,5 @@ std::unique_ptr<TextureAlphaCheckArea>
             "image name");
 
     return std::unique_ptr<TextureAlphaCheckArea>(
-        new TextureAlphaCheckArea(texture, x, y, width, height));
+        new TextureAlphaCheckArea(img, x, y, width, height));
 }

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -12,6 +12,8 @@ add_sources(
     "${CMAKE_CURRENT_SOURCE_DIR}/CEGUIVideoPlayer.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/VideoPlayer.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/VideoPlayer.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/gui_texture_helper.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/gui_texture_helper.cpp"
 )
 
 

--- a/src/gui/gui_texture_helper.cpp
+++ b/src/gui/gui_texture_helper.cpp
@@ -1,0 +1,28 @@
+#include "gui_texture_helper.h"
+
+#include <OgreRoot.h>
+#include <OgreImage.h>
+
+using namespace thrive;
+
+std::shared_ptr<Ogre::Image> GUITextureHelper::getTexture(const std::string &name){
+
+    // Use existing if found //
+    auto find = m_loadedImages.find(name);
+
+    if(find != m_loadedImages.end()){
+
+        return find->second;
+    }
+
+    auto img = std::make_shared<Ogre::Image>();
+
+    img->load(name, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+
+    std::cout << "Loaded new AlphaHit texture: " << name << std::endl;
+
+    m_loadedImages[name] = img;
+
+    return img;
+}
+

--- a/src/gui/gui_texture_helper.h
+++ b/src/gui/gui_texture_helper.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+#include <map>
+
+namespace Ogre{
+class Image;
+}
+
+namespace thrive {
+
+//! \brief Loads a texture once for GUI widgets that need to do pixel checking
+class GUITextureHelper{
+public:
+
+    
+    std::shared_ptr<Ogre::Image> getTexture(const std::string &name);
+
+private:
+
+    std::map<std::string, std::shared_ptr<Ogre::Image>> m_loadedImages;
+};
+
+}


### PR DESCRIPTION
The method that was used before used the same texture as rendering and
didn't work correctly on integrated graphics cards