### PR TITLE
Editor button disabled when start new game

### DIFF
--- a/scripts/gui/microbe_hud.mjs
+++ b/scripts/gui/microbe_hud.mjs
@@ -368,6 +368,8 @@ function onExitToMenuClicked() {
         document.getElementById("extinctionTitle").style.display = "none";
         document.getElementById("extinctionBody").style.display = "none";
         document.getElementById("extinctionContainer").style.display = "none";
+        document.getElementById("microbeToEditorButton").classList.add("DisabledButton");
+        readyToEdit = false;
         hideWinText();
 
         // Gotta reset this


### PR DESCRIPTION
* fixes #845
* be ready to enter editor go menu and start new game will reset editor button status