### PR TITLE
Update Thrive.csproj

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -13,6 +13,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Deterministic>false</Deterministic>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Explicitly call for C# 8.0. Change to 7.3 if version 8.0 is unsupported. 