### PR TITLE
Fix for duplicate cell division when leaving editor.

### DIFF
--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -802,17 +802,21 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
             // If the compound is for reproduction we give player and NPC microbes different amounts.
             if (reproductionCompounds.TryGetValue(compound, out float divideAmount))
             {
-                // Player cells receive the normal half split, NPC cells may receive less.
+                // The amount taken away from the parent cell depends on if it is a player or NPC. Player
+                // cells always have 50% of the compounds they divided with taken away.
                 float amountToTake = amount * 0.5f;
 
                 if (!IsPlayerMicrobe)
                 {
-                    // NPC cells are capped at 90% of the amount of compound required to divide.
+                    // NPC parent cells have at least 50% taken away, or more if it would leave them
+                    // with more than 90% of the compound it would take to immediately divide again.
                     amountToTake = Math.Max(amountToTake, amount - (divideAmount * 0.9f));
                 }
 
                 Compounds.TakeCompound(compound, amountToTake);
 
+                // Since the child cell is always an NPC they are given either 50% of the compound from the
+                // parent, or 90% of the amount required to immediately divide again, whichever is smaller.
                 float amountToGive = Math.Min(amount * 0.5f, divideAmount * 0.9f);
                 var didntFit = copyEntity.Compounds.AddCompound(compound, amountToGive);
 
@@ -823,7 +827,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
             }
             else
             {
-                // Other compounds just get split evenly to both cells.
+                // Non-reproductive compounds just always get split evenly to both cells.
                 Compounds.TakeCompound(compound, amount * 0.5f);
 
                 var didntFit = copyEntity.Compounds.AddCompound(compound, amount * 0.5f);

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -789,55 +789,48 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
         copyEntity.Compounds.ClearCompounds();
 
         var keys = new List<Compound>(Compounds.Compounds.Keys);
-        var reproductionCompounds = CalculateTotalCompounds();
+        var reproductionCompounds = copyEntity.CalculateTotalCompounds();
 
         // Split the compounds between the two cells.
         foreach (var compound in keys)
         {
             var amount = Compounds.GetCompoundAmount(compound);
 
-            if (amount > 0)
+            if (amount <= 0)
+                continue;
+
+            // If the compound is for reproduction we give player and NPC microbes different amounts.
+            if (reproductionCompounds.TryGetValue(compound, out float divideAmount))
             {
-                float divideAmount;
+                // Player cells receive the normal half split, NPC cells may receive less.
+                float amountToTake = amount * 0.5f;
 
-                // If the compound is needed for reproduction we give player and NPC microbes different
-                // amounts.
-                if (reproductionCompounds.TryGetValue(compound, out divideAmount))
+                if (!IsPlayerMicrobe)
                 {
-                    // First handle the original cell.
-                    if (IsPlayerMicrobe)
-                    {
-                        // Player microbes only lose half of reproductive compounds.
-                        Compounds.TakeCompound(compound, amount * 0.5f);
-                    }
-                    else
-                    {
-                        // NPC cells may not keep more than 90% of the amount of compound required to divide,
-                        // so they may lose more than half.
-                        float amountToTake = Math.Max(amount * 0.5f, amount - (divideAmount * 0.9f));
-                        Compounds.TakeCompound(compound, amountToTake);
-                    }
-
-                    // Now handle the new cell.
-                    float amountToGive = Math.Min(amount * 0.5f, divideAmount * 0.9f);
-                    var didntFit = copyEntity.Compounds.AddCompound(compound, amountToGive);
-
-                    if (didntFit > 0)
-                    {
-                        // TODO: handle the excess compound that didn't fit in the other cell
-                    }
+                    // NPC cells are capped at 90% of the amount of compound required to divide.
+                    amountToTake = Math.Max(amountToTake, amount - (divideAmount * 0.9f));
                 }
-                else
+
+                Compounds.TakeCompound(compound, amountToTake);
+
+                float amountToGive = Math.Min(amount * 0.5f, divideAmount * 0.9f);
+                var didntFit = copyEntity.Compounds.AddCompound(compound, amountToGive);
+
+                if (didntFit > 0)
                 {
-                    // Other compounds just get split evenly.
-                    Compounds.TakeCompound(compound, amount * 0.5f);
+                    // TODO: handle the excess compound that didn't fit in the other cell
+                }
+            }
+            else
+            {
+                // Other compounds just get split evenly to both cells.
+                Compounds.TakeCompound(compound, amount * 0.5f);
 
-                    var didntFit = copyEntity.Compounds.AddCompound(compound, amount * 0.5f);
+                var didntFit = copyEntity.Compounds.AddCompound(compound, amount * 0.5f);
 
-                    if (didntFit > 0)
-                    {
-                        // TODO: handle the excess compound that didn't fit in the other cell
-                    }
+                if (didntFit > 0)
+                {
+                    // TODO: handle the excess compound that didn't fit in the other cell
                 }
             }
         }


### PR DESCRIPTION
Implemented the fix suggested in the linked issue. NPC cells now only receive up to 90% of reproductive compounds required to divide again.
Closes #1497 