### PR TITLE
Compound panel control

### DIFF
--- a/assets/textures/gui/bevel/CompoundPanelShortened.png
+++ b/assets/textures/gui/bevel/CompoundPanelShortened.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c683cd70b6a24e4394d17b69e211e8e19f130343642f02322f5e2e5dd0c50abb
+size 5559

--- a/assets/textures/gui/bevel/CompoundPanelShortened.png.import
+++ b/assets/textures/gui/bevel/CompoundPanelShortened.png.import
@@ -1,0 +1,34 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/CompoundPanelShortened.png-b75edec292c6a0dd1053a840090327b7.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://assets/textures/gui/bevel/CompoundPanelShortened.png"
+dest_files=[ "res://.import/CompoundPanelShortened.png-b75edec292c6a0dd1053a840090327b7.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/assets/textures/gui/bevel/environmentPanelShortened.png
+++ b/assets/textures/gui/bevel/environmentPanelShortened.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c3d52f1e0f76cf692ad6a43da0a7a09775a42020f03595fc6717fdae7edaf22
+size 3833

--- a/assets/textures/gui/bevel/environmentPanelShortened.png.import
+++ b/assets/textures/gui/bevel/environmentPanelShortened.png.import
@@ -1,0 +1,34 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/environmentPanelShortened.png-64ebcfde04c6d943d4373f672d257ab1.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://assets/textures/gui/bevel/environmentPanelShortened.png"
+dest_files=[ "res://.import/environmentPanelShortened.png-64ebcfde04c6d943d4373f672d257ab1.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/scripts/gui/GUICommon.cs
+++ b/scripts/gui/GUICommon.cs
@@ -72,6 +72,15 @@ public class GUICommon : Node
         tween.Start();
     }
 
+    public void TweenUIProperty(Control ui, string property, object initialValue, object targetValue, 
+        float duration, Tween.TransitionType transitionType = Tween.TransitionType.Linear,
+        Tween.EaseType easeType = Tween.EaseType.InOut, float delay = 0)
+    {
+        tween.InterpolateProperty(ui, property, initialValue, targetValue, duration,
+            transitionType, easeType, delay);
+        tween.Start();
+    }
+
     /// <summary>
     ///   Creates an icon for the given compound.
     /// </summary>

--- a/scripts/gui/GUICommon.cs
+++ b/scripts/gui/GUICommon.cs
@@ -72,7 +72,7 @@ public class GUICommon : Node
         tween.Start();
     }
 
-    public void TweenUIProperty(Control ui, string property, object initialValue, object targetValue, 
+    public void TweenUIProperty(Control ui, string property, object initialValue, object targetValue,
         float duration, Tween.TransitionType transitionType = Tween.TransitionType.Linear,
         Tween.EaseType easeType = Tween.EaseType.InOut, float delay = 0)
     {

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -34,7 +34,7 @@ public class MicrobeHUD : Node
     public NodePath EditorButtonPath;
     [Export]
     public NodePath HelpScreenPath;
-
+    [Export]
     public NodePath EnvironmentPanelPath;
     [Export]
     public NodePath EnvironmentPanelBarContainerPath;
@@ -67,9 +67,6 @@ public class MicrobeHUD : Node
     [Export]
     public NodePath PhosphateReproductionBarPath;
     [Export]
-    public NodePath HelpScreenPath;
-
-    [Export]
     public PackedScene ExtinctionBoxScene;
     [Export]
     public PackedScene WinBoxScene;
@@ -81,6 +78,8 @@ public class MicrobeHUD : Node
     public Texture PhosphatesBW;
     [Export]
     public Texture AmmoniaInv;
+    [Export]
+    public Texture PhosphatesInv;
 
     public GridContainer CompoundsPanelBarContainer;
     private AnimationPlayer animationPlayer;

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -45,12 +45,21 @@ public class MicrobeHUD : Node
     public Texture PhosphatesBW;
     [Export]
     public Texture AmmoniaInv;
-    [Export]
+
     public Texture PhosphatesInv;
+    public VBoxContainer BarPanels;
+    private VBoxContainer iconPanels;
 
     private AnimationPlayer animationPlayer;
     private PanelContainer mouseHoverPanel;
     private VBoxContainer hoveredItems;
+    private Control agentsPanel;
+    private VBoxContainer leftPanels;
+    private List<ProgressBar> compoundBarArray;
+    private List<TextureRect> compoundIconArray;
+    private PanelContainer panelExpand;
+    private PanelContainer panelCompress;
+
     private Control menu;
     private TextureButton pauseButton;
     private TextureButton resumeButton;
@@ -98,6 +107,26 @@ public class MicrobeHUD : Node
 
     public override void _Ready()
     {
+        mouseHoverPanel = GetNode<PanelContainer>("MouseHoverPanel");
+        pauseButtonContainer = GetNode<MarginContainer>("BottomBar/PauseButtonMargin");
+        leftPanels = GetNode<VBoxContainer>("LeftPanels");
+        agentsPanel = GetNode<Control>("LeftPanels/AgentsPanel");
+        panelExpand = GetNode<PanelContainer>("LeftPanels/CompoundsPanel/Expand");
+        panelCompress = GetNode<PanelContainer>("LeftPanels/CompoundsPanel/Compress");
+
+        BarPanels = GetNode<VBoxContainer>(
+            "LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer");
+        iconPanels = GetNode<VBoxContainer>(
+            "LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/IconContainer");
+        compoundBarArray = new List<ProgressBar>();
+        compoundIconArray = new List<TextureRect>();
+        StoreCompoundBarAndIcon();
+
+        dataValue = GetNode<PanelContainer>("BottomRight/DataValue");
+        atpLabel = dataValue.GetNode<Label>("Margin/VBox/ATPValue");
+        hpLabel = dataValue.GetNode<Label>("Margin/VBox/HPValue");
+        menu = GetNode<Control>("CanvasLayer/PauseMenu");
+        animationPlayer = GetNode<AnimationPlayer>("AnimationPlayer");
         hudBars = GetTree().GetNodesInGroup("MicrobeHUDBar");
         textureHudBars = GetTree().GetNodesInGroup("MicrobeTextureHUDBar");
 
@@ -291,6 +320,64 @@ public class MicrobeHUD : Node
     }
 
     /// <summary>
+    ///   Updates the GUI bars to show only needed compounds
+    /// </summary>
+    public void UpdateNeededBars()
+    {
+        if (stage.Player == null)
+            return;
+
+        var compounds = stage.Player.Compounds;
+        if (!compounds.HasAnyBeenSetUseful())
+            return;
+        if (compounds.IsUseful("oxytoxy"))
+        {
+            if (agentsPanel.GetParent() == null)
+                leftPanels.AddChild(agentsPanel);
+        }
+        else
+        {
+            if (agentsPanel.GetParent() != null)
+                leftPanels.RemoveChild(agentsPanel);
+        }
+
+        for (int i = 0; i < stage.CompoundArray.Count; i++)
+        {
+            if (compounds.IsUseful(stage.CompoundArray[i]))
+            {
+                if (compoundBarArray[i].GetParent() == null)
+                    BarPanels.AddChild(compoundBarArray[i]);
+                if (compoundIconArray[i].GetParent() == null)
+                    iconPanels.AddChild(compoundIconArray[i]);
+            }
+            else
+            {
+                if (compoundBarArray[i].GetParent() != null)
+                    BarPanels.RemoveChild(compoundBarArray[i]);
+                if (compoundIconArray[i].GetParent() != null)
+                    iconPanels.RemoveChild(compoundIconArray[i]);
+            }
+        }
+    }
+
+    /// <summary>
+    ///   Stores the compound bar and icon in the class array
+    ///   Prevents bar nad icon from being lost when removes from tree
+    /// </summary>
+    private void StoreCompoundBarAndIcon()
+    {
+        foreach (ProgressBar bar in BarPanels.GetChildren())
+        {
+            compoundBarArray.Add(bar);
+        }
+
+        foreach (TextureRect icon in iconPanels.GetChildren())
+        {
+            compoundIconArray.Add(icon);
+        }
+    }
+
+    /// <summary>
     ///   Updates the mouse hover box with stuff.
     /// </summary>
     /// <remarks>
@@ -300,6 +387,7 @@ public class MicrobeHUD : Node
     ///     how the old JS code do it anyway.
     ///   </para>
     /// </remarks>
+
     private void UpdateHoverInfo()
     {
         foreach (Node children in hoveredItems.GetChildren())
@@ -481,7 +569,7 @@ public class MicrobeHUD : Node
         {
             if (bar.Name == "AmmoniaReproductionBar")
             {
-               bar.Value = fractionOfAmmonia * bar.MaxValue;
+                bar.Value = fractionOfAmmonia * bar.MaxValue;
             }
 
             if (bar.Name == "PhosphateReproductionBar")

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -11,6 +11,8 @@ public class MicrobeHUD : Node
     [Export]
     public NodePath AnimationPlayerPath;
     [Export]
+    public NodePath LeftPanelsPath;
+    [Export]
     public NodePath MouseHoverPanelPath;
     [Export]
     public NodePath HoveredItemsContainerPath;
@@ -33,6 +35,29 @@ public class MicrobeHUD : Node
     [Export]
     public NodePath HelpScreenPath;
 
+    public NodePath EnvironmentPanelPath;
+    [Export]
+    public NodePath EnvironmentPanelBarContainerPath;
+    [Export]
+    public NodePath CompoundsPanelPath;
+    [Export]
+    public NodePath GlucoseBarPath;
+    [Export]
+    public NodePath AmmoniaBarPath;
+    [Export]
+    public NodePath PhosphateBarPath;
+    [Export]
+    public NodePath HydrogenSulfideBarPath;
+    [Export]
+    public NodePath IronBarPath;
+    [Export]
+    public NodePath CompoundsPanelBarContainerPath;
+    [Export]
+    public NodePath AgentsPanelPath;
+    [Export]
+    public NodePath OxytoxyBarPath;
+    [Export]
+    public NodePath AgentsPanelBarContainerPath;
     [Export]
     public PackedScene ExtinctionBoxScene;
     [Export]
@@ -46,20 +71,21 @@ public class MicrobeHUD : Node
     [Export]
     public Texture AmmoniaInv;
 
-    public Texture PhosphatesInv;
-    public VBoxContainer BarPanels;
-    private VBoxContainer iconPanels;
-
+    public GridContainer CompoundsPanelBarContainer;
     private AnimationPlayer animationPlayer;
     private PanelContainer mouseHoverPanel;
     private VBoxContainer hoveredItems;
+    private NinePatchRect environmentPanel;
+    private GridContainer environmentPanelBarContainer;
+    private NinePatchRect compoundsPanel;
+    private ProgressBar glucoseBar;
+    private ProgressBar ammoniaBar;
+    private ProgressBar phosphateBar;
+    private ProgressBar hydrogenSulfideBar;
+    private ProgressBar ironBar;
     private Control agentsPanel;
+    private ProgressBar oxytoxyBar;
     private VBoxContainer leftPanels;
-    private List<ProgressBar> compoundBarArray;
-    private List<TextureRect> compoundIconArray;
-    private PanelContainer panelExpand;
-    private PanelContainer panelCompress;
-
     private Control menu;
     private TextureButton pauseButton;
     private TextureButton resumeButton;
@@ -72,11 +98,7 @@ public class MicrobeHUD : Node
     private Node winBox;
     private Control helpScreen;
 
-    /// <summary>
-    ///   The HUD bars is contained in this array to avoid
-    ///   having tons of extra separate variables.
-    /// </summary>
-    private Godot.Collections.Array hudBars;
+    private List<HBoxContainer> compoundBarArray = new List<HBoxContainer>();
 
     /// <summary>
     ///   The TextureProgress node version of the bars.
@@ -107,32 +129,23 @@ public class MicrobeHUD : Node
 
     public override void _Ready()
     {
-        mouseHoverPanel = GetNode<PanelContainer>("MouseHoverPanel");
-        pauseButtonContainer = GetNode<MarginContainer>("BottomBar/PauseButtonMargin");
-        leftPanels = GetNode<VBoxContainer>("LeftPanels");
-        agentsPanel = GetNode<Control>("LeftPanels/AgentsPanel");
-        panelExpand = GetNode<PanelContainer>("LeftPanels/CompoundsPanel/Expand");
-        panelCompress = GetNode<PanelContainer>("LeftPanels/CompoundsPanel/Compress");
-
-        BarPanels = GetNode<VBoxContainer>(
-            "LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer");
-        iconPanels = GetNode<VBoxContainer>(
-            "LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/IconContainer");
-        compoundBarArray = new List<ProgressBar>();
-        compoundIconArray = new List<TextureRect>();
-        StoreCompoundBarAndIcon();
-
-        dataValue = GetNode<PanelContainer>("BottomRight/DataValue");
-        atpLabel = dataValue.GetNode<Label>("Margin/VBox/ATPValue");
-        hpLabel = dataValue.GetNode<Label>("Margin/VBox/HPValue");
-        menu = GetNode<Control>("CanvasLayer/PauseMenu");
-        animationPlayer = GetNode<AnimationPlayer>("AnimationPlayer");
-        hudBars = GetTree().GetNodesInGroup("MicrobeHUDBar");
         textureHudBars = GetTree().GetNodesInGroup("MicrobeTextureHUDBar");
 
         mouseHoverPanel = GetNode<PanelContainer>(MouseHoverPanelPath);
         pauseButton = GetNode<TextureButton>(PauseButtonPath);
         resumeButton = GetNode<TextureButton>(ResumeButtonPath);
+        leftPanels = GetNode<VBoxContainer>(LeftPanelsPath);
+        agentsPanel = GetNode<Control>(AgentsPanelPath);
+        environmentPanel = GetNode<NinePatchRect>(EnvironmentPanelPath);
+        environmentPanelBarContainer = GetNode<GridContainer>(EnvironmentPanelBarContainerPath);
+        glucoseBar = GetNode<ProgressBar>(GlucoseBarPath);
+        ammoniaBar = GetNode<ProgressBar>(AmmoniaBarPath);
+        phosphateBar = GetNode<ProgressBar>(PhosphateBarPath);
+        hydrogenSulfideBar = GetNode<ProgressBar>(HydrogenSulfideBarPath);
+        ironBar = GetNode<ProgressBar>(IronBarPath);
+        compoundsPanel = GetNode<NinePatchRect>(CompoundsPanelPath);
+        CompoundsPanelBarContainer = GetNode<GridContainer>(CompoundsPanelBarContainerPath);
+        oxytoxyBar = GetNode<ProgressBar>(OxytoxyBarPath);
         atpLabel = GetNode<Label>(AtpLabelPath);
         hpLabel = GetNode<Label>(HpLabelPath);
         menu = GetNode<Control>(MenuPath);
@@ -144,6 +157,8 @@ public class MicrobeHUD : Node
         helpScreen = GetNode<Control>(HelpScreenPath);
 
         OnEnterStageTransition();
+
+        StoreCompoundBar();
     }
 
     public void OnEnterStageTransition()
@@ -160,7 +175,7 @@ public class MicrobeHUD : Node
 
         if (stage.Player != null)
         {
-            UpdateBars();
+            UpdateCompoundBars();
             UpdateReproductionProgress();
             UpdateATP();
             UpdateHealth();
@@ -189,31 +204,95 @@ public class MicrobeHUD : Node
 
     public void ResizeEnvironmentPanel(string mode)
     {
+        var bars = environmentPanelBarContainer.GetChildren();
+
         if (mode == "compress" && !environmentCompressed)
         {
-            animationPlayer.Play("EnvironmentPanelCompress");
             environmentCompressed = true;
+
+            GUICommon.Instance.TweenUIProperty(environmentPanel, "rect_min_size", environmentPanel.RectMinSize,
+                new Vector2(195, 150), 0.3f);
+            environmentPanelBarContainer.Columns = 2;
+            environmentPanelBarContainer.AddConstantOverride("vseparation", 10);
+
+            foreach (Node bar in bars)
+            {
+                var progressBar = bar.GetNode<ProgressBar>("Bar");
+
+                GUICommon.Instance.TweenUIProperty(progressBar, "rect_min_size", new Vector2(95, 25),
+                    new Vector2(73, 25), 0.3f);
+                progressBar.GetNode<Label>("Label").Hide();
+                progressBar.GetNode<Label>("Value").Align = Label.AlignEnum.Center;
+            }
         }
 
         if (mode == "expand" && environmentCompressed)
         {
-            animationPlayer.Play("EnvironmentPanelExpand");
             environmentCompressed = false;
+
+            GUICommon.Instance.TweenUIProperty(environmentPanel, "rect_min_size", environmentPanel.RectMinSize,
+                new Vector2(195, 224), 0.3f);
+            environmentPanelBarContainer.Columns = 1;
+            environmentPanelBarContainer.AddConstantOverride("vseparation", 4);
+
+            foreach (Node bar in bars)
+            {
+                var progressBar = bar.GetNode<ProgressBar>("Bar");
+
+                GUICommon.Instance.TweenUIProperty(progressBar, "rect_min_size", progressBar.RectMinSize,
+                    new Vector2(162, 25), 0.3f);
+                progressBar.GetNode<Label>("Label").Show();
+                progressBar.GetNode<Label>("Value").Align = Label.AlignEnum.Left;
+            }
         }
     }
 
     public void ResizeCompoundPanel(string mode)
     {
+        var bars = CompoundsPanelBarContainer.GetChildren();
+
         if (mode == "compress" && !compundCompressed)
         {
-            animationPlayer.Play("CompoundPanelCompress");
             compundCompressed = true;
+
+            GUICommon.Instance.TweenUIProperty(compoundsPanel, "rect_min_size", compoundsPanel.RectMinSize,
+                new Vector2(253, 120), 0.3f);
+
+            if (bars.Count < 4)
+            {
+                CompoundsPanelBarContainer.Columns = 2;
+            }
+            else
+            {
+                CompoundsPanelBarContainer.Columns = 3;
+            }
+
+            foreach (Node bar in bars)
+            {
+                var progressBar = bar.GetNode<ProgressBar>("Bar");
+
+                GUICommon.Instance.TweenUIProperty(progressBar, "rect_min_size", new Vector2(95, 25),
+                    new Vector2(63, 25), 0.3f);
+                progressBar.GetNode<Label>("Label").Hide();
+            }
         }
 
         if (mode == "expand" && compundCompressed)
         {
-            animationPlayer.Play("CompoundPanelExpand");
             compundCompressed = false;
+
+            GUICommon.Instance.TweenUIProperty(compoundsPanel, "rect_min_size", compoundsPanel.RectMinSize,
+                new Vector2(253, 239), 0.3f);
+            CompoundsPanelBarContainer.Columns = 1;
+
+            foreach (Node bar in bars)
+            {
+                var progressBar = bar.GetNode<ProgressBar>("Bar");
+
+                GUICommon.Instance.TweenUIProperty(progressBar, "rect_min_size", progressBar.RectMinSize,
+                    new Vector2(220, 25), 0.3f);
+                progressBar.GetNode<Label>("Label").Show();
+            }
         }
     }
 
@@ -346,16 +425,12 @@ public class MicrobeHUD : Node
             if (compounds.IsUseful(stage.CompoundArray[i]))
             {
                 if (compoundBarArray[i].GetParent() == null)
-                    BarPanels.AddChild(compoundBarArray[i]);
-                if (compoundIconArray[i].GetParent() == null)
-                    iconPanels.AddChild(compoundIconArray[i]);
+                    CompoundsPanelBarContainer.AddChild(compoundBarArray[i]);
             }
             else
             {
                 if (compoundBarArray[i].GetParent() != null)
-                    BarPanels.RemoveChild(compoundBarArray[i]);
-                if (compoundIconArray[i].GetParent() != null)
-                    iconPanels.RemoveChild(compoundIconArray[i]);
+                    CompoundsPanelBarContainer.RemoveChild(compoundBarArray[i]);
             }
         }
     }
@@ -364,16 +439,11 @@ public class MicrobeHUD : Node
     ///   Stores the compound bar and icon in the class array
     ///   Prevents bar nad icon from being lost when removes from tree
     /// </summary>
-    private void StoreCompoundBarAndIcon()
+    private void StoreCompoundBar()
     {
-        foreach (ProgressBar bar in BarPanels.GetChildren())
+        foreach (HBoxContainer bar in CompoundsPanelBarContainer.GetChildren())
         {
             compoundBarArray.Add(bar);
-        }
-
-        foreach (TextureRect icon in iconPanels.GetChildren())
-        {
-            compoundIconArray.Add(icon);
         }
     }
 
@@ -484,58 +554,36 @@ public class MicrobeHUD : Node
     }
 
     /// <summary>
-    ///   Updates the GUI bars with the correct values.
+    ///   Updates the compound bars with the correct values.
     /// </summary>
-    private void UpdateBars()
+    private void UpdateCompoundBars()
     {
         var compounds = stage.Player.Compounds;
 
-        foreach (ProgressBar bar in hudBars)
-        {
-            var label = bar.GetNode<Label>("Value");
+        glucoseBar.MaxValue = compounds.Capacity;
+        glucoseBar.Value = compounds.GetCompoundAmount("glucose");
+        glucoseBar.GetNode<Label>("Value").Text = glucoseBar.Value + " / " + glucoseBar.MaxValue;
 
-            if (bar.Name == "GlucoseBar")
-            {
-                bar.MaxValue = compounds.Capacity;
-                bar.Value = compounds.GetCompoundAmount("glucose");
-                label.Text = bar.Value + " / " + bar.MaxValue;
-            }
+        ammoniaBar.MaxValue = compounds.Capacity;
+        ammoniaBar.Value = compounds.GetCompoundAmount("ammonia");
+        ammoniaBar.GetNode<Label>("Value").Text = ammoniaBar.Value + " / " + ammoniaBar.MaxValue;
 
-            if (bar.Name == "AmmoniaBar")
-            {
-                bar.MaxValue = compounds.Capacity;
-                bar.Value = compounds.GetCompoundAmount("ammonia");
-                label.Text = bar.Value + " / " + bar.MaxValue;
-            }
+        phosphateBar.MaxValue = compounds.Capacity;
+        phosphateBar.Value = compounds.GetCompoundAmount("phosphates");
+        phosphateBar.GetNode<Label>("Value").Text = phosphateBar.Value + " / " + phosphateBar.MaxValue;
 
-            if (bar.Name == "PhosphateBar")
-            {
-                bar.MaxValue = compounds.Capacity;
-                bar.Value = compounds.GetCompoundAmount("phosphates");
-                label.Text = bar.Value + " / " + bar.MaxValue;
-            }
+        hydrogenSulfideBar.MaxValue = compounds.Capacity;
+        hydrogenSulfideBar.Value = compounds.GetCompoundAmount("hydrogensulfide");
+        hydrogenSulfideBar.GetNode<Label>("Value").Text = hydrogenSulfideBar.Value + " / " +
+            hydrogenSulfideBar.MaxValue;
 
-            if (bar.Name == "HydrogenSulfideBar")
-            {
-                bar.MaxValue = compounds.Capacity;
-                bar.Value = compounds.GetCompoundAmount("hydrogensulfide");
-                label.Text = bar.Value + " / " + bar.MaxValue;
-            }
+        ironBar.MaxValue = compounds.Capacity;
+        ironBar.Value = compounds.GetCompoundAmount("iron");
+        ironBar.GetNode<Label>("Value").Text = ironBar.Value + " / " + ironBar.MaxValue;
 
-            if (bar.Name == "IronBar")
-            {
-                bar.MaxValue = compounds.Capacity;
-                bar.Value = compounds.GetCompoundAmount("iron");
-                label.Text = bar.Value + " / " + bar.MaxValue;
-            }
-
-            if (bar.Name == "OxyToxyBar")
-            {
-                bar.MaxValue = compounds.Capacity;
-                bar.Value = compounds.GetCompoundAmount("oxytoxy");
-                label.Text = bar.Value + " / " + bar.MaxValue;
-            }
-        }
+        oxytoxyBar.MaxValue = compounds.Capacity;
+        oxytoxyBar.Value = compounds.GetCompoundAmount("oxytoxy");
+        oxytoxyBar.GetNode<Label>("Value").Text = oxytoxyBar.Value + " / " + oxytoxyBar.MaxValue;
     }
 
     private void UpdateReproductionProgress()
@@ -672,17 +720,35 @@ public class MicrobeHUD : Node
 
     private void CompoundButtonPressed()
     {
-        GUICommon.Instance.PlayButtonPressSound();
+        var guiCommon = GUICommon.Instance;
+
+        guiCommon.PlayButtonPressSound();
 
         if (!leftPanelsActive)
         {
-            animationPlayer.Play("HideLeftPanels");
             leftPanelsActive = true;
+
+            guiCommon.TweenUIProperty(environmentPanel, "rect_position", environmentPanel.RectPosition, new Vector2(
+                -300, environmentPanel.RectPosition.y), 0.3f, Tween.TransitionType.Linear, Tween.EaseType.Out, 0.1f);
+            guiCommon.TweenUIProperty(compoundsPanel, "rect_position", compoundsPanel.RectPosition, new Vector2(
+                -300, compoundsPanel.RectPosition.y), 0.3f, Tween.TransitionType.Linear, Tween.EaseType.Out, 0.05f);
+            guiCommon.TweenUIProperty(agentsPanel, "rect_position", agentsPanel.RectPosition, new Vector2(
+                -300, agentsPanel.RectPosition.y), 0.3f, Tween.TransitionType.Linear, Tween.EaseType.Out);
+
+            guiCommon.TweenUIProperty(leftPanels, "modulate", leftPanels.Modulate, new Color(1, 1, 1, 0), 0.3f);
         }
         else
         {
-            animationPlayer.Play("ShowLeftPanels");
             leftPanelsActive = false;
+
+            guiCommon.TweenUIProperty(environmentPanel, "rect_position", environmentPanel.RectPosition, new Vector2(
+                0, environmentPanel.RectPosition.y), 0.4f, Tween.TransitionType.Linear, Tween.EaseType.In, 0.1f);
+            guiCommon.TweenUIProperty(compoundsPanel, "rect_position", compoundsPanel.RectPosition, new Vector2(
+                0, compoundsPanel.RectPosition.y), 0.4f, Tween.TransitionType.Linear, Tween.EaseType.In, 0.05f);
+            guiCommon.TweenUIProperty(agentsPanel, "rect_position", agentsPanel.RectPosition, new Vector2(
+                0, agentsPanel.RectPosition.y), 0.4f, Tween.TransitionType.Linear, Tween.EaseType.In);
+
+            guiCommon.TweenUIProperty(leftPanels, "modulate", new Color(1, 1, 1, 0), new Color(1, 1, 1, 1), 0.3f);
         }
     }
 

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Godot;
 
 /// <summary>
@@ -41,6 +42,7 @@ public class MicrobeStage : Node
     public TimedLifeSystem TimedLifeSystem { get; private set; }
 
     public ProcessSystem ProcessSystem { get; private set; }
+    public List<Compound> CompoundArray { get; private set; }
 
     /// <summary>
     ///   The main current game object holding various details
@@ -78,6 +80,8 @@ public class MicrobeStage : Node
 
         // Do stage setup to spawn things and setup all parts of the stage
         SetupStage();
+        GenerateCompoundsArray();
+        HUD.UpdateNeededBars();
     }
 
     // Prepares the stage for playing
@@ -182,6 +186,7 @@ public class MicrobeStage : Node
         FluidSystem.Process(delta);
         TimedLifeSystem.Process(delta);
         ProcessSystem.Process(delta);
+        HUD.UpdateNeededBars();
         microbeAISystem.Process(delta);
 
         if (gameOver)
@@ -277,6 +282,39 @@ public class MicrobeStage : Node
         HUD.HideReproductionDialog();
 
         StartMusic();
+    }
+
+    public void GenerateCompoundsArray()
+    {
+        CompoundArray = new List<Compound>();
+        foreach (ProgressBar bar in HUD.BarPanels.GetChildren())
+        {
+            string text = bar.GetNode<Label>("Label").Text;
+            Compound compound;
+
+            switch (text)
+            {
+                case "Glucose":
+                    compound = SimulationParameters.Instance.GetCompound("glucose");
+                    break;
+                case "Ammonia":
+                    compound = SimulationParameters.Instance.GetCompound("ammonia");
+                    break;
+                case "Phosphate":
+                    compound = SimulationParameters.Instance.GetCompound("phosphates");
+                    break;
+                case "Hydrogen Sulfide":
+                    compound = SimulationParameters.Instance.GetCompound("hydrogensulfide");
+                    break;
+                case "Iron":
+                    compound = SimulationParameters.Instance.GetCompound("iron");
+                    break;
+                default:
+                    throw new NotImplementedException("Compound not implemented");
+            }
+
+            CompoundArray.Add(compound);
+        }
     }
 
     private void CreatePatchManagerIfNeeded()

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -42,7 +42,6 @@ public class MicrobeStage : Node
     public TimedLifeSystem TimedLifeSystem { get; private set; }
 
     public ProcessSystem ProcessSystem { get; private set; }
