### PR TITLE
Updated engine to fix breakpad compile on windows

### DIFF
--- a/SetupThrive.rb
+++ b/SetupThrive.rb
@@ -78,7 +78,7 @@ WantedURL = "https://#{$svnUser}@boostslair.com/svn/thrive_assets"
 leviathan = Leviathan.new(
   # Use this if you always want the latest commit
   # version: "develop",
-  version: "28cd2c52dd583e9537f1df32cac91d9b4ed2da2d",
+  version: "02599f1c44a37d6d84bf9cdd1051b8debdd4815c",
   # Doesn't actually work, but leviathan doesn't install with sudo by
   # default, or install at all for that matter
   noInstallSudo: true


### PR DESCRIPTION
I'm making this a pull request to give people a chance to check that this didn't break anything.