### PR TITLE
Made temporary node deleter catch disposed exception 

### DIFF
--- a/src/saving/TemporaryLoadedNodeDeleter.cs
+++ b/src/saving/TemporaryLoadedNodeDeleter.cs
@@ -63,7 +63,14 @@ public class TemporaryLoadedNodeDeleter : Node
 
         foreach (var node in nodesToDelete)
         {
-            node.QueueFree();
+            try
+            {
+                node.QueueFree();
+            }
+            catch (ObjectDisposedException)
+            {
+                GD.PrintErr("TemporaryLoadedNodeDeleter failed to delete a node because it was already disposed");
+            }
         }
 
         nodesToDelete.Clear();


### PR DESCRIPTION
to guard against a crash where it tries to free something already destroyed
I decided to catch the exception here as it doesn't really matter that
a node that it needs to delete is already disposed, and also it would
be very hard to track down what all can cause a crash here.

This is the crash I got when randomly spamming load and save in the editor:
```
E 0:00:29.943   IntPtr Godot.Object.GetPtr(Godot.Object ): System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'MicrobeStage'.
  <C++ virhe>   Unhandled exception
  <C++ lähdekoodi>/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.base.cs:37 @ IntPtr Godot.Object.GetPtr(Godot.Object )()
  <Pinojäljitys>Object.base.cs:37 @ IntPtr Godot.Object.GetPtr(Godot.Object )()
                Node.cs:1344 @ void Godot.Node.QueueFree()()
                TemporaryLoadedNodeDeleter.cs:66 @ void TemporaryLoadedNodeDeleter._Process(Single )()
```