### PR TITLE
Removed the script folder description on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Repository structure:
 - simulation_parameters: Contains JSON files as well as C# constants for tweaking the game.
 - scripts: Utility scripts for Thrive development
 - src: The core of the game written in C# as well as Godot scenes.
-- script: Contains the game configuration files for existing Compounds, Organelles, Biomes etc. as well as the main menu GUI files.
 - test: Contains tests that will ensure that core parts work correctly. These don't currently exist for the Godot version.
 
 Getting Involved


### PR DESCRIPTION
the scripts folder doesn't exist anymore as of #1195 , so I removed the description for it on the readme in order for it to not be confused with the utility scripts folder.