### PR TITLE
Symmetry Fix in Microbe Editor

### DIFF
--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -1108,8 +1108,11 @@ public class MicrobeEditor : Node
                 {
                     PlaceIfPossible(organelleType, -1 * q, r + q, 6 + (-1 * organelleRot));
                     PlaceIfPossible(organelleType, -1 * q, -1 * r, (organelleRot + 3) % 6);
-                    PlaceIfPossible(organelleType, q, -1 * (r + q),
-                        (8 + (-1 * organelleRot)) % 6);
+                    PlaceIfPossible(organelleType, q, -1 * (r + q), (8 + (-1 * organelleRot)) % 6);
+                }
+                else
+                {
+                    PlaceIfPossible(organelleType, -1 * q, -1 * r, (organelleRot + 3) % 6);
                 }
 
                 break;
@@ -1119,16 +1122,13 @@ public class MicrobeEditor : Node
             {
                 PlaceIfPossible(organelleType, q, r, organelleRot);
 
-                if (q != -1 * q || r != r + q)
-                {
-                    PlaceIfPossible(organelleType, -1 * r, r + q, (organelleRot + 1) % 6);
-                    PlaceIfPossible(organelleType, -1 * (r + q), q,
-                        (organelleRot + 2) % 6);
-                    PlaceIfPossible(organelleType, -1 * q, -1 * r, (organelleRot + 3) % 6);
-                    PlaceIfPossible(organelleType, r, -1 * (r + q),
-                        (organelleRot + 4) % 6);
-                    PlaceIfPossible(organelleType, r + q, -1 * q, (organelleRot + 5) % 6);
-                }
+                PlaceIfPossible(organelleType, -1 * r, r + q, (organelleRot + 1) % 6);
+                PlaceIfPossible(organelleType, -1 * (r + q), q,
+                    (organelleRot + 2) % 6);
+                PlaceIfPossible(organelleType, -1 * q, -1 * r, (organelleRot + 3) % 6);
+                PlaceIfPossible(organelleType, r, -1 * (r + q),
+                    (organelleRot + 4) % 6);
+                PlaceIfPossible(organelleType, r + q, -1 * q, (organelleRot + 5) % 6);
 
                 break;
             }

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -628,6 +628,10 @@ public class MicrobeEditor : Node
                     RemoveOrganelleAt(new Hex(-1 * q, -1 * r));
                     RemoveOrganelleAt(new Hex(q, -1 * (r + q)));
                 }
+                else
+                {
+                    RemoveOrganelleAt(new Hex(-1 * q, -1 * r));
+                }
 
                 break;
             }
@@ -636,15 +640,12 @@ public class MicrobeEditor : Node
             {
                 RemoveOrganelleAt(new Hex(q, r));
 
-                if (q != -1 * q || r != r + q)
-                {
-                    RemoveOrganelleAt(new Hex(-1 * r, r + q));
-                    RemoveOrganelleAt(new Hex(-1 * (r + q), q));
-                    RemoveOrganelleAt(new Hex(-1 * q, -1 * r));
-                    RemoveOrganelleAt(new Hex(r, -1 * (r + q)));
-                    RemoveOrganelleAt(new Hex(r, -1 * (r + q)));
-                    RemoveOrganelleAt(new Hex(r + q, -1 * q));
-                }
+                RemoveOrganelleAt(new Hex(-1 * r, r + q));
+                RemoveOrganelleAt(new Hex(-1 * (r + q), q));
+                RemoveOrganelleAt(new Hex(-1 * q, -1 * r));
+                RemoveOrganelleAt(new Hex(r, -1 * (r + q)));
+                RemoveOrganelleAt(new Hex(r, -1 * (r + q)));
+                RemoveOrganelleAt(new Hex(r + q, -1 * q));
 
                 break;
             }


### PR DESCRIPTION
There was just a little bit of off Math in the hex editor.
I fixed it for both placement and removal of hexes.

closes #1299 