### PR TITLE
Saving/General : remove trailing and leading whitespaces in texts

### DIFF
--- a/src/general/OptionsMenu.tscn
+++ b/src/general/OptionsMenu.tscn
@@ -232,12 +232,12 @@ margin_right = 517.0
 margin_bottom = 159.0
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Graphics/VBoxContainer/HBoxContainer4"]
-margin_right = 118.0
+margin_right = 112.0
 margin_bottom = 23.0
-text = "Resolution: "
+text = "Resolution:"
 
 [node name="HSeparator" type="HSeparator" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Graphics/VBoxContainer/HBoxContainer4"]
-margin_left = 122.0
+margin_left = 116.0
 margin_right = 468.0
 margin_bottom = 23.0
 size_flags_horizontal = 3
@@ -255,12 +255,12 @@ margin_right = 517.0
 margin_bottom = 192.0
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Graphics/VBoxContainer/HBoxContainer3"]
-margin_right = 91.0
+margin_right = 85.0
 margin_bottom = 23.0
-text = "Max FPS: "
+text = "Max FPS:"
 
 [node name="HSeparator" type="HSeparator" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Graphics/VBoxContainer/HBoxContainer3"]
-margin_left = 95.0
+margin_left = 89.0
 margin_right = 474.0
 margin_bottom = 23.0
 size_flags_horizontal = 3
@@ -280,13 +280,13 @@ size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Graphics/VBoxContainer/HBoxContainer2"]
 margin_top = 1.0
-margin_right = 237.0
+margin_right = 231.0
 margin_bottom = 24.0
 mouse_filter = 0
-text = "Colourblind Correction: "
+text = "Colourblind Correction:"
 
 [node name="HSeparator" type="HSeparator" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Graphics/VBoxContainer/HBoxContainer2"]
-margin_left = 241.0
+margin_left = 235.0
 margin_right = 313.0
 margin_bottom = 25.0
 size_flags_horizontal = 3
@@ -435,7 +435,7 @@ margin_bottom = 68.0
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Performance/VBoxContainer/HBoxContainer/VBoxContainer"]
 margin_right = 263.0
 margin_bottom = 49.0
-text = "Cloud Simulation Minimum 
+text = "Cloud Simulation Minimum
 Interval:"
 
 [node name="Label2" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Performance/VBoxContainer/HBoxContainer/VBoxContainer"]
@@ -477,7 +477,7 @@ margin_right = 254.0
 margin_bottom = 23.0
 hint_tooltip = "This value only applies to new games started after changing this option"
 mouse_filter = 0
-text = "Cloud Resolution Divisor: "
+text = "Cloud Resolution Divisor:"
 
 [node name="Label2" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Performance/VBoxContainer/HBoxContainer2/VBoxContainer"]
 margin_top = 27.0

--- a/src/microbe_stage/editor/MicrobeEditor.tscn
+++ b/src/microbe_stage/editor/MicrobeEditor.tscn
@@ -1983,7 +1983,7 @@ margin_right = 80.0
 margin_bottom = 80.0
 custom_fonts/font = SubResource( 26 )
 custom_constants/line_spacing = -2
-text = "Rusticyanin	
+text = "Rusticyanin
 45 MP"
 align = 1
 

--- a/src/saving/SaveListItem.tscn
+++ b/src/saving/SaveListItem.tscn
@@ -43,7 +43,7 @@ LoadButtonPath = NodePath("SaveListItem/VBoxContainer/HBoxContainer/HBoxContaine
 [node name="SaveListItem" type="HBoxContainer" parent="."]
 margin_left = 3.0
 margin_top = 3.0
-margin_right = 654.0
+margin_right = 650.0
 margin_bottom = 131.0
 size_flags_horizontal = 3
 __meta__ = {
@@ -51,7 +51,7 @@ __meta__ = {
 }
 
 [node name="Screenshot" type="TextureRect" parent="SaveListItem"]
-margin_right = 129.0
+margin_right = 128.0
 margin_bottom = 128.0
 rect_min_size = Vector2( 128, 128 )
 size_flags_horizontal = 3
@@ -60,8 +60,8 @@ expand = true
 stretch_mode = 6
 
 [node name="VBoxContainer" type="VBoxContainer" parent="SaveListItem"]
-margin_left = 133.0
-margin_right = 651.0
+margin_left = 132.0
+margin_right = 647.0
 margin_bottom = 128.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 4.0
@@ -70,7 +70,7 @@ __meta__ = {
 }
 
 [node name="HBoxContainer" type="HBoxContainer" parent="SaveListItem/VBoxContainer"]
-margin_right = 518.0
+margin_right = 515.0
 margin_bottom = 43.0
 
 [node name="Label1" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer"]
@@ -86,57 +86,62 @@ margin_right = 160.0
 margin_bottom = 33.0
 text = "Loading..."
 
-[node name="Label2" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer"]
+[node name="Spacer" type="Control" parent="SaveListItem/VBoxContainer/HBoxContainer"]
 margin_left = 164.0
+margin_right = 167.0
+margin_bottom = 43.0
+rect_min_size = Vector2( 3, 0 )
+
+[node name="Label2" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer"]
+margin_left = 171.0
 margin_top = 10.0
-margin_right = 251.0
+margin_right = 252.0
 margin_bottom = 33.0
-text = " Version:"
+text = "Version:"
 
 [node name="Version" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer"]
-margin_left = 255.0
+margin_left = 256.0
 margin_top = 10.0
-margin_right = 270.0
+margin_right = 271.0
 margin_bottom = 33.0
 text = "..."
 
 [node name="VersionWarning" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer"]
-margin_left = 274.0
+margin_left = 275.0
 margin_top = 10.0
-margin_right = 301.0
+margin_right = 302.0
 margin_bottom = 33.0
 text = "( ! )"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="SaveListItem/VBoxContainer/HBoxContainer"]
-margin_left = 305.0
-margin_right = 518.0
+margin_left = 306.0
+margin_right = 515.0
 margin_bottom = 43.0
 size_flags_horizontal = 3
 alignment = 2
 
 [node name="SelectBox" type="CheckBox" parent="SaveListItem/VBoxContainer/HBoxContainer/HBoxContainer"]
-margin_left = 4.0
-margin_right = 94.0
+margin_right = 90.0
 margin_bottom = 43.0
 text = "select"
 
 [node name="Delete" type="TextureButton" parent="SaveListItem/VBoxContainer/HBoxContainer/HBoxContainer"]
-margin_left = 98.0
-margin_right = 140.0
+margin_left = 94.0
+margin_right = 136.0
 margin_bottom = 43.0
 texture_normal = ExtResource( 6 )
 texture_hover = ExtResource( 4 )
 texture_disabled = ExtResource( 1 )
 
 [node name="Load" type="Button" parent="SaveListItem/VBoxContainer/HBoxContainer/HBoxContainer"]
-margin_left = 144.0
-margin_right = 213.0
+margin_left = 140.0
+margin_right = 209.0
 margin_bottom = 43.0
 text = "Load"
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="SaveListItem/VBoxContainer"]
 margin_top = 47.0
-margin_right = 518.0
+margin_right = 515.0
 margin_bottom = 70.0
 
 [node name="Label" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer2"]
@@ -150,21 +155,27 @@ margin_right = 128.0
 margin_bottom = 23.0
 text = "..."
 
-[node name="Label3" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer2"]
+[node name="Spacer" type="Control" parent="SaveListItem/VBoxContainer/HBoxContainer2"]
 margin_left = 132.0
-margin_right = 169.0
+margin_right = 135.0
 margin_bottom = 23.0
-text = " By:"
+rect_min_size = Vector2( 3, 0 )
+
+[node name="Label3" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer2"]
+margin_left = 139.0
+margin_right = 170.0
+margin_bottom = 23.0
+text = "By:"
 
 [node name="Creator" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer2"]
-margin_left = 173.0
-margin_right = 188.0
+margin_left = 174.0
+margin_right = 189.0
 margin_bottom = 23.0
 text = "..."
 
 [node name="HBoxContainer4" type="HBoxContainer" parent="SaveListItem/VBoxContainer"]
 margin_top = 74.0
-margin_right = 518.0
+margin_right = 515.0
 margin_bottom = 97.0
 
 [node name="Label" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer4"]
@@ -178,21 +189,27 @@ margin_right = 73.0
 margin_bottom = 23.0
 text = "..."
 
-[node name="Label2" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer4"]
+[node name="Spacer" type="Control" parent="SaveListItem/VBoxContainer/HBoxContainer4"]
 margin_left = 77.0
-margin_right = 288.0
+margin_right = 80.0
 margin_bottom = 23.0
-text = " Created on Platform:"
+rect_min_size = Vector2( 3, 0 )
+
+[node name="Label2" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer4"]
+margin_left = 84.0
+margin_right = 289.0
+margin_bottom = 23.0
+text = "Created on Platform:"
 
 [node name="Platform" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer4"]
-margin_left = 292.0
-margin_right = 307.0
+margin_left = 293.0
+margin_right = 308.0
 margin_bottom = 23.0
 text = "..."
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="SaveListItem/VBoxContainer"]
 margin_top = 101.0
-margin_right = 518.0
+margin_right = 515.0
 margin_bottom = 124.0
 
 [node name="Label" type="Label" parent="SaveListItem/VBoxContainer/HBoxContainer3"]

--- a/src/saving/SaveManagerGUI.tscn
+++ b/src/saving/SaveManagerGUI.tscn
@@ -100,6 +100,7 @@ SelectableItems = true
 margin_top = 526.0
 margin_right = 1000.0
 margin_bottom = 550.0
+custom_constants/separation = 3
 
 [node name="Back" type="Button" parent="CenterContainer/VBoxContainer/BottomBox"]
 margin_right = 67.0
@@ -107,43 +108,55 @@ margin_bottom = 24.0
 text = "Back"
 
 [node name="VSeparator2" type="VSeparator" parent="CenterContainer/VBoxContainer/BottomBox"]
-margin_left = 71.0
-margin_right = 75.0
+margin_left = 70.0
+margin_right = 74.0
 margin_bottom = 24.0
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/BottomBox"]
-margin_left = 79.0
-margin_right = 200.0
+margin_left = 77.0
+margin_right = 198.0
 margin_bottom = 23.0
 text = "Total saves:"
 
 [node name="SaveCount" type="Label" parent="CenterContainer/VBoxContainer/BottomBox"]
-margin_left = 204.0
-margin_right = 217.0
+margin_left = 201.0
+margin_right = 214.0
 margin_bottom = 23.0
 text = "0"
+
+[node name="Spacer" type="Control" parent="CenterContainer/VBoxContainer/BottomBox"]
+margin_left = 217.0
+margin_right = 220.0
+margin_bottom = 24.0
+rect_min_size = Vector2( 3, 0 )
 
 [node name="Label3" type="Label" parent="CenterContainer/VBoxContainer/BottomBox"]
-margin_left = 221.0
-margin_right = 354.0
+margin_left = 223.0
+margin_right = 350.0
 margin_bottom = 23.0
-text = " Space used:"
+text = "Space used:"
 
 [node name="SavesSpaceUsed" type="Label" parent="CenterContainer/VBoxContainer/BottomBox"]
-margin_left = 358.0
-margin_right = 371.0
+margin_left = 353.0
+margin_right = 366.0
 margin_bottom = 23.0
 text = "0"
+
+[node name="Spacer2" type="Control" parent="CenterContainer/VBoxContainer/BottomBox"]
+margin_left = 369.0
+margin_right = 372.0
+margin_bottom = 24.0
+rect_min_size = Vector2( 3, 0 )
 
 [node name="Label2" type="Label" parent="CenterContainer/VBoxContainer/BottomBox"]
 margin_left = 375.0
-margin_right = 477.0
+margin_right = 471.0
 margin_bottom = 23.0
-text = " Selected:"
+text = "Selected:"
 
 [node name="SelectedCount" type="Label" parent="CenterContainer/VBoxContainer/BottomBox"]
-margin_left = 481.0
-margin_right = 494.0
+margin_left = 474.0
+margin_right = 487.0
 margin_bottom = 23.0
 text = "0"
 


### PR DESCRIPTION
Remove all the trailing and leading whitespaces in texts on various screens, to prepare for localization.

I couldn't find more spaces than that, but maybe we'll find more as the work on the localization continues.

Close [issue 1509](https://github.com/Revolutionary-Games/Thrive/issues/1509)