### PR TITLE
Saving: add a button to open the save directory

### DIFF
--- a/src/saving/SaveManagerGUI.cs
+++ b/src/saving/SaveManagerGUI.cs
@@ -180,6 +180,11 @@ public class SaveManagerGUI : Control
         Selected[0].LoadThisSave();
     }
 
+    private void OpenSaveDirectoryPressed()
+    {
+        OS.ShellOpen(ProjectSettings.GlobalizePath(Constants.SAVE_FOLDER));
+    }
+
     private void DeleteSelectedButtonPressed()
     {
         deleteSelectedConfirmDialog.DialogText =

--- a/src/saving/SaveManagerGUI.tscn
+++ b/src/saving/SaveManagerGUI.tscn
@@ -32,9 +32,9 @@ __meta__ = {
 }
 
 [node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer"]
-margin_left = 139.0
+margin_left = 140.0
 margin_top = 85.0
-margin_right = 1139.0
+margin_right = 1140.0
 margin_bottom = 635.0
 rect_min_size = Vector2( 1000, 550 )
 size_flags_vertical = 3
@@ -45,36 +45,47 @@ margin_bottom = 24.0
 alignment = 1
 
 [node name="LoadButton" type="Button" parent="CenterContainer/VBoxContainer/TopBox"]
-margin_left = 212.0
-margin_right = 281.0
+margin_left = 96.0
+margin_right = 165.0
 margin_bottom = 24.0
 disabled = true
 text = "Load"
 
 [node name="VSeparator" type="VSeparator" parent="CenterContainer/VBoxContainer/TopBox"]
-margin_left = 285.0
-margin_right = 289.0
+margin_left = 169.0
+margin_right = 173.0
 margin_bottom = 24.0
 
 [node name="Refresh" type="Button" parent="CenterContainer/VBoxContainer/TopBox"]
-margin_left = 293.0
-margin_right = 391.0
+margin_left = 177.0
+margin_right = 275.0
 margin_bottom = 24.0
 text = "Refresh"
 
 [node name="DeleteSelected" type="Button" parent="CenterContainer/VBoxContainer/TopBox"]
-margin_left = 395.0
-margin_right = 575.0
+margin_left = 279.0
+margin_right = 459.0
 margin_bottom = 24.0
 disabled = true
 text = "Delete Selected"
 
 [node name="DeleteOld" type="Button" parent="CenterContainer/VBoxContainer/TopBox"]
-margin_left = 579.0
-margin_right = 787.0
+margin_left = 463.0
+margin_right = 671.0
 margin_bottom = 24.0
 disabled = true
 text = "Clean Up Old Saves"
+
+[node name="VSeparator2" type="VSeparator" parent="CenterContainer/VBoxContainer/TopBox"]
+margin_left = 675.0
+margin_right = 679.0
+margin_bottom = 24.0
+
+[node name="OpenSaveDir" type="Button" parent="CenterContainer/VBoxContainer/TopBox"]
+margin_left = 683.0
+margin_right = 903.0
+margin_bottom = 24.0
+text = "Open Save Directory"
 
 [node name="SaveList" parent="CenterContainer/VBoxContainer" instance=ExtResource( 3 )]
 anchor_right = 0.0
@@ -158,6 +169,7 @@ dialog_text = "Text not set...
 [connection signal="pressed" from="CenterContainer/VBoxContainer/TopBox/Refresh" to="." method="RefreshList"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/TopBox/DeleteSelected" to="." method="DeleteSelectedButtonPressed"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/TopBox/DeleteOld" to="." method="DeleteOldButtonPressed"]
+[connection signal="pressed" from="CenterContainer/VBoxContainer/TopBox/OpenSaveDir" to="." method="OpenSaveDirectoryPressed"]
 [connection signal="OnSelectedChanged" from="CenterContainer/VBoxContainer/SaveList" to="." method="OnSelectedChanged"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/BottomBox/Back" to="." method="OnBackButton"]
 [connection signal="confirmed" from="CenterContainer/VBoxContainer/DeleteSelectedConfirmDialog" to="." method="OnConfirmDeleteSelected"]


### PR DESCRIPTION
Add a button to open the save directory on top of the loading screen.

Should close [issue 1553](https://github.com/Revolutionary-Games/Thrive/issues/1553)

![image](https://user-images.githubusercontent.com/5007519/92153480-a30d1b80-ee24-11ea-831a-11222438a353.png)
