### PR TITLE
Fixed useful compounds being vented

### DIFF
--- a/src/microbe_stage/CompoundBag.cs
+++ b/src/microbe_stage/CompoundBag.cs
@@ -128,7 +128,7 @@ public class CompoundBag
             return true;
         }
 
-        return IsUseful(compound.Name);
+        return IsUseful(compound.InternalName);
     }
 
     public bool IsUseful(string compound)


### PR DESCRIPTION
basically one place was using the player readable compound name when checking is something useful, so the cell didn't consider glucose useful.

fixes #1031 
