### PR TITLE
Add drag to floating chunks

### DIFF
--- a/src/microbe_stage/FloatingChunk.tscn
+++ b/src/microbe_stage/FloatingChunk.tscn
@@ -10,6 +10,8 @@ process_priority = 2
 collision_mask = 3
 contact_monitor = true
 axis_lock_linear_y = true
+linear_damp = 0.961
+angular_damp = 0.1
 script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="."]


### PR DESCRIPTION
Floating chunks currently seem to experience no drag; this is especially visible when you push on an organelle from a fallen cell and see it sailing through the water, unpowered, faster than you, and with no sign of slowing down.