### PR TITLE
#849 #862 more patch details

### DIFF
--- a/scripts/gui/microbe_editor.mjs
+++ b/scripts/gui/microbe_editor.mjs
@@ -892,6 +892,21 @@ function updateSelectedPatchData(patch){
                                                                species.population));
         descriptionElement.appendChild(document.createElement("br"));
     }
+
+    descriptionElement.appendChild(document.createTextNode("Environment:"));
+    descriptionElement.appendChild(document.createElement("br"));
+    descriptionElement.appendChild(document.createTextNode("O2: " +
+        (patch.biome.compounds.oxygen.dissolved * 100).toString() + "%"));
+    descriptionElement.appendChild(document.createElement("br"));
+    descriptionElement.appendChild(document.createTextNode("CO2: " +
+        (patch.biome.compounds.carbondioxide.dissolved * 100).toString() + "%"));
+    descriptionElement.appendChild(document.createElement("br"));
+    descriptionElement.appendChild(document.createTextNode("N2: " +
+        (patch.biome.compounds.nitrogen.dissolved * 100).toString() + "%"));
+    descriptionElement.appendChild(document.createElement("br"));
+    descriptionElement.appendChild(document.createTextNode("Sunlight: " +
+        (patch.biome.compounds.sunlight.dissolved * 100).toString() + "%"));
+    descriptionElement.appendChild(document.createElement("br"));
 }
 
 function patchMoveAllowed(targetId){

--- a/scripts/gui/microbe_editor.mjs
+++ b/scripts/gui/microbe_editor.mjs
@@ -893,6 +893,7 @@ function updateSelectedPatchData(patch){
         descriptionElement.appendChild(document.createElement("br"));
     }
 
+    descriptionElement.appendChild(document.createElement("br"));
     descriptionElement.appendChild(document.createTextNode("Environment:"));
     descriptionElement.appendChild(document.createElement("br"));
     descriptionElement.appendChild(document.createTextNode("O2: " +

--- a/scripts/gui/thrive_gui.html
+++ b/scripts/gui/thrive_gui.html
@@ -627,7 +627,7 @@ For this Release if your population (top tab) drops to zero you go extinct.
 				    <span class="tgold">Photosynthesis</span> <br>
 				    <span class="tkey">+0.25</span> <span class="compoundIcon" id="GlucoseIcon"></span> <span class="tkey">/second&emsp;@&emsp;0.09%</span> <span class="compoundIcon" id="CO2NormalIcon"></span> <span class="tkey">, 10,000 lux</span> <span class="compoundIcon" id="LightIcon"></span><br> <br>
 				    <span class="tbonus">+2</span> <span class="tkey">Storage</span> <span class="compoundIcon" id="VacuoleTooltipIcon"></span> <br>
-				    <span class="tmalus">+2</span> <span class="tkey">Osmoregulation Cost</span> <br> <br> <hr>
+				    <span class="tmalus">+3</span> <span class="tkey">Osmoregulation Cost</span> <br> <br> <hr>
 				    <span class="tdesc">The chloroplast is a double membrane structure containing photosensitive pigments stacked together in membranous sacs.
                       It is a prokaryote that has been assimilated for use by its eukaryotic host. The pigments in the chloroplast are able to use the
                       energy of light to produce glucose from water and gaseous carbon dioxide in a process called Photosynthesis. These pigments are 

--- a/scripts/microbe_stage/microbe_operations.as
+++ b/scripts/microbe_stage/microbe_operations.as
@@ -282,9 +282,6 @@ void respawnPlayer(CellStageWorld@ world)
 
         // Reset membrane color to fix the bug that made membranes sometimes red after you respawn.
         MicrobeOperations::applyMembraneColour(world, playerEntity);
-        //If you died before entering the editor disable that
-        microbeComponent.reproductionStage = 0;
-        hideReproductionDialog(world);
         // Reset the player cell to be the same as the species template
         Species::restoreOrganelleLayout(world, playerEntity, microbeComponent, playerSpecies);
     }
@@ -1237,6 +1234,10 @@ void kill(CellStageWorld@ world, ObjectID microbeEntity)
             // cell entity is destroyed
             microbeComponent.organelles[i].hideEntity();
         }
+    } else {
+        //If you died before entering the editor disable that
+        microbeComponent.reproductionStage = 0;
+        hideReproductionDialog(world);
     }
 
     if(microbeComponent.wasBeingEngulfed){

--- a/src/microbe_stage/biomes.cpp
+++ b/src/microbe_stage/biomes.cpp
@@ -190,6 +190,23 @@ Json::Value
     direction["z"] = sunlightDirection.Z;
     result["sunlightDirection"] = direction;
 
+    Json::Value compoundsData;
+
+    for(auto compoundRef : compounds) {
+        thrive::Compound compound =
+            SimulationParameters::compoundRegistry.getTypeData(
+                SimulationParameters::compoundRegistry.getInternalName(
+                    compoundRef.first));
+        Json::Value compoundData;
+        compoundData["name"] = compound.displayName;
+        compoundData["amount"] = compoundRef.second.amount;
+        compoundData["density"] = compoundRef.second.density;
+        compoundData["dissolved"] = compoundRef.second.dissolved;
+        compoundsData[compound.internalName] = compoundData;
+    }
+
+    result["compounds"] = compoundsData;
+
     if(full) {
         LOG_WARNING("Biome: toJSON: full is not implemented");
     }


### PR DESCRIPTION
Changes:
- Fixes the chloroplast tooltip inaccuracy.
- Adds dissolved amount of O2, CO2, N2, and Sunlight to the patch details.
- Prevents the player from entering the editor after dying but before respawning (I noticed this and used it as a cheat, but not anymore).

fixes #862