### PR TITLE
Check if organelle performs process before adding ATP production from…

### DIFF
--- a/src/microbe_stage/ProcessSystem.cs
+++ b/src/microbe_stage/ProcessSystem.cs
@@ -64,24 +64,28 @@ public class ProcessSystem
             {
                 foreach (var processData in efficiencyInfo.Value.Processes)
                 {
-                    // Find process inputs and outputs that use/produce ATP and add to
-                    // totals
-                    if (processData.OtherInputs.ContainsKey(atp.InternalName))
+                    // Find process inputs and outputs that use/produce ATP
+                    // and that are performed by that organelle
+                    // and add to totals
+                    if (organelle.Processes.ContainsKey(processData.Process.InternalName))
                     {
-                        var amount = processData.OtherInputs[atp.InternalName].Amount;
+                        if (processData.OtherInputs.ContainsKey(atp.InternalName))
+                        {
+                            var amount = processData.OtherInputs[atp.InternalName].Amount;
 
-                        processATPConsumption += amount;
+                            processATPConsumption += amount;
 
-                        result.AddConsumption(organelle.Name, amount);
-                    }
+                            result.AddConsumption(organelle.Name, amount);
+                        }
 
-                    if (processData.Outputs.ContainsKey(atp.InternalName))
-                    {
-                        var amount = processData.Outputs[atp.InternalName].Amount;
+                        if (processData.Outputs.ContainsKey(atp.InternalName))
+                        {
+                            var amount = processData.Outputs[atp.InternalName].Amount;
 
-                        processATPProduction += amount;
+                            processATPProduction += amount;
 
-                        result.AddProduction(organelle.Name, amount);
+                            result.AddProduction(organelle.Name, amount);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
… process to display in editor.

closes #1168 which occurred because, for each process in the cell, the ATP production was added for every organelle in the cell, regardless of whether that organelle was actually doing that process (giving a purported ATP production larger than what the cell produces).