-    public List<Compound> CompoundArray { get; private set; }
 
     /// <summary>
     ///   The main current game object holding various details
@@ -80,8 +79,6 @@ public class MicrobeStage : Node
 
         // Do stage setup to spawn things and setup all parts of the stage
         SetupStage();
-        GenerateCompoundsArray();
-        HUD.UpdateNeededBars();
     }
 
     // Prepares the stage for playing
@@ -186,7 +183,6 @@ public class MicrobeStage : Node
         FluidSystem.Process(delta);
         TimedLifeSystem.Process(delta);
         ProcessSystem.Process(delta);
-        HUD.UpdateNeededBars();
         microbeAISystem.Process(delta);
 
         if (gameOver)
@@ -282,38 +278,6 @@ public class MicrobeStage : Node
         HUD.HideReproductionDialog();
 
         StartMusic();
-    }
-
-    public void GenerateCompoundsArray()
-    {
-        CompoundArray = new List<Compound>();
-        foreach (HBoxContainer bar in HUD.CompoundsPanelBarContainer.GetChildren())
-        {
-            Compound compound;
-
-            switch (bar.Name)
-            {
-                case "Glucose":
-                    compound = SimulationParameters.Instance.GetCompound("glucose");
-                    break;
-                case "Ammonia":
-                    compound = SimulationParameters.Instance.GetCompound("ammonia");
-                    break;
-                case "Phosphate":
-                    compound = SimulationParameters.Instance.GetCompound("phosphates");
-                    break;
-                case "HydrogenSulfide":
-                    compound = SimulationParameters.Instance.GetCompound("hydrogensulfide");
-                    break;
-                case "Iron":
-                    compound = SimulationParameters.Instance.GetCompound("iron");
-                    break;
-                default:
-                    throw new NotImplementedException("Compound not implemented");
-            }
-
-            CompoundArray.Add(compound);
-        }
     }
 
     private void CreatePatchManagerIfNeeded()

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -287,12 +287,11 @@ public class MicrobeStage : Node
     public void GenerateCompoundsArray()
     {
         CompoundArray = new List<Compound>();
-        foreach (ProgressBar bar in HUD.BarPanels.GetChildren())
+        foreach (HBoxContainer bar in HUD.CompoundsPanelBarContainer.GetChildren())
         {
-            string text = bar.GetNode<Label>("Label").Text;
             Compound compound;
 
-            switch (text)
+            switch (bar.Name)
             {
                 case "Glucose":
                     compound = SimulationParameters.Instance.GetCompound("glucose");
@@ -303,7 +302,7 @@ public class MicrobeStage : Node
                 case "Phosphate":
                     compound = SimulationParameters.Instance.GetCompound("phosphates");
                     break;
-                case "Hydrogen Sulfide":
+                case "HydrogenSulfide":
                     compound = SimulationParameters.Instance.GetCompound("hydrogensulfide");
                     break;
                 case "Iron":

--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -1919,7 +1919,7 @@ margin_right = 95.0
 margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
 custom_fonts/font = SubResource( 25 )
-text = "Phospate"
+text = "Phosphate"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false

--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=127 format=2]
+[gd_scene load_steps=115 format=2]
 
 [ext_resource path="res://src/microbe_stage/MicrobeStage.cs" type="Script" id=1]
 [ext_resource path="res://src/microbe_stage/MicrobeCamera.tscn" type="PackedScene" id=2]
@@ -12,8 +12,8 @@
 [ext_resource path="res://src/microbe_stage/CompoundCloudSystem.cs" type="Script" id=10]
 [ext_resource path="res://assets/textures/gui/menu_theme.tres" type="Theme" id=11]
 [ext_resource path="res://assets/fonts/Jura-DemiBold.ttf" type="DynamicFontData" id=12]
-[ext_resource path="res://assets/textures/gui/bevel/CompoundPanelExpand.png" type="Texture" id=13]
-[ext_resource path="res://assets/textures/gui/bevel/environmentPanelExpand.png" type="Texture" id=14]
+[ext_resource path="res://assets/textures/gui/bevel/CompoundPanelShortened.png" type="Texture" id=13]
+[ext_resource path="res://assets/textures/gui/bevel/environmentPanelShortened.png" type="Texture" id=14]
 [ext_resource path="res://assets/textures/gui/bevel/agentsPanel.png" type="Texture" id=15]
 [ext_resource path="res://assets/textures/gui/bevel/helpButton.png" type="Texture" id=16]
 [ext_resource path="res://assets/textures/gui/bevel/searchButton.png" type="Texture" id=17]
@@ -66,8 +66,6 @@
 [ext_resource path="res://assets/textures/gui/bevel/HealthBarBg.png" type="Texture" id=64]
 [ext_resource path="res://assets/textures/gui/bevel/ReproductionBar.png" type="Texture" id=65]
 [ext_resource path="res://assets/fonts/Jura-Medium.ttf" type="DynamicFontData" id=66]
-[ext_resource path="res://assets/textures/gui/bevel/CompoundPanelCompress.png" type="Texture" id=67]
-[ext_resource path="res://assets/textures/gui/bevel/environmentPanelCompress.png" type="Texture" id=68]
 [ext_resource path="res://assets/fonts/thrive.ttf" type="DynamicFontData" id=69]
 [ext_resource path="res://scripts/gui/ExtinctionBox.tscn" type="PackedScene" id=70]
 [ext_resource path="res://assets/textures/gui/bevel/AmmoniaBW.png" type="Texture" id=71]
@@ -95,44 +93,11 @@ corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
-[sub_resource type="StyleBoxTexture" id=4]
-texture = ExtResource( 14 )
-region_rect = Rect2( 0, 0, 214, 240 )
-
-[sub_resource type="DynamicFont" id=5]
+[sub_resource type="DynamicFont" id=4]
 size = 20
 font_data = ExtResource( 12 )
 
-[sub_resource type="StyleBoxFlat" id=6]
-bg_color = Color( 0, 0.596078, 0.764706, 1 )
-
-[sub_resource type="StyleBoxFlat" id=7]
-bg_color = Color( 0, 0, 0, 0.196078 )
-
-[sub_resource type="DynamicFont" id=8]
-size = 14
-font_data = ExtResource( 12 )
-
-[sub_resource type="StyleBoxFlat" id=9]
-bg_color = Color( 0.141176, 0.278431, 0.682353, 1 )
-
-[sub_resource type="StyleBoxFlat" id=10]
-bg_color = Color( 0.407843, 0.698039, 0.431373, 1 )
-
-[sub_resource type="StyleBoxFlat" id=11]
-bg_color = Color( 0.67451, 0.996078, 0.235294, 1 )
-
-[sub_resource type="StyleBoxFlat" id=12]
-bg_color = Color( 0.984314, 0.913725, 0.580392, 1 )
-
-[sub_resource type="StyleBoxFlat" id=13]
-bg_color = Color( 0.905882, 0.909804, 0.929412, 1 )
-
-[sub_resource type="StyleBoxTexture" id=14]
-texture = ExtResource( 68 )
-region_rect = Rect2( 0, 0, 214, 183 )
-
-[sub_resource type="StyleBoxTexture" id=15]
+[sub_resource type="StyleBoxTexture" id=5]
 texture = ExtResource( 43 )
 region_rect = Rect2( 0, 0, 20, 20 )
 expand_margin_left = 1.0
@@ -140,7 +105,7 @@ expand_margin_right = 1.0
 expand_margin_top = 1.0
 expand_margin_bottom = 1.0
 
-[sub_resource type="StyleBoxTexture" id=16]
+[sub_resource type="StyleBoxTexture" id=6]
 texture = ExtResource( 44 )
 region_rect = Rect2( 0, 0, 20, 20 )
 expand_margin_left = 1.0
@@ -148,65 +113,60 @@ expand_margin_right = 1.0
 expand_margin_top = 1.0
 expand_margin_bottom = 1.0
 
-[sub_resource type="StyleBoxTexture" id=17]
+[sub_resource type="StyleBoxTexture" id=7]
 texture = ExtResource( 43 )
 region_rect = Rect2( 0, 0, 20, 20 )
 
-[sub_resource type="ButtonGroup" id=18]
+[sub_resource type="ButtonGroup" id=8]
 
-[sub_resource type="StyleBoxTexture" id=19]
+[sub_resource type="StyleBoxTexture" id=9]
 texture = ExtResource( 42 )
 region_rect = Rect2( 0, 0, 20, 20 )
 
-[sub_resource type="StyleBoxTexture" id=20]
+[sub_resource type="StyleBoxTexture" id=10]
 texture = ExtResource( 45 )
 region_rect = Rect2( 0, 0, 20, 20 )
 expand_margin_left = 1.0
 expand_margin_right = 1.0
 expand_margin_top = 1.0
 expand_margin_bottom = 1.0
+
+[sub_resource type="StyleBoxTexture" id=11]
+texture = ExtResource( 42 )
+region_rect = Rect2( 0, 0, 20, 20 )
+
+[sub_resource type="StyleBoxFlat" id=12]
+bg_color = Color( 0, 0.596078, 0.764706, 1 )
+
+[sub_resource type="StyleBoxFlat" id=13]
+bg_color = Color( 0, 0, 0, 0.196078 )
+
+[sub_resource type="DynamicFont" id=14]
+size = 14
+font_data = ExtResource( 12 )
+
+[sub_resource type="StyleBoxFlat" id=15]
+bg_color = Color( 0.141176, 0.278431, 0.682353, 1 )
+
+[sub_resource type="StyleBoxFlat" id=16]
+bg_color = Color( 0.407843, 0.698039, 0.431373, 1 )
+
+[sub_resource type="StyleBoxFlat" id=17]
+bg_color = Color( 0.67451, 0.996078, 0.235294, 1 )
+
+[sub_resource type="StyleBoxFlat" id=18]
+bg_color = Color( 0.984314, 0.913725, 0.580392, 1 )
+
+[sub_resource type="StyleBoxFlat" id=19]
+bg_color = Color( 0.905882, 0.909804, 0.929412, 1 )
+
+[sub_resource type="ButtonGroup" id=20]
 
 [sub_resource type="StyleBoxTexture" id=21]
 texture = ExtResource( 42 )
 region_rect = Rect2( 0, 0, 20, 20 )
 
 [sub_resource type="StyleBoxTexture" id=22]
-texture = ExtResource( 13 )
-region_rect = Rect2( 0, 0, 249, 238 )
-
-[sub_resource type="StyleBoxFlat" id=23]
-bg_color = Color( 0.568627, 0.611765, 0.615686, 1 )
-
-[sub_resource type="StyleBoxFlat" id=24]
-bg_color = Color( 0, 0, 0, 0.196078 )
-
-[sub_resource type="DynamicFont" id=25]
-size = 14
-font_data = ExtResource( 12 )
-
-[sub_resource type="StyleBoxFlat" id=26]
-bg_color = Color( 0.631373, 0.396078, 0, 1 )
-
-[sub_resource type="StyleBoxFlat" id=27]
-bg_color = Color( 0.380392, 0.141176, 0.8, 1 )
-
-[sub_resource type="StyleBoxFlat" id=28]
-bg_color = Color( 0.462745, 0.470588, 0.184314, 1 )
-
-[sub_resource type="StyleBoxFlat" id=29]
-bg_color = Color( 0.541176, 0.141176, 0.0745098, 1 )
-
-[sub_resource type="StyleBoxTexture" id=30]
-texture = ExtResource( 67 )
-region_rect = Rect2( 0, 0, 249, 145 )
-
-[sub_resource type="ButtonGroup" id=31]
-
-[sub_resource type="StyleBoxTexture" id=32]
-texture = ExtResource( 42 )
-region_rect = Rect2( 0, 0, 20, 20 )
-
-[sub_resource type="StyleBoxTexture" id=33]
 texture = ExtResource( 45 )
 region_rect = Rect2( 0, 0, 20, 20 )
 expand_margin_left = 1.0
@@ -214,31 +174,53 @@ expand_margin_right = 1.0
 expand_margin_top = 1.0
 expand_margin_bottom = 1.0
 
-[sub_resource type="StyleBoxTexture" id=34]
+[sub_resource type="StyleBoxTexture" id=23]
 texture = ExtResource( 42 )
 region_rect = Rect2( 0, 0, 20, 20 )
 
-[sub_resource type="StyleBoxTexture" id=35]
-texture = ExtResource( 15 )
-region_rect = Rect2( 0, 0, 250, 91 )
+[sub_resource type="StyleBoxFlat" id=24]
+bg_color = Color( 0.568627, 0.611765, 0.615686, 1 )
 
-[sub_resource type="StyleBoxFlat" id=36]
-bg_color = Color( 0.623529, 0.0745098, 0.376471, 1 )
-
-[sub_resource type="StyleBoxFlat" id=37]
+[sub_resource type="StyleBoxFlat" id=25]
 bg_color = Color( 0, 0, 0, 0.196078 )
 
-[sub_resource type="DynamicFont" id=38]
+[sub_resource type="DynamicFont" id=26]
 size = 14
 font_data = ExtResource( 12 )
 
-[sub_resource type="StyleBoxEmpty" id=39]
+[sub_resource type="StyleBoxFlat" id=27]
+bg_color = Color( 0.631373, 0.396078, 0, 1 )
 
-[sub_resource type="DynamicFont" id=40]
+[sub_resource type="StyleBoxFlat" id=28]
+bg_color = Color( 0.380392, 0.141176, 0.8, 1 )
+
+[sub_resource type="StyleBoxFlat" id=29]
+bg_color = Color( 0.462745, 0.470588, 0.184314, 1 )
+
+[sub_resource type="StyleBoxFlat" id=30]
+bg_color = Color( 0.541176, 0.141176, 0.0745098, 1 )
+
+[sub_resource type="StyleBoxTexture" id=31]
+texture = ExtResource( 15 )
+region_rect = Rect2( 0, 0, 250, 91 )
+
+[sub_resource type="StyleBoxFlat" id=32]
+bg_color = Color( 0.623529, 0.0745098, 0.376471, 1 )
+
+[sub_resource type="StyleBoxFlat" id=33]
+bg_color = Color( 0, 0, 0, 0.196078 )
+
+[sub_resource type="DynamicFont" id=34]
+size = 14
+font_data = ExtResource( 12 )
+
+[sub_resource type="StyleBoxEmpty" id=35]
+
+[sub_resource type="DynamicFont" id=36]
 size = 25
 font_data = ExtResource( 66 )
 
-[sub_resource type="StyleBoxFlat" id=41]
+[sub_resource type="StyleBoxFlat" id=37]
 bg_color = Color( 0.47451, 0.560784, 0.588235, 0.392157 )
 border_width_left = 2
 border_width_top = 2
@@ -246,19 +228,19 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color( 0.533333, 0.745098, 0.815686, 0.392157 )
 
-[sub_resource type="DynamicFont" id=42]
+[sub_resource type="DynamicFont" id=38]
 size = 13
 font_data = ExtResource( 12 )
 
-[sub_resource type="StyleBoxTexture" id=43]
+[sub_resource type="StyleBoxTexture" id=39]
 texture = ExtResource( 62 )
 region_rect = Rect2( 0, 0, 86, 52 )
 
-[sub_resource type="DynamicFont" id=44]
+[sub_resource type="DynamicFont" id=40]
 size = 14
 font_data = ExtResource( 69 )
 
-[sub_resource type="Animation" id=45]
+[sub_resource type="Animation" id=41]
 length = 5.0
 loop = true
 tracks/0/type = "value"
@@ -286,387 +268,7 @@ tracks/1/keys = {
 "values": [ 1.0, 1.0, 0.0, 0.0, 1.0 ]
 }
 
-[sub_resource type="Animation" id=46]
-tracks/0/type = "value"
-tracks/0/path = NodePath("LeftPanels/CompoundsPanel:rect_min_size")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( 253, 239 ), Vector2( 253, 150 ) ]
-}
-tracks/1/type = "value"
-tracks/1/path = NodePath("LeftPanels/CompoundsPanel/Compress:rect_size")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( 253, 239 ), Vector2( 253, 150 ) ]
-}
-tracks/2/type = "value"
-tracks/2/path = NodePath("LeftPanels/CompoundsPanel/Expand:visible")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/keys = {
-"times": PoolRealArray( 0, 0.2 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ true, false ]
-}
-tracks/3/type = "value"
-tracks/3/path = NodePath("LeftPanels/CompoundsPanel/Expand:modulate")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/keys = {
-"times": PoolRealArray( 0, 0.2 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
-}
-tracks/4/type = "value"
-tracks/4/path = NodePath("LeftPanels/CompoundsPanel/Compress:modulate")
-tracks/4/interp = 1
-tracks/4/loop_wrap = true
-tracks/4/imported = false
-tracks/4/enabled = true
-tracks/4/keys = {
-"times": PoolRealArray( 0, 0.2 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ) ]
-}
-tracks/5/type = "value"
-tracks/5/path = NodePath("LeftPanels/CompoundsPanel/Compress:visible")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ true ]
-}
-tracks/6/type = "value"
-tracks/6/path = NodePath("LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer/VBoxContainer:rect_size")
-tracks/6/interp = 1
-tracks/6/loop_wrap = true
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( 100, 75 ), Vector2( 65, 75 ) ]
-}
-tracks/7/type = "value"
-tracks/7/path = NodePath("LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer2/VBoxContainer2:rect_size")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( 100, 75 ), Vector2( 65, 75 ) ]
-}
-tracks/8/type = "value"
-tracks/8/path = NodePath("LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer3/VBoxContainer3:rect_size")
-tracks/8/interp = 1
-tracks/8/loop_wrap = true
-tracks/8/imported = false
-tracks/8/enabled = true
-tracks/8/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( 100, 75 ), Vector2( 65, 25 ) ]
-}
-
-[sub_resource type="Animation" id=47]
-tracks/0/type = "value"
-tracks/0/path = NodePath("LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer:rect_size")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/keys = {
-"times": PoolRealArray( 0, 0.5 ),
-"transitions": PoolRealArray( 0.5, 0.5 ),
-"update": 0,
-"values": [ Vector2( 68, 185 ), Vector2( 220, 185 ) ]
-}
-tracks/1/type = "value"
-tracks/1/path = NodePath("LeftPanels/CompoundsPanel:rect_min_size")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/keys = {
-"times": PoolRealArray( 0, 0.3 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ Vector2( 0, 150 ), Vector2( 0, 239 ) ]
-}
-tracks/2/type = "value"
-tracks/2/path = NodePath("LeftPanels/CompoundsPanel/Compress:rect_size")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/keys = {
-"times": PoolRealArray( 0, 0.2 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ Vector2( 253, 150 ), Vector2( 253, 239 ) ]
-}
-tracks/3/type = "value"
-tracks/3/path = NodePath("LeftPanels/CompoundsPanel/Compress:visible")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/keys = {
-"times": PoolRealArray( 0, 0.2 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ true, false ]
-}
-tracks/4/type = "value"
-tracks/4/path = NodePath("LeftPanels/CompoundsPanel/Compress:modulate")
-tracks/4/interp = 1
-tracks/4/loop_wrap = true
-tracks/4/imported = false
-tracks/4/enabled = true
-tracks/4/keys = {
-"times": PoolRealArray( 0, 0.2 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
-}
-tracks/5/type = "value"
-tracks/5/path = NodePath("LeftPanels/CompoundsPanel/Expand:modulate")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
-"times": PoolRealArray( 0, 0.2 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ) ]
-}
-tracks/6/type = "value"
-tracks/6/path = NodePath("LeftPanels/CompoundsPanel/Expand:visible")
-tracks/6/interp = 1
-tracks/6/loop_wrap = true
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ true ]
-}
-
-[sub_resource type="Animation" id=48]
-tracks/0/type = "value"
-tracks/0/path = NodePath("LeftPanels/EnvironmentPanel/Compress:visible")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ true ]
-}
-tracks/1/type = "value"
-tracks/1/path = NodePath("LeftPanels/EnvironmentPanel/Expand:visible")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/keys = {
-"times": PoolRealArray( 0, 0.2 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ true, false ]
-}
-tracks/2/type = "value"
-tracks/2/path = NodePath("LeftPanels/EnvironmentPanel:rect_min_size")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( 195, 224 ), Vector2( 195, 170 ) ]
-}
-tracks/3/type = "value"
-tracks/3/path = NodePath("LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer2/VBoxContainer3:rect_size")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( 100, 111 ), Vector2( 65, 111 ) ]
-}
-tracks/4/type = "value"
-tracks/4/path = NodePath("LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer/VBoxContainer2:rect_size")
-tracks/4/interp = 1
-tracks/4/loop_wrap = true
-tracks/4/imported = false
-tracks/4/enabled = true
-tracks/4/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( 100, 111 ), Vector2( 65, 111 ) ]
-}
-tracks/5/type = "value"
-tracks/5/path = NodePath("LeftPanels/EnvironmentPanel/Compress:rect_size")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( 195, 224 ), Vector2( 195, 170 ) ]
-}
-tracks/6/type = "value"
-tracks/6/path = NodePath("LeftPanels/EnvironmentPanel/Compress:modulate")
-tracks/6/interp = 1
-tracks/6/loop_wrap = true
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/keys = {
-"times": PoolRealArray( 0, 0.2 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ) ]
-}
-tracks/7/type = "value"
-tracks/7/path = NodePath("LeftPanels/EnvironmentPanel/Expand:modulate")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/keys = {
-"times": PoolRealArray( 0, 0.2 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
-}
-
-[sub_resource type="Animation" id=49]
-tracks/0/type = "value"
-tracks/0/path = NodePath("LeftPanels/EnvironmentPanel:rect_min_size")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( 195, 170 ), Vector2( 195, 224 ) ]
-}
-tracks/1/type = "value"
-tracks/1/path = NodePath("LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer:rect_size")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( 68, 170 ), Vector2( 162, 170 ) ]
-}
-tracks/2/type = "value"
-tracks/2/path = NodePath("LeftPanels/EnvironmentPanel/Compress:rect_size")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( 195, 170 ), Vector2( 195, 224 ) ]
-}
-tracks/3/type = "value"
-tracks/3/path = NodePath("LeftPanels/EnvironmentPanel/Expand:modulate")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/keys = {
-"times": PoolRealArray( 0, 0.2 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ) ]
-}
-tracks/4/type = "value"
-tracks/4/path = NodePath("LeftPanels/EnvironmentPanel/Compress:modulate")
-tracks/4/interp = 1
-tracks/4/loop_wrap = true
-tracks/4/imported = false
-tracks/4/enabled = true
-tracks/4/keys = {
-"times": PoolRealArray( 0, 0.2 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
-}
-tracks/5/type = "value"
-tracks/5/path = NodePath("LeftPanels/EnvironmentPanel/Compress:visible")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
-"times": PoolRealArray( 0, 0.2 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ true, false ]
-}
-tracks/6/type = "value"
-tracks/6/path = NodePath("LeftPanels/EnvironmentPanel/Expand:visible")
-tracks/6/interp = 1
-tracks/6/loop_wrap = true
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ true ]
-}
-
-[sub_resource type="Animation" id=50]
+[sub_resource type="Animation" id=42]
 tracks/0/type = "value"
 tracks/0/path = NodePath("LeftPanels:modulate")
 tracks/0/interp = 1
