### PR TITLE
Change buttons and font size of menu theme

### DIFF
--- a/assets/textures/gui/menu_theme.tres
+++ b/assets/textures/gui/menu_theme.tres
@@ -1,30 +1,60 @@
-[gd_resource type="Theme" load_steps=11 format=2]
+[gd_resource type="Theme" load_steps=8 format=2]
 
-[ext_resource path="res://assets/textures/gui/bevel/MenuHover.png" type="Texture" id=1]
-[ext_resource path="res://assets/textures/gui/bevel/MenuDisabled.png" type="Texture" id=2]
-[ext_resource path="res://assets/textures/gui/bevel/MenuNormal.png" type="Texture" id=3]
 [ext_resource path="res://assets/fonts/Jura-DemiBold.ttf" type="DynamicFontData" id=4]
 
-[sub_resource type="StyleBoxTexture" id=1]
-texture = ExtResource( 2 )
-region_rect = Rect2( 0, 0, 250, 40 )
+[sub_resource type="StyleBoxFlat" id=1]
+bg_color = Color( 0.164706, 0.215686, 0.235294, 1 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 0.360784, 0.552941, 0.52549, 1 )
+corner_radius_top_left = 7
+corner_radius_top_right = 7
+corner_radius_bottom_right = 7
+corner_radius_bottom_left = 7
 
 [sub_resource type="StyleBoxTexture" id=2]
 
-[sub_resource type="StyleBoxTexture" id=3]
-texture = ExtResource( 1 )
-region_rect = Rect2( 0, 0, 250, 40 )
+[sub_resource type="StyleBoxFlat" id=3]
+bg_color = Color( 0, 0.435294, 0.52549, 1 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 0.00392157, 0.956863, 0.905882, 1 )
+corner_radius_top_left = 7
+corner_radius_top_right = 7
+corner_radius_bottom_right = 7
+corner_radius_bottom_left = 7
 
-[sub_resource type="StyleBoxTexture" id=4]
-texture = ExtResource( 3 )
-region_rect = Rect2( 0, 0, 250, 40 )
+[sub_resource type="StyleBoxFlat" id=4]
+bg_color = Color( 0.0666667, 0.168627, 0.211765, 1 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 0.0666667, 0.6, 0.537255, 1 )
+corner_radius_top_left = 7
+corner_radius_top_right = 7
+corner_radius_bottom_right = 7
+corner_radius_bottom_left = 7
 
-[sub_resource type="StyleBoxTexture" id=5]
-texture = ExtResource( 1 )
-region_rect = Rect2( 0, 0, 250, 40 )
+[sub_resource type="StyleBoxFlat" id=7]
+bg_color = Color( 0, 0.435294, 0.52549, 1 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 0.00392157, 0.956863, 0.905882, 1 )
+corner_radius_top_left = 7
+corner_radius_top_right = 7
+corner_radius_bottom_right = 7
+corner_radius_bottom_left = 7
 
 [sub_resource type="DynamicFont" id=6]
 size = 20
+use_filter = true
 font_data = ExtResource( 4 )
 
 [resource]
@@ -39,7 +69,7 @@ Button/styles/disabled = SubResource( 1 )
 Button/styles/focus = SubResource( 2 )
 Button/styles/hover = SubResource( 3 )
 Button/styles/normal = SubResource( 4 )
-Button/styles/pressed = SubResource( 5 )
+Button/styles/pressed = SubResource( 7 )
 CheckBox/colors/font_color = Color( 0, 0, 0, 1 )
 CheckBox/colors/font_color_disabled = Color( 0, 0, 0, 1 )
 CheckBox/colors/font_color_hover = Color( 0, 0, 0, 1 )


### PR DESCRIPTION
I've changed the buttons in the menu theme to use a Godot style box instead of the png button images. This means there's no weird stretching issue, and they should scale with the UI without any graphical artifacts. The new buttons should be identical to the old ones. I also made the font bigger by two so it's more readable and enabled font filtering so it's less pixely.

Unrelated to this PR, I'm getting build issues when I try to run the project, where should I go for help with that?