### PR TITLE
Updated setup instructions to mention VS build tools 2019 is required

### DIFF
--- a/doc/setup_instructions.md
+++ b/doc/setup_instructions.md
@@ -121,18 +121,21 @@ For better experience make sure to install the Godot plugin for Rider.
 ### Visual Studio 2019
 
 On Windows you can use Visual Studio 2019 to work on Thrive. You can
-find download and setup instructions here https://docs.godotengine.org/en/stable/getting_started/scripting/c_sharp/c_sharp_basics.html#configuring-vs-2019-for-debugging
+find download and setup instructions here:
+https://docs.godotengine.org/en/stable/getting_started/scripting/c_sharp/c_sharp_basics.html#configuring-vs-2019-for-debugging
 
 ### Visual Studio Code
 
 Note: Setting up Visual Studio Code with Linux is possible,
 however it is recommended to use MonoDevelop instead
 
-Visual Studio Code, not to be confused with Visual Studio,
-doesn't come with build tools, so you'll need to install
-the build tools for Visual Studio from here: https://visualstudio.microsoft.com/downloads/?q=build+tools
-During the installation process, make sure MSBuild tools is listed under
-the installation details.
+Visual Studio Code, not to be confused with Visual Studio, doesn't
+come with build tools, so you'll need to install the build tools for
+Visual Studio from here:
+https://visualstudio.microsoft.com/downloads/?q=build+tools You will
+need **at least** VS Build tools 2019 due to the version of C# used by
+Thrive. During the installation process, make sure MSBuild tools is
+listed under the installation details.
 
 Go to https://dotnet.microsoft.com/download Under the .NET Core
 section, click on _Download .NET Core SDK_ and run the installer.
@@ -485,6 +488,13 @@ instructions, you should verify that it's using the proper toolset. Go
 to Editor > Editor Settings > Builds under Mono in the panel on the
 left. For VS2019, you should select MSBuild (VS Build Tools) for the
 build tool option, if it isn't already.
+
+### Build problems with unsupported C# version
+
+If the build fails with errors about unsupported C# language version,
+you need to update your VS build tools, if you are on Windows, or
+mono, if on Linux. Note that you should use the official mono repo on
+Linux to get the latest version of mono.
 
 ### Cleaning Godot
 


### PR DESCRIPTION
and too old mono version will also not work due to requiring C# 8