### PR TITLE
Fixes issue #723 Invisible compound clouds (for AMD graphics).

### DIFF
--- a/src/microbe_stage/compound_cloud_system.h
+++ b/src/microbe_stage/compound_cloud_system.h
@@ -10,6 +10,7 @@
 #include <Entities/System.h>
 
 #include <OgreMesh.h>
+#include <OgreVector2.h>
 
 #include <vector>
 
@@ -338,6 +339,11 @@ protected:
 //! \see \ref how_compound_clouds_work
 class CompoundCloudSystem {
     friend CompoundCloudComponent;
+
+    struct CloudPlaneVertex {
+        Ogre::Vector3 m_pos;
+        Ogre::Vector2 m_uv;
+    };
 
 public:
     /**


### PR DESCRIPTION
Replaces the Ogre::v1 plane mesh generation technique with the plane mesh generation technique used for the membrane.

As it stands this is all it took to get the clouds working on my radeon RX580; although (as a note for any future issues) there did seem to be earlier problems when I was debugging involving the casted pixelbox::data pointer in **CompoundCloudSystem::processCloud(CompoundCloudComponent&, int)**