### PR TITLE
Make things spawn when the player is stationary

### DIFF
--- a/src/microbe_stage/spawn_system.cpp
+++ b/src/microbe_stage/spawn_system.cpp
@@ -254,7 +254,7 @@ void
                         previousDisplacement.LengthSquared();
 
                     if(squaredDistance <= spawnType.spawnRadiusSqr &&
-                        previousSquaredDistance > spawnType.spawnRadiusSqr) {
+                        squaredDistance + 100 > spawnType.spawnRadiusSqr) {
                         // Second condition passed. Spawn the entity.
                         ObjectID spawnedEntity = spawnType.factoryFunction(
                             world, playerPosition + displacement);


### PR DESCRIPTION
Offset may need some tweaking, but the current results seem similar to the amount of stuff spawned before this change.

Possibly close #124, there may be more changes needed though.

I don't remember if this is actually desired, I know @Untrustedlife said it should be implemented so sessile organisms could work. However sessile organisms would be moved by currents...