### PR TITLE
 Add a warning for loading a save made with a different thrive version

### DIFF
--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -21,6 +21,7 @@
     <Rule Id="CA1301" Action="Warning" />
     <Rule Id="CA1303" Action="None" /> <!-- resource table usage.
       probably should use once we implement localization -->
+    <Rule Id="CA1308" Action="None" /> <!-- tells to use ToUpperInvariant instead of ToLower -->
     <Rule Id="CA1400" Action="Warning" />
     <Rule Id="CA1401" Action="Warning" />
     <Rule Id="CA1403" Action="Warning" />

--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -227,6 +227,7 @@
     <Compile Include="src\saving\serializers\ThriveJsonConverter.cs" />
     <Compile Include="src\saving\serializers\ThriveTypeConverter.cs" />
     <Compile Include="src\saving\TemporaryLoadedNodeDeleter.cs" />
+    <Compile Include="src\general\VersionUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="StyleCop.ruleset" />

--- a/src/general/VersionUtils.cs
+++ b/src/general/VersionUtils.cs
@@ -1,0 +1,43 @@
+﻿/// <summary>
+///   Helpers for dealing with Thrive's version number
+/// </summary>
+public static class VersionUtils
+{
+    /// <summary>
+    /// Compare the given version numbers.
+    /// </summary>
+    /// <returns>
+    /// 0 if the versions are the same,
+    /// a negative integer if a is a smaller (older) version than b and
+    /// a positive integer if a is a bigger (newer) version than b
+    /// </returns>
+    /// <param name="a">The first version to compare.</param>
+    /// <param name="b">The second version to compare.</param>
+    public static int Compare(string a, string b)
+    {
+        if (a == b)
+        {
+            return 0;
+        }
+
+        var aSplit = a.Split('.');
+        var bSplit = b.Split('.');
+
+        for (int i = 0; i < aSplit.Length; i++)
+        {
+            int aNumber = int.Parse(aSplit[i]);
+            int bNumber = int.Parse(bSplit[i]);
+
+            int diff = aNumber - bNumber;
+
+            if (diff == 0)
+            {
+                continue;
+            }
+
+            return diff;
+        }
+
+        return 0;
+    }
+}

--- a/src/general/VersionUtils.cs
+++ b/src/general/VersionUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Godot;
 /// <summary>
 ///   Helpers for dealing with Thrive's version number
 /// </summary>
@@ -40,7 +41,8 @@ public static class VersionUtils
             }
             catch (Exception e)
             {
-                continue;
+                GD.Print(e.Message);
+                GD.Print($"Probably non-numeric version difference: {a} vs. {b}");
             }
         }
 

--- a/src/general/VersionUtils.cs
+++ b/src/general/VersionUtils.cs
@@ -72,11 +72,12 @@ public static class VersionUtils
             return aSuffixIndex - bSuffixIndex;
         }
 
-        // Fallback in case one of the suffixes is unknow
-        return string.Compare(aSplit[1], bSplit[1], true, CultureInfo.InvariantCulture);
+        // Fallback in case one of the suffixes is unknown
+        return string.Compare(aSplit[1], bSplit[1], CultureInfo.InvariantCulture, CompareOptions.OrdinalIgnoreCase);
     }
 
     // TODO: Use actual unit tests instead
