### PR TITLE
Fixed the hover panel in place

### DIFF
--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -293,6 +293,11 @@ public class MicrobeHUD : Node
         if (mouseHoverPanel.RectSize != new Vector2(270, 130))
             mouseHoverPanel.RectSize = new Vector2(270, 130);
 
+        if (mouseHoverPanel.MarginLeft != -280)
+            mouseHoverPanel.MarginLeft = -280;
+        if (mouseHoverPanel.MarginRight != -10)
+            mouseHoverPanel.MarginRight = -10;
+
         var compounds = stage.Clouds.GetAllAvailableAt(stage.Camera.CursorWorldPos);
 
         var builder = new StringBuilder(string.Empty, 250);


### PR DESCRIPTION
The problem I found was that if a cell species name was too long, it would stretch the box and start moving it left. The more the box had to stretch, the faster it would go. I set the margins in place so it wouldn't slide anymore. If a name is too long, the panel still expands, but it doesn't move. 

Closes #1165 