@@ -692,7 +294,7 @@ tracks/1/keys = {
 "values": [ 0.0, -0.2 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("LeftPanels/EnvironmentPanel:anchor_left")
+tracks/2/path = NodePath("LeftPanels/AgentsPanel:anchor_left")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -701,70 +303,46 @@ tracks/2/keys = {
 "times": PoolRealArray( 0, 0.4 ),
 "transitions": PoolRealArray( 2, 1 ),
 "update": 0,
-"values": [ 0.0, -2.0 ]
+"values": [ 0.0, -1.0 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("LeftPanels/CompoundsPanel:anchor_left")
+tracks/3/path = NodePath("LeftPanels/AgentsPanel:mouse_filter")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
 tracks/3/enabled = true
 tracks/3/keys = {
 "times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 2, 1 ),
-"update": 0,
-"values": [ 0.0, -1.5 ]
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ 0, 2 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("LeftPanels/AgentsPanel:anchor_left")
+tracks/4/path = NodePath("LeftPanels/CompoundsPanel:rect_position")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0, 0.4 ),
+"times": PoolRealArray( 0.1, 0.5 ),
 "transitions": PoolRealArray( 2, 1 ),
 "update": 0,
-"values": [ 0.0, -1.0 ]
+"values": [ Vector2( 0, 234 ), Vector2( -300, 234 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("LeftPanels/EnvironmentPanel:mouse_filter")
+tracks/5/path = NodePath("LeftPanels/EnvironmentPanel:rect_position")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
 tracks/5/enabled = true
 tracks/5/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 0, 2 ]
-}
-tracks/6/type = "value"
-tracks/6/path = NodePath("LeftPanels/CompoundsPanel:mouse_filter")
-tracks/6/interp = 1
-tracks/6/loop_wrap = true
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 0, 2 ]
-}
-tracks/7/type = "value"
-tracks/7/path = NodePath("LeftPanels/AgentsPanel:mouse_filter")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 0, 2 ]
+"times": PoolRealArray( 0.3, 0.7 ),
+"transitions": PoolRealArray( 2, 1 ),
+"update": 0,
+"values": [ Vector2( 0, 0 ), Vector2( -300, 0 ) ]
 }
 
