### PR TITLE
Small Editor Feature

### DIFF
--- a/simulation_parameters/common/help_texts.json
+++ b/simulation_parameters/common/help_texts.json
@@ -19,7 +19,7 @@
     },
     "MicrobeEditor": {
         "LeftTexts": [
-            "Each generation, you have 100 mutation points to spend, and each change (or mutation) will cost a certain amount of that MP, removing costs mutation points aswell as adding. You can remove an organelle by right-clicking on it. You can rotate your organelles, with A and D",
+            "Each generation, you have 100 mutation points to spend, and each change (or mutation) will cost a certain amount of that MP. Adding and removing organelles cost MP, however removing organelles that were placed in the current mutation session refunds MP for that organelle. You can remove an organelle by right-clicking on it. You can rotate your organelles, with A and D",
             "External Organelles\n\nFlagella: Moves your cell faster by consuming ATP.\n\nPilus: Can be used to stab other cells.",
             "Membrane Bound Organelles\n\nNucleus: Takes up 11 hexes and allows for evolution of membrane bound organelles. And also doubles your cells size. (Can only be evolved once)\n\nMitochondrion: Produces ATP out of glucose and atmospheric 02. Much more efficiently then cytoplasm\n\nChloroplast: Makes glucose out of sunlight and atmospheric CO2.\n\nChemoplast: Makes glucose out of Hydrogen Sulfide.\n\nNitrogen Fixing Plastid: Makes ammonia from ATP and atmospheric Nitrogen and Oxygen.\n\nVacuole: Stores 15 collected compounds.\n\nToxin Vacuoles: Produces toxins (called OxyToxyNT)."
         ],

--- a/src/microbe_stage/OrganelleTemplate.cs
+++ b/src/microbe_stage/OrganelleTemplate.cs
@@ -19,6 +19,8 @@ public class OrganelleTemplate : IPositionedOrganelle, ICloneable
         Orientation = rotation;
     }
 
+    public bool PlacedThisSession {get; set; }
+
     public Hex Position { get; set; }
 
     /// <summary>

--- a/src/microbe_stage/OrganelleTemplate.cs
+++ b/src/microbe_stage/OrganelleTemplate.cs
@@ -19,7 +19,7 @@ public class OrganelleTemplate : IPositionedOrganelle, ICloneable
         Orientation = rotation;
     }
 
-    public bool PlacedThisSession {get; set; }
+    public bool PlacedThisSession { get; set; }
 
     public Hex Position { get; set; }
 

--- a/src/microbe_stage/OrganelleTemplate.cs
+++ b/src/microbe_stage/OrganelleTemplate.cs
@@ -19,6 +19,9 @@ public class OrganelleTemplate : IPositionedOrganelle, ICloneable
         Orientation = rotation;
     }
 
+    /// <summary>
+    /// Used to flag whether this Organelle was placed during the current editor session.
+    /// </summary>
     public bool PlacedThisSession { get; set; }
 
     public Hex Position { get; set; }

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -392,7 +392,9 @@ public class MicrobeEditor : Node, ILoadableGameState
 
         foreach (var organelle in editedMicrobeOrganelles.Organelles)
         {
-            editedSpecies.Organelles.Add((OrganelleTemplate)organelle.Clone());
+            var organelleToAdd = (OrganelleTemplate)organelle.Clone();
+            organelleToAdd.PlacedThisSession = false;
+            editedSpecies.Organelles.Add(organelleToAdd);
         }
 
         // Update bacteria status
@@ -1355,6 +1357,8 @@ public class MicrobeEditor : Node, ILoadableGameState
                 && organelle.Definition.ChanceToCreate != 0))
             return;
 
+        organelle.PlacedThisSession = true;
+
         var action = new EditorAction(this, organelle.Definition.MPCost,
             DoOrganellePlaceAction, UndoOrganellePlaceAction,
             new PlacementActionData(organelle));
@@ -1385,7 +1389,9 @@ public class MicrobeEditor : Node, ILoadableGameState
         if (organelleHere.Definition.InternalName == "nucleus" || MicrobeSize < 2)
             return;
 
-        int cost = Constants.ORGANELLE_REMOVE_COST;
+        // If it was placed this session, just refund the cost of adding it.
+        int cost = organelleHere.PlacedThisSession ?
+            -organelleHere.Definition.MPCost : Constants.ORGANELLE_REMOVE_COST;
 
         var action = new EditorAction(this, cost,
             DoOrganelleRemoveAction, UndoOrganelleRemoveAction,


### PR DESCRIPTION
Updated the editor so when you remove an organelle that was placed during this editor session, it will refund MP (as if you'd undone the action) rather than spending MP to remove it.

I think this makes sense, it also lets the player avoid having to undo a whole heap of changes just to change a single cell.