+    // https://github.com/Revolutionary-Games/Thrive/issues/1571
     public static bool TestCompare()
     {
         return Compare("1.2.3-pre-alpha", "1.2.3") < 0

--- a/src/general/VersionUtils.cs
+++ b/src/general/VersionUtils.cs
@@ -9,18 +9,18 @@ public static class VersionUtils
 {
     public static readonly string[] Suffixes =
     {
-        "PRE-ALPHA",
-        "ALPHA",
-        "BETA",
-        "RC1",
-        "RC2",
-        "RC3",
-        "RC4",
-        "RC5",
-        "RC6",
-        "RC7",
-        "RC8",
-        "RC9",
+        "pre-alpha",
+        "alpha",
+        "beta",
+        "rc1",
+        "rc2",
+        "rc3",
+        "rc4",
+        "rc5",
+        "rc6",
+        "rc7",
+        "rc8",
+        "rc9",
     };
 
     /// <summary>
@@ -68,8 +68,8 @@ public static class VersionUtils
         }
 
         // Compare predefined suffixes
-        int aSuffixIndex = Array.IndexOf(Suffixes, aSplit[1].ToUpperInvariant());
-        int bSuffixIndex = Array.IndexOf(Suffixes, bSplit[1].ToUpperInvariant());
+        int aSuffixIndex = Array.IndexOf(Suffixes, aSplit[1].ToLowerInvariant());
+        int bSuffixIndex = Array.IndexOf(Suffixes, bSplit[1].ToLowerInvariant());
         if (aSuffixIndex >= 0 && bSuffixIndex >= 0)
         {
             return aSuffixIndex - bSuffixIndex;

--- a/src/general/VersionUtils.cs
+++ b/src/general/VersionUtils.cs
@@ -1,17 +1,19 @@
 ﻿using System;
+using System.Globalization;
 using Godot;
+
 /// <summary>
 ///   Helpers for dealing with Thrive's version number
 /// </summary>
 public static class VersionUtils
 {
     /// <summary>
-    /// Compare the given version numbers.
+    ///   Compare the given version numbers.
     /// </summary>
     /// <returns>
-    /// 0 if the versions are the same,
-    /// a negative integer if a is a smaller (older) version than b and
-    /// a positive integer if a is a bigger (newer) version than b
+    ///   0 if the versions are the same,
+    ///   a negative integer if a is a smaller (older) version than b and
+    ///   a positive integer if a is a bigger (newer) version than b
     /// </returns>
     /// <param name="a">The first version to compare.</param>
     /// <param name="b">The second version to compare.</param>
@@ -30,8 +32,8 @@ public static class VersionUtils
         {
             try
             {
-                int aNumber = int.Parse(aSplit[i]);
-                int bNumber = int.Parse(bSplit[i]);
+                int aNumber = int.Parse(aSplit[i], CultureInfo.CurrentCulture);
+                int bNumber = int.Parse(bSplit[i], CultureInfo.CurrentCulture);
 
                 int diff = aNumber - bNumber;
                 if (diff != 0)

--- a/src/general/VersionUtils.cs
+++ b/src/general/VersionUtils.cs
@@ -1,4 +1,5 @@
-﻿/// <summary>
+﻿using System;
+/// <summary>
 ///   Helpers for dealing with Thrive's version number
 /// </summary>
 public static class VersionUtils
@@ -20,22 +21,27 @@ public static class VersionUtils
             return 0;
         }
 
-        var aSplit = a.Split('.');
-        var bSplit = b.Split('.');
+        char[] separators = { '.', '-' };
+        var aSplit = a.Split(separators);
+        var bSplit = b.Split(separators);
 
         for (int i = 0; i < aSplit.Length; i++)
         {
-            int aNumber = int.Parse(aSplit[i]);
-            int bNumber = int.Parse(bSplit[i]);
+            try
+            {
+                int aNumber = int.Parse(aSplit[i]);
+                int bNumber = int.Parse(bSplit[i]);
 
-            int diff = aNumber - bNumber;
-
-            if (diff == 0)
+                int diff = aNumber - bNumber;
+                if (diff != 0)
+                {
+                    return diff;
+                }
+            }
+            catch (Exception e)
             {
                 continue;
             }
-
-            return diff;
         }
 
         return 0;

--- a/src/general/VersionUtils.cs
+++ b/src/general/VersionUtils.cs
@@ -9,18 +9,18 @@ public static class VersionUtils
 {
     public static readonly string[] Suffixes =
     {
-        "pre-alpha",
-        "alpha",
-        "beta",
-        "rc1",
-        "rc2",
-        "rc3",
-        "rc4",
-        "rc5",
-        "rc6",
-        "rc7",
-        "rc8",
-        "rc9",
+        "PRE-ALPHA",
+        "ALPHA",
+        "BETA",
+        "RC1",
+        "RC2",
+        "RC3",
+        "RC4",
+        "RC5",
+        "RC6",
+        "RC7",
+        "RC8",
+        "RC9",
     };
 
     /// <summary>
@@ -45,10 +45,17 @@ public static class VersionUtils
         var bSplit = b.Split(separator, 2);
 
         // Compare the numeric versions
-        int versionDiff = Version.Parse(aSplit[0]).CompareTo(Version.Parse(bSplit[0]));
-        if (versionDiff != 0)
+        try
         {
-            return versionDiff;
+            int versionDiff = Version.Parse(aSplit[0]).CompareTo(Version.Parse(bSplit[0]));
+            if (versionDiff != 0)
+            {
+                return versionDiff;
+            }
+        }
+        catch (Exception e)
+        {
+            GD.PrintErr(e);
         }
 
         // If only one of the version has a suffix, that one is older
@@ -57,23 +64,22 @@ public static class VersionUtils
             return bSplit.Length - aSplit.Length;
         }
 
-        // Compare predefine suffixes
-        int aSuffixIndex = Array.IndexOf(Suffixes, aSplit[1].ToLower(CultureInfo.CurrentCulture));
-        int bSuffixIndex = Array.IndexOf(Suffixes, bSplit[1].ToLower(CultureInfo.CurrentCulture));
+        // Compare predefined suffixes
+        int aSuffixIndex = Array.IndexOf(Suffixes, aSplit[1].ToUpperInvariant());
+        int bSuffixIndex = Array.IndexOf(Suffixes, bSplit[1].ToUpperInvariant());
         if (aSuffixIndex >= 0 && bSuffixIndex >= 0)
         {
             return aSuffixIndex - bSuffixIndex;
         }
 
         // Fallback in case one of the suffixes is unknow
-        return string.Compare(aSplit[1], bSplit[1], true, CultureInfo.CurrentCulture);
+        return string.Compare(aSplit[1], bSplit[1], true, CultureInfo.InvariantCulture);
     }
 
     // TODO: Use actual unit tests instead
     public static bool TestCompare()
     {
-        return true
-            && Compare("1.2.3-pre-alpha", "1.2.3") < 0
+        return Compare("1.2.3-pre-alpha", "1.2.3") < 0
             && Compare("1.2.3-rc1", "1.2.3-pre-alpha") > 0
             && Compare("1.2.3-rc1", "1.2.4-pre-alpha") < 0
             && Compare("3.2.1-pre-alpha", "1.2.3") > 0

--- a/src/general/VersionUtils.cs
+++ b/src/general/VersionUtils.cs
@@ -30,6 +30,7 @@ public static class VersionUtils
     ///   0 if the versions are the same,
     ///   a negative integer if a is a smaller (older) version than b and
     ///   a positive integer if a is a bigger (newer) version than b
+    ///   int.MaxValue if comparison fails
     /// </returns>
     /// <param name="a">The first version to compare.</param>
     /// <param name="b">The second version to compare.</param>
@@ -55,7 +56,9 @@ public static class VersionUtils
         }
         catch (Exception e)
         {
+            GD.PrintErr($"Failed to compare versions {a} and {b}.");
             GD.PrintErr(e);
+            return int.MaxValue;
         }
 
         // If only one of the version has a suffix, that one is older

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -29,9 +29,13 @@ public class SaveList : ScrollContainer
     [Export]
     public NodePath DeleteConfirmDialogPath;
 
+    [Export]
+    public NodePath LoadConfirmDialogPath;
+
     private Control loadingItem;
     private BoxContainer savesList;
     private ConfirmationDialog deleteConfirmDialog;
+    private ConfirmationDialog loadConfirmDialog;
 
     private PackedScene listItemScene;
 
@@ -41,6 +45,7 @@ public class SaveList : ScrollContainer
     private Task<List<string>> readSavesList;
 
     private string saveToBeDeleted;
+    private string saveToBeLoaded;
 
     private bool wasVisible;
 
@@ -55,6 +60,7 @@ public class SaveList : ScrollContainer
         loadingItem = GetNode<Control>(LoadingItemPath);
         savesList = GetNode<BoxContainer>(SavesListPath);
         deleteConfirmDialog = GetNode<ConfirmationDialog>(DeleteConfirmDialogPath);
+        loadConfirmDialog = GetNode<ConfirmationDialog>(LoadConfirmDialogPath);
 
         listItemScene = GD.Load<PackedScene>("res://src/saving/SaveListItem.tscn");
     }
@@ -94,6 +100,7 @@ public class SaveList : ScrollContainer
                 item.Connect(nameof(SaveListItem.OnSelectedChanged), this, nameof(OnSubItemSelectedChanged));
 
             item.Connect(nameof(SaveListItem.OnDeleted), this, nameof(OnDeletePressed), new Array { save });
+            item.Connect(nameof(SaveListItem.OnOldSaveLoaded), this, nameof(OnOldSaveLoaded), new Array { save });
 
             item.SaveName = save;
             savesList.AddChild(item);
@@ -151,5 +158,16 @@ public class SaveList : ScrollContainer
 
         Refresh();
         EmitSignal(nameof(OnItemsChanged));
+    }
+
+    private void OnOldSaveLoaded(string saveName)
+    {
+        saveToBeLoaded = saveName;
+        loadConfirmDialog.PopupCenteredMinsize();
+    }
+
+    private void OnConfirmSaveLoad()
+    {
+        SaveHelper.LoadSave(saveToBeLoaded);
     }
 }

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -32,6 +32,7 @@ public class SaveList : ScrollContainer
     [Export]
     public NodePath LoadConfirmDialogPath;
 
