### PR TITLE
Disabled the mac release execute hack as it seems godot may have fixed it

### DIFF
--- a/make_release.rb
+++ b/make_release.rb
@@ -32,7 +32,7 @@ LICENSE_FILES = [
   ['doc/GodotLicense.txt', 'GodotLicense.txt']
 ].freeze
 
-SET_EXECUTE_FOR_MAC = true
+SET_EXECUTE_FOR_MAC = false
 
 @options = {
   custom_targets: false,


### PR DESCRIPTION
themselves and we don't need to do this.
As long as Godot 3.2.3 is released soon