-[sub_resource type="Animation" id=51]
+[sub_resource type="Animation" id=43]
 tracks/0/type = "value"
 tracks/0/path = NodePath("LeftPanels:modulate")
 tracks/0/interp = 1
@@ -790,7 +368,7 @@ tracks/1/keys = {
 "values": [ -0.3, 0.0 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("LeftPanels/EnvironmentPanel:anchor_left")
+tracks/2/path = NodePath("LeftPanels/AgentsPanel:anchor_left")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -799,22 +377,22 @@ tracks/2/keys = {
 "times": PoolRealArray( 0, 0.4 ),
 "transitions": PoolRealArray( 0.5, 1 ),
 "update": 0,
-"values": [ -1.0, 0.0 ]
+"values": [ -2.0, 0.0 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("LeftPanels/CompoundsPanel:anchor_left")
+tracks/3/path = NodePath("LeftPanels/AgentsPanel:mouse_filter")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
 tracks/3/enabled = true
 tracks/3/keys = {
 "times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ -1.5, 0.0 ]
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ 2, 0 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("LeftPanels/AgentsPanel:anchor_left")
+tracks/4/path = NodePath("LeftPanels/CompoundsPanel:rect_position")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -823,47 +401,22 @@ tracks/4/keys = {
 "times": PoolRealArray( 0, 0.4 ),
 "transitions": PoolRealArray( 0.5, 1 ),
 "update": 0,
-"values": [ -2.0, 0.0 ]
+"values": [ Vector2( -300, 234 ), Vector2( 0, 234 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("LeftPanels/EnvironmentPanel:mouse_filter")
+tracks/5/path = NodePath("LeftPanels/EnvironmentPanel:rect_position")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
 tracks/5/enabled = true
 tracks/5/keys = {
 "times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 2, 0 ]
-}
-tracks/6/type = "value"
-tracks/6/path = NodePath("LeftPanels/CompoundsPanel:mouse_filter")
-tracks/6/interp = 1
-tracks/6/loop_wrap = true
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 2, 0 ]
-}
-tracks/7/type = "value"
-tracks/7/path = NodePath("LeftPanels/AgentsPanel:mouse_filter")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 2, 0 ]
+"transitions": PoolRealArray( 0.5, 1 ),
+"update": 0,
+"values": [ Vector2( -300, 0 ), Vector2( 0, 0 ) ]
 }
 
 [node name="MicrobeStage" type="Node"]
-process_priority = -1
 script = ExtResource( 1 )
 
 [node name="World" type="Node" parent="."]
@@ -876,10 +429,6 @@ pause_mode = 2
 [node name="CompoundClouds" type="Node" parent="World"]
 script = ExtResource( 10 )
 
-[node name="WorldLight" type="DirectionalLight" parent="World"]
-transform = Transform( -0.687551, 0.322878, -0.650403, 0.0453496, 0.913048, 0.405323, 0.724719, 0.249185, -0.642409, 0, 1.19209e-07, 0 )
-shadow_enabled = true
-
 [node name="PlayerMicrobeInput" type="Node" parent="."]
 script = ExtResource( 7 )
 
@@ -890,6 +439,7 @@ __meta__ = {
 "_editor_description_": ""
 }
 AnimationPlayerPath = NodePath("AnimationPlayer")
+LeftPanelsPath = NodePath("LeftPanels")
 MouseHoverPanelPath = NodePath("MouseHoverPanel")
 HoveredItemsContainerPath = NodePath("MouseHoverPanel/MarginContainer/VBoxContainer/HoveredItems")
 MenuPath = NodePath("CanvasLayer/PauseMenu")
@@ -901,6 +451,18 @@ PopulationLabelPath = NodePath("BottomRight/PopulationData/Value")
 PatchLabelPath = NodePath("BottomBar/PatchLabel")
 EditorButtonPath = NodePath("BottomRight/EditorButton")
 HelpScreenPath = NodePath("CanvasLayer/HelpScreen")
+EnvironmentPanelPath = NodePath("LeftPanels/EnvironmentPanel")
+EnvironmentPanelBarContainerPath = NodePath("LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer")
+CompoundsPanelPath = NodePath("LeftPanels/CompoundsPanel")
+GlucoseBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Glucose/Bar")
+AmmoniaBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Ammonia/Bar")
+PhosphateBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Phosphate/Bar")
+HydrogenSulfideBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/HydrogenSulfide/Bar")
+IronBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Iron/Bar")
+CompoundsPanelBarContainerPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer")
+AgentsPanelPath = NodePath("LeftPanels/AgentsPanel")
+OxytoxyBarPath = NodePath("LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/OxyToxy/Bar")
+AgentsPanelBarContainerPath = NodePath("LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer")
 ExtinctionBoxScene = ExtResource( 70 )
 WinBoxScene = ExtResource( 8 )
 MicrobePickupOrganelleSound = ExtResource( 6 )
@@ -966,84 +528,143 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="EnvironmentPanel" type="Control" parent="MicrobeHUD/LeftPanels"]
+[node name="EnvironmentPanel" type="NinePatchRect" parent="MicrobeHUD/LeftPanels"]
 margin_right = 195.0
 margin_bottom = 224.0
 rect_min_size = Vector2( 195, 224 )
 size_flags_horizontal = 0
-
-[node name="Expand" type="PanelContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel"]
-margin_right = 195.0
-margin_bottom = 224.0
-mouse_filter = 2
-size_flags_horizontal = 0
 size_flags_vertical = 0
-custom_styles/panel = SubResource( 4 )
+texture = ExtResource( 14 )
+patch_margin_left = 5
+patch_margin_top = 45
+patch_margin_right = 5
+patch_margin_bottom = 15
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel"]
 margin_right = 195.0
 margin_bottom = 224.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="MarginContainer" type="MarginContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer"]
+[node name="Header" type="MarginContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer"]
 margin_right = 195.0
 margin_bottom = 35.0
 rect_min_size = Vector2( 195, 35 )
 mouse_filter = 1
 custom_constants/margin_left = 10
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Header"]
 margin_left = 10.0
 margin_right = 195.0
 margin_bottom = 35.0
 custom_constants/separation = 6
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer"]
 margin_top = 6.0
 margin_right = 123.0
 margin_bottom = 28.0
-custom_fonts/font = SubResource( 5 )
+custom_fonts/font = SubResource( 4 )
 text = "Environment"
 
-[node name="MarginContainer2" type="MarginContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer"]
+[node name="MarginContainer4" type="MarginContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer"]
+margin_left = 129.0
+margin_right = 149.0
+margin_bottom = 35.0
+custom_constants/margin_top = 8
+custom_constants/margin_bottom = 7
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="EnvironmentExpandButton" type="Button" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer/MarginContainer4"]
+margin_top = 8.0
+margin_right = 20.0
+margin_bottom = 28.0
+rect_min_size = Vector2( 20, 20 )
+focus_mode = 0
+custom_styles/hover = SubResource( 5 )
+custom_styles/pressed = SubResource( 6 )
+custom_styles/normal = SubResource( 7 )
+toggle_mode = true
+pressed = true
+action_mode = 0
+enabled_focus_mode = 0
+group = SubResource( 8 )
+
+[node name="MarginContainer3" type="MarginContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer"]
+margin_left = 155.0
+margin_right = 175.0
+margin_bottom = 35.0
+custom_constants/margin_top = 8
+custom_constants/margin_bottom = 7
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="EnvironmentCompressButton" type="Button" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer/MarginContainer3"]
+margin_top = 8.0
+margin_right = 20.0
+margin_bottom = 28.0
+rect_min_size = Vector2( 20, 20 )
+focus_mode = 0
+custom_styles/hover = SubResource( 9 )
+custom_styles/pressed = SubResource( 10 )
+custom_styles/normal = SubResource( 11 )
+toggle_mode = true
+action_mode = 0
+enabled_focus_mode = 0
+group = SubResource( 8 )
+
+[node name="Body" type="MarginContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer"]
 margin_top = 39.0
 margin_right = 195.0
 margin_bottom = 224.0
 rect_min_size = Vector2( 195, 185 )
-custom_constants/margin_right = 10
 custom_constants/margin_top = 5
-custom_constants/margin_left = 10
+custom_constants/margin_left = 7
 custom_constants/margin_bottom = 10
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="MarginContainer" type="MarginContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2"]
-margin_left = 10.0
+[node name="BarContainer" type="GridContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body"]
+margin_left = 7.0
 margin_top = 5.0
-margin_right = 185.0
+margin_right = 195.0
 margin_bottom = 175.0
-custom_constants/margin_left = 13
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer"]
-margin_left = 13.0
-margin_right = 175.0
-margin_bottom = 170.0
+[node name="Oxygen" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer"]
+margin_right = 177.0
+margin_bottom = 25.0
+custom_constants/separation = -15
 
-[node name="OxygenBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer" groups=[
+[node name="OxygenIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Oxygen"]
+margin_right = 30.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 30, 25 )
+size_flags_horizontal = 0
+size_flags_vertical = 0
+texture = ExtResource( 51 )
+expand = true
+
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Oxygen" groups=[
 "MicrobeHUDBar",
 ]]
-margin_right = 162.0
+show_behind_parent = true
+margin_left = 15.0
+margin_right = 177.0
 margin_bottom = 25.0
-rect_min_size = Vector2( 0, 25 )
-custom_styles/fg = SubResource( 6 )
-custom_styles/bg = SubResource( 7 )
+rect_min_size = Vector2( 162, 25 )
+custom_styles/fg = SubResource( 12 )
+custom_styles/bg = SubResource( 13 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/OxygenBar"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Oxygen/Bar"]
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_left = 20.0
@@ -1051,14 +672,14 @@ margin_top = -12.5
 margin_right = 38.0
 margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 8 )
+custom_fonts/font = SubResource( 14 )
 text = "02"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/OxygenBar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Oxygen/Bar"]
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -1069,26 +690,42 @@ margin_right = -6.99998
 margin_bottom = 12.5
 grow_horizontal = 0
 rect_min_size = Vector2( 55, 25 )
-custom_fonts/font = SubResource( 8 )
+custom_fonts/font = SubResource( 14 )
 text = "0%"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="CO2Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer" groups=[
+[node name="CarbonDioxide" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer"]
+margin_top = 29.0
+margin_right = 177.0
+margin_bottom = 54.0
+custom_constants/separation = -15
+
+[node name="CO2Icon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/CarbonDioxide"]
+margin_right = 30.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 30, 25 )
+size_flags_horizontal = 0
+size_flags_vertical = 0
+texture = ExtResource( 55 )
+expand = true
+
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/CarbonDioxide" groups=[
 "MicrobeHUDBar",
 ]]
-margin_top = 29.0
-margin_right = 162.0
-margin_bottom = 54.0
-rect_min_size = Vector2( 0, 25 )
-custom_styles/fg = SubResource( 9 )
-custom_styles/bg = SubResource( 7 )
+show_behind_parent = true
+margin_left = 15.0
+margin_right = 177.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 162, 25 )
+custom_styles/fg = SubResource( 15 )
+custom_styles/bg = SubResource( 13 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/CO2Bar"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/CarbonDioxide/Bar"]
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_left = 20.0
@@ -1096,14 +733,14 @@ margin_top = -12.5
 margin_right = 38.0
 margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 8 )
+custom_fonts/font = SubResource( 14 )
 text = "CO2"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/CO2Bar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/CarbonDioxide/Bar"]
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -1114,26 +751,42 @@ margin_right = -6.99998
 margin_bottom = 12.5
 grow_horizontal = 0
 rect_min_size = Vector2( 55, 25 )
-custom_fonts/font = SubResource( 8 )
+custom_fonts/font = SubResource( 14 )
 text = "0%"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="NitrogenBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer" groups=[
+[node name="Nitrogen" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer"]
+margin_top = 58.0
+margin_right = 177.0
+margin_bottom = 83.0
+custom_constants/separation = -15
+
+[node name="NitrogenIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Nitrogen"]
+margin_right = 30.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 30, 25 )
+size_flags_horizontal = 0
+size_flags_vertical = 0
+texture = ExtResource( 56 )
+expand = true
+
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Nitrogen" groups=[
 "MicrobeHUDBar",
 ]]
-margin_top = 58.0
-margin_right = 162.0
-margin_bottom = 83.0
-rect_min_size = Vector2( 0, 25 )
-custom_styles/fg = SubResource( 10 )
-custom_styles/bg = SubResource( 7 )
+show_behind_parent = true
+margin_left = 15.0
+margin_right = 177.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 162, 25 )
+custom_styles/fg = SubResource( 16 )
+custom_styles/bg = SubResource( 13 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/NitrogenBar"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Nitrogen/Bar"]
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_left = 20.0
@@ -1141,14 +794,14 @@ margin_top = -12.5
 margin_right = 49.0
 margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 8 )
+custom_fonts/font = SubResource( 14 )
 text = "N2"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/NitrogenBar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Nitrogen/Bar"]
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -1159,26 +812,42 @@ margin_right = -6.99998
 margin_bottom = 12.5
 grow_horizontal = 0
 rect_min_size = Vector2( 55, 25 )
-custom_fonts/font = SubResource( 8 )
+custom_fonts/font = SubResource( 14 )
 text = "0%"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="TemperatureIcon" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer" groups=[
+[node name="Temperature" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer"]
+margin_top = 87.0
+margin_right = 177.0
+margin_bottom = 112.0
+custom_constants/separation = -16
+
+[node name="TemperatureIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Temperature"]
+margin_right = 30.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 30, 25 )
+size_flags_horizontal = 0
+size_flags_vertical = 0
+texture = ExtResource( 54 )
+expand = true
+
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Temperature" groups=[
 "MicrobeHUDBar",
 ]]
-margin_top = 87.0
-margin_right = 162.0
-margin_bottom = 112.0
-rect_min_size = Vector2( 0, 25 )
-custom_styles/fg = SubResource( 11 )
-custom_styles/bg = SubResource( 7 )
+show_behind_parent = true
+margin_left = 14.0
+margin_right = 176.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 162, 25 )
+custom_styles/fg = SubResource( 17 )
+custom_styles/bg = SubResource( 13 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/TemperatureIcon"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Temperature/Bar"]
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_left = 20.0
@@ -1186,14 +855,14 @@ margin_top = -12.5
 margin_right = 49.0
 margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 8 )
+custom_fonts/font = SubResource( 14 )
 text = "Temp."
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/TemperatureIcon"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Temperature/Bar"]
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -1204,26 +873,42 @@ margin_right = -6.99998
 margin_bottom = 12.5
 grow_horizontal = 0
 rect_min_size = Vector2( 55, 25 )
-custom_fonts/font = SubResource( 8 )
+custom_fonts/font = SubResource( 14 )
 text = "55° C"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="LightIcon" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer" groups=[
+[node name="Sunlight" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer"]
+margin_top = 116.0
+margin_right = 177.0
+margin_bottom = 141.0
+custom_constants/separation = -15
+
+[node name="LightIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Sunlight"]
+margin_right = 30.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 30, 25 )
+size_flags_horizontal = 0
+size_flags_vertical = 0
+texture = ExtResource( 53 )
+expand = true
+
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Sunlight" groups=[
 "MicrobeHUDBar",
 ]]
-margin_top = 116.0
-margin_right = 162.0
-margin_bottom = 141.0
-rect_min_size = Vector2( 0, 25 )
-custom_styles/fg = SubResource( 12 )
-custom_styles/bg = SubResource( 7 )
+show_behind_parent = true
+margin_left = 15.0
+margin_right = 177.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 162, 25 )
+custom_styles/fg = SubResource( 18 )
+custom_styles/bg = SubResource( 13 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/LightIcon"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Sunlight/Bar"]
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_left = 20.0
@@ -1231,14 +916,14 @@ margin_top = -12.5
 margin_right = 66.0
 margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 8 )
+custom_fonts/font = SubResource( 14 )
 text = "Light"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/LightIcon"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Sunlight/Bar"]
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -1249,26 +934,42 @@ margin_right = -6.99998
 margin_bottom = 12.5
 grow_horizontal = 0
 rect_min_size = Vector2( 55, 25 )
