### PR TITLE
Fixed the cell physics not matching the visual size

### DIFF
--- a/src/microbe_stage/PlacedOrganelle.cs
+++ b/src/microbe_stage/PlacedOrganelle.cs
@@ -219,7 +219,7 @@ public class PlacedOrganelle : Spatial, IPositionedOrganelle
 
             // The shape is in our parent so the final position is our
             // offset plus the hex offset
-            Vector3 shapePosition = Hex.AxialToCartesian(hex) + Translation;
+            Vector3 shapePosition = Hex.AxialToCartesian(hex) + Hex.AxialToCartesian(Position);
 
             // Scale for bacteria physics.
             if (microbe.Species.IsBacteria)


### PR DESCRIPTION
Turns out the problem was a simple miscalculation of the hex collision shapes positioning,
causing the shapes to be positioned only at the cell's center and not where the hex actually is.

Closes #1251