### PR TITLE
Move organelle center of mass to cell origin

### DIFF
--- a/src/microbe_stage/Membrane.cs
+++ b/src/microbe_stage/Membrane.cs
@@ -313,14 +313,19 @@ public class Membrane : MeshInstance
 
         float distanceSquared = 0;
 
-        foreach (var vertex in vertices2D)
+        foreach (var vertexA in vertices2D)
         {
-            var currentDistance = vertex.LengthSquared();
-            if (currentDistance > distanceSquared)
-                distanceSquared = currentDistance;
+            foreach (var vertexB in vertices2D)
+            {
+                var currentDistance = vertexA.DistanceSquaredTo(vertexB);
+                if (currentDistance > distanceSquared)
+                {
+                    distanceSquared = currentDistance;
+                }
+            }
         }
 
-        return Mathf.Sqrt(distanceSquared);
+        return Mathf.Sqrt(distanceSquared) / 2;
     }
 
     /// <summary>

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -388,6 +388,11 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
         Membrane.Dirty = true;
 
         SetupMicrobeHitpoints();
+
+        // Move the center of mass of the organelles to the center of the microbe
+        var massOffset = -organelles.CenterOfMass * scale;
+        Membrane.Translation = massOffset;
+        OrganelleParent.Translation = massOffset;
     }
 
     /// <summary>

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -245,6 +245,8 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
     [JsonIgnore]
     public Spatial OrganelleParent { get; private set; }
 
+    public Area EngulfDetector { get; private set; }
+
     [JsonProperty]
     public int DespawnRadiusSqr { get; set; }
 
@@ -346,11 +348,11 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
         cellBurstEffectScene = GD.Load<PackedScene>("res://src/microbe_stage/particles/CellBurst.tscn");
 
         // Setup physics callback stuff
-        var engulfDetector = GetNode<Area>("EngulfDetector");
-        engulfShape = (SphereShape)engulfDetector.GetNode<CollisionShape>("EngulfShape").Shape;
+        EngulfDetector = GetNode<Area>("EngulfDetector");
+        engulfShape = (SphereShape)EngulfDetector.GetNode<CollisionShape>("EngulfShape").Shape;
 
-        engulfDetector.Connect("body_entered", this, "OnBodyEnteredEngulfArea");
-        engulfDetector.Connect("body_exited", this, "OnBodyExitedEngulfArea");
+        EngulfDetector.Connect("body_entered", this, "OnBodyEnteredEngulfArea");
+        EngulfDetector.Connect("body_exited", this, "OnBodyExitedEngulfArea");
 
         ContactsReported = Constants.DEFAULT_STORE_CONTACTS_COUNT;
         Connect("body_shape_entered", this, "OnContactBegin");
@@ -393,6 +395,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
         var massOffset = -organelles.CenterOfMass * scale;
         Membrane.Translation = massOffset;
         OrganelleParent.Translation = massOffset;
+        EngulfDetector.Translation = massOffset;
     }
 
     /// <summary>

--- a/src/microbe_stage/OrganelleLayout.cs
+++ b/src/microbe_stage/OrganelleLayout.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using Godot;
 using Newtonsoft.Json;
 
 /// <summary>
@@ -33,6 +34,30 @@ public class OrganelleLayout<T> : ICollection<T>
     public int Count => Organelles.Count;
 
     public bool IsReadOnly => false;
+
+    /// <summary>
+    /// The center of mass of the contained organelles.
+    /// </summary>
+    public Vector3 CenterOfMass
+    {
+        get
+        {
+            float totalMass = 0;
+            Vector3 weightedSum = Vector3.Zero;
+            foreach (var organelle in Organelles)
+            {
+                totalMass += organelle.Definition.Mass;
+                weightedSum += Hex.AxialToCartesian(organelle.Position) * organelle.Definition.Mass;
+            }
+
+            if (totalMass <= 0)
+            {
+                return Vector3.Zero;
+            }
+
+            return weightedSum / totalMass;
+        }
+    }
 
     /// <summary>
     ///   Access organelle by index


### PR DESCRIPTION
Closes #1645 by translating the membrane and organelles of a microbe so that the center of mass is at the cell's origin.