### PR TITLE
Update to Godot 3.2.1

### DIFF
--- a/doc/setup_instructions.md
+++ b/doc/setup_instructions.md
@@ -28,7 +28,7 @@ issues please don't hesitate to bring them up.
 Godot with mono
 ---------------
 
-The currently used Godot version is __3.2 mono__. You can find it on
+The currently used Godot version is __3.2.1 mono__. You can find it on
 the Godot download page: https://godotengine.org/download/ if it is
 still the latest stable version. If a new version of Godot has been
 released but Thrive has not been updated yet, you need to look through

--- a/doc/updating_godot_version.md
+++ b/doc/updating_godot_version.md
@@ -1,0 +1,9 @@
+Updating Godot Version
+======================
+
+When updating to a newer version of Godot the version number needs
+to be changed in the following files:
+
+- setup_instructions.md
+- install_godot_linux.rb
+- Dockerfile

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -9,7 +9,7 @@ RUN git lfs install
 RUN gem install os colorize rubyzip json sha3
 
 # Godot install
-ENV GODOT_VERSION "3.2"
+ENV GODOT_VERSION "3.2.1"
 
 RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/mono/Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64.zip \
     && wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/mono/Godot_v${GODOT_VERSION}-stable_mono_export_templates.tpz \

--- a/install_godot_linux.rb
+++ b/install_godot_linux.rb
@@ -8,7 +8,7 @@ require 'fileutils'
 require 'tmpdir'
 require 'httparty'
 
-GODOT_VERSION = '3.2'.freeze
+GODOT_VERSION = '3.2.1'.freeze
 INSTALL_TARGET = '/usr/local/bin/'.freeze
 
 def download(godot_folder, target)


### PR DESCRIPTION
The project files themselves don't need to be updated but these files do. I searched the entire repository and these were the only files that referenced the specific version of Godot. closes #972 