-custom_fonts/font = SubResource( 8 )
+custom_fonts/font = SubResource( 14 )
 text = "0%"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="PressureIcon" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer" groups=[
+[node name="Pressure" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer"]
+margin_top = 145.0
+margin_right = 177.0
+margin_bottom = 170.0
+custom_constants/separation = -15
+
+[node name="PressureIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Pressure"]
+margin_right = 30.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 30, 25 )
+size_flags_horizontal = 0
+size_flags_vertical = 0
+texture = ExtResource( 52 )
+expand = true
+
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Pressure" groups=[
 "MicrobeHUDBar",
 ]]
-margin_top = 145.0
-margin_right = 162.0
-margin_bottom = 170.0
-rect_min_size = Vector2( 0, 25 )
-custom_styles/fg = SubResource( 13 )
-custom_styles/bg = SubResource( 7 )
+show_behind_parent = true
+margin_left = 15.0
+margin_right = 177.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 162, 25 )
+custom_styles/fg = SubResource( 19 )
+custom_styles/bg = SubResource( 13 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/PressureIcon"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Pressure/Bar"]
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_left = 20.0
@@ -1276,14 +977,14 @@ margin_top = -12.5
 margin_right = 69.0
 margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 8 )
+custom_fonts/font = SubResource( 14 )
 text = "Press."
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/PressureIcon"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Pressure/Bar"]
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -1294,531 +995,156 @@ margin_right = -4.0
 margin_bottom = 12.5
 grow_horizontal = 0
 rect_min_size = Vector2( 55, 25 )
-custom_fonts/font = SubResource( 8 )
+custom_fonts/font = SubResource( 14 )
 text = "200 kPa"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2"]
-margin_left = 10.0
-margin_top = 5.0
-margin_right = 185.0
-margin_bottom = 175.0
-
-[node name="OxygenIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/VBoxContainer"]
-margin_right = 30.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 30, 25 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-texture = ExtResource( 51 )
-expand = true
-
-[node name="CO2Icon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/VBoxContainer"]
-margin_top = 29.0
-margin_right = 30.0
-margin_bottom = 54.0
-rect_min_size = Vector2( 30, 25 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-texture = ExtResource( 55 )
-expand = true
-
-[node name="NitrogenIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/VBoxContainer"]
-margin_top = 58.0
-margin_right = 30.0
-margin_bottom = 83.0
-rect_min_size = Vector2( 30, 25 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-texture = ExtResource( 56 )
-expand = true
-
-[node name="TemperatureIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/VBoxContainer"]
-margin_top = 87.0
-margin_right = 30.0
-margin_bottom = 112.0
-rect_min_size = Vector2( 30, 25 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-texture = ExtResource( 54 )
-expand = true
-
-[node name="LightIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/VBoxContainer"]
-margin_top = 116.0
-margin_right = 30.0
-margin_bottom = 141.0
-rect_min_size = Vector2( 30, 25 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-texture = ExtResource( 53 )
-expand = true
-
-[node name="PressureIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Expand/VBoxContainer/MarginContainer2/VBoxContainer"]
-margin_top = 145.0
-margin_right = 30.0
-margin_bottom = 170.0
-rect_min_size = Vector2( 30, 25 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-texture = ExtResource( 52 )
-expand = true
-
-[node name="Compress" type="PanelContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel"]
-modulate = Color( 1, 1, 1, 0 )
-margin_right = 195.0
-margin_bottom = 224.0
-mouse_filter = 2
-size_flags_horizontal = 0
-size_flags_vertical = 0
-custom_styles/panel = SubResource( 14 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress"]
-margin_right = 195.0
-margin_bottom = 224.0
-
-[node name="MarginContainer" type="MarginContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer"]
-margin_right = 195.0
-margin_bottom = 35.0
-mouse_filter = 1
-custom_constants/margin_left = 10
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer"]
-margin_left = 10.0
-margin_right = 195.0
-margin_bottom = 35.0
-rect_min_size = Vector2( 0, 35 )
-custom_constants/separation = 6
-
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer/HBoxContainer"]
-margin_top = 6.0
-margin_right = 123.0
-margin_bottom = 28.0
-custom_fonts/font = SubResource( 5 )
-text = "Environment"
-
-[node name="MarginContainer2" type="MarginContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer"]
-margin_top = 39.0
-margin_right = 195.0
-margin_bottom = 170.0
-custom_constants/margin_right = 10
-custom_constants/margin_top = 5
-custom_constants/margin_left = 10
-custom_constants/margin_bottom = 15
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HBoxContainer3" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2"]
-margin_left = 10.0
-margin_top = 5.0
-margin_right = 185.0
-margin_bottom = 116.0
-custom_constants/separation = 11
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3"]
-margin_right = 82.0
-margin_bottom = 111.0
-custom_constants/separation = -13
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer"]
-margin_right = 30.0
-margin_bottom = 111.0
-size_flags_vertical = 0
-custom_constants/separation = 18
-
-[node name="OxygenIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer/VBoxContainer"]
-margin_right = 30.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 30, 25 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-texture = ExtResource( 51 )
-expand = true
-
-[node name="CO2Icon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer/VBoxContainer"]
-margin_top = 43.0
-margin_right = 30.0
-margin_bottom = 68.0
-rect_min_size = Vector2( 30, 25 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-texture = ExtResource( 55 )
-expand = true
-
-[node name="NitrogenIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer/VBoxContainer"]
-margin_top = 86.0
-margin_right = 30.0
-margin_bottom = 111.0
-rect_min_size = Vector2( 30, 25 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-texture = ExtResource( 56 )
-expand = true
-
-[node name="VBoxContainer2" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer"]
-show_behind_parent = true
-margin_left = 17.0
-margin_right = 82.0
-margin_bottom = 111.0
-size_flags_vertical = 0
-custom_constants/separation = 18
-
-[node name="OxygenBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer/VBoxContainer2" groups=[
-"MicrobeHUDBar",
-]]
-margin_right = 65.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 65, 25 )
-custom_styles/fg = SubResource( 6 )
-custom_styles/bg = SubResource( 7 )
-step = 0.1
-percent_visible = false
-
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer/VBoxContainer2/OxygenBar"]
-anchor_left = 1.0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -45.0
-margin_top = -12.5
-margin_bottom = 12.5
-rect_min_size = Vector2( 45, 25 )
-custom_fonts/font = SubResource( 8 )
-text = "0%"
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="CO2Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer/VBoxContainer2" groups=[
-"MicrobeHUDBar",
-]]
-margin_top = 43.0
-margin_right = 65.0
-margin_bottom = 68.0
-rect_min_size = Vector2( 65, 25 )
-custom_styles/fg = SubResource( 9 )
-custom_styles/bg = SubResource( 7 )
-step = 0.1
-percent_visible = false
-
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer/VBoxContainer2/CO2Bar"]
-anchor_left = 1.0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -45.0
-margin_top = -12.5
-margin_bottom = 12.5
-rect_min_size = Vector2( 45, 25 )
-custom_fonts/font = SubResource( 8 )
-text = "0%"
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="NitrogenBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer/VBoxContainer2" groups=[
-"MicrobeHUDBar",
-]]
-margin_top = 86.0
-margin_right = 65.0
-margin_bottom = 111.0
-rect_min_size = Vector2( 65, 25 )
-custom_styles/fg = SubResource( 10 )
-custom_styles/bg = SubResource( 7 )
-step = 0.1
-percent_visible = false
-
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer/VBoxContainer2/NitrogenBar"]
-anchor_left = 1.0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -45.0
-margin_top = -12.5
-margin_bottom = 12.5
-rect_min_size = Vector2( 45, 25 )
-custom_fonts/font = SubResource( 8 )
-text = "0%"
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HBoxContainer2" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3"]
-margin_left = 93.0
-margin_right = 175.0
-margin_bottom = 111.0
-custom_constants/separation = -13
-
-[node name="VBoxContainer2" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer2"]
-margin_right = 30.0
-margin_bottom = 111.0
-size_flags_vertical = 0
-custom_constants/separation = 18
-
-[node name="TemperatureIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer2/VBoxContainer2"]
-margin_right = 30.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 30, 25 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-texture = ExtResource( 54 )
-expand = true
-
-[node name="LightIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer2/VBoxContainer2"]
-margin_top = 43.0
-margin_right = 30.0
-margin_bottom = 68.0
-rect_min_size = Vector2( 30, 25 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-texture = ExtResource( 53 )
-expand = true
-
-[node name="PressureIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer2/VBoxContainer2"]
-margin_top = 86.0
-margin_right = 30.0
-margin_bottom = 111.0
-rect_min_size = Vector2( 30, 25 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-texture = ExtResource( 52 )
-expand = true
-
-[node name="VBoxContainer3" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer2"]
-show_behind_parent = true
-margin_left = 17.0
-margin_right = 82.0
-margin_bottom = 111.0
-size_flags_vertical = 0
-custom_constants/separation = 18
-
-[node name="TemperatureIcon" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer2/VBoxContainer3" groups=[
-"MicrobeHUDBar",
-]]
-margin_right = 65.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 65, 25 )
-custom_styles/fg = SubResource( 11 )
-custom_styles/bg = SubResource( 7 )
-step = 0.1
-percent_visible = false
-
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer2/VBoxContainer3/TemperatureIcon"]
-anchor_left = 1.0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -45.0
-margin_top = -12.5
-margin_bottom = 12.5
-grow_horizontal = 0
-rect_min_size = Vector2( 45, 25 )
-custom_fonts/font = SubResource( 8 )
-text = "55° C"
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="LightIcon" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer2/VBoxContainer3" groups=[
-"MicrobeHUDBar",
-]]
-margin_top = 43.0
-margin_right = 65.0
-margin_bottom = 68.0
-rect_min_size = Vector2( 65, 25 )
-custom_styles/fg = SubResource( 12 )
-custom_styles/bg = SubResource( 7 )
-step = 0.1
-percent_visible = false
-
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer2/VBoxContainer3/LightIcon"]
-anchor_left = 1.0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -45.0
-margin_top = -12.5
-margin_bottom = 12.5
-grow_horizontal = 0
-rect_min_size = Vector2( 45, 25 )
-custom_fonts/font = SubResource( 8 )
-text = "0%"
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="PressureIcon" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer2/VBoxContainer3" groups=[
-"MicrobeHUDBar",
-]]
-margin_top = 86.0
-margin_right = 65.0
-margin_bottom = 111.0
-rect_min_size = Vector2( 65, 25 )
-custom_styles/fg = SubResource( 13 )
-custom_styles/bg = SubResource( 7 )
-step = 0.1
-percent_visible = false
-
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/Compress/VBoxContainer/MarginContainer2/HBoxContainer3/HBoxContainer2/VBoxContainer3/PressureIcon"]
-anchor_left = 1.0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -45.0
-margin_top = -12.5
-margin_right = 6.0
-margin_bottom = 12.5
-grow_horizontal = 0
-rect_min_size = Vector2( 45, 25 )
-custom_fonts/font = SubResource( 8 )
-text = "200 kPa"
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="MarginContainer4" type="MarginContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel"]
-margin_left = 139.0
-margin_right = 159.0
-margin_bottom = 35.0
-custom_constants/margin_top = 8
-custom_constants/margin_bottom = 7
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="EnvironmentExpandButton" type="Button" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/MarginContainer4"]
-margin_top = 8.0
-margin_right = 20.0
-margin_bottom = 28.0
-rect_min_size = Vector2( 20, 20 )
-focus_mode = 0
-custom_styles/hover = SubResource( 15 )
-custom_styles/pressed = SubResource( 16 )
-custom_styles/normal = SubResource( 17 )
-toggle_mode = true
-pressed = true
-action_mode = 0
-enabled_focus_mode = 0
-group = SubResource( 18 )
-
-[node name="MarginContainer3" type="MarginContainer" parent="MicrobeHUD/LeftPanels/EnvironmentPanel"]
-margin_left = 165.0
-margin_right = 185.0
-margin_bottom = 35.0
-custom_constants/margin_top = 8
-custom_constants/margin_bottom = 7
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="EnvironmentCompressButton" type="Button" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/MarginContainer3"]
-margin_top = 8.0
-margin_right = 20.0
-margin_bottom = 28.0
-rect_min_size = Vector2( 20, 20 )
-focus_mode = 0
-custom_styles/hover = SubResource( 19 )
-custom_styles/pressed = SubResource( 20 )
-custom_styles/normal = SubResource( 21 )
-toggle_mode = true
-action_mode = 0
-enabled_focus_mode = 0
-group = SubResource( 18 )
-
-[node name="CompoundsPanel" type="Control" parent="MicrobeHUD/LeftPanels"]
+[node name="CompoundsPanel" type="NinePatchRect" parent="MicrobeHUD/LeftPanels"]
 margin_top = 234.0
 margin_right = 253.0
 margin_bottom = 473.0
 rect_min_size = Vector2( 253, 239 )
 size_flags_horizontal = 0
-
-[node name="Expand" type="PanelContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel"]
-margin_right = 253.0
-margin_bottom = 239.0
-size_flags_horizontal = 0
-size_flags_vertical = 0
-custom_styles/panel = SubResource( 22 )
+texture = ExtResource( 13 )
+patch_margin_left = 5
+patch_margin_top = 45
+patch_margin_right = 5
+patch_margin_bottom = 20
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand"]
-margin_right = 253.0
-margin_bottom = 239.0
+[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel"]
+margin_right = 252.0
+margin_bottom = 204.0
+size_flags_vertical = 4
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="MarginContainer" type="MarginContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer"]
-margin_right = 253.0
+[node name="Header" type="MarginContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer"]
+margin_right = 252.0
 margin_bottom = 40.0
 rect_min_size = Vector2( 230, 40 )
 custom_constants/margin_right = 0
 custom_constants/margin_left = 45
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Header"]
 margin_left = 45.0
-margin_right = 253.0
+margin_right = 252.0
 margin_bottom = 40.0
 custom_constants/separation = 6
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Header/HBoxContainer"]
 margin_top = 9.0
-margin_right = 119.0
+margin_right = 145.0
 margin_bottom = 31.0
-custom_fonts/font = SubResource( 5 )
+rect_min_size = Vector2( 145, 0 )
+custom_fonts/font = SubResource( 4 )
 text = "Compounds"
 
-[node name="MarginContainer2" type="MarginContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer"]
-margin_top = 44.0
-margin_right = 253.0
-margin_bottom = 239.0
-rect_min_size = Vector2( 240, 195 )
-custom_constants/margin_right = 10
-custom_constants/margin_top = 5
-custom_constants/margin_left = 10
-custom_constants/margin_bottom = 5
+[node name="MarginContainer3" type="MarginContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Header/HBoxContainer"]
+margin_left = 151.0
+margin_right = 171.0
+margin_bottom = 40.0
+rect_min_size = Vector2( 20, 20 )
+custom_constants/margin_top = 10
+custom_constants/margin_bottom = 10
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="MarginContainer" type="MarginContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2"]
+[node name="CompoundExpandButton" type="Button" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Header/HBoxContainer/MarginContainer3"]
+margin_top = 10.0
+margin_right = 20.0
+margin_bottom = 30.0
+rect_min_size = Vector2( 20, 20 )
+focus_mode = 0
+custom_styles/hover = SubResource( 5 )
+custom_styles/pressed = SubResource( 6 )
+custom_styles/normal = SubResource( 7 )
+toggle_mode = true
+pressed = true
+action_mode = 0
+enabled_focus_mode = 0
+group = SubResource( 20 )
+
+[node name="MarginContainer4" type="MarginContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Header/HBoxContainer"]
+margin_left = 177.0
+margin_right = 197.0
+margin_bottom = 40.0
+custom_constants/margin_top = 10
+custom_constants/margin_bottom = 10
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="CompoundCompressButton" type="Button" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Header/HBoxContainer/MarginContainer4"]
+margin_top = 10.0
+margin_right = 20.0
+margin_bottom = 30.0
+rect_min_size = Vector2( 20, 20 )
+focus_mode = 0
+custom_styles/hover = SubResource( 21 )
+custom_styles/pressed = SubResource( 22 )
+custom_styles/normal = SubResource( 23 )
+toggle_mode = true
+action_mode = 0
+enabled_focus_mode = 0
+group = SubResource( 20 )
+
+[node name="Body" type="MarginContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer"]
+margin_top = 44.0
+margin_right = 252.0
+margin_bottom = 204.0
+custom_constants/margin_right = 10
+custom_constants/margin_top = 5
+custom_constants/margin_left = 10
+custom_constants/margin_bottom = 10
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="BarContainer" type="GridContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body"]
 margin_left = 10.0
 margin_top = 5.0
-margin_right = 243.0
-margin_bottom = 190.0
-custom_constants/margin_left = 13
+margin_right = 242.0
+margin_bottom = 150.0
+custom_constants/vseparation = 5
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer"]
-margin_left = 13.0
-margin_right = 233.0
-margin_bottom = 185.0
-custom_constants/separation = 6
+[node name="Glucose" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer"]
+margin_right = 232.0
+margin_bottom = 25.0
+custom_constants/separation = -13
 
-[node name="GlucoseBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer" groups=[
+[node name="Icon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Glucose"]
+margin_right = 25.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 25, 25 )
+texture = ExtResource( 46 )
+expand = true
+stretch_mode = 1
+
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Glucose" groups=[
 "MicrobeHUDBar",
 ]]
-margin_right = 220.0
+show_behind_parent = true
+margin_left = 12.0
+margin_right = 232.0
 margin_bottom = 25.0
