### PR TITLE
Add a link to the planning board in the readme and contributing files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,10 @@ code to disable your changes. Note: currently we don't have an options
 menu that could be used to enable inbuilt mods, so this is a bit
 difficult at the time of writing.
 
+## Planning Board
+
+The planning board contains all issues and pull requests grouped
+by their priority and status. It can be found [here](https://github.com/orgs/Revolutionary-Games/projects/2).
 
 ## Getting help
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ There are also other useful documents in the [doc](doc) folder not mentioned her
 If you have game development skills, you can apply to the team
 [here](https://revolutionarygamesstudio.com/application/).
 
+The planning board contains all issues and pull requests grouped
+by their priority and status. It can be found [here](https://github.com/orgs/Revolutionary-Games/projects/2).
+
 ### Programmers 
 Thrive is written in C# with a few helper scripts written in ruby. In
 order to work on the C# you need to compile Thrive yourself. You can


### PR DESCRIPTION
Adds a link to the planning board in the readme and contributing files. Closes #1453.