### PR TITLE
Add vscode to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ export.cfg
 
 .svn
 .vs
+.vscode
 
 # Merge tool left over files
 *.orig


### PR DESCRIPTION
Adds the folder `.vscode` to the `.gitignore` file. The folder is created when you setup debugging in VSCode.