### PR TITLE
Reimplemented biome light parameters

### DIFF
--- a/assets/models/EditorHexMaterial.material
+++ b/assets/models/EditorHexMaterial.material
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:58a61becbe6a358b5ffadcaf3dd044f238fb218dd75cd7e5afa2b7db80ad1ada
-size 1626
+oid sha256:a958b411b57cdd141ef722c72ec22da38fcbe40c311e5e32bd719dba1c5810c2
+size 742

--- a/scripts/simulation_parameters/microbe_stage/biomes.json
+++ b/scripts/simulation_parameters/microbe_stage/biomes.json
@@ -3,25 +3,21 @@
         "name": "Epipelagic",
         "background": "ocean",
         "icon": "res://assets/textures/gui/bevel/epipelagic.png",
-        "skybox": "Thrive_ocean_skybox",
-        "skyboxLightIntensity": 0.5,
         "sunlight": {
-            "color": {
+            "colour": {
                 "r": 1,
                 "g": 1,
-                "b": 1
+                "b": 1,
+                "a": 1
             },
-            "intensity": 0.0001,
+            "energy": 1,
+            "specular": 0.5,
+            "shadows": true,
             "direction": {
-                "x": 0.55,
+                "x": 0.25,
                 "y": -0.3,
                 "z": 0.75
-            },
-            "sourceRadius": 0.5
-        },
-        "eyeAdaptation": {
-            "min": 0.003,
-            "max": 2
+            }
         },
         "chunks": {
             "floatingToxin": {
@@ -144,26 +140,7 @@
         "name": "Volcanic vent",
         "background": "vent",
         "icon": "res://assets/textures/gui/bevel/vents.png",
-        "skybox": "Thrive_vent_skybox",
-        "skyboxLightIntensity": 0.5,
-        "sunlight": {
-            "color": {
-                "r": 1,
-                "g": 1,
-                "b": 1
-            },
-            "intensity": 0.0001,
-            "direction": {
-                "x": 0.55,
-                "y": -0.3,
-                "z": 0.75
-            },
-            "sourceRadius": 0.5
-        },
-        "eyeAdaptation": {
-            "min": 0.003,
-            "max": 0.8
-        },
+        "sunlight": {},
         "chunks": {
             "floatingToxin": {
                 "name": "Floating Hazard",
@@ -355,22 +332,7 @@
         "name": "Tidepool",
         "background": "tidepool",
         "icon": "res://assets/textures/gui/bevel/tidepool.png",
-        "skybox": "Thrive_tidepool_skybox",
-        "skyboxLightIntensity": 0.5,
-        "sunlight": {
-            "color": {
-                "r": 1,
-                "g": 1,
-                "b": 1
-            },
-            "intensity": 0.0001,
-            "direction": {
-                "x": 0.55,
-                "y": -0.3,
-                "z": 0.75
-            },
-            "sourceRadius": 0.5
-        },
+        "sunlight": {},
         "eyeAdaptation": {
             "min": 0.003,
             "max": 2
@@ -496,22 +458,7 @@
         "name": "Bathypalagic",
         "background": "bathypalagic",
         "icon": "res://assets/textures/gui/bevel/bathy.png",
-        "skybox": "Thrive_bathy_skybox",
-        "skyboxLightIntensity": 0.5,
-        "sunlight": {
-            "color": {
-                "r": 1,
-                "g": 1,
-                "b": 1
-            },
-            "intensity": 0.0001,
-            "direction": {
-                "x": 0.55,
-                "y": -0.3,
-                "z": 0.75
-            },
-            "sourceRadius": 0.5
-        },
+        "sunlight": {},
         "eyeAdaptation": {
             "min": 0.003,
             "max": 1.5
@@ -707,26 +654,7 @@
         "name": "Abyssopelagic",
         "background": "abyssopelagic",
         "icon": "res://assets/textures/gui/bevel/abyss.png",
-        "skybox": "Thrive_abyss_skybox",
-        "skyboxLightIntensity": 0.5,
-        "sunlight": {
-            "color": {
-                "r": 1,
-                "g": 1,
-                "b": 1
-            },
-            "intensity": 0.0001,
-            "direction": {
-                "x": 0.55,
-                "y": -0.3,
-                "z": 0.75
-            },
-            "sourceRadius": 0.5
-        },
-        "eyeAdaptation": {
-            "min": 0.003,
-            "max": 0.8
-        },
+        "sunlight": {},
         "chunks": {
             "floatingToxin": {
                 "name": "Floating Hazard",
@@ -918,22 +846,7 @@
         "name": "Mesopelagic",
         "background": "mesopelagic",
         "icon": "res://assets/textures/gui/bevel/mesopelagic.png",
-        "skybox": "Thrive_meso_skybox",
-        "skyboxLightIntensity": 0.5,
-        "sunlight": {
-            "color": {
-                "r": 1,
-                "g": 1,
-                "b": 1
-            },
-            "intensity": 0.0001,
-            "direction": {
-                "x": 0.55,
-                "y": -0.3,
-                "z": 0.75
-            },
-            "sourceRadius": 0.5
-        },
+        "sunlight": {},
         "eyeAdaptation": {
             "min": 0.003,
             "max": 1.7
@@ -1129,22 +1042,7 @@
         "name": "Coastal",
         "background": "coastal",
         "icon": "res://assets/textures/gui/bevel/shallow.png",
-        "skybox": "Thrive_shallow_skybox",
-        "skyboxLightIntensity": 0.5,
-        "sunlight": {
-            "color": {
-                "r": 1,
-                "g": 1,
-                "b": 1
-            },
-            "intensity": 0.0001,
-            "direction": {
-                "x": 0.55,
-                "y": -0.3,
-                "z": 0.75
-            },
-            "sourceRadius": 0.5
-        },
+        "sunlight": {},
         "eyeAdaptation": {
             "min": 0.003,
             "max": 2
@@ -1270,26 +1168,7 @@
         "name": "UnderwaterCave",
         "background": "cave",
         "icon": "res://assets/textures/gui/bevel/cave.png",
-        "skybox": "Thrive_cave_skybox",
-        "skyboxLightIntensity": 0.5,
-        "sunlight": {
-            "color": {
-                "r": 1,
-                "g": 1,
-                "b": 1
-            },
-            "intensity": 0.0001,
-            "direction": {
-                "x": 0.55,
-                "y": -0.3,
-                "z": 0.75
-            },
-            "sourceRadius": 0.5
-        },
-        "eyeAdaptation": {
-            "min": 0.003,
-            "max": 0.8
-        },
+        "sunlight": {},
         "chunks": {
             "floatingToxin": {
                 "name": "Floating Hazard",
@@ -1411,22 +1290,7 @@
         "name": "IceShelf",
         "background": "iceshelf",
         "icon": "res://assets/textures/gui/bevel/iceshelf.png",
-        "skybox": "Thrive_iceshelf_skybox",
-        "skyboxLightIntensity": 0.5,
-        "sunlight": {
-            "color": {
-                "r": 1,
-                "g": 1,
-                "b": 1
-            },
-            "intensity": 0.0001,
-            "direction": {
-                "x": 0.55,
-                "y": -0.3,
-                "z": 0.75
-            },
-            "sourceRadius": 0.5
-        },
+        "sunlight": {},
         "eyeAdaptation": {
             "min": 0.003,
             "max": 2
@@ -1570,22 +1434,7 @@
         "name": "Estuary",
         "background": "estuary",
         "icon": "res://assets/textures/gui/bevel/estuary.png",
-        "skybox": "Thrive_estuary_skybox",
-        "skyboxLightIntensity": 0.5,
-        "sunlight": {
-            "color": {
-                "r": 1,
-                "g": 1,
-                "b": 1
-            },
-            "intensity": 0.0001,
-            "direction": {
-                "x": 0.55,
-                "y": -0.3,
-                "z": 0.75
-            },
-            "sourceRadius": 0.5
-        },
+        "sunlight": {},
         "eyeAdaptation": {
             "min": 0.003,
             "max": 2
@@ -1711,22 +1560,7 @@
         "name": "Sea Floor",
         "background": "seafloor",
         "icon": "res://assets/textures/gui/bevel/bathyFloor.png",
-        "skybox": "Thrive_seafloor_skybox",
-        "skyboxLightIntensity": 0.5,
-        "sunlight": {
-            "color": {
-                "r": 1,
-                "g": 1,
-                "b": 1
-            },
-            "intensity": 0.0001,
-            "direction": {
-                "x": 0.55,
-                "y": -0.3,
-                "z": 0.75
-            },
-            "sourceRadius": 0.5
-        },
+        "sunlight": {},
         "eyeAdaptation": {
             "min": 0.003,
             "max": 1

--- a/src/microbe_stage/Biome.cs
+++ b/src/microbe_stage/Biome.cs
@@ -24,6 +24,11 @@ public class Biome : IRegistryType, ICloneable
     /// </summary>
     public string Icon;
 
+    /// <summary>
+    ///   The light to use for this biome
+    /// </summary>
+    public LightDetails Sunlight;
+
     [JsonIgnore]
     public Texture LoadedIcon;
 
@@ -60,6 +65,12 @@ public class Biome : IRegistryType, ICloneable
             throw new InvalidRegistryData(name, this.GetType().Name,
                 "icon missing");
         }
+
+        if (Sunlight == null)
+        {
+            throw new InvalidRegistryData(name, this.GetType().Name,
+                "sunlight missing");
+        }
     }
 
     /// <summary>
@@ -91,6 +102,9 @@ public class Biome : IRegistryType, ICloneable
             Chunks = new Dictionary<string, ChunkConfiguration>(Chunks.Count),
             Icon = Icon,
             LoadedIcon = LoadedIcon,
+
+            // Clone this as well if needed (if the light properties can change)
+            Sunlight = Sunlight,
         };
 
         foreach (var entry in Compounds)
@@ -159,5 +173,34 @@ public class Biome : IRegistryType, ICloneable
             [JsonIgnore]
             public PackedScene LoadedScene;
         }
+    }
+
+    public class LightDetails
+    {
+        /// <summary>
+        ///   Colour of the light
+        /// </summary>
+        public Color Colour = new Color(1, 1, 1, 1);
+
+        /// <summary>
+        ///   Strength of the light
+        /// </summary>
+        public float Energy = 1.0f;
+
+        /// <summary>
+        ///   How much specular there is
+        /// </summary>
+        public float Specular = 0.5f;
+
+        /// <summary>
+        ///   Shadow casting enabled / disabled
+        /// </summary>
+        public bool Shadows = true;
+
+        /// <summary>
+        ///   The direction the light is pointing at. This is done by placing the light and making it look at a relative
+        ///   position with these coordinates.
+        /// </summary>
+        public Vector3 Direction = new Vector3(0.25f, -0.3f, 0.75f);
     }
 }

--- a/src/microbe_stage/Membrane.cs
+++ b/src/microbe_stage/Membrane.cs
@@ -380,6 +380,12 @@ public class Membrane : MeshInstance
     /// </summary>
     private void InitializeMesh()
     {
+        // For preview scenes, add just one organelle
+        if (OrganellePositions == null)
+        {
+            OrganellePositions = new List<Vector2>() { new Vector2(0, 0) };
+        }
+
         foreach (var pos in OrganellePositions)
         {
             if (Mathf.Abs(pos.x) + 1 > cellDimensions)

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -12,6 +12,8 @@ public class MicrobeStage : Node
     private MicrobeAISystem microbeAISystem;
     private PatchManager patchManager;
 
+    private DirectionalLight worldLight;
+
     /// <summary>
     ///   Used to differentiate between spawning the player and respawning
     /// </summary>
@@ -66,6 +68,7 @@ public class MicrobeStage : Node
         spawner = new SpawnSystem(rootOfDynamicallySpawned);
         Camera = world.GetNode<MicrobeCamera>("PrimaryCamera");
         Clouds = world.GetNode<CompoundCloudSystem>("CompoundClouds");
+        worldLight = world.GetNode<DirectionalLight>("WorldLight");
         TimedLifeSystem = new TimedLifeSystem(rootOfDynamicallySpawned);
         ProcessSystem = new ProcessSystem(rootOfDynamicallySpawned);
         microbeAISystem = new MicrobeAISystem(rootOfDynamicallySpawned);
@@ -281,7 +284,7 @@ public class MicrobeStage : Node
         if (patchManager != null)
             return;
         patchManager = new PatchManager(spawner, ProcessSystem, Clouds, TimedLifeSystem,
-            CurrentGame);
+            worldLight, CurrentGame);
     }
 
     /// <summary>

--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -875,6 +875,10 @@ pause_mode = 2
 [node name="CompoundClouds" type="Node" parent="World"]
 script = ExtResource( 10 )
 
+[node name="WorldLight" type="DirectionalLight" parent="World"]
+transform = Transform( -0.687551, 0.322878, -0.650403, 0.0453496, 0.913048, 0.405323, 0.724719, 0.249185, -0.642409, 0, 1.19209e-07, 0 )
+shadow_enabled = true
+
 [node name="PlayerMicrobeInput" type="Node" parent="."]
 script = ExtResource( 7 )
 

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -12,6 +12,7 @@ public class PatchManager
     private ProcessSystem processSystem;
     private CompoundCloudSystem compoundCloudSystem;
     private TimedLifeSystem timedLife;
+    private DirectionalLight worldLight;
     private GameProperties currentGame;
 
     private Patch previousPatch;
@@ -22,12 +23,14 @@ public class PatchManager
     private List<CreatedSpawner> microbeSpawners = new List<CreatedSpawner>();
 
     public PatchManager(SpawnSystem spawnSystem, ProcessSystem processSystem,
-        CompoundCloudSystem compoundCloudSystem, TimedLifeSystem timedLife, GameProperties currentGame)
+        CompoundCloudSystem compoundCloudSystem, TimedLifeSystem timedLife, DirectionalLight worldLight,
+        GameProperties currentGame)
     {
         this.spawnSystem = spawnSystem;
         this.processSystem = processSystem;
         this.compoundCloudSystem = compoundCloudSystem;
         this.timedLife = timedLife;
+        this.worldLight = worldLight;
         this.currentGame = currentGame;
     }
 
@@ -71,11 +74,7 @@ public class PatchManager
         // Change the lighting
         UpdateLight(currentPatch.Biome);
 
-        // // Changing the background.
-        // ThriveGame::get()->setBackgroundMaterial(biome.background);
-
         // updateBiomeStatsForGUI(biome);
-        // updateCurrentPatchInfoForGUI(*patch);
     }
 
     private void HandleChunkSpawns(Biome biome)
@@ -178,18 +177,20 @@ public class PatchManager
 
     private void UpdateLight(Biome biome)
     {
-        // // Sunlight
-        // InWorld.SetLightProperties(biome.sunlightColor, biome.sunlightIntensity,
-        //     biome.sunlightDirection, biome.sunlightSourceRadius);
+        if (biome.Sunlight == null)
+        {
+            GD.PrintErr("biome has no sunlight parameters");
+            return;
+        }
 
-        // // Skybox with indirect light
-        // ThriveGame::get()->setSkybox(biome.skybox, biome.skyboxLightIntensity);
+        worldLight.Translation = new Vector3(0, 0, 0);
+        worldLight.LookAt(biome.Sunlight.Direction, new Vector3(0, 1, 0));
 
-        // // Eye adaptation settings
-        // LOG_INFO("Setting eye adaptation: min: " +
-        //          std::to_string(biome.minEyeAdaptation) +
-        //          " max: " + std::to_string(biome.maxEyeAdaptation));
-        // InWorld.SetAutoExposure(biome.minEyeAdaptation, biome.maxEyeAdaptation);
+        worldLight.ShadowEnabled = biome.Sunlight.Shadows;
+
+        worldLight.LightColor = biome.Sunlight.Colour;
+        worldLight.LightEnergy = biome.Sunlight.Energy;
+        worldLight.LightSpecular = biome.Sunlight.Specular;
     }
 
     private void UpdateBiomeStatsForGUI(Biome biome)
@@ -209,12 +210,6 @@ public class PatchManager
         // vars->Add(std::make_shared<NamedVariableList>("sunlightPercent",
         //     new Leviathan::IntBlock(
         //         cellWorld.GetProcessSystem().getDissolved(lightId) * 100)));
-    }
-
-    private void UpdateCurrentPatchInfoForGUI(Patch patch)
-    {
-        // vars->Add(std::make_shared<NamedVariableList>(
-        //     "patchName", new Leviathan::StringBlock(patch.getName())));
     }
 
     private void UnmarkAllSpawners()

--- a/src/microbe_stage/editor/InvalidHex.material
+++ b/src/microbe_stage/editor/InvalidHex.material
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c80de21a4e71d5928efacd9752c1ba9d5b6af069bc1040d0e4b30581aa050783
-size 825
+oid sha256:fe4f3a89969ccbf7a073998b2a0b80fe6d214e0cccec8dd9444ea8cd25cb1ed0
+size 839

--- a/src/microbe_stage/editor/ValidHex.material
+++ b/src/microbe_stage/editor/ValidHex.material
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01842892451ac271affc8cf45a270576fae295359ef46ea73c43cd7923a8cd7b
-size 820
+oid sha256:770c91ca23300eb974a99c8f4430838665c8957f3057d5ce66f0f521a94b94c8
+size 834

--- a/test/OrganelleLightTest.tscn
+++ b/test/OrganelleLightTest.tscn
@@ -1,0 +1,67 @@
+[gd_scene load_steps=13 format=2]
+
+[ext_resource path="res://shaders/Organelle.shader" type="Shader" id=1]
+[ext_resource path="res://assets/models/organelles/Mitochondrion.tscn" type="PackedScene" id=2]
+[ext_resource path="res://assets/textures/mitochondrion.png" type="Texture" id=3]
+[ext_resource path="res://assets/models/organelles/Chemoplast.tscn" type="PackedScene" id=4]
+[ext_resource path="res://assets/textures/chemoplast.png" type="Texture" id=5]
+[ext_resource path="res://assets/textures/FresnelGradientDamaged.png" type="Texture" id=6]
+[ext_resource path="res://assets/textures/FresnelGradient.png" type="Texture" id=7]
+[ext_resource path="res://src/microbe_stage/Membrane.tscn" type="PackedScene" id=8]
+[ext_resource path="res://shaders/Membrane.shader" type="Shader" id=9]
+
+[sub_resource type="ShaderMaterial" id=1]
+resource_local_to_scene = true
+shader = ExtResource( 1 )
+shader_param/tint = Color( 1, 1, 1, 1 )
+shader_param/texture = ExtResource( 3 )
+
+[sub_resource type="ShaderMaterial" id=2]
+resource_local_to_scene = true
+shader = ExtResource( 1 )
+shader_param/tint = Color( 1, 1, 1, 1 )
+shader_param/texture = ExtResource( 5 )
+
+[sub_resource type="ShaderMaterial" id=3]
+resource_local_to_scene = true
+render_priority = 1
+shader = ExtResource( 9 )
+shader_param/wigglyNess = 1.0
+shader_param/movementWigglyNess = 1.0
+shader_param/healthFraction = 0.25
+shader_param/tint = Plane( 1, 1, 1, 1 )
+shader_param/albedoTexture = ExtResource( 7 )
+shader_param/damagedTexture = ExtResource( 6 )
+
+[node name="Spatial" type="Spatial"]
+
+[node name="Mitochondrion" parent="." instance=ExtResource( 2 )]
+material_override = SubResource( 1 )
+
+[node name="DirectionalLight" type="DirectionalLight" parent="."]
+transform = Transform( 0.866025, 0.25, -0.433013, 0, 0.866025, 0.5, 0.5, -0.433013, 0.75, -3, 2, 3 )
+shadow_enabled = true
+
+[node name="Chemoplast" parent="." instance=ExtResource( 4 )]
+transform = Transform( -28.3865, 95.8864, 1.56219e-05, 0, -1.62921e-05, 100, 95.8864, 28.3865, 4.62475e-06, -2.37408, 0, 0 )
+material_override = SubResource( 2 )
+
+[node name="CSGBox" type="CSGBox" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2.19501, -1.17122 )
+width = 33.445
+depth = 38.246
+
+[node name="CSGBox2" type="CSGBox" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -5.66004, -0.174119, 0 )
+width = 2.45813
+
+[node name="CSGBox3" type="CSGBox" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0240011, 1.7432, 3.09903 )
+width = 2.45813
+
+[node name="Camera" type="Camera" parent="."]
+transform = Transform( 0.952724, 0.219617, -0.209965, -0.0332861, 0.762328, 0.646334, 0.302008, -0.608789, 0.733599, -3.19108, 3.1727, 3.8879 )
+
+[node name="Membrane" parent="." instance=ExtResource( 8 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.00755703, 0, -1.75788 )
+MaterialToEdit = SubResource( 3 )


### PR DESCRIPTION
also fixed the editor hexes displaying in front of the organelles. This causes an issue where the organelles themselves flicker, but that is the same as in the stage: https://github.com/Revolutionary-Games/Thrive/issues/1077

fixes #1080
fixes #1152
fixes #1083