### PR TITLE
Removal of keypress log spam

### DIFF
--- a/src/microbe_stage/microbe_editor_key_handler.cpp
+++ b/src/microbe_stage/microbe_editor_key_handler.cpp
@@ -20,12 +20,10 @@ bool
 
 
     if(m_rotateRight.Match(key, modifiers)) {
-        LOG_INFO("Right pressed");
         Engine::Get()->GetEventHandler()->CallEvent(
             new Leviathan::GenericEvent("PressedRightRotate"));
         return true;
     } else if(m_rotateLeft.Match(key, modifiers)) {
-        LOG_INFO("Left pressed");
         Engine::Get()->GetEventHandler()->CallEvent(
             new Leviathan::GenericEvent("PressedLeftRotate"));
         return true;

--- a/src/microbe_stage/player_microbe_control.cpp
+++ b/src/microbe_stage/player_microbe_control.cpp
@@ -90,7 +90,7 @@ bool
 
         if(ThriveGame::get()->areCheatsEnabled()) {
 
-            if (initialCloudsPress){
+            if(initialCloudsPress) {
                 LOG_INFO("Glucose cloud cheat pressed");
                 initialCloudsPress = false;
             }
@@ -101,7 +101,7 @@ bool
 
         if(ThriveGame::get()->areCheatsEnabled()) {
 
-            if (initialPhosphateCloudsPress){
+            if(initialPhosphateCloudsPress) {
                 LOG_INFO("Phosphate cloud cheat pressed");
                 initialPhosphateCloudsPress = false;
             }
@@ -111,8 +111,8 @@ bool
     } else if(m_spawnAmmoniaCheat.Match(key, modifiers)) {
 
         if(ThriveGame::get()->areCheatsEnabled()) {
-            
-            if (intialAmmoniaCloudsPress){
+
+            if(intialAmmoniaCloudsPress) {
                 LOG_INFO("Ammonia cloud cheat pressed");
                 initialAmmoniaCloudsPress = false;
             }

--- a/src/microbe_stage/player_microbe_control.cpp
+++ b/src/microbe_stage/player_microbe_control.cpp
@@ -90,7 +90,10 @@ bool
 
         if(ThriveGame::get()->areCheatsEnabled()) {
 
-            LOG_INFO("Glucose cloud cheat pressed");
+            if (initialCloudsPress){
+                LOG_INFO("Glucose cloud cheat pressed");
+                initialCloudsPress = false;
+            }
             cheatCloudsDown = true;
         }
         return true;
@@ -98,15 +101,21 @@ bool
 
         if(ThriveGame::get()->areCheatsEnabled()) {
 
-            LOG_INFO("Phosphate cloud cheat pressed");
+            if (initialPhosphateCloudsPress){
+                LOG_INFO("Phosphate cloud cheat pressed");
+                initialPhosphateCloudsPress = false;
+            }
             cheatPhosphateCloudsDown = true;
         }
         return true;
     } else if(m_spawnAmmoniaCheat.Match(key, modifiers)) {
 
         if(ThriveGame::get()->areCheatsEnabled()) {
-
-            LOG_INFO("Ammonia cloud cheat pressed");
+            
+            if (intialAmmoniaCloudsPress){
+                LOG_INFO("Ammonia cloud cheat pressed");
+                initialAmmoniaCloudsPress = false;
+            }
             cheatAmmoniaCloudsDown = true;
         }
         return true;
@@ -308,8 +317,6 @@ void
     // Activate engulf mode
     if(thrive->getPlayerInput()->getPressedEngulf()) {
 
-        LOG_INFO("Engulf mode pressed");
-
         thrive->getPlayerInput()->setPressedEngulf(false);
 
         ScriptRunningSetup setup("applyEngulfMode");
@@ -324,8 +331,6 @@ void
 
     // Fire Toxin
     if(thrive->getPlayerInput()->getPressedToxin()) {
-
-        LOG_INFO("Toxin Shoot pressed");
 
         thrive->getPlayerInput()->setPressedToxin(false);
 

--- a/src/microbe_stage/player_microbe_control.cpp
+++ b/src/microbe_stage/player_microbe_control.cpp
@@ -112,7 +112,7 @@ bool
 
         if(ThriveGame::get()->areCheatsEnabled()) {
 
-            if(intialAmmoniaCloudsPress) {
+            if(initialAmmoniaCloudsPress) {
                 LOG_INFO("Ammonia cloud cheat pressed");
                 initialAmmoniaCloudsPress = false;
             }

--- a/src/microbe_stage/player_microbe_control.h
+++ b/src/microbe_stage/player_microbe_control.h
@@ -117,11 +117,20 @@ private:
     //! True when cheat clouds should be spawned all the time
     bool cheatCloudsDown = false;
 
+    //! False when the cheat is pressed for the first time, used for only one log output
+    bool initialCloudsPress = false
+
     //! Phosphate cheat cloud
     bool cheatPhosphateCloudsDown = false;
 
+    //! //! False when the cheat is pressed for the first time, used for one log output
+    bool initialPhosphateCloudsPress = false
+
     //! Ammonia cheat cloud
     bool cheatAmmoniaCloudsDown = false;
+
+    //! //! False when the cheat is pressed for the first time, used for one log output
+    bool initialAmmoniaCloudsPress = false
 
     //! Set to false when not in the microbe stage (or maybe editor as
     //! well could use this) to not send control events

--- a/src/microbe_stage/player_microbe_control.h
+++ b/src/microbe_stage/player_microbe_control.h
@@ -117,20 +117,20 @@ private:
     //! True when cheat clouds should be spawned all the time
     bool cheatCloudsDown = false;
 
-    //! False when the cheat is pressed for the first time, used for only one log output
-    bool initialCloudsPress = false
+    //! False when the cheat is pressed for the first time, used for one log
+    bool initialCloudsPress = false;
 
     //! Phosphate cheat cloud
     bool cheatPhosphateCloudsDown = false;
 
-    //! //! False when the cheat is pressed for the first time, used for one log output
-    bool initialPhosphateCloudsPress = false
+    //! False when the cheat is pressed for the first time, used for one log
+    bool initialPhosphateCloudsPress = false;
 
     //! Ammonia cheat cloud
     bool cheatAmmoniaCloudsDown = false;
 
-    //! //! False when the cheat is pressed for the first time, used for one log output
-    bool initialAmmoniaCloudsPress = false
+    //! False when the cheat is pressed for the first time, used for one log
+    bool initialAmmoniaCloudsPress = false;
 
     //! Set to false when not in the microbe stage (or maybe editor as
     //! well could use this) to not send control events


### PR DESCRIPTION
This pull request addresses #900, and removes the excess button press keylogs found within the project, mainly within microbe_editor_key_handler.cpp and player_microbe_control.cpp.

I have also added a few flags to ensure the logging for cloud cheats is only done on the first press of each.

Please let me know if I have missed any keypress logs that need to be removed.

fixes #900 