-rect_min_size = Vector2( 0, 25 )
-custom_styles/fg = SubResource( 23 )
-custom_styles/bg = SubResource( 24 )
+rect_min_size = Vector2( 220, 25 )
+custom_styles/fg = SubResource( 24 )
+custom_styles/bg = SubResource( 25 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/GlucoseBar"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Glucose/Bar"]
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_left = 20.0
@@ -1826,14 +1152,14 @@ margin_top = -12.5
 margin_right = 86.0
 margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
+custom_fonts/font = SubResource( 26 )
 text = "Glucose"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/GlucoseBar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Glucose/Bar"]
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -1844,7 +1170,7 @@ margin_right = -4.0
 margin_bottom = 12.5
 grow_horizontal = 0
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
+custom_fonts/font = SubResource( 26 )
 text = "0.0 / 4"
 align = 2
 valign = 1
@@ -1852,19 +1178,33 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="AmmoniaBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer" groups=[
+[node name="Ammonia" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer"]
+margin_top = 30.0
+margin_right = 232.0
+margin_bottom = 55.0
+custom_constants/separation = -13
+
+[node name="AmmoniaIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Ammonia"]
+margin_right = 25.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 25, 25 )
+texture = ExtResource( 48 )
+expand = true
+
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Ammonia" groups=[
 "MicrobeHUDBar",
 ]]
-margin_top = 31.0
-margin_right = 220.0
-margin_bottom = 56.0
-rect_min_size = Vector2( 0, 25 )
-custom_styles/fg = SubResource( 26 )
-custom_styles/bg = SubResource( 24 )
+show_behind_parent = true
+margin_left = 12.0
+margin_right = 232.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 220, 25 )
+custom_styles/fg = SubResource( 27 )
+custom_styles/bg = SubResource( 25 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/AmmoniaBar"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Ammonia/Bar"]
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_left = 20.0
@@ -1872,14 +1212,14 @@ margin_top = -12.5
 margin_right = 91.0
 margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
+custom_fonts/font = SubResource( 26 )
 text = "Ammonia"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/AmmoniaBar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Ammonia/Bar"]
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -1890,7 +1230,7 @@ margin_right = -4.0
 margin_bottom = 12.5
 grow_horizontal = 0
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
+custom_fonts/font = SubResource( 26 )
 text = "0.0 / 4"
 align = 2
 valign = 1
@@ -1898,19 +1238,33 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="PhosphateBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer" groups=[
+[node name="Phosphate" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer"]
+margin_top = 60.0
+margin_right = 232.0
+margin_bottom = 85.0
+custom_constants/separation = -13
+
+[node name="PhospateIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Phosphate"]
+margin_right = 25.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 25, 25 )
+texture = ExtResource( 50 )
+expand = true
+
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Phosphate" groups=[
 "MicrobeHUDBar",
 ]]
-margin_top = 62.0
-margin_right = 220.0
-margin_bottom = 87.0
-rect_min_size = Vector2( 0, 25 )
-custom_styles/fg = SubResource( 27 )
-custom_styles/bg = SubResource( 24 )
+show_behind_parent = true
+margin_left = 12.0
+margin_right = 232.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 220, 25 )
+custom_styles/fg = SubResource( 28 )
+custom_styles/bg = SubResource( 25 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/PhosphateBar"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Phosphate/Bar"]
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_left = 20.0
@@ -1918,14 +1272,14 @@ margin_top = -12.5
 margin_right = 95.0
 margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
+custom_fonts/font = SubResource( 26 )
 text = "Phosphate"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/PhosphateBar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Phosphate/Bar"]
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -1936,7 +1290,7 @@ margin_right = -4.0
 margin_bottom = 12.5
 grow_horizontal = 0
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
+custom_fonts/font = SubResource( 26 )
 text = "0.0 / 4"
 align = 2
 valign = 1
@@ -1944,19 +1298,33 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="HydrogenSulfideBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer" groups=[
+[node name="HydrogenSulfide" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer"]
+margin_top = 90.0
+margin_right = 232.0
+margin_bottom = 115.0
+custom_constants/separation = -13
+
+[node name="HydrogenSulfideIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/HydrogenSulfide"]
+margin_right = 25.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 25, 25 )
+texture = ExtResource( 47 )
+expand = true
+
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/HydrogenSulfide" groups=[
 "MicrobeHUDBar",
 ]]
-margin_top = 93.0
-margin_right = 220.0
-margin_bottom = 118.0
-rect_min_size = Vector2( 0, 25 )
-custom_styles/fg = SubResource( 28 )
-custom_styles/bg = SubResource( 24 )
+show_behind_parent = true
+margin_left = 12.0
+margin_right = 232.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 220, 25 )
+custom_styles/fg = SubResource( 29 )
+custom_styles/bg = SubResource( 25 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/HydrogenSulfideBar"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/HydrogenSulfide/Bar"]
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_left = 20.0
@@ -1964,14 +1332,14 @@ margin_top = -12.5
 margin_right = 157.0
 margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
+custom_fonts/font = SubResource( 26 )
 text = "Hydrogen Sulfide"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/HydrogenSulfideBar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/HydrogenSulfide/Bar"]
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -1982,7 +1350,7 @@ margin_right = -4.0
 margin_bottom = 12.5
 grow_horizontal = 0
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
+custom_fonts/font = SubResource( 26 )
 text = "0.0 / 4"
 align = 2
 valign = 1
@@ -1990,19 +1358,33 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="IronBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer" groups=[
+[node name="Iron" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer"]
+margin_top = 120.0
+margin_right = 232.0
+margin_bottom = 145.0
+custom_constants/separation = -13
+
+[node name="IronIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Iron"]
+margin_right = 25.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 25, 25 )
+texture = ExtResource( 49 )
+expand = true
+
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Iron" groups=[
 "MicrobeHUDBar",
 ]]
-margin_top = 124.0
-margin_right = 220.0
-margin_bottom = 149.0
-rect_min_size = Vector2( 0, 25 )
-custom_styles/fg = SubResource( 29 )
-custom_styles/bg = SubResource( 24 )
+show_behind_parent = true
+margin_left = 12.0
+margin_right = 232.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 220, 25 )
+custom_styles/fg = SubResource( 30 )
+custom_styles/bg = SubResource( 25 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/IronBar"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Iron/Bar"]
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_left = 20.0
@@ -2010,14 +1392,14 @@ margin_top = -12.5
 margin_right = 51.0
 margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
+custom_fonts/font = SubResource( 26 )
 text = "Iron"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/IronBar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Iron/Bar"]
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -2028,421 +1410,13 @@ margin_right = -4.0
 margin_bottom = 12.5
 grow_horizontal = 0
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
+custom_fonts/font = SubResource( 26 )
 text = "0.0 / 4"
 align = 2
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
-
-[node name="IconContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2"]
-margin_left = 10.0
-margin_top = 5.0
-margin_right = 35.0
-margin_bottom = 165.0
-rect_min_size = Vector2( 25, 160 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-custom_constants/separation = 6
-
-[node name="GlucoseIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/IconContainer"]
-margin_right = 25.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 25, 25 )
-texture = ExtResource( 46 )
-expand = true
-stretch_mode = 1
-
-[node name="AmmoniaIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/IconContainer"]
-margin_top = 31.0
-margin_right = 25.0
-margin_bottom = 56.0
-rect_min_size = Vector2( 25, 25 )
-texture = ExtResource( 48 )
-expand = true
-
-[node name="PhospateIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/IconContainer"]
-margin_top = 62.0
-margin_right = 25.0
-margin_bottom = 87.0
-rect_min_size = Vector2( 25, 25 )
-texture = ExtResource( 50 )
-expand = true
-
-[node name="HydrogenSulfideIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/IconContainer"]
-margin_top = 93.0
-margin_right = 25.0
-margin_bottom = 118.0
-rect_min_size = Vector2( 25, 25 )
-texture = ExtResource( 47 )
-expand = true
-
-[node name="IronIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Expand/VBoxContainer/MarginContainer2/IconContainer"]
-margin_top = 124.0
-margin_right = 25.0
-margin_bottom = 149.0
-rect_min_size = Vector2( 25, 25 )
-texture = ExtResource( 49 )
-expand = true
-
-[node name="Compress" type="PanelContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel"]
-modulate = Color( 1, 1, 1, 0 )
-margin_right = 253.0
-margin_bottom = 239.0
-size_flags_horizontal = 0
-size_flags_vertical = 0
-custom_styles/panel = SubResource( 30 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress"]
-margin_right = 253.0
-margin_bottom = 239.0
-
-[node name="MarginContainer3" type="MarginContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer"]
-margin_right = 253.0
-margin_bottom = 40.0
-rect_min_size = Vector2( 0, 40 )
-size_flags_vertical = 0
-custom_constants/margin_right = 0
-custom_constants/margin_left = 45
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer3"]
-margin_left = 45.0
-margin_right = 253.0
-margin_bottom = 40.0
-custom_constants/separation = 6
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer3/HBoxContainer"]
-margin_top = 9.0
-margin_right = 119.0
-margin_bottom = 31.0
-custom_fonts/font = SubResource( 5 )
-text = "Compounds"
-
-[node name="MarginContainer4" type="MarginContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer"]
-margin_top = 44.0
-margin_right = 242.0
-margin_bottom = 124.0
-size_flags_horizontal = 0
-size_flags_vertical = 0
-custom_constants/margin_top = 5
-custom_constants/margin_left = 9
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4"]
-margin_left = 9.0
-margin_top = 5.0
-margin_right = 242.0
-margin_bottom = 80.0
-custom_constants/separation = 1
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer"]
-margin_right = 77.0
-margin_bottom = 75.0
-custom_constants/separation = -13
-
-[node name="IconContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer"]
-margin_right = 25.0
-margin_bottom = 75.0
-size_flags_horizontal = 0
-size_flags_vertical = 0
-custom_constants/separation = 25
-
-[node name="GlucoseIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer/IconContainer"]
-margin_right = 25.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 25, 25 )
-texture = ExtResource( 46 )
-expand = true
-stretch_mode = 1
-
-[node name="AmmoniaIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer/IconContainer"]
-margin_top = 50.0
-margin_right = 25.0
-margin_bottom = 75.0
-rect_min_size = Vector2( 25, 25 )
-texture = ExtResource( 48 )
-expand = true
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer"]
-show_behind_parent = true
-margin_left = 12.0
-margin_right = 77.0
-margin_bottom = 75.0
-custom_constants/separation = 25
-
-[node name="GlucoseBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer/VBoxContainer" groups=[
-"MicrobeHUDBar",
-]]
-margin_right = 65.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 65, 25 )
-custom_styles/fg = SubResource( 23 )
-custom_styles/bg = SubResource( 24 )
-step = 0.1
-percent_visible = false
-
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer/VBoxContainer/GlucoseBar"]
-anchor_left = 1.0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -49.0
-margin_top = -12.5
-margin_right = -4.0
-margin_bottom = 12.5
-grow_horizontal = 0
-rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
-text = "0.0 / 4"
-align = 2
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="AmmoniaBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer/VBoxContainer" groups=[
-"MicrobeHUDBar",
-]]
-margin_top = 50.0
-margin_right = 65.0
-margin_bottom = 75.0
-rect_min_size = Vector2( 65, 25 )
-custom_styles/fg = SubResource( 26 )
-custom_styles/bg = SubResource( 24 )
-step = 0.1
-percent_visible = false
-
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer/VBoxContainer/AmmoniaBar"]
-anchor_left = 1.0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -49.0
-margin_top = -12.5
-margin_right = -4.0
-margin_bottom = 12.5
-grow_horizontal = 0
-rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
-text = "0.0 / 4"
-align = 2
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HBoxContainer2" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer"]
-margin_left = 78.0
-margin_right = 155.0
-margin_bottom = 75.0
-custom_constants/separation = -13
-
-[node name="IconContainer2" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer2"]
-margin_right = 25.0
-margin_bottom = 75.0
-size_flags_horizontal = 0
-size_flags_vertical = 0
-custom_constants/separation = 25
-
-[node name="PhospateIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer2/IconContainer2"]
-margin_right = 25.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 25, 25 )
-texture = ExtResource( 50 )
-expand = true
-
-[node name="HydrogenSulfideIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer2/IconContainer2"]
-margin_top = 50.0
-margin_right = 25.0
-margin_bottom = 75.0
-rect_min_size = Vector2( 25, 25 )
-texture = ExtResource( 47 )
-expand = true
-
-[node name="VBoxContainer2" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer2"]
-show_behind_parent = true
-margin_left = 12.0
-margin_right = 77.0
-margin_bottom = 75.0
-custom_constants/separation = 25
-
-[node name="PhosphateBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer2/VBoxContainer2" groups=[
-"MicrobeHUDBar",
-]]
-margin_right = 65.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 65, 25 )
-custom_styles/fg = SubResource( 27 )
-custom_styles/bg = SubResource( 24 )
-step = 0.1
-percent_visible = false
-
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer2/VBoxContainer2/PhosphateBar"]
-anchor_left = 1.0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -49.0
-margin_top = -12.5
-margin_right = -4.0
-margin_bottom = 12.5
-grow_horizontal = 0
-rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
-text = "0.0 / 4"
-align = 2
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HydrogenSulfideBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer2/VBoxContainer2" groups=[
-"MicrobeHUDBar",
-]]
-margin_top = 50.0
-margin_right = 65.0
-margin_bottom = 75.0
-rect_min_size = Vector2( 65, 25 )
-custom_styles/fg = SubResource( 28 )
-custom_styles/bg = SubResource( 24 )
-step = 0.1
-percent_visible = false
-
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer2/VBoxContainer2/HydrogenSulfideBar"]
-anchor_left = 1.0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -49.0
-margin_top = -12.5
-margin_right = -4.0
-margin_bottom = 12.5
-grow_horizontal = 0
-rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
-text = "0.0 / 4"
-align = 2
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HBoxContainer3" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer"]
-margin_left = 156.0
-margin_right = 233.0
-margin_bottom = 75.0
-custom_constants/separation = -13
-
-[node name="IconContainer3" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer3"]
-margin_right = 25.0
-margin_bottom = 25.0
-size_flags_horizontal = 0
-size_flags_vertical = 0
-custom_constants/separation = 6
-
-[node name="IronIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer3/IconContainer3"]
-margin_right = 25.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 25, 25 )
-texture = ExtResource( 49 )
-expand = true
-
-[node name="VBoxContainer3" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer3"]
-show_behind_parent = true
-margin_left = 12.0
-margin_right = 77.0
-margin_bottom = 25.0
-size_flags_vertical = 0
-custom_constants/separation = 6
-
-[node name="IronBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer3/VBoxContainer3" groups=[
-"MicrobeHUDBar",
-]]
-margin_right = 65.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 65, 25 )
-custom_styles/fg = SubResource( 29 )
-custom_styles/bg = SubResource( 24 )
-step = 0.1
-percent_visible = false
-
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/Compress/VBoxContainer/MarginContainer4/HBoxContainer/HBoxContainer3/VBoxContainer3/IronBar"]
-anchor_left = 1.0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -49.0
-margin_top = -12.5
-margin_right = -4.0
-margin_bottom = 12.5
-grow_horizontal = 0
-rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 25 )
-text = "0.0 / 4"
-align = 2
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="MarginContainer3" type="MarginContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel"]
-margin_left = 196.0
-margin_right = 216.0
-margin_bottom = 40.0
-rect_min_size = Vector2( 20, 20 )
-custom_constants/margin_top = 10
-custom_constants/margin_bottom = 10
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="CompoundExpandButton" type="Button" parent="MicrobeHUD/LeftPanels/CompoundsPanel/MarginContainer3"]
-margin_top = 10.0
-margin_right = 20.0
-margin_bottom = 30.0
-rect_min_size = Vector2( 20, 20 )
-focus_mode = 0
-custom_styles/hover = SubResource( 15 )
-custom_styles/pressed = SubResource( 16 )
-custom_styles/normal = SubResource( 17 )
-toggle_mode = true
-pressed = true
-action_mode = 0
-enabled_focus_mode = 0
-group = SubResource( 31 )
-
-[node name="MarginContainer4" type="MarginContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel"]
-margin_left = 222.0
-margin_right = 242.0
-margin_bottom = 40.0
-custom_constants/margin_top = 10
-custom_constants/margin_bottom = 10
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="CompoundCompressButton" type="Button" parent="MicrobeHUD/LeftPanels/CompoundsPanel/MarginContainer4"]
-margin_top = 10.0
-margin_right = 20.0
-margin_bottom = 30.0
-rect_min_size = Vector2( 20, 20 )
-focus_mode = 0
-custom_styles/hover = SubResource( 32 )
-custom_styles/pressed = SubResource( 33 )
-custom_styles/normal = SubResource( 34 )
-toggle_mode = true
-action_mode = 0
-enabled_focus_mode = 0
-group = SubResource( 31 )
 
 [node name="AgentsPanel" type="Control" parent="MicrobeHUD/LeftPanels"]
 margin_top = 483.0
@@ -2455,7 +1429,7 @@ margin_right = 253.0
 margin_bottom = 89.0
 size_flags_horizontal = 0
 size_flags_vertical = 0
