### PR TITLE
Allow replacing last cytoplasm with organelle

### DIFF
--- a/src/microbe_stage/OrganelleLayout.cs
+++ b/src/microbe_stage/OrganelleLayout.cs
@@ -72,24 +72,29 @@ public class OrganelleLayout<T> : ICollection<T>
 
     /// <summary>
     ///   Returns true if CanPlace would return true and an existing
-    ///   hex touches one of the new hexes.
+    ///   hex touches one of the new hexes, or is the last hex and replaced.
     /// </summary>
-    public bool CanPlaceAndIsTouching(T organelle, bool allowCytoplasmOverlap = false)
+    public bool CanPlaceAndIsTouchingOrReplacingLast(T organelle, bool allowCytoplasmOverlap = false)
     {
         if (!CanPlace(organelle, allowCytoplasmOverlap))
             return false;
 
-        return IsTouchingExistingHex(organelle);
+        return IsTouchingExistingHexOrReplacingLast(organelle);
     }
 
     /// <summary>
     ///   Returns true if the specified organelle is touching an already added hex
+    ///   or replacing the last one.
     /// </summary>
-    public bool IsTouchingExistingHex(T organelle)
+    public bool IsTouchingExistingHexOrReplacingLast(T organelle)
     {
         foreach (var hex in organelle.Definition.GetRotatedHexes(organelle.Orientation))
         {
             if (CheckIfAHexIsNextTo(hex + organelle.Position))
+                return true;
+
+            // Allow deleting the last cytoplasm if an organelle is about to be placed
+            if (Count == 1 && (GetOrganelleAt(hex + organelle.Position) != null))
                 return true;
         }
 

--- a/src/microbe_stage/OrganelleLayout.cs
+++ b/src/microbe_stage/OrganelleLayout.cs
@@ -74,33 +74,41 @@ public class OrganelleLayout<T> : ICollection<T>
     ///   Returns true if CanPlace would return true and an existing
     ///   hex touches one of the new hexes, or is the last hex and replaced.
     /// </summary>
-    public bool CanPlaceAndIsTouchingOrReplacingLast(T organelle, bool allowCytoplasmOverlap = false)
+    public bool CanPlaceAndIsTouching(
+        T organelle,
+        bool allowCytoplasmOverlap = false,
+        bool allowReplacingLastCytoplasm = false
+    )
     {
         if (!CanPlace(organelle, allowCytoplasmOverlap))
             return false;
 
-        return IsTouchingExistingHexOrReplacingLast(organelle);
+        return IsTouchingExistingHex(organelle) || (allowReplacingLastCytoplasm && IsReplacingLast(organelle));
     }
 
     /// <summary>
     ///   Returns true if the specified organelle is touching an already added hex
     ///   or replacing the last one.
     /// </summary>
-    public bool IsTouchingExistingHexOrReplacingLast(T organelle)
+    public bool IsTouchingExistingHex(T organelle)
     {
         foreach (var hex in organelle.Definition.GetRotatedHexes(organelle.Orientation))
         {
             if (CheckIfAHexIsNextTo(hex + organelle.Position))
-                return true;
-
-            // Allow deleting the last cytoplasm if an organelle is about to be placed
-            if (Count == 1 && (GetOrganelleAt(hex + organelle.Position) != null))
                 return true;
         }
 
         return false;
     }
 
+    public bool IsReplacingLast(T organelle)
+    {
+        // Allow deleting the last cytoplasm if an organelle is about to be placed
+        if (Count == 1 && (GetOrganelleAt(organelle.Position) != null))
+            return true;
+
+        return false;
+    }
     /// <summary>
     ///   Returns true if there is some placed organelle that has a
     ///   hex next to the specified location.

--- a/src/microbe_stage/OrganelleLayout.cs
+++ b/src/microbe_stage/OrganelleLayout.cs
@@ -77,8 +77,7 @@ public class OrganelleLayout<T> : ICollection<T>
     public bool CanPlaceAndIsTouching(
         T organelle,
         bool allowCytoplasmOverlap = false,
-        bool allowReplacingLastCytoplasm = false
-    )
+        bool allowReplacingLastCytoplasm = false)
     {
         if (!CanPlace(organelle, allowCytoplasmOverlap))
             return false;

--- a/src/microbe_stage/OrganelleLayout.cs
+++ b/src/microbe_stage/OrganelleLayout.cs
@@ -105,9 +105,10 @@ public class OrganelleLayout<T> : ICollection<T>
     public bool IsReplacingLast(T organelle)
     {
         var replacedOrganelle = GetOrganelleAt(organelle.Position);
-        if (Count == 1 &&
-            (replacedOrganelle != null) &&
-            (replacedOrganelle.Definition.InternalName == "cytoplasm"))
+        if (Count != 1)
+            return false;
+
+        if ((replacedOrganelle != null) && (replacedOrganelle.Definition.InternalName == "cytoplasm"))
             return true;
 
         return false;

--- a/src/microbe_stage/OrganelleLayout.cs
+++ b/src/microbe_stage/OrganelleLayout.cs
@@ -72,7 +72,7 @@ public class OrganelleLayout<T> : ICollection<T>
 
     /// <summary>
     ///   Returns true if CanPlace would return true and an existing
-    ///   hex touches one of the new hexes, or is the last hex and replaced.
+    ///   hex touches one of the new hexes, or is the last hex and can be replaced.
     /// </summary>
     public bool CanPlaceAndIsTouching(
         T organelle,
@@ -88,7 +88,6 @@ public class OrganelleLayout<T> : ICollection<T>
 
     /// <summary>
     ///   Returns true if the specified organelle is touching an already added hex
-    ///   or replacing the last one.
     /// </summary>
     public bool IsTouchingExistingHex(T organelle)
     {
@@ -101,14 +100,17 @@ public class OrganelleLayout<T> : ICollection<T>
         return false;
     }
 
+    /// <summary>
+    ///     Returns true if the specified organelle is replacing the last hex.
+    /// </summary>
     public bool IsReplacingLast(T organelle)
     {
-        // Allow deleting the last cytoplasm if an organelle is about to be placed
         if (Count == 1 && (GetOrganelleAt(organelle.Position) != null))
             return true;
 
         return false;
     }
+
     /// <summary>
     ///   Returns true if there is some placed organelle that has a
     ///   hex next to the specified location.

--- a/src/microbe_stage/OrganelleLayout.cs
+++ b/src/microbe_stage/OrganelleLayout.cs
@@ -104,9 +104,10 @@ public class OrganelleLayout<T> : ICollection<T>
     /// </summary>
     public bool IsReplacingLast(T organelle)
     {
-        var replacedOrganelle = GetOrganelleAt(organelle.Position);
         if (Count != 1)
             return false;
+
+        var replacedOrganelle = GetOrganelleAt(organelle.Position);
 
         if ((replacedOrganelle != null) && (replacedOrganelle.Definition.InternalName == "cytoplasm"))
             return true;

--- a/src/microbe_stage/OrganelleLayout.cs
+++ b/src/microbe_stage/OrganelleLayout.cs
@@ -100,11 +100,14 @@ public class OrganelleLayout<T> : ICollection<T>
     }
 
     /// <summary>
-    ///     Returns true if the specified organelle is replacing the last hex.
+    ///   Returns true if the specified organelle is replacing the last hex of cytoplasm.
     /// </summary>
     public bool IsReplacingLast(T organelle)
     {
-        if (Count == 1 && (GetOrganelleAt(organelle.Position) != null))
+        var replacedOrganelle = GetOrganelleAt(organelle.Position);
+        if (Count == 1 &&
+            (replacedOrganelle != null) &&
+            (replacedOrganelle.Definition.InternalName == "cytoplasm"))
             return true;
 
         return false;

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -1303,13 +1303,10 @@ public class MicrobeEditor : Node, ILoadableGameState
     {
         bool notPlacingCytoplasm = organelle.Definition.InternalName != "cytoplasm";
 
-        // Allow deleting the last cytoplasm if an organelle is about to be placed
-        bool allowReplacingLast = true;
-
         return editedMicrobeOrganelles.CanPlaceAndIsTouching(
             organelle,
             notPlacingCytoplasm,
-            allowReplacingLast);
+            notPlacingCytoplasm);
     }
 
     private OrganelleDefinition GetOrganelleDefinition(string name)

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -1302,7 +1302,12 @@ public class MicrobeEditor : Node, ILoadableGameState
     private bool IsValidPlacement(OrganelleTemplate organelle)
     {
         bool notPlacingCytoplasm = organelle.Definition.InternalName != "cytoplasm";
-        return editedMicrobeOrganelles.CanPlaceAndIsTouchingOrReplacingLast(organelle, notPlacingCytoplasm);
+        bool allowReplacingLastCytoplasm = true;
+        return editedMicrobeOrganelles.CanPlaceAndIsTouching(
+            organelle,
+            notPlacingCytoplasm,
+            allowReplacingLastCytoplasm
+        );
     }
 
     private OrganelleDefinition GetOrganelleDefinition(string name)

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -1302,7 +1302,7 @@ public class MicrobeEditor : Node, ILoadableGameState
     private bool IsValidPlacement(OrganelleTemplate organelle)
     {
         bool notPlacingCytoplasm = organelle.Definition.InternalName != "cytoplasm";
-        return editedMicrobeOrganelles.CanPlaceAndIsTouching(organelle, notPlacingCytoplasm);
+        return editedMicrobeOrganelles.CanPlaceAndIsTouchingOrReplacingLast(organelle, notPlacingCytoplasm);
     }
 
     private OrganelleDefinition GetOrganelleDefinition(string name)
@@ -1395,7 +1395,6 @@ public class MicrobeEditor : Node, ILoadableGameState
             return;
 
         // Dont allow deletion of nucleus or the last organelle
-        // TODO: allow deleting the last cytoplasm if an organelle is about to be placed
         if (organelleHere.Definition.InternalName == "nucleus" || MicrobeSize < 2)
             return;
 

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -1302,7 +1302,10 @@ public class MicrobeEditor : Node, ILoadableGameState
     private bool IsValidPlacement(OrganelleTemplate organelle)
     {
         bool notPlacingCytoplasm = organelle.Definition.InternalName != "cytoplasm";
+
+        // Allow deleting the last cytoplasm if an organelle is about to be placed
         bool allowReplacingLastCytoplasm = true;
+
         return editedMicrobeOrganelles.CanPlaceAndIsTouching(
             organelle,
             notPlacingCytoplasm,

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -1304,13 +1304,12 @@ public class MicrobeEditor : Node, ILoadableGameState
         bool notPlacingCytoplasm = organelle.Definition.InternalName != "cytoplasm";
 
         // Allow deleting the last cytoplasm if an organelle is about to be placed
-        bool allowReplacingLastCytoplasm = true;
+        bool allowReplacingLast = true;
 
         return editedMicrobeOrganelles.CanPlaceAndIsTouching(
             organelle,
             notPlacingCytoplasm,
-            allowReplacingLastCytoplasm
-        );
+            allowReplacingLast);
     }
 
     private OrganelleDefinition GetOrganelleDefinition(string name)


### PR DESCRIPTION
Allows us to replace the last cytoplasm hex with an organelle hex. (CanPlace makes sure we aren't replacing the last organelle hex.)

Everything changed appeared to only be called in one specific place in the code, but perhaps not changing the public function names would be better...

Closes #1006 