### PR TITLE
ShapeOwner / Physics fixes

### DIFF
--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -1815,8 +1815,13 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
             if (microbe.Dead)
                 return;
 
-            bool otherIsPilus = microbe.IsPilus(microbe.ShapeFindOwner(bodyShape));
-            bool oursIsPilus = IsPilus(ShapeFindOwner(localShape));
+            uint microbeOwner = microbe.ShapeFindOwner(bodyShape);
+            uint localShapeOwner = microbe.ShapeFindOwner(localShape);
+
+            bool otherIsPilus = microbe.IsPilus(microbeOwner);
+            bool oursIsPilus = IsPilus(localShapeOwner);
+
+            GD.Print("Other: ", microbeOwner, " LocalOwner: ", localShapeOwner);
 
             // Pilus logic
             if (otherIsPilus && oursIsPilus)

--- a/src/microbe_stage/organelle_components/PilusComponent.cs
+++ b/src/microbe_stage/organelle_components/PilusComponent.cs
@@ -84,10 +84,13 @@ public class PilusComponent : ExternallyPositionedComponent
 
         parentMicrobe.RemovePilus(ownerId);
 
-        var shapeCount = parentMicrobe.ShapeOwnerGetShapeCount(ownerId);
-        for (int i = 0; i < shapeCount; ++i)
+        if(parentMicrobe.GetShapeOwners().Count > 0)
         {
-            parentMicrobe.ShapeOwnerRemoveShape(ownerId, i);
+            var shapeCount = parentMicrobe.ShapeOwnerGetShapeCount(ownerId);
+            for (int i = 0; i < shapeCount; ++i)
+            {
+                parentMicrobe.ShapeOwnerRemoveShape(ownerId, i);
+            }
         }
 
         parentMicrobe.RemoveShapeOwner(ownerId);

--- a/src/microbe_stage/organelle_components/PilusComponent.cs
+++ b/src/microbe_stage/organelle_components/PilusComponent.cs
@@ -81,17 +81,14 @@ public class PilusComponent : ExternallyPositionedComponent
     private void DestroyShape()
     {
         var parentMicrobe = organelle.ParentMicrobe;
-        GD.Print("Before: ", parentMicrobe.ShapeOwnerGetShapeCount(ownerId));
 
         parentMicrobe.RemovePilus(ownerId);
 
         var shapeCount = parentMicrobe.ShapeOwnerGetShapeCount(ownerId);
-         for (int i = 0; i < shapeCount; ++i)
-         {
-             parentMicrobe.ShapeOwnerRemoveShape(ownerId, i);
-         }
-
-        GD.Print("After: ", parentMicrobe.ShapeOwnerGetShapeCount(ownerId));
+        for (int i = 0; i < shapeCount; ++i)
+        {
+            parentMicrobe.ShapeOwnerRemoveShape(ownerId, i);
+        }
 
         parentMicrobe.RemoveShapeOwner(ownerId);
         ownerSet = false;


### PR DESCRIPTION
Fixing the way we are doing physics.

So far i've refactored how we do them in PilusComponent. I removed the List (as its not needed).
Before we had

ownerId = parentMicrobe.CreateShapeOwner(shape);

Which was causing shape to own itself.
Now all shapes are owned by the parentMicrobe, but I think I will make them owned by the Pilus.