-custom_styles/panel = SubResource( 35 )
+custom_styles/panel = SubResource( 31 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -2475,7 +1449,7 @@ margin_left = 40.0
 margin_top = 6.0
 margin_right = 253.0
 margin_bottom = 28.0
-custom_fonts/font = SubResource( 5 )
+custom_fonts/font = SubResource( 4 )
 text = "Agents"
 
 [node name="MarginContainer2" type="MarginContainer" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer"]
@@ -2491,30 +1465,39 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="MarginContainer" type="MarginContainer" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2"]
+[node name="BarContainer" type="GridContainer" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2"]
 margin_left = 10.0
 margin_top = 5.0
 margin_right = 243.0
 margin_bottom = 45.0
-custom_constants/margin_left = 13
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer"]
-margin_left = 13.0
-margin_right = 233.0
-margin_bottom = 40.0
+[node name="OxyToxy" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer"]
+margin_right = 232.0
+margin_bottom = 25.0
+custom_constants/separation = -13
 
-[node name="OxyToxyBar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer" groups=[
+[node name="OxyToxyIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/OxyToxy"]
+margin_right = 25.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 25, 25 )
+size_flags_horizontal = 0
+size_flags_vertical = 0
+texture = ExtResource( 57 )
+expand = true
+
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/OxyToxy" groups=[
 "MicrobeHUDBar",
 ]]
-margin_right = 220.0
+margin_left = 12.0
+margin_right = 232.0
 margin_bottom = 25.0
 rect_min_size = Vector2( 220, 25 )
-custom_styles/fg = SubResource( 36 )
-custom_styles/bg = SubResource( 37 )
+custom_styles/fg = SubResource( 32 )
+custom_styles/bg = SubResource( 33 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/OxyToxyBar"]
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/OxyToxy/Bar"]
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_left = 20.0
@@ -2522,14 +1505,14 @@ margin_top = -12.5
 margin_right = 111.0
 margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 38 )
+custom_fonts/font = SubResource( 34 )
 text = "OxyToxy NT"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/OxyToxyBar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/OxyToxy/Bar"]
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -2540,28 +1523,13 @@ margin_right = -5.0
 margin_bottom = 12.5
 grow_horizontal = 0
 rect_min_size = Vector2( 0, 25 )
-custom_fonts/font = SubResource( 38 )
+custom_fonts/font = SubResource( 34 )
 text = "0.0 / 4"
 align = 2
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2"]
-margin_left = 10.0
-margin_top = 5.0
-margin_right = 243.0
-margin_bottom = 45.0
-
-[node name="OxyToxyIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/VBoxContainer"]
-margin_right = 25.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 25, 25 )
-size_flags_horizontal = 0
-size_flags_vertical = 0
-texture = ExtResource( 57 )
-expand = true
 
 [node name="BottomBar" type="HBoxContainer" parent="MicrobeHUD"]
 anchor_top = 1.0
@@ -2694,14 +1662,14 @@ margin_left = 369.0
 margin_right = 384.0
 margin_bottom = 43.0
 rect_min_size = Vector2( 15, 0 )
-custom_styles/separator = SubResource( 39 )
+custom_styles/separator = SubResource( 35 )
 
 [node name="PatchLabel" type="Label" parent="MicrobeHUD/BottomBar"]
 margin_left = 388.0
 margin_top = 8.0
 margin_right = 462.0
 margin_bottom = 35.0
-custom_fonts/font = SubResource( 40 )
+custom_fonts/font = SubResource( 36 )
 text = "Patch:"
 
 [node name="BottomRight" type="Control" parent="MicrobeHUD"]
@@ -2731,8 +1699,8 @@ __meta__ = {
 [node name="Label" type="Label" parent="MicrobeHUD/BottomRight/PopulationData"]
 margin_right = 79.0
 margin_bottom = 18.0
-custom_styles/normal = SubResource( 41 )
-custom_fonts/font = SubResource( 42 )
+custom_styles/normal = SubResource( 37 )
+custom_fonts/font = SubResource( 38 )
 text = "POPULATION:"
 __meta__ = {
 "_edit_use_anchors_": false
@@ -2742,8 +1710,8 @@ __meta__ = {
 margin_left = 83.0
 margin_right = 111.0
 margin_bottom = 18.0
-custom_styles/normal = SubResource( 41 )
-custom_fonts/font = SubResource( 42 )
+custom_styles/normal = SubResource( 37 )
+custom_fonts/font = SubResource( 38 )
 text = "100"
 align = 1
 __meta__ = {
@@ -2759,7 +1727,7 @@ margin_left = 30.0
 margin_top = -108.0
 margin_right = 117.0
 margin_bottom = -58.0
-custom_styles/panel = SubResource( 43 )
+custom_styles/panel = SubResource( 39 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -2782,14 +1750,14 @@ custom_constants/separation = 8
 [node name="HPValue" type="Label" parent="MicrobeHUD/BottomRight/DataValue/Margin/VBox"]
 margin_right = 77.0
 margin_bottom = 15.0
-custom_fonts/font = SubResource( 44 )
+custom_fonts/font = SubResource( 40 )
 text = "Hitpoints"
 
 [node name="ATPValue" type="Label" parent="MicrobeHUD/BottomRight/DataValue/Margin/VBox"]
 margin_top = 23.0
 margin_right = 77.0
 margin_bottom = 38.0
-custom_fonts/font = SubResource( 44 )
+custom_fonts/font = SubResource( 40 )
 text = "ATP"
 
 [node name="ATPBar" type="TextureProgress" parent="MicrobeHUD/BottomRight" groups=[
@@ -2982,7 +1950,7 @@ __meta__ = {
 }
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="MicrobeHUD/BottomRight/EditorButton"]
-anims/EditorButtonFlash = SubResource( 45 )
+anims/EditorButtonFlash = SubResource( 41 )
 
 [node name="CanvasLayer" type="CanvasLayer" parent="MicrobeHUD"]
 __meta__ = {
@@ -3234,16 +2202,12 @@ margin_bottom = 59.0
 text = "Be wary because your competitors are evolving alongside you. Every time you enter the editor they evolve as well."
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="MicrobeHUD"]
-anims/CompoundPanelCompress = SubResource( 46 )
-anims/CompoundPanelExpand = SubResource( 47 )
-anims/EnvironmentPanelCompress = SubResource( 48 )
-anims/EnvironmentPanelExpand = SubResource( 49 )
-anims/HideLeftPanels = SubResource( 50 )
-anims/ShowLeftPanels = SubResource( 51 )
-[connection signal="pressed" from="MicrobeHUD/LeftPanels/EnvironmentPanel/MarginContainer4/EnvironmentExpandButton" to="MicrobeHUD" method="ResizeEnvironmentPanel" binds= [ "expand" ]]
-[connection signal="pressed" from="MicrobeHUD/LeftPanels/EnvironmentPanel/MarginContainer3/EnvironmentCompressButton" to="MicrobeHUD" method="ResizeEnvironmentPanel" binds= [ "compress" ]]
-[connection signal="pressed" from="MicrobeHUD/LeftPanels/CompoundsPanel/MarginContainer3/CompoundExpandButton" to="MicrobeHUD" method="ResizeCompoundPanel" binds= [ "expand" ]]
-[connection signal="pressed" from="MicrobeHUD/LeftPanels/CompoundsPanel/MarginContainer4/CompoundCompressButton" to="MicrobeHUD" method="ResizeCompoundPanel" binds= [ "compress" ]]
+anims/HideLeftPanels = SubResource( 42 )
+anims/ShowLeftPanels = SubResource( 43 )
+[connection signal="pressed" from="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer/MarginContainer4/EnvironmentExpandButton" to="MicrobeHUD" method="ResizeEnvironmentPanel" binds= [ "expand" ]]
+[connection signal="pressed" from="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer/MarginContainer3/EnvironmentCompressButton" to="MicrobeHUD" method="ResizeEnvironmentPanel" binds= [ "compress" ]]
+[connection signal="pressed" from="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Header/HBoxContainer/MarginContainer3/CompoundExpandButton" to="MicrobeHUD" method="ResizeCompoundPanel" binds= [ "expand" ]]
+[connection signal="pressed" from="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Header/HBoxContainer/MarginContainer4/CompoundCompressButton" to="MicrobeHUD" method="ResizeCompoundPanel" binds= [ "compress" ]]
 [connection signal="pressed" from="MicrobeHUD/BottomBar/OpenMicrobeMenu" to="MicrobeHUD" method="OpenMicrobeStageMenuPressed"]
 [connection signal="pressed" from="MicrobeHUD/BottomBar/PauseButtonMargin/Pause" to="MicrobeHUD" method="PauseButtonPressed"]
 [connection signal="pressed" from="MicrobeHUD/BottomBar/PauseButtonMargin/Resume" to="MicrobeHUD" method="PauseButtonPressed"]

--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=115 format=2]
+[gd_scene load_steps=117 format=2]
 
 [ext_resource path="res://src/microbe_stage/MicrobeStage.cs" type="Script" id=1]
 [ext_resource path="res://src/microbe_stage/MicrobeCamera.tscn" type="PackedScene" id=2]
@@ -178,27 +178,39 @@ expand_margin_bottom = 1.0
 texture = ExtResource( 42 )
 region_rect = Rect2( 0, 0, 20, 20 )
 
-[sub_resource type="StyleBoxFlat" id=24]
+[sub_resource type="StyleBoxFlat" id=27]
 bg_color = Color( 0.568627, 0.611765, 0.615686, 1 )
+corner_radius_top_left = 15
+corner_radius_bottom_left = 15
 
 [sub_resource type="StyleBoxFlat" id=25]
 bg_color = Color( 0, 0, 0, 0.196078 )
+corner_radius_top_left = 15
+corner_radius_bottom_left = 15
 
 [sub_resource type="DynamicFont" id=26]
 size = 14
 font_data = ExtResource( 12 )
 
-[sub_resource type="StyleBoxFlat" id=27]
+[sub_resource type="StyleBoxFlat" id=44]
 bg_color = Color( 0.631373, 0.396078, 0, 1 )
+corner_radius_top_left = 15
+corner_radius_bottom_left = 15
 
 [sub_resource type="StyleBoxFlat" id=28]
 bg_color = Color( 0.380392, 0.141176, 0.8, 1 )
+corner_radius_top_left = 15
+corner_radius_bottom_left = 15
 
 [sub_resource type="StyleBoxFlat" id=29]
 bg_color = Color( 0.462745, 0.470588, 0.184314, 1 )
+corner_radius_top_left = 15
+corner_radius_bottom_left = 15
 
 [sub_resource type="StyleBoxFlat" id=30]
 bg_color = Color( 0.541176, 0.141176, 0.0745098, 1 )
+corner_radius_top_left = 15
+corner_radius_bottom_left = 15
 
 [sub_resource type="StyleBoxTexture" id=31]
 texture = ExtResource( 15 )
@@ -206,9 +218,13 @@ region_rect = Rect2( 0, 0, 250, 91 )
 
 [sub_resource type="StyleBoxFlat" id=32]
 bg_color = Color( 0.623529, 0.0745098, 0.376471, 1 )
+corner_radius_top_left = 15
+corner_radius_bottom_left = 15
 
 [sub_resource type="StyleBoxFlat" id=33]
 bg_color = Color( 0, 0, 0, 0.196078 )
+corner_radius_top_left = 15
+corner_radius_bottom_left = 15
 
 [sub_resource type="DynamicFont" id=34]
 size = 14
@@ -282,64 +298,28 @@ tracks/0/keys = {
 "values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("LeftPanels:anchor_left")
+tracks/1/path = NodePath("LeftPanels:rect_position")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
-tracks/1/enabled = false
+tracks/1/enabled = true
 tracks/1/keys = {
 "times": PoolRealArray( 0, 0.4 ),
 "transitions": PoolRealArray( 2, 1 ),
 "update": 0,
-"values": [ 0.0, -0.2 ]
+"values": [ Vector2( 10, 89 ), Vector2( -300, 89 ) ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("LeftPanels/AgentsPanel:anchor_left")
+tracks/2/path = NodePath("LeftPanels:visible")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
 tracks/2/enabled = true
 tracks/2/keys = {
 "times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 2, 1 ),
-"update": 0,
-"values": [ 0.0, -1.0 ]
-}
-tracks/3/type = "value"
-tracks/3/path = NodePath("LeftPanels/AgentsPanel:mouse_filter")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/keys = {
-"times": PoolRealArray( 0, 0.4 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
-"values": [ 0, 2 ]
-}
-tracks/4/type = "value"
-tracks/4/path = NodePath("LeftPanels/CompoundsPanel:rect_position")
-tracks/4/interp = 1
-tracks/4/loop_wrap = true
-tracks/4/imported = false
-tracks/4/enabled = true
-tracks/4/keys = {
-"times": PoolRealArray( 0.1, 0.5 ),
-"transitions": PoolRealArray( 2, 1 ),
-"update": 0,
-"values": [ Vector2( 0, 234 ), Vector2( -300, 234 ) ]
-}
-tracks/5/type = "value"
-tracks/5/path = NodePath("LeftPanels/EnvironmentPanel:rect_position")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
-"times": PoolRealArray( 0.3, 0.7 ),
-"transitions": PoolRealArray( 2, 1 ),
-"update": 0,
-"values": [ Vector2( 0, 0 ), Vector2( -300, 0 ) ]
+"values": [ true, false ]
 }
 
 [sub_resource type="Animation" id=43]
@@ -356,67 +336,32 @@ tracks/0/keys = {
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("LeftPanels:anchor_left")
+tracks/1/path = NodePath("LeftPanels:rect_position")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
-tracks/1/enabled = false
+tracks/1/enabled = true
 tracks/1/keys = {
 "times": PoolRealArray( 0, 0.4 ),
 "transitions": PoolRealArray( 0.5, 1 ),
 "update": 0,
-"values": [ -0.3, 0.0 ]
+"values": [ Vector2( -300, 89 ), Vector2( 10, 89 ) ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("LeftPanels/AgentsPanel:anchor_left")
+tracks/2/path = NodePath("LeftPanels:visible")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
 tracks/2/enabled = true
 tracks/2/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ -2.0, 0.0 ]
-}
-tracks/3/type = "value"
-tracks/3/path = NodePath("LeftPanels/AgentsPanel:mouse_filter")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 1, 1 ),
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
 "update": 1,
-"values": [ 2, 0 ]
-}
-tracks/4/type = "value"
-tracks/4/path = NodePath("LeftPanels/CompoundsPanel:rect_position")
-tracks/4/interp = 1
-tracks/4/loop_wrap = true
-tracks/4/imported = false
-tracks/4/enabled = true
-tracks/4/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( -300, 234 ), Vector2( 0, 234 ) ]
-}
-tracks/5/type = "value"
-tracks/5/path = NodePath("LeftPanels/EnvironmentPanel:rect_position")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
-"times": PoolRealArray( 0, 0.4 ),
-"transitions": PoolRealArray( 0.5, 1 ),
-"update": 0,
-"values": [ Vector2( -300, 0 ), Vector2( 0, 0 ) ]
+"values": [ true ]
 }
 
 [node name="MicrobeStage" type="Node"]
+process_priority = -1
 script = ExtResource( 1 )
 
 [node name="World" type="Node" parent="."]
@@ -428,6 +373,10 @@ pause_mode = 2
 
 [node name="CompoundClouds" type="Node" parent="World"]
 script = ExtResource( 10 )
+
+[node name="WorldLight" type="DirectionalLight" parent="World"]
+transform = Transform( -0.687551, 0.322878, -0.650403, 0.0453496, 0.913048, 0.405323, 0.724719, 0.249185, -0.642409, 0, 1.19209e-07, 0 )
+shadow_enabled = true
 
 [node name="PlayerMicrobeInput" type="Node" parent="."]
 script = ExtResource( 7 )
@@ -454,15 +403,20 @@ HelpScreenPath = NodePath("CanvasLayer/HelpScreen")
 EnvironmentPanelPath = NodePath("LeftPanels/EnvironmentPanel")
 EnvironmentPanelBarContainerPath = NodePath("LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer")
 CompoundsPanelPath = NodePath("LeftPanels/CompoundsPanel")
-GlucoseBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Glucose/Bar")
-AmmoniaBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Ammonia/Bar")
-PhosphateBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Phosphate/Bar")
-HydrogenSulfideBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/HydrogenSulfide/Bar")
-IronBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Iron/Bar")
+GlucoseBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/glucose")
+AmmoniaBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/ammonia")
+PhosphateBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/phosphates")
+HydrogenSulfideBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/hydrogensulfide")
+IronBarPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/iron")
 CompoundsPanelBarContainerPath = NodePath("LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer")
 AgentsPanelPath = NodePath("LeftPanels/AgentsPanel")
-OxytoxyBarPath = NodePath("LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/OxyToxy/Bar")
+OxytoxyBarPath = NodePath("LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/oxytoxy")
 AgentsPanelBarContainerPath = NodePath("LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer")
+AtpBarPath = NodePath("BottomRight/ATPBar")
+HealthBarPath = NodePath("BottomRight/HealthBar")
+AmmoniaReproductionBarPath = NodePath("BottomRight/EditorButton/ReproductionBar/AmmoniaReproductionBar")
+PhosphateReproductionBarPath = NodePath("BottomRight/EditorButton/ReproductionBar/PhosphateReproductionBar")
+HelpScreenPath = NodePath("CanvasLayer/HelpScreen")
 ExtinctionBoxScene = ExtResource( 70 )
 WinBoxScene = ExtResource( 8 )
 MicrobePickupOrganelleSound = ExtResource( 6 )
@@ -651,9 +605,7 @@ size_flags_vertical = 0
 texture = ExtResource( 51 )
 expand = true
 
-[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Oxygen" groups=[
-"MicrobeHUDBar",
-]]
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Oxygen"]
 show_behind_parent = true
 margin_left = 15.0
 margin_right = 177.0
@@ -712,9 +664,7 @@ size_flags_vertical = 0
 texture = ExtResource( 55 )
 expand = true
 
-[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/CarbonDioxide" groups=[
-"MicrobeHUDBar",
-]]
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/CarbonDioxide"]
 show_behind_parent = true
 margin_left = 15.0
 margin_right = 177.0
@@ -773,9 +723,7 @@ size_flags_vertical = 0
 texture = ExtResource( 56 )
 expand = true
 
-[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Nitrogen" groups=[
-"MicrobeHUDBar",
-]]
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Nitrogen"]
 show_behind_parent = true
 margin_left = 15.0
 margin_right = 177.0
@@ -834,9 +782,7 @@ size_flags_vertical = 0
 texture = ExtResource( 54 )
 expand = true
 
-[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Temperature" groups=[
-"MicrobeHUDBar",
-]]
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Temperature"]
 show_behind_parent = true
 margin_left = 14.0
 margin_right = 176.0
@@ -895,9 +841,7 @@ size_flags_vertical = 0
 texture = ExtResource( 53 )
 expand = true
 
-[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Sunlight" groups=[
-"MicrobeHUDBar",
-]]
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Sunlight"]
 show_behind_parent = true
 margin_left = 15.0
 margin_right = 177.0
@@ -956,9 +900,7 @@ size_flags_vertical = 0
 texture = ExtResource( 52 )
 expand = true
 
-[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Pressure" groups=[
-"MicrobeHUDBar",
-]]
+[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Pressure"]
 show_behind_parent = true
 margin_left = 15.0
 margin_right = 177.0
@@ -1020,7 +962,9 @@ __meta__ = {
 [node name="VBoxContainer" type="VBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel"]
 margin_right = 252.0
 margin_bottom = 204.0
-size_flags_vertical = 4
+rect_min_size = Vector2( 252, 0 )
+size_flags_horizontal = 0
+size_flags_vertical = 0
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -1029,7 +973,6 @@ __meta__ = {
 margin_right = 252.0
 margin_bottom = 40.0
 rect_min_size = Vector2( 230, 40 )
-custom_constants/margin_right = 0
 custom_constants/margin_left = 45
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Header"]
@@ -1102,11 +1045,11 @@ group = SubResource( 20 )
 [node name="Body" type="MarginContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer"]
 margin_top = 44.0
 margin_right = 252.0
-margin_bottom = 204.0
+margin_bottom = 209.0
 custom_constants/margin_right = 10
 custom_constants/margin_top = 5
 custom_constants/margin_left = 10
-custom_constants/margin_bottom = 10
+custom_constants/margin_bottom = 15
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -1116,41 +1059,39 @@ margin_left = 10.0
 margin_top = 5.0
 margin_right = 242.0
 margin_bottom = 150.0
+size_flags_horizontal = 0
 custom_constants/vseparation = 5
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="Glucose" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer"]
+[node name="glucose" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer" groups=[
+"CompoundBar",
+]]
+show_behind_parent = true
 margin_right = 232.0
 margin_bottom = 25.0
-custom_constants/separation = -13
+rect_min_size = Vector2( 232, 25 )
+size_flags_horizontal = 0
+custom_styles/fg = SubResource( 27 )
+custom_styles/bg = SubResource( 25 )
+step = 0.1
+percent_visible = false
 
-[node name="Icon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Glucose"]
+[node name="AmmoniaIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/glucose"]
 margin_right = 25.0
 margin_bottom = 25.0
 rect_min_size = Vector2( 25, 25 )
 texture = ExtResource( 46 )
 expand = true
-stretch_mode = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Glucose" groups=[
-"MicrobeHUDBar",
-]]
-show_behind_parent = true
-margin_left = 12.0
-margin_right = 232.0
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/glucose"]
+margin_left = 30.0
+margin_right = 91.0
 margin_bottom = 25.0