+
     private Control loadingItem;
     private BoxContainer savesList;
     private ConfirmationDialog deleteConfirmDialog;
@@ -100,7 +101,9 @@ public class SaveList : ScrollContainer
                 item.Connect(nameof(SaveListItem.OnSelectedChanged), this, nameof(OnSubItemSelectedChanged));
 
             item.Connect(nameof(SaveListItem.OnDeleted), this, nameof(OnDeletePressed), new Array { save });
+
             item.Connect(nameof(SaveListItem.OnOldSaveLoaded), this, nameof(OnOldSaveLoaded), new Array { save });
+            item.Connect(nameof(SaveListItem.OnNewSaveLoaded), this, nameof(OnNewSaveLoaded), new Array { save });
 
             item.SaveName = save;
             savesList.AddChild(item);
@@ -163,6 +166,20 @@ public class SaveList : ScrollContainer
     private void OnOldSaveLoaded(string saveName)
     {
         saveToBeLoaded = saveName;
+
+        loadConfirmDialog.DialogText = "This save is from an old version of Thrive and may be incompatible.\n";
+        loadConfirmDialog.DialogText += "As Thrive is currently early in development save compatibility is not a priority.\n";
+        loadConfirmDialog.DialogText += "You may report any issues you encounter, but they aren't the highest priority right now.\n";
+        loadConfirmDialog.DialogText += "Do you want to try loading the save anyway?";
+        loadConfirmDialog.PopupCenteredMinsize();
+    }
+
+    private void OnNewSaveLoaded(string saveName)
+    {
+        saveToBeLoaded = saveName;
+
+        loadConfirmDialog.DialogText = "This save is from a newer version of Thrive and very likely incompatible.\n";
+        loadConfirmDialog.DialogText += "Do you want to try loading the save anyway?";
         loadConfirmDialog.PopupCenteredMinsize();
     }
 

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -168,8 +168,10 @@ public class SaveList : ScrollContainer
         saveToBeLoaded = saveName;
 
         loadConfirmDialog.DialogText = "This save is from an old version of Thrive and may be incompatible.\n";
