### PR TITLE
Added emitter to the collision exceptions on _Ready

### DIFF
--- a/src/microbe_stage/AgentProjectile.cs
+++ b/src/microbe_stage/AgentProjectile.cs
@@ -1,4 +1,5 @@
 using Godot;
+using System;
 
 /// <summary>
 ///   This is a shot agent projectile, does damage on hitting a cell of different species
@@ -14,14 +15,12 @@ public class AgentProjectile : RigidBody, ITimedLife
 
     public override void _Ready()
     {
+        AddCollisionExceptionWith(Emitter);
         Connect("body_entered", this, "OnBodyEntered");
     }
 
     public void OnBodyEntered(Node body)
     {
-        if (body == Emitter)
-            return; // Kinda hacky.
-
         if (body is Microbe)
         {
             var microbe = (Microbe)body;

--- a/src/microbe_stage/AgentProjectile.cs
+++ b/src/microbe_stage/AgentProjectile.cs
@@ -1,5 +1,4 @@
 using Godot;
-using System;
 
 /// <summary>
 ///   This is a shot agent projectile, does damage on hitting a cell of different species


### PR DESCRIPTION
I tested this and it seems to work.
It's for issue #1101.

I don't remove the Emitter from the Collision exceptions, as it appears it is already disposed at that point. I could however add the remove inside a try/catch block on Destroy if that seems like a better idea, and just catch the Dispose exception or something. Not sure if that is needed though.

fixes #1101 