-rect_min_size = Vector2( 220, 25 )
-custom_styles/fg = SubResource( 24 )
-custom_styles/bg = SubResource( 25 )
-step = 0.1
-percent_visible = false
-
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Glucose/Bar"]
-anchor_top = 0.5
-anchor_bottom = 0.5
-margin_left = 20.0
-margin_top = -12.5
-margin_right = 86.0
-margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
 custom_fonts/font = SubResource( 26 )
 text = "Glucose"
@@ -1159,15 +1100,12 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Glucose/Bar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/glucose"]
 anchor_left = 1.0
-anchor_top = 0.5
 anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -49.0
-margin_top = -12.5
+margin_left = -44.0
 margin_right = -4.0
-margin_bottom = 12.5
+margin_bottom = 25.0
 grow_horizontal = 0
 rect_min_size = Vector2( 0, 25 )
 custom_fonts/font = SubResource( 26 )
@@ -1178,39 +1116,34 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Ammonia" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer"]
+[node name="ammonia" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer" groups=[
+"CompoundBar",
+]]
+show_behind_parent = true
 margin_top = 30.0
 margin_right = 232.0
 margin_bottom = 55.0
-custom_constants/separation = -13
+rect_min_size = Vector2( 232, 25 )
+size_flags_horizontal = 0
+custom_styles/fg = SubResource( 44 )
+custom_styles/bg = SubResource( 25 )
+step = 0.1
+percent_visible = false
 
-[node name="AmmoniaIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Ammonia"]
+[node name="AmmoniaIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/ammonia"]
 margin_right = 25.0
 margin_bottom = 25.0
 rect_min_size = Vector2( 25, 25 )
 texture = ExtResource( 48 )
 expand = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Ammonia" groups=[
-"MicrobeHUDBar",
-]]
-show_behind_parent = true
-margin_left = 12.0
-margin_right = 232.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 220, 25 )
-custom_styles/fg = SubResource( 27 )
-custom_styles/bg = SubResource( 25 )
-step = 0.1
-percent_visible = false
-
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Ammonia/Bar"]
-anchor_top = 0.5
-anchor_bottom = 0.5
-margin_left = 20.0
-margin_top = -12.5
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/ammonia"]
+margin_left = 30.0
 margin_right = 91.0
-margin_bottom = 12.5
+margin_bottom = 25.0
 rect_min_size = Vector2( 0, 25 )
 custom_fonts/font = SubResource( 26 )
 text = "Ammonia"
@@ -1219,15 +1152,12 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Ammonia/Bar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/ammonia"]
 anchor_left = 1.0
-anchor_top = 0.5
 anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -49.0
-margin_top = -12.5
+margin_left = -44.0
 margin_right = -4.0
-margin_bottom = 12.5
+margin_bottom = 25.0
 grow_horizontal = 0
 rect_min_size = Vector2( 0, 25 )
 custom_fonts/font = SubResource( 26 )
@@ -1238,39 +1168,34 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Phosphate" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer"]
+[node name="phosphates" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer" groups=[
+"CompoundBar",
+]]
+show_behind_parent = true
 margin_top = 60.0
 margin_right = 232.0
 margin_bottom = 85.0
-custom_constants/separation = -13
-
-[node name="PhospateIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Phosphate"]
-margin_right = 25.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 25, 25 )
-texture = ExtResource( 50 )
-expand = true
-
-[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Phosphate" groups=[
-"MicrobeHUDBar",
-]]
-show_behind_parent = true
-margin_left = 12.0
-margin_right = 232.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 220, 25 )
+rect_min_size = Vector2( 232, 25 )
+size_flags_horizontal = 0
 custom_styles/fg = SubResource( 28 )
 custom_styles/bg = SubResource( 25 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Phosphate/Bar"]
-anchor_top = 0.5
-anchor_bottom = 0.5
-margin_left = 20.0
-margin_top = -12.5
-margin_right = 95.0
-margin_bottom = 12.5
+[node name="PhospateIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/phosphates"]
+margin_right = 25.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 25, 25 )
+texture = ExtResource( 50 )
+expand = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/phosphates"]
+margin_left = 30.0
+margin_right = 105.0
+margin_bottom = 25.0
 rect_min_size = Vector2( 0, 25 )
 custom_fonts/font = SubResource( 26 )
 text = "Phosphate"
@@ -1279,15 +1204,12 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Phosphate/Bar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/phosphates"]
 anchor_left = 1.0
-anchor_top = 0.5
 anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -49.0
-margin_top = -12.5
-margin_right = -4.0
-margin_bottom = 12.5
+margin_left = -44.0
+margin_right = -3.99998
+margin_bottom = 25.0
 grow_horizontal = 0
 rect_min_size = Vector2( 0, 25 )
 custom_fonts/font = SubResource( 26 )
@@ -1298,39 +1220,34 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="HydrogenSulfide" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer"]
+[node name="hydrogensulfide" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer" groups=[
+"CompoundBar",
+]]
+show_behind_parent = true
 margin_top = 90.0
 margin_right = 232.0
 margin_bottom = 115.0
-custom_constants/separation = -13
-
-[node name="HydrogenSulfideIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/HydrogenSulfide"]
-margin_right = 25.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 25, 25 )
-texture = ExtResource( 47 )
-expand = true
-
-[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/HydrogenSulfide" groups=[
-"MicrobeHUDBar",
-]]
-show_behind_parent = true
-margin_left = 12.0
-margin_right = 232.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 220, 25 )
+rect_min_size = Vector2( 232, 25 )
+size_flags_horizontal = 0
 custom_styles/fg = SubResource( 29 )
 custom_styles/bg = SubResource( 25 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/HydrogenSulfide/Bar"]
-anchor_top = 0.5
-anchor_bottom = 0.5
-margin_left = 20.0
-margin_top = -12.5
-margin_right = 157.0
-margin_bottom = 12.5
+[node name="HydrogenSulfideIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/hydrogensulfide"]
+margin_right = 25.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 25, 25 )
+texture = ExtResource( 47 )
+expand = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/hydrogensulfide"]
+margin_left = 30.0
+margin_right = 151.0
+margin_bottom = 25.0
 rect_min_size = Vector2( 0, 25 )
 custom_fonts/font = SubResource( 26 )
 text = "Hydrogen Sulfide"
@@ -1339,15 +1256,12 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/HydrogenSulfide/Bar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/hydrogensulfide"]
 anchor_left = 1.0
-anchor_top = 0.5
 anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -49.0
-margin_top = -12.5
-margin_right = -4.0
-margin_bottom = 12.5
+margin_left = -44.0
+margin_right = -3.99998
+margin_bottom = 25.0
 grow_horizontal = 0
 rect_min_size = Vector2( 0, 25 )
 custom_fonts/font = SubResource( 26 )
@@ -1358,39 +1272,34 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Iron" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer"]
+[node name="iron" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer" groups=[
+"CompoundBar",
+]]
+show_behind_parent = true
 margin_top = 120.0
 margin_right = 232.0
 margin_bottom = 145.0
-custom_constants/separation = -13
-
-[node name="IronIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Iron"]
-margin_right = 25.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 25, 25 )
-texture = ExtResource( 49 )
-expand = true
-
-[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Iron" groups=[
-"MicrobeHUDBar",
-]]
-show_behind_parent = true
-margin_left = 12.0
-margin_right = 232.0
-margin_bottom = 25.0
-rect_min_size = Vector2( 220, 25 )
+rect_min_size = Vector2( 232, 25 )
+size_flags_horizontal = 0
 custom_styles/fg = SubResource( 30 )
 custom_styles/bg = SubResource( 25 )
 step = 0.1
 percent_visible = false
 
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Iron/Bar"]
-anchor_top = 0.5
-anchor_bottom = 0.5
-margin_left = 20.0
-margin_top = -12.5
-margin_right = 51.0
-margin_bottom = 12.5
+[node name="IronIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/iron"]
+margin_right = 25.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 25, 25 )
+texture = ExtResource( 49 )
+expand = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/iron"]
+margin_left = 30.0
+margin_right = 57.0
+margin_bottom = 25.0
 rect_min_size = Vector2( 0, 25 )
 custom_fonts/font = SubResource( 26 )
 text = "Iron"
@@ -1399,15 +1308,12 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/Iron/Bar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/CompoundsPanel/VBoxContainer/Body/BarContainer/iron"]
 anchor_left = 1.0
-anchor_top = 0.5
 anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -49.0
-margin_top = -12.5
-margin_right = -4.0
-margin_bottom = 12.5
+margin_left = -44.0
+margin_right = -3.99998
+margin_bottom = 25.0
 grow_horizontal = 0
 rect_min_size = Vector2( 0, 25 )
 custom_fonts/font = SubResource( 26 )
@@ -1423,6 +1329,7 @@ margin_top = 483.0
 margin_right = 253.0
 margin_bottom = 572.0
 rect_min_size = Vector2( 253, 89 )
+mouse_filter = 2
 
 [node name="Expand" type="PanelContainer" parent="MicrobeHUD/LeftPanels/AgentsPanel"]
 margin_right = 253.0
@@ -1471,12 +1378,19 @@ margin_top = 5.0
 margin_right = 243.0
 margin_bottom = 45.0
 
-[node name="OxyToxy" type="HBoxContainer" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer"]
+[node name="oxytoxy" type="ProgressBar" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer" groups=[
+"CompoundBar",
+]]
 margin_right = 232.0
 margin_bottom = 25.0
-custom_constants/separation = -13
+rect_min_size = Vector2( 232, 25 )
+size_flags_horizontal = 0
+custom_styles/fg = SubResource( 32 )
+custom_styles/bg = SubResource( 33 )
+step = 0.1
+percent_visible = false
 
-[node name="OxyToxyIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/OxyToxy"]
+[node name="OxyToxyIcon" type="TextureRect" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/oxytoxy"]
 margin_right = 25.0
 margin_bottom = 25.0
 rect_min_size = Vector2( 25, 25 )
@@ -1484,26 +1398,14 @@ size_flags_horizontal = 0
 size_flags_vertical = 0
 texture = ExtResource( 57 )
 expand = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="Bar" type="ProgressBar" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/OxyToxy" groups=[
-"MicrobeHUDBar",
-]]
-margin_left = 12.0
-margin_right = 232.0
+[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/oxytoxy"]
+margin_left = 30.0
+margin_right = 109.0
 margin_bottom = 25.0
-rect_min_size = Vector2( 220, 25 )
-custom_styles/fg = SubResource( 32 )
-custom_styles/bg = SubResource( 33 )
-step = 0.1
-percent_visible = false
-
-[node name="Label" type="Label" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/OxyToxy/Bar"]
-anchor_top = 0.5
-anchor_bottom = 0.5
-margin_left = 20.0
-margin_top = -12.5
-margin_right = 111.0
-margin_bottom = 12.5
 rect_min_size = Vector2( 0, 25 )
 custom_fonts/font = SubResource( 34 )
 text = "OxyToxy NT"
@@ -1512,15 +1414,12 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/OxyToxy/Bar"]
+[node name="Value" type="Label" parent="MicrobeHUD/LeftPanels/AgentsPanel/Expand/VBoxContainer/MarginContainer2/BarContainer/oxytoxy"]
 anchor_left = 1.0
-anchor_top = 0.5
 anchor_right = 1.0
-anchor_bottom = 0.5
-margin_left = -50.0
-margin_top = -12.5
-margin_right = -5.0
-margin_bottom = 12.5
+margin_left = -45.0
+margin_right = -4.99998
+margin_bottom = 25.0
 grow_horizontal = 0
 rect_min_size = Vector2( 0, 25 )
 custom_fonts/font = SubResource( 34 )

--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -178,7 +178,7 @@ expand_margin_bottom = 1.0
 texture = ExtResource( 42 )
 region_rect = Rect2( 0, 0, 20, 20 )
 
-[sub_resource type="StyleBoxFlat" id=27]
+[sub_resource type="StyleBoxFlat" id=24]
 bg_color = Color( 0.568627, 0.611765, 0.615686, 1 )
 corner_radius_top_left = 15
 corner_radius_bottom_left = 15
@@ -192,7 +192,7 @@ corner_radius_bottom_left = 15
 size = 14
 font_data = ExtResource( 12 )
 
-[sub_resource type="StyleBoxFlat" id=44]
+[sub_resource type="StyleBoxFlat" id=27]
 bg_color = Color( 0.631373, 0.396078, 0, 1 )
 corner_radius_top_left = 15
 corner_radius_bottom_left = 15
@@ -416,7 +416,6 @@ AtpBarPath = NodePath("BottomRight/ATPBar")
 HealthBarPath = NodePath("BottomRight/HealthBar")
 AmmoniaReproductionBarPath = NodePath("BottomRight/EditorButton/ReproductionBar/AmmoniaReproductionBar")
 PhosphateReproductionBarPath = NodePath("BottomRight/EditorButton/ReproductionBar/PhosphateReproductionBar")
-HelpScreenPath = NodePath("CanvasLayer/HelpScreen")
 ExtinctionBoxScene = ExtResource( 70 )
 WinBoxScene = ExtResource( 8 )
 MicrobePickupOrganelleSound = ExtResource( 6 )
@@ -1073,7 +1072,7 @@ margin_right = 232.0
 margin_bottom = 25.0
 rect_min_size = Vector2( 232, 25 )
 size_flags_horizontal = 0
-custom_styles/fg = SubResource( 27 )
+custom_styles/fg = SubResource( 24 )
 custom_styles/bg = SubResource( 25 )
 step = 0.1
 percent_visible = false
@@ -1125,7 +1124,7 @@ margin_right = 232.0
 margin_bottom = 55.0
 rect_min_size = Vector2( 232, 25 )
 size_flags_horizontal = 0
-custom_styles/fg = SubResource( 44 )
+custom_styles/fg = SubResource( 27 )
 custom_styles/bg = SubResource( 25 )
 step = 0.1
 percent_visible = false


### PR DESCRIPTION
Removes compounds from the GUI that aren't useful. 2 things should be done before this is merged. 1) Make the panel resize dynamically to not have a huge gap when there are less compounds. 2) Make this work for the compressed panel mode. The way the nodes are structured in the compressed panel mode makes the logic a lot more difficult. I don't feel like fixing those two things right now. If no one picks this up after a while, I'll probably have to push myself to finish it.