-        loadConfirmDialog.DialogText += "As Thrive is currently early in development save compatibility is not a priority.\n";
-        loadConfirmDialog.DialogText += "You may report any issues you encounter, but they aren't the highest priority right now.\n";
+        loadConfirmDialog.DialogText += "As Thrive is currently early in development ";
+        loadConfirmDialog.DialogText += "save compatibility is not a priority.\n";
+        loadConfirmDialog.DialogText += "You may report any issues you encounter, ";
+        loadConfirmDialog.DialogText += "but they aren't the highest priority right now.\n";
         loadConfirmDialog.DialogText += "Do you want to try loading the save anyway?";
         loadConfirmDialog.PopupCenteredMinsize();
     }

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -32,7 +32,6 @@ public class SaveList : ScrollContainer
     [Export]
     public NodePath LoadConfirmDialogPath;
 
-
     private Control loadingItem;
     private BoxContainer savesList;
     private ConfirmationDialog deleteConfirmDialog;

--- a/src/saving/SaveList.tscn
+++ b/src/saving/SaveList.tscn
@@ -16,6 +16,7 @@ __meta__ = {
 LoadingItemPath = NodePath("VBoxContainer/LoadingLabel")
 SavesListPath = NodePath("VBoxContainer/ItemList")
 DeleteConfirmDialogPath = NodePath("VBoxContainer/DeleteConfirmDialog")
+LoadConfirmDialogPath = NodePath("VBoxContainer/LoadConfirmDialog")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 margin_right = 1280.0
@@ -39,4 +40,12 @@ size_flags_vertical = 5
 popup_exclusive = true
 window_title = "Delete this Save?"
 dialog_text = "Text not set..."
+
+[node name="LoadConfirmDialog" type="ConfirmationDialog" parent="VBoxContainer"]
+size_flags_horizontal = 5
+size_flags_vertical = 5
+popup_exclusive = true
+window_title = "Load this save?"
+dialog_text = "This save is from an different version of Thrive and may be incompatible. Do you want to load it anyway?"
 [connection signal="confirmed" from="VBoxContainer/DeleteConfirmDialog" to="." method="OnConfirmDelete"]
+[connection signal="confirmed" from="VBoxContainer/LoadConfirmDialog" to="." method="OnConfirmSaveLoad"]

--- a/src/saving/SaveList.tscn
+++ b/src/saving/SaveList.tscn
@@ -45,7 +45,7 @@ dialog_text = "Text not set..."
 size_flags_horizontal = 5
 size_flags_vertical = 5
 popup_exclusive = true
-window_title = "Load this save?"
-dialog_text = "This save is from an different version of Thrive and may be incompatible. Do you want to load it anyway?"
+window_title = "Load incompatible save?"
+dialog_text = "Text not set..."
 [connection signal="confirmed" from="VBoxContainer/DeleteConfirmDialog" to="." method="OnConfirmDelete"]
 [connection signal="confirmed" from="VBoxContainer/LoadConfirmDialog" to="." method="OnConfirmSaveLoad"]

--- a/src/saving/SaveListItem.cs
+++ b/src/saving/SaveListItem.cs
@@ -24,6 +24,9 @@ public class SaveListItem : PanelContainer
     public NodePath VersionPath;
 
     [Export]
+    public NodePath VersionWarningPath;
+
+    [Export]
     public NodePath TypePath;
 
     [Export]
@@ -47,6 +50,7 @@ public class SaveListItem : PanelContainer
     private Label saveNameLabel;
     private TextureRect screenshot;
     private Label version;
+    private Label versionWarning;
     private Label type;
     private Label createdAt;
     private Label createdBy;
@@ -103,6 +107,7 @@ public class SaveListItem : PanelContainer
         saveNameLabel = GetNode<Label>(SaveNamePath);
         screenshot = GetNode<TextureRect>(ScreenshotPath);
         version = GetNode<Label>(VersionPath);
+        versionWarning = GetNode<Label>(VersionWarningPath);
         type = GetNode<Label>(TypePath);
         createdAt = GetNode<Label>(CreatedAtPath);
         createdBy = GetNode<Label>(CreatedByPath);
@@ -138,6 +143,7 @@ public class SaveListItem : PanelContainer
 
         // General info
         version.Text = save.Info.ThriveVersion;
+        versionWarning.Visible = save.Info.ThriveVersion != Constants.Version;
         type.Text = save.Info.Type.ToString();
         createdAt.Text = save.Info.CreatedAt.ToString("G", CultureInfo.CurrentCulture);
         createdBy.Text = save.Info.Creator;

--- a/src/saving/SaveListItem.cs
+++ b/src/saving/SaveListItem.cs
@@ -70,6 +70,9 @@ public class SaveListItem : PanelContainer
     [Signal]
     public delegate void OnDeleted();
 
+    [Signal]
+    public delegate void OnOldSaveLoaded();
+
     public string SaveName
     {
         get => saveName;
@@ -153,6 +156,17 @@ public class SaveListItem : PanelContainer
         loadingData = false;
     }
 
+    public void LoadThisSave()
+    {
+        if (versionWarning.Visible)
+        {
+            EmitSignal(nameof(OnOldSaveLoaded));
+            return;
+        }
+
+        SaveHelper.LoadSave(SaveName);
+    }
+
     private void LoadSaveData()
     {
         loadingData = true;
@@ -188,13 +202,9 @@ public class SaveListItem : PanelContainer
         EmitSignal(nameof(OnSelectedChanged));
     }
 
-    private void LoadThisSave()
-    {
-        SaveHelper.LoadSave(SaveName);
-    }
-
     private void DeletePressed()
     {
         EmitSignal(nameof(OnDeleted));
     }
+
 }

