### PR TITLE
Options menu can open in different modes

### DIFF
--- a/src/general/OptionsMenu.cs
+++ b/src/general/OptionsMenu.cs
@@ -391,7 +391,7 @@ public class OptionsMenu : Control
         maxAutosaves.Editable = settings.AutoSaveEnabled;
         maxQuicksaves.Value = settings.MaxQuickSaves;
     }
-    
+
     private void SwitchMode(OptionsMode mode)
     {
         if (mode == OptionsMode.MainMenu)

--- a/src/general/OptionsMenu.cs
+++ b/src/general/OptionsMenu.cs
@@ -108,7 +108,7 @@ public class OptionsMenu : Control
     public NodePath PlayMicrobeIntroPath;
 
     [Export]
-    public NodePath TutorialsEnabledPath;
+    public NodePath TutorialsEnabledOnNewGamePath;
 
     [Export]
     public NodePath CheatsPath;
@@ -126,12 +126,17 @@ public class OptionsMenu : Control
     public NodePath BackConfirmationBoxPath;
 
     [Export]
+    public NodePath LocalSettingsVBoxPath;
+
+    [Export]
+    public NodePath TutorialsEnabledPath;
+
+    [Export]
     public NodePath DefaultsConfirmationBoxPath;
 
     [Export]
     public NodePath ErrorAcceptBoxPath;
 
-    private const float AUDIO_BAR_SCALE = 6f;
     private Button resetButton;
     private Button saveButton;
 
@@ -173,10 +178,14 @@ public class OptionsMenu : Control
     private CheckBox playIntro;
     private CheckBox playMicrobeIntro;
     private CheckBox cheats;
-    private CheckBox tutorialsEnabled;
+    private CheckBox tutorialsEnabledOnNewGame;
     private CheckBox autosave;
     private SpinBox maxAutosaves;
     private SpinBox maxQuicksaves;
+
+    private VBoxContainer localSettingsVBox;
+
+    private CheckBox tutorialsEnabled;
 
     // Confirmation Boxes
     private WindowDialog backConfirmationBox;
@@ -187,13 +196,18 @@ public class OptionsMenu : Control
       Misc
     */
 
+    private OptionsMode optionsMode;
+    private SelectedOptionsTab selectedOptionsTab;
+
     /// <summary>
     ///   Copy of the settings object that should match what is saved to the configuration file,
     ///   used for comparing and restoring to previous state.
     /// </summary>
     private Settings savedSettings;
 
-    private SelectedOptionsTab selectedOptionsTab;
+    private bool savedTutorialsEnabled;
+
+    private GameProperties gameProperties;
 
     /*
       Signals
@@ -202,6 +216,12 @@ public class OptionsMenu : Control
     [Signal]
     public delegate void OnOptionsClosed();
 
+    public enum OptionsMode
+    {
+        MainMenu,
+        MicrobeStage,
+    }
+
     private enum SelectedOptionsTab
     {
         Graphics,
@@ -209,11 +229,6 @@ public class OptionsMenu : Control
         Performance,
         Miscellaneous,
     }
-
-    /// <summary>
-    ///   Returns the place to save the new settings values
-    /// </summary>
-    public Settings Settings => Settings.Instance;
 
     public override void _Ready()
     {
@@ -258,24 +273,19 @@ public class OptionsMenu : Control
         miscTab = GetNode<Control>(MiscTabPath);
         playIntro = GetNode<CheckBox>(PlayIntroPath);
         playMicrobeIntro = GetNode<CheckBox>(PlayMicrobeIntroPath);
-        tutorialsEnabled = GetNode<CheckBox>(TutorialsEnabledPath);
+        tutorialsEnabledOnNewGame = GetNode<CheckBox>(TutorialsEnabledOnNewGamePath);
         cheats = GetNode<CheckBox>(CheatsPath);
         autosave = GetNode<CheckBox>(AutoSavePath);
         maxAutosaves = GetNode<SpinBox>(MaxAutoSavesPath);
         maxQuicksaves = GetNode<SpinBox>(MaxQuickSavesPath);
+        localSettingsVBox = GetNode<VBoxContainer>(LocalSettingsVBoxPath);
+        tutorialsEnabled = GetNode<CheckBox>(TutorialsEnabledPath);
 
         backConfirmationBox = GetNode<WindowDialog>(BackConfirmationBoxPath);
         defaultsConfirmationBox = GetNode<ConfirmationDialog>(DefaultsConfirmationBoxPath);
         errorAcceptBox = GetNode<AcceptDialog>(ErrorAcceptBoxPath);
 
         selectedOptionsTab = SelectedOptionsTab.Graphics;
-
-        // Copy settings from the singleton to serve as a copy of the last saved settings.
-        savedSettings = Settings.Instance.Clone();
-
-        // Set the initial state of the options controls to match the settings data.
-        ApplySettingsToControls(savedSettings);
-        CompareSettings();
     }
 
     public override void _Process(float delta)
@@ -283,7 +293,67 @@ public class OptionsMenu : Control
     }
 
     /// <summary>
-    ///   Applies the values of the specified settings object to all corresponding menu controls.
+    ///   Opens the options menu with main menu configuration settings.
+    /// </summary>
+    public void OpenFromMainMenu()
+    {
+        // Shouldn't do anything if options is already open.
+        if (Visible)
+            return;
+
+        // Copy the live game settings so we can check against them for changes.
+        savedSettings = Settings.Instance.Clone();
+
+        // Set the mode to the one we opened with, and disable any options that should only be visible in game.
+        SwitchMode(OptionsMode.MainMenu);
+
+        // Set the state of the gui controls to match the settings.
+        ApplySettingsToControls(savedSettings);
+        UpdateResetSaveButtonState();
+
+        Show();
+    }
+
+    /// <summary>
+    ///   Opens the options menu with microbe stage settings.
+    /// </summary>
+    public void OpenFromMicrobeStage(GameProperties gameProperties)
+    {
+        // Shouldn't do anything if options is already open.
+        if (Visible)
+            return;
+
+        // Copy the live game settings so we can check against them for changes.
+        savedSettings = Settings.Instance.Clone();
+        savedTutorialsEnabled = gameProperties.TutorialState.Enabled;
+
+        // Need a reference to game properties in the current game for later comparisons.
+        this.gameProperties = gameProperties;
+
+        // If we're in free build mode then tutorials should not be toggleable.
+        if (gameProperties.FreeBuild)
+        {
+            tutorialsEnabled.Hide();
+        }
+
+        // Set the mode to the one we opened with, and enable any options that should only be visible
+        // when the options menu is opened from in-game.
+        SwitchMode(OptionsMode.MicrobeStage);
+
+        if (savedTutorialsEnabled)
+        {
+            tutorialsEnabled.Pressed = savedTutorialsEnabled;
+        }
+
+        // Set the state of the gui controls to match the settings.
+        ApplySettingsToControls(savedSettings);
+        UpdateResetSaveButtonState();
+
+        Show();
+    }
+
+    /// <summary>
+    ///   Applies the values of a settings object to all corresponding options menu GUI controls.
     /// </summary>
     public void ApplySettingsToControls(Settings settings)
     {
@@ -314,24 +384,41 @@ public class OptionsMenu : Control
         // Misc
         playIntro.Pressed = settings.PlayIntroVideo;
         playMicrobeIntro.Pressed = settings.PlayMicrobeIntroVideo;
-        tutorialsEnabled.Pressed = settings.TutorialsEnabled;
+        tutorialsEnabledOnNewGame.Pressed = settings.TutorialsEnabled;
         cheats.Pressed = settings.CheatsEnabled;
         autosave.Pressed = settings.AutoSaveEnabled;
         maxAutosaves.Value = settings.MaxAutoSaves;
         maxAutosaves.Editable = settings.AutoSaveEnabled;
         maxQuicksaves.Value = settings.MaxQuickSaves;
     }
+    
+    private void SwitchMode(OptionsMode mode)
+    {
+        if (mode == OptionsMode.MainMenu)
+        {
+            // Hide the local game settings if opened from the main menu.
+            localSettingsVBox.Hide();
+            optionsMode = OptionsMode.MainMenu;
+        }
+        else if (mode == OptionsMode.MicrobeStage)
+        {
+            // Show the local game settings if opened from the microbe stage or editor.
+            localSettingsVBox.Show();
+            optionsMode = OptionsMode.MicrobeStage;
+        }
+    }
 
-    private void SetSettingsTab(string tab)
+    /// <summary>
+    ///   Changes the active settings tab that is displayed, or returns if the tab is already active.
+    /// </summary>
+    private void ChangeSettingsTab(string newTabName)
     {
         // Convert from the string binding to an enum.
-        SelectedOptionsTab selection = (SelectedOptionsTab)Enum.Parse(typeof(SelectedOptionsTab), tab);
+        SelectedOptionsTab selection = (SelectedOptionsTab)Enum.Parse(typeof(SelectedOptionsTab), newTabName);
 
         // Pressing the same button that's already active, so just return.
         if (selection == selectedOptionsTab)
-        {
             return;
-        }
 
         graphicsTab.Hide();
         soundTab.Hide();
@@ -370,12 +457,12 @@ public class OptionsMenu : Control
     /// </summary>
     private float ConvertSoundBarToDb(float value)
     {
-        return (value - 100) / AUDIO_BAR_SCALE;
+        return GD.Linear2Db(value / 100.0f);
     }
 
     private float ConvertDBToSoundBar(float value)
     {
-        return value * AUDIO_BAR_SCALE + 100;
+        return GD.Db2Linear(value) * 100.0f;
     }
 
     private int CloudIntervalToIndex(float interval)
@@ -491,21 +578,36 @@ public class OptionsMenu : Control
         }
     }
 
-    private void CompareSettings()
+    /// <summary>
+    ///   Returns whether current settings match their saved originals. Settings that are
+    ///   inactive due to a different options menu mode will not be used in the comparison.
+    /// </summary>
+    private bool CompareSettings()
+    {
+        // Compare global settings.
+        if (Settings.Instance != savedSettings)
+            return false;
+
+        // If we're in game we need to compare the tutorials enabled state as well.
+        if (optionsMode == OptionsMode.MicrobeStage)
+        {
+            if (gameProperties.TutorialState.Enabled != savedTutorialsEnabled)
+            {
+                return false;
+            }
+        }
+
+        // All active settings match.
+        return true;
+    }
+
+    private void UpdateResetSaveButtonState()
     {
         // Enable the save and reset buttons if the current setting values differ from the saved ones.
-        if (Settings.Instance == savedSettings)
-        {
-            // Settings match
-            resetButton.Disabled = true;
-            saveButton.Disabled = true;
-        }
-        else
-        {
-            // Settings differ
-            resetButton.Disabled = false;
-            saveButton.Disabled = false;
-        }
+        bool result = CompareSettings();
+
+        resetButton.Disabled = result;
+        saveButton.Disabled = result;
     }
 
     /*
@@ -518,7 +620,7 @@ public class OptionsMenu : Control
 
         // If any settings have been changed, show a dialogue asking if the changes should be kept or
         // discarded.
-        if (Settings.Instance != savedSettings)
+        if (!CompareSettings())
         {
             backConfirmationBox.PopupCenteredMinsize();
             return;
@@ -533,10 +635,16 @@ public class OptionsMenu : Control
 
         // Restore and apply the old saved settings.
         Settings.Instance.LoadFromObject(savedSettings);
-        Settings.ApplyAll();
+        Settings.Instance.ApplyAll();
         ApplySettingsToControls(Settings.Instance);
 
-        CompareSettings();
+        if (optionsMode == OptionsMode.MicrobeStage)
+        {
+            gameProperties.TutorialState.Enabled = savedTutorialsEnabled;
+            tutorialsEnabled.Pressed = savedTutorialsEnabled;
+        }
+
+        UpdateResetSaveButtonState();
     }
 
     private void OnSavePressed()
@@ -544,7 +652,7 @@ public class OptionsMenu : Control
         GUICommon.Instance.PlayButtonPressSound();
 
         // Save the new settings to the config file.
-        if (!Settings.Save())
+        if (!Settings.Instance.Save())
         {
             GD.PrintErr("Failed to save new options menu settings to configuration file.");
             errorAcceptBox.PopupCenteredMinsize();
@@ -554,7 +662,10 @@ public class OptionsMenu : Control
         // Copy over the new saved settings.
         savedSettings = Settings.Instance.Clone();
 
-        CompareSettings();
+        if (optionsMode == OptionsMode.MicrobeStage)
+            savedTutorialsEnabled = gameProperties.TutorialState.Enabled;
+
+        UpdateResetSaveButtonState();
     }
 
     private void OnDefaultsPressed()
@@ -567,7 +678,7 @@ public class OptionsMenu : Control
     private void BackSaveSelected()
     {
         // Save the new settings to the config file.
-        if (!Settings.Save())
+        if (!Settings.Instance.Save())
         {
             GD.PrintErr("Failed to save new options menu settings to configuration file.");
             backConfirmationBox.Hide();
@@ -580,19 +691,25 @@ public class OptionsMenu : Control
         savedSettings = Settings.Instance.Clone();
         backConfirmationBox.Hide();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
         EmitSignal(nameof(OnOptionsClosed));
     }
 
     private void BackDiscardSelected()
     {
         Settings.Instance.LoadFromObject(savedSettings);
-        Settings.ApplyAll();
+        Settings.Instance.ApplyAll();
         ApplySettingsToControls(Settings.Instance);
+
+        if (optionsMode == OptionsMode.MicrobeStage)
+        {
+            gameProperties.TutorialState.Enabled = savedTutorialsEnabled;
+            tutorialsEnabled.Pressed = savedTutorialsEnabled;
+        }
 
         backConfirmationBox.Hide();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
         EmitSignal(nameof(OnOptionsClosed));
     }
 
@@ -605,138 +722,138 @@ public class OptionsMenu : Control
     {
         // Sets active settings to default values and applies them to the options controls.
         Settings.Instance.LoadDefaults();
-        Settings.ApplyAll();
+        Settings.Instance.ApplyAll();
         ApplySettingsToControls(Settings.Instance);
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     // Graphics Button Callbacks
     private void OnFullScreenToggled(bool pressed)
     {
         Settings.Instance.FullScreen.Value = pressed;
-        Settings.ApplyWindowSettings();
+        Settings.Instance.ApplyWindowSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnVSyncToggled(bool pressed)
     {
         Settings.Instance.VSync.Value = pressed;
-        Settings.ApplyWindowSettings();
+        Settings.Instance.ApplyWindowSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnMSAAResolutionSelected(int index)
     {
         Settings.Instance.MSAAResolution.Value = MSAAIndexToResolution(index);
-        Settings.ApplyGraphicsSettings();
+        Settings.Instance.ApplyGraphicsSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnColourblindSettingSelected(int index)
     {
         Settings.Instance.ColourblindSetting.Value = index;
-        Settings.ApplyGraphicsSettings();
+        Settings.Instance.ApplyGraphicsSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnChromaticAberrationToggled(bool toggle)
     {
         Settings.Instance.ChromaticEnabled.Value = toggle;
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnChromaticAberrationValueChanged(float amount)
     {
         Settings.Instance.ChromaticAmount.Value = amount;
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     // Sound Button Callbacks
     private void OnMasterVolumeChanged(float value)
     {
         Settings.Instance.VolumeMaster.Value = ConvertSoundBarToDb(value);
-        Settings.ApplySoundSettings();
+        Settings.Instance.ApplySoundSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnMasterMutedToggled(bool pressed)
     {
         Settings.Instance.VolumeMasterMuted.Value = pressed;
-        Settings.ApplySoundSettings();
+        Settings.Instance.ApplySoundSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnMusicVolumeChanged(float value)
     {
         Settings.Instance.VolumeMusic.Value = ConvertSoundBarToDb(value);
-        Settings.ApplySoundSettings();
+        Settings.Instance.ApplySoundSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnMusicMutedToggled(bool pressed)
     {
         Settings.Instance.VolumeMusicMuted.Value = pressed;
-        Settings.ApplySoundSettings();
+        Settings.Instance.ApplySoundSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnAmbianceVolumeChanged(float value)
     {
         Settings.Instance.VolumeAmbiance.Value = ConvertSoundBarToDb(value);
-        Settings.ApplySoundSettings();
+        Settings.Instance.ApplySoundSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnAmbianceMutedToggled(bool pressed)
     {
         Settings.Instance.VolumeAmbianceMuted.Value = pressed;
-        Settings.ApplySoundSettings();
+        Settings.Instance.ApplySoundSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnSFXVolumeChanged(float value)
     {
         Settings.Instance.VolumeSFX.Value = ConvertSoundBarToDb(value);
-        Settings.ApplySoundSettings();
+        Settings.Instance.ApplySoundSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnSFXMutedToggled(bool pressed)
     {
         Settings.Instance.VolumeSFXMuted.Value = pressed;
-        Settings.ApplySoundSettings();
+        Settings.Instance.ApplySoundSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnGUIVolumeChanged(float value)
     {
         Settings.Instance.VolumeGUI.Value = ConvertSoundBarToDb(value);
-        Settings.ApplySoundSettings();
+        Settings.Instance.ApplySoundSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnGUIMutedToggled(bool pressed)
     {
         Settings.Instance.VolumeGUIMuted.Value = pressed;
-        Settings.ApplySoundSettings();
+        Settings.Instance.ApplySoundSettings();
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     // Performance Button Callbacks
@@ -744,14 +861,14 @@ public class OptionsMenu : Control
     {
         Settings.Instance.CloudUpdateInterval.Value = CloudIndexToInterval(index);
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnCloudResolutionSelected(int index)
     {
         Settings.Instance.CloudResolution.Value = CloudIndexToResolution(index);
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     // Misc Button Callbacks
@@ -759,28 +876,28 @@ public class OptionsMenu : Control
     {
         Settings.Instance.PlayIntroVideo.Value = pressed;
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnMicrobeIntroToggled(bool pressed)
     {
         Settings.Instance.PlayMicrobeIntroVideo.Value = pressed;
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
-    private void OnTutorialsToggled(bool pressed)
+    private void OnTutorialsOnNewGameToggled(bool pressed)
     {
         Settings.Instance.TutorialsEnabled.Value = pressed;
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnCheatsToggled(bool pressed)
     {
         Settings.Instance.CheatsEnabled.Value = pressed;
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnAutoSaveToggled(bool pressed)
@@ -788,20 +905,27 @@ public class OptionsMenu : Control
         Settings.Instance.AutoSaveEnabled.Value = pressed;
         maxAutosaves.Editable = pressed;
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnMaxAutoSavesValueChanged(float value)
     {
         Settings.Instance.MaxAutoSaves.Value = (int)value;
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
     }
 
     private void OnMaxQuickSavesValueChanged(float value)
     {
         Settings.Instance.MaxQuickSaves.Value = (int)value;
 
-        CompareSettings();
+        UpdateResetSaveButtonState();
+    }
+
+    private void OnTutorialsEnabledToggled(bool pressed)
+    {
+        gameProperties.TutorialState.Enabled = pressed;
+
+        UpdateResetSaveButtonState();
     }
 }

--- a/src/general/OptionsMenu.tscn
+++ b/src/general/OptionsMenu.tscn
@@ -77,8 +77,7 @@ AutoSavePath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginCont
 MaxAutoSavesPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/HBoxContainer/MaxAutoSaves")
 MaxQuickSavesPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/HBoxContainer2/MaxQuickSaves")
 BackConfirmationBoxPath = NodePath("CenterContainer/BackConfirm")
-LocalSettingsVBoxPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/VBoxContainer")
-TutorialsEnabledPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/VBoxContainer/TutorialsEnabled")
+TutorialsEnabledPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/TutorialsEnabled")
 DefaultsConfirmationBoxPath = NodePath("CenterContainer/DefaultsConfirm")
 ErrorAcceptBoxPath = NodePath("CenterContainer/ErrorAccept")
 
@@ -663,47 +662,35 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_right = 520.0
-margin_bottom = 23.0
-text = "Global Settings"
-align = 1
-
-[node name="HSeparator2" type="HSeparator" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 33.0
-margin_right = 520.0
-margin_bottom = 37.0
-
 [node name="Intro" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 47.0
 margin_right = 188.0
-margin_bottom = 72.0
+margin_bottom = 25.0
 size_flags_horizontal = 0
 custom_styles/hover_pressed = SubResource( 2 )
 text = "Play intro video"
 
 [node name="MicrobeIntro" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 82.0
+margin_top = 35.0
 margin_right = 368.0
-margin_bottom = 107.0
+margin_bottom = 60.0
 rect_pivot_offset = Vector2( 114, 23 )
 size_flags_horizontal = 0
 custom_styles/hover_pressed = SubResource( 2 )
 text = "Play Microbe Intro on New Game"
 
 [node name="AutoSave" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 117.0
+margin_top = 70.0
 margin_right = 307.0
-margin_bottom = 142.0
+margin_bottom = 95.0
 rect_pivot_offset = Vector2( 114, 23 )
 size_flags_horizontal = 0
 custom_styles/hover_pressed = SubResource( 2 )
 text = "Autosave during the game"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 152.0
+margin_top = 105.0
 margin_right = 520.0
-margin_bottom = 177.0
+margin_bottom = 130.0
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/HBoxContainer"]
 margin_top = 1.0
@@ -729,9 +716,9 @@ max_value = 50.0
 value = 1.0
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 187.0
+margin_top = 140.0
 margin_right = 520.0
-margin_bottom = 212.0
+margin_bottom = 165.0
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/HBoxContainer2"]
 margin_top = 1.0
@@ -757,53 +744,37 @@ max_value = 50.0
 value = 1.0
 
 [node name="TutorialsEnabledOnNewGame" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 222.0
+margin_top = 175.0
 margin_right = 349.0
-margin_bottom = 247.0
+margin_bottom = 200.0
 size_flags_horizontal = 0
 custom_styles/hover_pressed = SubResource( 2 )
 pressed = true
 text = "Show tutorials (in new games)"
 
-[node name="Cheats" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 257.0
-margin_right = 239.0
-margin_bottom = 282.0
+[node name="TutorialsEnabled" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
+margin_top = 210.0
+margin_right = 370.0
+margin_bottom = 235.0
 size_flags_horizontal = 0
 custom_styles/hover_pressed = SubResource( 2 )
-text = "Cheat keys enabled"
+text = "Show tutorials (in current game)"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="HSeparator" type="HSeparator" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 292.0
+margin_top = 245.0
 margin_right = 520.0
-margin_bottom = 296.0
+margin_bottom = 249.0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 306.0
-margin_right = 520.0
-margin_bottom = 366.0
-
-[node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/VBoxContainer"]
-margin_right = 520.0
-margin_bottom = 23.0
-text = "Current Game Settings"
-align = 1
-
-[node name="HSeparator" type="HSeparator" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/VBoxContainer"]
-margin_top = 27.0
-margin_right = 520.0
-margin_bottom = 31.0
-
-[node name="TutorialsEnabled" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/VBoxContainer"]
-margin_top = 35.0
-margin_right = 209.0
-margin_bottom = 60.0
+[node name="Cheats" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
+margin_top = 259.0
+margin_right = 239.0
+margin_bottom = 284.0
 size_flags_horizontal = 0
 custom_styles/hover_pressed = SubResource( 2 )
-text = "Tutorials Enabled"
+text = "Cheat keys enabled"
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -998,8 +969,8 @@ dialog_text = "Error: Failed to save new settings to configuration file."
 [connection signal="value_changed" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/HBoxContainer/MaxAutoSaves" to="." method="OnMaxAutoSavesValueChanged"]
 [connection signal="value_changed" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/HBoxContainer2/MaxQuickSaves" to="." method="OnMaxQuickSavesValueChanged"]
 [connection signal="toggled" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/TutorialsEnabledOnNewGame" to="." method="OnTutorialsOnNewGameToggled"]
+[connection signal="toggled" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/TutorialsEnabled" to="." method="OnTutorialsEnabledToggled"]
 [connection signal="toggled" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/Cheats" to="." method="OnCheatsToggled"]
-[connection signal="toggled" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/VBoxContainer/TutorialsEnabled" to="." method="OnTutorialsEnabledToggled"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/HBoxContainer/Back" to="." method="OnBackPressed"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/HBoxContainer/Reset" to="." method="OnResetPressed"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/HBoxContainer/Save" to="." method="OnSavePressed"]

--- a/src/general/OptionsMenu.tscn
+++ b/src/general/OptionsMenu.tscn
@@ -71,12 +71,14 @@ CloudResolutionPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/Mar
 MiscTabPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc")
 PlayIntroPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/Intro")
 PlayMicrobeIntroPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/MicrobeIntro")
-TutorialsEnabledPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/ShowTutorials")
+TutorialsEnabledOnNewGamePath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/TutorialsEnabledOnNewGame")
 CheatsPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/Cheats")
 AutoSavePath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/AutoSave")
 MaxAutoSavesPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/HBoxContainer/MaxAutoSaves")
 MaxQuickSavesPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/HBoxContainer2/MaxQuickSaves")
 BackConfirmationBoxPath = NodePath("CenterContainer/BackConfirm")
+LocalSettingsVBoxPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/VBoxContainer")
+TutorialsEnabledPath = NodePath("CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/VBoxContainer/TutorialsEnabled")
 DefaultsConfirmationBoxPath = NodePath("CenterContainer/DefaultsConfirm")
 ErrorAcceptBoxPath = NodePath("CenterContainer/ErrorAccept")
 
@@ -655,40 +657,53 @@ margin_bottom = 583.0
 [node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+margin_right = 3.0
 custom_constants/separation = 10
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
+margin_right = 520.0
+margin_bottom = 23.0
+text = "Global Settings"
+align = 1
+
+[node name="HSeparator2" type="HSeparator" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
+margin_top = 33.0
+margin_right = 520.0
+margin_bottom = 37.0
+
 [node name="Intro" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
+margin_top = 47.0
 margin_right = 188.0
-margin_bottom = 25.0
+margin_bottom = 72.0
 size_flags_horizontal = 0
 custom_styles/hover_pressed = SubResource( 2 )
 text = "Play intro video"
 
 [node name="MicrobeIntro" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 35.0
+margin_top = 82.0
 margin_right = 368.0
-margin_bottom = 60.0
+margin_bottom = 107.0
 rect_pivot_offset = Vector2( 114, 23 )
 size_flags_horizontal = 0
 custom_styles/hover_pressed = SubResource( 2 )
 text = "Play Microbe Intro on New Game"
 
 [node name="AutoSave" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 70.0
+margin_top = 117.0
 margin_right = 307.0
-margin_bottom = 95.0
+margin_bottom = 142.0
 rect_pivot_offset = Vector2( 114, 23 )
 size_flags_horizontal = 0
 custom_styles/hover_pressed = SubResource( 2 )
 text = "Autosave during the game"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 105.0
+margin_top = 152.0
 margin_right = 520.0
-margin_bottom = 130.0
+margin_bottom = 177.0
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/HBoxContainer"]
 margin_top = 1.0
@@ -714,9 +729,9 @@ max_value = 50.0
 value = 1.0
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 140.0
+margin_top = 187.0
 margin_right = 520.0
-margin_bottom = 165.0
+margin_bottom = 212.0
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/HBoxContainer2"]
 margin_top = 1.0
@@ -741,27 +756,54 @@ min_value = 1.0
 max_value = 50.0
 value = 1.0
 
-[node name="ShowTutorials" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 175.0
+[node name="TutorialsEnabledOnNewGame" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
+margin_top = 222.0
 margin_right = 349.0
-margin_bottom = 200.0
+margin_bottom = 247.0
 size_flags_horizontal = 0
 custom_styles/hover_pressed = SubResource( 2 )
 pressed = true
 text = "Show tutorials (in new games)"
 
-[node name="HSeparator" type="HSeparator" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 210.0
-margin_right = 520.0
-margin_bottom = 214.0
-
 [node name="Cheats" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
-margin_top = 224.0
+margin_top = 257.0
 margin_right = 239.0
-margin_bottom = 249.0
+margin_bottom = 282.0
 size_flags_horizontal = 0
 custom_styles/hover_pressed = SubResource( 2 )
 text = "Cheat keys enabled"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="HSeparator" type="HSeparator" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
+margin_top = 292.0
+margin_right = 520.0
+margin_bottom = 296.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer"]
+margin_top = 306.0
+margin_right = 520.0
+margin_bottom = 366.0
+
+[node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/VBoxContainer"]
+margin_right = 520.0
+margin_bottom = 23.0
+text = "Current Game Settings"
+align = 1
+
+[node name="HSeparator" type="HSeparator" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/VBoxContainer"]
+margin_top = 27.0
+margin_right = 520.0
+margin_bottom = 31.0
+
+[node name="TutorialsEnabled" type="CheckBox" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/VBoxContainer"]
+margin_top = 35.0
+margin_right = 209.0
+margin_bottom = 60.0
+size_flags_horizontal = 0
+custom_styles/hover_pressed = SubResource( 2 )
+text = "Tutorials Enabled"
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -928,10 +970,10 @@ margin_bottom = 395.0
 popup_exclusive = true
 window_title = "Error"
 dialog_text = "Error: Failed to save new settings to configuration file."
-[connection signal="pressed" from="CenterContainer/VBoxContainer/TabButtons/GraphicsButton" to="." method="SetSettingsTab" binds= [ "Graphics" ]]
-[connection signal="pressed" from="CenterContainer/VBoxContainer/TabButtons/SoundButton" to="." method="SetSettingsTab" binds= [ "Sound" ]]
-[connection signal="pressed" from="CenterContainer/VBoxContainer/TabButtons/PerformanceButton" to="." method="SetSettingsTab" binds= [ "Performance" ]]
-[connection signal="pressed" from="CenterContainer/VBoxContainer/TabButtons/MiscButton" to="." method="SetSettingsTab" binds= [ "Miscellaneous" ]]
+[connection signal="pressed" from="CenterContainer/VBoxContainer/TabButtons/GraphicsButton" to="." method="ChangeSettingsTab" binds= [ "Graphics" ]]
+[connection signal="pressed" from="CenterContainer/VBoxContainer/TabButtons/SoundButton" to="." method="ChangeSettingsTab" binds= [ "Sound" ]]
+[connection signal="pressed" from="CenterContainer/VBoxContainer/TabButtons/PerformanceButton" to="." method="ChangeSettingsTab" binds= [ "Performance" ]]
+[connection signal="pressed" from="CenterContainer/VBoxContainer/TabButtons/MiscButton" to="." method="ChangeSettingsTab" binds= [ "Miscellaneous" ]]
 [connection signal="toggled" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Graphics/VBoxContainer/Vsync" to="." method="OnVSyncToggled"]
 [connection signal="toggled" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Graphics/VBoxContainer/Fullscreen" to="." method="OnFullScreenToggled"]
 [connection signal="item_selected" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Graphics/VBoxContainer/HBoxContainer/MSAAResolution" to="." method="OnMSAAResolutionSelected"]
@@ -955,8 +997,9 @@ dialog_text = "Error: Failed to save new settings to configuration file."
 [connection signal="toggled" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/AutoSave" to="." method="OnAutoSaveToggled"]
 [connection signal="value_changed" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/HBoxContainer/MaxAutoSaves" to="." method="OnMaxAutoSavesValueChanged"]
 [connection signal="value_changed" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/HBoxContainer2/MaxQuickSaves" to="." method="OnMaxQuickSavesValueChanged"]
-[connection signal="toggled" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/ShowTutorials" to="." method="OnTutorialsToggled"]
+[connection signal="toggled" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/TutorialsEnabledOnNewGame" to="." method="OnTutorialsOnNewGameToggled"]
 [connection signal="toggled" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/Cheats" to="." method="OnCheatsToggled"]
+[connection signal="toggled" from="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/Misc/VBoxContainer/VBoxContainer/TutorialsEnabled" to="." method="OnTutorialsEnabledToggled"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/HBoxContainer/Back" to="." method="OnBackPressed"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/HBoxContainer/Reset" to="." method="OnResetPressed"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/HBoxContainer/Save" to="." method="OnSavePressed"]

--- a/src/general/PauseMenu.cs
+++ b/src/general/PauseMenu.cs
@@ -203,7 +203,7 @@ public class PauseMenu : Control
                 loadMenu.Show();
                 break;
             case "options":
-                optionsMenu.OpenFromMicrobeStage(GameProperties);
+                optionsMenu.OpenFromInGame(GameProperties);
                 break;
             case "save":
                 saveMenu.Show();

--- a/src/general/PauseMenu.cs
+++ b/src/general/PauseMenu.cs
@@ -50,10 +50,9 @@ public class PauseMenu : Control
     public delegate void MakeSave(string name);
 
     /// <summary>
-    ///   The tutorial state reported by the game state, this is needed to not allow pausing while exclusive tutorial
-    ///   is open. As well as to disable tutorials from the in-game options menu
+    ///   The GameProperties object holding settings and state for the current game session.
     /// </summary>
-    public TutorialState GameTutorialState { get; set; }
+    public GameProperties GameProperties { get; set; }
 
     public override void _EnterTree()
     {
@@ -80,7 +79,7 @@ public class PauseMenu : Control
 
                 EmitSignal(nameof(OnClosed));
             }
-            else if (GameTutorialState == null || !GameTutorialState.ExclusiveTutorialActive())
+            else if (GameProperties.TutorialState == null || !GameProperties.TutorialState.ExclusiveTutorialActive())
             {
                 EmitSignal(nameof(OnOpenWithKeyPress));
             }
@@ -204,7 +203,7 @@ public class PauseMenu : Control
                 loadMenu.Show();
                 break;
             case "options":
-                optionsMenu.Show();
+                optionsMenu.OpenFromMicrobeStage(GameProperties);
                 break;
             case "save":
                 saveMenu.Show();

--- a/src/gui_common/MainMenu.cs
+++ b/src/gui_common/MainMenu.cs
@@ -267,7 +267,7 @@ public class MainMenu : Node
         SetCurrentMenu(uint.MaxValue, false);
 
         // Show the options
-        options.Visible = true;
+        options.OpenFromMainMenu();
 
         thriveLogo.Hide();
     }

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -187,7 +187,7 @@ public class MicrobeStage : Node, ILoadableGameState
         }
 
         tutorialGUI.EventReceiver = TutorialState;
-        pauseMenu.GameTutorialState = TutorialState;
+        pauseMenu.GameProperties = CurrentGame;
 
         CreatePatchManagerIfNeeded();
 
@@ -214,7 +214,7 @@ public class MicrobeStage : Node, ILoadableGameState
         StartMusic();
 
         tutorialGUI.EventReceiver = TutorialState;
-        pauseMenu.GameTutorialState = TutorialState;
+        pauseMenu.GameProperties = CurrentGame;
     }
 
     public void StartNewGame()

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -965,8 +965,7 @@ public class MicrobeEditor : Node, ILoadableGameState
 
         // Make tutorials run
         tutorialGUI.EventReceiver = TutorialState;
-
-        pauseMenu.GameTutorialState = TutorialState;
+        pauseMenu.GameProperties = CurrentGame;
 
         // Send undo button to the tutorial system
         gui.SendUndoToTutorial(TutorialState);


### PR DESCRIPTION
Changed options so it can be opened with different methods in game vs on the main menu. Currently only displays a setting for tutorials being enabled or disabled in the current game.

As a note: While it technically enables and disables the tutorial correctly, the tutorial code doesn't quite handle the state switching that elegantly. Enabling the tutorials for the first time won't display the initial opening tutorial, and toggling the enabled state off and on seems to make it skip whatever the previous objective was.

Closes #1217 