### PR TITLE
Set Rigidity before adding organelles so editor displays speed correc…

### DIFF
--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -824,6 +824,7 @@ public class MicrobeEditor : Node
         // bar can take it into account (the bar is updated when
         // organelles are added)
         Membrane = species.MembraneType;
+        Rigidity = species.MembraneRigidity;
 
         // Get the species organelles to be edited. This also updates the placeholder hexes
         foreach (var organelle in species.Organelles.Organelles)
@@ -847,7 +848,6 @@ public class MicrobeEditor : Node
         }
 
         NewName = species.FormattedName;
-        Rigidity = species.MembraneRigidity;
 
         gui.SetSpeciesInfo(NewName, Membrane, species.Colour, Rigidity);
 


### PR DESCRIPTION
…tly initially.

Turns out that issue #1230 occurred because the GUI is updated when the organelles are placed, but the membrane Rigidity is initially set _after_ that, so the first time the speed is shown it's the speed at 0 rigidity.

closes #1230