### PR TITLE
Fixed tooltips being displayed even when the cursor is out of Control area

### DIFF
--- a/src/gui_common/tooltip/DefaultToolTip.cs
+++ b/src/gui_common/tooltip/DefaultToolTip.cs
@@ -64,7 +64,6 @@ public class DefaultToolTip : Control, ICustomToolTip
     {
         descriptionLabel = GetNode<Label>(DescriptionLabelPath);
         tween = GetNode<Tween>("Tween");
-        tween.Connect("tween_started", this, nameof(OnFadeInStarted));
 
         UpdateDescription();
     }
@@ -92,13 +91,5 @@ public class DefaultToolTip : Control, ICustomToolTip
         {
             descriptionLabel.Text = Description;
         }
-    }
-
-    private void OnFadeInStarted(Object obj, NodePath key)
-    {
-        _ = obj;
-        _ = key;
-
-        Show();
     }
 }

--- a/src/gui_common/tooltip/ToolTipCallbackData.cs
+++ b/src/gui_common/tooltip/ToolTipCallbackData.cs
@@ -20,6 +20,7 @@ public class ToolTipCallbackData : Reference
 
     public void OnMouseExit()
     {
+        ToolTipManager.Instance.MainToolTip = null;
         ToolTipManager.Instance.Display = false;
     }
 }

--- a/src/gui_common/tooltip/ToolTipHelper.cs
+++ b/src/gui_common/tooltip/ToolTipHelper.cs
@@ -36,6 +36,9 @@ public static class ToolTipHelper
     /// <param name="control">The tooltip's control node</param>
     public static void TooltipFadeIn(Tween tween, Control control)
     {
+        control.Show();
+        control.Modulate = new Color(1, 1, 1, 0);
+
         tween.InterpolateProperty(control, "modulate", new Color(1, 1, 1, 0), new Color(1, 1, 1, 1),
             Constants.TOOLTIP_FADE_SPEED, Tween.TransitionType.Sine, Tween.EaseType.In);
 

--- a/src/gui_common/tooltip/ToolTipManager.cs
+++ b/src/gui_common/tooltip/ToolTipManager.cs
@@ -51,12 +51,15 @@ public class ToolTipManager : CanvasLayer
     {
         holder = GetNode<Control>("Holder");
 
+        // Make sure the tooltip parent control is visible
+        holder.Show();
+
         FetchToolTips();
     }
 
     public override void _Process(float delta)
     {
-        if (MainToolTip == null || !Display)
+        if (MainToolTip == null)
             return;
 
         // Wait for duration of the delay and then show the tooltip
@@ -67,8 +70,6 @@ public class ToolTipManager : CanvasLayer
             if (displayTimer < 0)
             {
                 lastMousePosition = GetViewport().GetMousePosition();
-
-                holder.Show();
                 MainToolTip.OnDisplay();
             }
         }
@@ -172,32 +173,23 @@ public class ToolTipManager : CanvasLayer
 
     private void UpdateToolTipVisibility()
     {
-        if (MainToolTip == null)
-            return;
-
         // TODO: Fix the current tooltip changing while still fading out
         // when quickly mousing over multiple closely positioned elements
         // (Happens when a single tooltip is registered to multiple Controls)
 
+        // Make sure to hide any other tooltips that are still visible
+        HideAllToolTips();
+
         if (Display)
         {
+            // Set timer
             displayTimer = MainToolTip.DisplayDelay;
-        }
-        else
-        {
-            if (!MainToolTip.ToolTipVisible)
-                return;
-
-            holder.Hide();
-            MainToolTip.OnHide();
         }
     }
 
     private void HideAllToolTips()
     {
-        holder.Hide();
-
         foreach (var group in tooltips.Keys)
-            tooltips[group].ForEach(tooltip => tooltip.ToolTipVisible = false);
+            tooltips[group].ForEach(tooltip => tooltip.OnHide());
     }
 }

--- a/src/gui_common/tooltip/microbe_editor/SelectionMenuToolTip.cs
+++ b/src/gui_common/tooltip/microbe_editor/SelectionMenuToolTip.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using Godot;
-using Object = Godot.Object;
 
 /// <summary>
 ///   The main tooltip class for the selections on the microbe editor's selection menu.
@@ -102,7 +101,6 @@ public class SelectionMenuToolTip : Control, ICustomToolTip
         processList = GetNode<VBoxContainer>(ProcessListPath);
 
         tween = GetNode<Tween>("Tween");
-        tween.Connect("tween_started", this, nameof(OnFadeInStarted));
 
         UpdateName();
         UpdateDescription();
@@ -316,13 +314,5 @@ public class SelectionMenuToolTip : Control, ICustomToolTip
         {
             modifierInfos.Add(item);
         }
-    }
-
-    private void OnFadeInStarted(Object obj, NodePath key)
-    {
-        _ = obj;
-        _ = key;
-
-        Show();
     }
 }


### PR DESCRIPTION
A simple fix by removing the OnFadeInStarted callback (which is actually unnecessary, dunno why I use it) in the tooltip classes since that seem to be the cause of the problem.

Steps to easily reproduce the issue for playtest (in master branch):
- Set DisplayDelay of SelectionMenuToolTip to 0.0f
- Mouse over the many organelle buttons
- Tooltips popping up everywhere

Closes #1693 
Closes #1703 