--- a/src/saving/SaveListItem.cs
+++ b/src/saving/SaveListItem.cs
@@ -60,6 +60,7 @@ public class SaveListItem : PanelContainer
     private Button loadButton;
 
     private string saveName;
+    private bool compatibleVersion;
 
     private bool loadingData;
     private Task<Save> saveInfoLoadTask;
@@ -145,8 +146,10 @@ public class SaveListItem : PanelContainer
         screenshot.Texture = texture;
 
         // General info
+        compatibleVersion = save.Info.ThriveVersion == Constants.Version;
+
         version.Text = save.Info.ThriveVersion;
-        versionWarning.Visible = save.Info.ThriveVersion != Constants.Version;
+        versionWarning.Visible = !compatibleVersion;
         type.Text = save.Info.Type.ToString();
         createdAt.Text = save.Info.CreatedAt.ToString("G", CultureInfo.CurrentCulture);
         createdBy.Text = save.Info.Creator;
@@ -158,13 +161,13 @@ public class SaveListItem : PanelContainer
 
     public void LoadThisSave()
     {
-        if (versionWarning.Visible)
+        if (compatibleVersion)
         {
-            EmitSignal(nameof(OnOldSaveLoaded));
+            SaveHelper.LoadSave(SaveName);
             return;
         }
 
-        SaveHelper.LoadSave(SaveName);
+        EmitSignal(nameof(OnOldSaveLoaded));
     }
 
     private void LoadSaveData()
