### PR TITLE
Increase ice shard damage from 0.5/s to 10/s.

### DIFF
--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -1345,7 +1345,7 @@
                 "chunkScale": 1,
                 "mass": 100,
                 "size": 1000,
-                "damages": 0.5,
+                "damages": 10,
                 "deleteOnTouch": false,
                 "compounds": {}
             },

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -475,6 +475,11 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
             // Divide damage by physical resistance
             amount /= Species.MembraneType.PhysicalResistance;
         }
+        else if (source == "chunk")
+        {
+            // Divide damage by physical resistance
+            amount /= Species.MembraneType.PhysicalResistance;
+        }
 
         Hitpoints -= amount;
 


### PR DESCRIPTION
The damage for ice shards was 0.5/s when cell is in contact - this seemed more sensible (possibly intended?) as a damage per frame, so I bumped it up to 10/s.

Closes #1258