### PR TITLE
Made membrane regeneration code more robust

### DIFF
--- a/src/microbe_stage/Membrane.tscn
+++ b/src/microbe_stage/Membrane.tscn
@@ -20,6 +20,7 @@ shader_param/albedoTexture = ExtResource( 3 )
 shader_param/damagedTexture = ExtResource( 4 )
 
 [node name="Membrane" type="MeshInstance"]
+process_priority = 2
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.00755703, 0, 0.034008 )
 mesh = SubResource( 1 )
 material/0 = null

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -52,6 +52,8 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
     private bool cachedHexCountDirty = true;
     private int cachedHexCount;
 
+    private bool membraneOrganellePositionsAreDirty = true;
+
     private Vector3 queuedMovementForce;
 
     // variables for engulfing
@@ -377,8 +379,6 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
 
             organelles.Add(placed);
         }
-
-        SendOrganellePositionsToMembrane();
 
         // Reproduction progress is lost
         allOrganellesDivided = false;
@@ -889,6 +889,12 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
 
     public override void _Process(float delta)
     {
+        if (membraneOrganellePositionsAreDirty)
+        {
+            // Redo the cell membrane.
+            SendOrganellePositionsToMembrane();
+        }
+
         CheckEngulfShapeSize();
         HandleCompoundAbsorbing(delta);
 
@@ -1169,14 +1175,6 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
             organelle2.WasSplit = true;
             organelle2.IsDuplicate = true;
             organelle2.SisterOrganelle = organelle;
-        }
-
-        if (organellesToAdd.Count > 0)
-        {
-            // Redo the cell membrane.
-            SendOrganellePositionsToMembrane();
-
-            // Process list is varmatically marked dirty when the split organelle is added
         }
 
         if (reproductionStageComplete)
@@ -1549,6 +1547,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
         organelle.OnAddedToMicrobe(this);
         processesDirty = true;
         cachedHexCountDirty = true;
+        membraneOrganellePositionsAreDirty = true;
 
         if (organelle.IsAgentVacuole)
             AgentVacuoleCount += 1;
@@ -1571,6 +1570,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
 
         processesDirty = true;
         cachedHexCountDirty = true;
+        membraneOrganellePositionsAreDirty = true;
 
         Compounds.Capacity = organellesCapacity;
     }
@@ -1619,6 +1619,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
 
         Membrane.OrganellePositions = organellePositions;
         Membrane.Dirty = true;
+        membraneOrganellePositionsAreDirty = false;
     }
 
     /// <summary>


### PR DESCRIPTION
now it should not be possible for a microbe's organelles to change
without the membrane being regenerated

closes #1219
but doesn't fix the problem of organelles being outside the membrane (#1215)