@@ -206,5 +209,4 @@ public class SaveListItem : PanelContainer
     {
         EmitSignal(nameof(OnDeleted));
     }
-
 }

--- a/src/saving/SaveListItem.tscn
+++ b/src/saving/SaveListItem.tscn
@@ -31,6 +31,7 @@ __meta__ = {
 SaveNamePath = NodePath("SaveListItem/VBoxContainer/HBoxContainer/SaveName")
 ScreenshotPath = NodePath("SaveListItem/Screenshot")
 VersionPath = NodePath("SaveListItem/VBoxContainer/HBoxContainer/Version")
+VersionWarningPath = NodePath("SaveListItem/VBoxContainer/HBoxContainer/VersionWarning")
 TypePath = NodePath("SaveListItem/VBoxContainer/HBoxContainer4/Type")
 CreatedAtPath = NodePath("SaveListItem/VBoxContainer/HBoxContainer2/CreatedAt")
 CreatedByPath = NodePath("SaveListItem/VBoxContainer/HBoxContainer2/Creator")
@@ -42,7 +43,7 @@ LoadButtonPath = NodePath("SaveListItem/VBoxContainer/HBoxContainer/HBoxContaine
 [node name="SaveListItem" type="HBoxContainer" parent="."]
 margin_left = 3.0
 margin_top = 3.0
-margin_right = 618.0
+margin_right = 654.0
 margin_bottom = 131.0
 size_flags_horizontal = 3
 __meta__ = {
@@ -50,7 +51,7 @@ __meta__ = {
 }
 
 [node name="Screenshot" type="TextureRect" parent="SaveListItem"]
-margin_right = 128.0
+margin_right = 129.0
 margin_bottom = 128.0
 rect_min_size = Vector2( 128, 128 )
 size_flags_horizontal = 3
@@ -59,8 +60,8 @@ expand = true
 stretch_mode = 6
 
 [node name="VBoxContainer" type="VBoxContainer" parent="SaveListItem"]
-margin_left = 132.0
-margin_right = 615.0
+margin_left = 133.0
+margin_right = 651.0
 margin_bottom = 128.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 4.0
@@ -69,7 +70,7 @@ __meta__ = {
 }
 
 [node name="HBoxContainer" type="HBoxContainer" parent="SaveListItem/VBoxContainer"]
-margin_right = 483.0
+margin_right = 518.0
 margin_bottom = 43.0
 
 [node name="Label1" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer"]
@@ -99,35 +100,43 @@ margin_right = 270.0
 margin_bottom = 33.0
 text = "..."
 
-[node name="HBoxContainer" type="HBoxContainer" parent="SaveListItem/VBoxContainer/HBoxContainer"]
+[node name="VersionWarning" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer"]
 margin_left = 274.0
-margin_right = 483.0
+margin_top = 10.0
+margin_right = 301.0
+margin_bottom = 33.0
+text = "( ! )"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="SaveListItem/VBoxContainer/HBoxContainer"]
+margin_left = 305.0
+margin_right = 518.0
 margin_bottom = 43.0
 size_flags_horizontal = 3
 alignment = 2
 
 [node name="SelectBox" type="CheckBox" parent="SaveListItem/VBoxContainer/HBoxContainer/HBoxContainer"]
-margin_right = 90.0
+margin_left = 4.0
+margin_right = 94.0
 margin_bottom = 43.0
 text = "select"
 
 [node name="Delete" type="TextureButton" parent="SaveListItem/VBoxContainer/HBoxContainer/HBoxContainer"]
-margin_left = 94.0
-margin_right = 136.0
+margin_left = 98.0
+margin_right = 140.0
 margin_bottom = 43.0
 texture_normal = ExtResource( 6 )
 texture_hover = ExtResource( 4 )
 texture_disabled = ExtResource( 1 )
 
 [node name="Load" type="Button" parent="SaveListItem/VBoxContainer/HBoxContainer/HBoxContainer"]
-margin_left = 140.0
-margin_right = 209.0
+margin_left = 144.0
+margin_right = 213.0
 margin_bottom = 43.0
 text = "Load"
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="SaveListItem/VBoxContainer"]
 margin_top = 47.0
-margin_right = 483.0
+margin_right = 518.0
 margin_bottom = 70.0
 
 [node name="Label" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer2"]
@@ -155,7 +164,7 @@ text = "..."
 
 [node name="HBoxContainer4" type="HBoxContainer" parent="SaveListItem/VBoxContainer"]
 margin_top = 74.0
-margin_right = 483.0
+margin_right = 518.0
 margin_bottom = 97.0
 
 [node name="Label" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer4"]
@@ -183,7 +192,7 @@ text = "..."
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="SaveListItem/VBoxContainer"]
 margin_top = 101.0
-margin_right = 483.0
+margin_right = 518.0
 margin_bottom = 124.0
 
 [node name="Label" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer3"]

--- a/src/saving/SaveManagerGUI.cs
+++ b/src/saving/SaveManagerGUI.cs
@@ -155,7 +155,7 @@ public class SaveManagerGUI : Control
         if (Selected.Count < 1)
             return;
 
-        SaveHelper.LoadSave(Selected[0].SaveName);
+        Selected[0].LoadThisSave();
     }
 
     private void DeleteSelectedButtonPressed()


### PR DESCRIPTION
Two solutions to #1478: show a mark next to the version of saves made with a different version of Thrive and ask for confirmation before loading them.

fixes #1478