### PR TITLE
1726 disable engulfing for wall type membranes

### DIFF
--- a/src/gui_common/tooltip/ToolTipManager.tscn
+++ b/src/gui_common/tooltip/ToolTipManager.tscn
@@ -5624,7 +5624,7 @@ custom_constants/margin_bottom = 15
 margin_left = 15.0
 margin_top = 15.0
 margin_right = 333.0
-margin_bottom = 304.0
+margin_bottom = 328.0
 mouse_filter = 2
 custom_constants/separation = 15
 
@@ -5859,14 +5859,14 @@ margin_top = 1.0
 margin_right = 27.0
 margin_bottom = 18.0
 custom_fonts/font = SubResource( 7 )
-custom_colors/font_color = Color( 1, 0.301961, 0.301961, 1 )
-text = "Can not engulf"
 
 [node name="Name" type="Label" parent="Holder/membraneSelection/cellulose/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
 margin_left = 31.0
 margin_right = 164.0
 margin_bottom = 19.0
 custom_fonts/font = SubResource( 8 )
+custom_colors/font_color = Color( 1, 0.301961, 0.301961, 1 )
+text = "Cannot engulf"
 
 [node name="Icon" type="TextureRect" parent="Holder/membraneSelection/cellulose/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
 margin_left = 168.0
@@ -5928,7 +5928,7 @@ custom_constants/margin_bottom = 15
 margin_left = 15.0
 margin_top = 15.0
 margin_right = 333.0
-margin_bottom = 304.0
+margin_bottom = 328.0
 mouse_filter = 2
 custom_constants/separation = 15
 
@@ -6163,14 +6163,14 @@ margin_top = 1.0
 margin_right = 27.0
 margin_bottom = 18.0
 custom_fonts/font = SubResource( 7 )
-custom_colors/font_color = Color( 1, 0.301961, 0.301961, 1 )
-text = "Can not engulf"
 
 [node name="Name" type="Label" parent="Holder/membraneSelection/chitin/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
 margin_left = 31.0
 margin_right = 164.0
 margin_bottom = 19.0
 custom_fonts/font = SubResource( 8 )
+custom_colors/font_color = Color( 1, 0.301961, 0.301961, 1 )
+text = "Cannot engulf"
 
 [node name="Icon" type="TextureRect" parent="Holder/membraneSelection/chitin/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
 margin_left = 168.0
@@ -6232,7 +6232,7 @@ custom_constants/margin_bottom = 15
 margin_left = 15.0
 margin_top = 15.0
 margin_right = 333.0
-margin_bottom = 378.0
+margin_bottom = 402.0
 mouse_filter = 2
 custom_constants/separation = 15
 
@@ -6497,14 +6497,14 @@ margin_top = 1.0
 margin_right = 27.0
 margin_bottom = 18.0
 custom_fonts/font = SubResource( 7 )
-custom_colors/font_color = Color( 1, 0.301961, 0.301961, 1 )
-text = "Can not engulf"
 
 [node name="Name" type="Label" parent="Holder/membraneSelection/calcium_carbonate/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
 margin_left = 31.0
 margin_right = 164.0
 margin_bottom = 19.0
 custom_fonts/font = SubResource( 8 )
+custom_colors/font_color = Color( 1, 0.301961, 0.301961, 1 )
+text = "Cannot engulf"
 
 [node name="Icon" type="TextureRect" parent="Holder/membraneSelection/calcium_carbonate/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
 margin_left = 168.0
@@ -6566,7 +6566,7 @@ custom_constants/margin_bottom = 15
 margin_left = 15.0
 margin_top = 15.0
 margin_right = 333.0
-margin_bottom = 348.0
+margin_bottom = 372.0
 mouse_filter = 2
 custom_constants/separation = 15
 
@@ -6831,14 +6831,14 @@ margin_top = 1.0
 margin_right = 27.0
 margin_bottom = 18.0
 custom_fonts/font = SubResource( 7 )
-custom_colors/font_color = Color( 1, 0.301961, 0.301961, 1 )
-text = "Can not engulf"
 
 [node name="Name" type="Label" parent="Holder/membraneSelection/silica/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
 margin_left = 31.0
 margin_right = 164.0
 margin_bottom = 19.0
 custom_fonts/font = SubResource( 8 )
+custom_colors/font_color = Color( 1, 0.301961, 0.301961, 1 )
+text = "Cannot engulf"
 
 [node name="Icon" type="TextureRect" parent="Holder/membraneSelection/silica/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
 margin_left = 168.0

--- a/src/gui_common/tooltip/ToolTipManager.tscn
+++ b/src/gui_common/tooltip/ToolTipManager.tscn
@@ -5129,7 +5129,7 @@ ModifierInfoScene = ExtResource( 2 )
 margin_left = 1.0
 margin_top = 1.0
 margin_right = 349.0
-margin_bottom = 296.0
+margin_bottom = 320.0
 mouse_filter = 2
 custom_constants/margin_right = 15
 custom_constants/margin_top = 15
@@ -5140,7 +5140,7 @@ custom_constants/margin_bottom = 15
 margin_left = 15.0
 margin_top = 15.0
 margin_right = 333.0
-margin_bottom = 280.0
+margin_bottom = 304.0
 mouse_filter = 2
 custom_constants/separation = 15
 
@@ -5221,22 +5221,22 @@ script = ExtResource( 21 )
 
 [node name="Value" type="Label" parent="Holder/membraneSelection/single/MarginContainer/VBoxContainer/ModifierList/Mobility"]
 margin_top = 1.0
-margin_right = 27.0
+margin_right = 35.0
 margin_bottom = 18.0
 custom_fonts/font = SubResource( 7 )
 custom_colors/font_color = Color( 0, 1, 0, 1 )
 text = "+10%"
 
 [node name="Name" type="Label" parent="Holder/membraneSelection/single/MarginContainer/VBoxContainer/ModifierList/Mobility"]
-margin_left = 31.0
-margin_right = 89.0
+margin_left = 39.0
+margin_right = 97.0
 margin_bottom = 19.0
 custom_fonts/font = SubResource( 8 )
 text = "Mobility"
 
 [node name="Icon" type="TextureRect" parent="Holder/membraneSelection/single/MarginContainer/VBoxContainer/ModifierList/Mobility"]
-margin_left = 93.0
-margin_right = 113.0
+margin_left = 101.0
+margin_right = 121.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 20, 20 )
 mouse_filter = 2
@@ -5282,22 +5282,22 @@ script = ExtResource( 21 )
 
 [node name="Value" type="Label" parent="Holder/membraneSelection/single/MarginContainer/VBoxContainer/ModifierList/Resource Absorption Speed"]
 margin_top = 1.0
-margin_right = 27.0
+margin_right = 35.0
 margin_bottom = 18.0
 custom_fonts/font = SubResource( 7 )
 custom_colors/font_color = Color( 0, 1, 0, 1 )
 text = "+30%"
 
 [node name="Name" type="Label" parent="Holder/membraneSelection/single/MarginContainer/VBoxContainer/ModifierList/Resource Absorption Speed"]
-margin_left = 31.0
-margin_right = 220.0
+margin_left = 39.0
+margin_right = 228.0
 margin_bottom = 19.0
 custom_fonts/font = SubResource( 8 )
 text = "Resource Absorption Speed"
 
 [node name="Icon" type="TextureRect" parent="Holder/membraneSelection/single/MarginContainer/VBoxContainer/ModifierList/Resource Absorption Speed"]
-margin_left = 224.0
-margin_right = 244.0
+margin_left = 232.0
+margin_right = 252.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 20, 20 )
 mouse_filter = 2
@@ -5847,6 +5847,35 @@ rect_min_size = Vector2( 20, 20 )
 mouse_filter = 2
 expand = true
 
+[node name="Can Engulf" type="HBoxContainer" parent="Holder/membraneSelection/cellulose/MarginContainer/VBoxContainer/ModifierList"]
+margin_top = 72.0
+margin_right = 318.0
+margin_bottom = 92.0
+mouse_filter = 2
+script = ExtResource( 21 )
+
+[node name="Value" type="Label" parent="Holder/membraneSelection/cellulose/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
+margin_top = 1.0
+margin_right = 27.0
+margin_bottom = 18.0
+custom_fonts/font = SubResource( 7 )
+custom_colors/font_color = Color( 1, 0.301961, 0.301961, 1 )
+text = "Can not engulf"
+
+[node name="Name" type="Label" parent="Holder/membraneSelection/cellulose/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
+margin_left = 31.0
+margin_right = 164.0
+margin_bottom = 19.0
+custom_fonts/font = SubResource( 8 )
+
+[node name="Icon" type="TextureRect" parent="Holder/membraneSelection/cellulose/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
+margin_left = 168.0
+margin_right = 188.0
+margin_bottom = 20.0
+rect_min_size = Vector2( 20, 20 )
+mouse_filter = 2
+expand = true
+
 [node name="HSeparator" type="HSeparator" parent="Holder/membraneSelection/cellulose/MarginContainer/VBoxContainer"]
 margin_top = 149.0
 margin_right = 318.0
@@ -6117,6 +6146,35 @@ text = "Toxin Resistance"
 [node name="Icon" type="TextureRect" parent="Holder/membraneSelection/chitin/MarginContainer/VBoxContainer/ModifierList/Toxin Resistance"]
 margin_left = 151.0
 margin_right = 171.0
+margin_bottom = 20.0
+rect_min_size = Vector2( 20, 20 )
+mouse_filter = 2
+expand = true
+
+[node name="Can Engulf" type="HBoxContainer" parent="Holder/membraneSelection/chitin/MarginContainer/VBoxContainer/ModifierList"]
+margin_top = 72.0
+margin_right = 318.0
+margin_bottom = 92.0
+mouse_filter = 2
+script = ExtResource( 21 )
+
+[node name="Value" type="Label" parent="Holder/membraneSelection/chitin/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
+margin_top = 1.0
+margin_right = 27.0
+margin_bottom = 18.0
+custom_fonts/font = SubResource( 7 )
+custom_colors/font_color = Color( 1, 0.301961, 0.301961, 1 )
+text = "Can not engulf"
+
+[node name="Name" type="Label" parent="Holder/membraneSelection/chitin/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
+margin_left = 31.0
+margin_right = 164.0
+margin_bottom = 19.0
+custom_fonts/font = SubResource( 8 )
+
+[node name="Icon" type="TextureRect" parent="Holder/membraneSelection/chitin/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
+margin_left = 168.0
+margin_right = 188.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 20, 20 )
 mouse_filter = 2
@@ -6427,6 +6485,35 @@ rect_min_size = Vector2( 20, 20 )
 mouse_filter = 2
 expand = true
 
+[node name="Can Engulf" type="HBoxContainer" parent="Holder/membraneSelection/calcium_carbonate/MarginContainer/VBoxContainer/ModifierList"]
+margin_top = 42.0
+margin_right = 318.0
+margin_bottom = 62.0
+mouse_filter = 2
+script = ExtResource( 21 )
+
+[node name="Value" type="Label" parent="Holder/membraneSelection/calcium_carbonate/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
+margin_top = 1.0
+margin_right = 27.0
+margin_bottom = 18.0
+custom_fonts/font = SubResource( 7 )
+custom_colors/font_color = Color( 1, 0.301961, 0.301961, 1 )
+text = "Can not engulf"
+
+[node name="Name" type="Label" parent="Holder/membraneSelection/calcium_carbonate/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
+margin_left = 31.0
+margin_right = 164.0
+margin_bottom = 19.0
+custom_fonts/font = SubResource( 8 )
+
+[node name="Icon" type="TextureRect" parent="Holder/membraneSelection/calcium_carbonate/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
+margin_left = 168.0
+margin_right = 188.0
+margin_bottom = 20.0
+rect_min_size = Vector2( 20, 20 )
+mouse_filter = 2
+expand = true
+
 [node name="HSeparator" type="HSeparator" parent="Holder/membraneSelection/calcium_carbonate/MarginContainer/VBoxContainer"]
 margin_top = 227.0
 margin_right = 318.0
@@ -6727,6 +6814,35 @@ text = "Toxin Resistance"
 [node name="Icon" type="TextureRect" parent="Holder/membraneSelection/silica/MarginContainer/VBoxContainer/ModifierList/Toxin Resistance"]
 margin_left = 151.0
 margin_right = 171.0
+margin_bottom = 20.0
+rect_min_size = Vector2( 20, 20 )
+mouse_filter = 2
+expand = true
+
+[node name="Can Engulf" type="HBoxContainer" parent="Holder/membraneSelection/silica/MarginContainer/VBoxContainer/ModifierList"]
+margin_top = 72.0
+margin_right = 318.0
+margin_bottom = 92.0
+mouse_filter = 2
+script = ExtResource( 21 )
+
+[node name="Value" type="Label" parent="Holder/membraneSelection/silica/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
+margin_top = 1.0
+margin_right = 27.0
+margin_bottom = 18.0
+custom_fonts/font = SubResource( 7 )
+custom_colors/font_color = Color( 1, 0.301961, 0.301961, 1 )
+text = "Can not engulf"
+
+[node name="Name" type="Label" parent="Holder/membraneSelection/silica/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
+margin_left = 31.0
+margin_right = 164.0
+margin_bottom = 19.0
+custom_fonts/font = SubResource( 8 )
+
+[node name="Icon" type="TextureRect" parent="Holder/membraneSelection/silica/MarginContainer/VBoxContainer/ModifierList/Can Engulf"]
+margin_left = 168.0
+margin_right = 188.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 20, 20 )
 mouse_filter = 2

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -394,6 +394,12 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
         Membrane.Tint = Species.Colour;
         Membrane.Dirty = true;
 
+        if (Membrane.Type.CellWall)
+        {
+            // Reset engulf mode if the new membrane doesn't allow it
+            EngulfMode = false;
+        }
+
         SetupMicrobeHitpoints();
     }
 

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -386,6 +386,10 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
         Membrane.Type = Species.MembraneType;
         Membrane.Tint = Species.Colour;
         Membrane.Dirty = true;
+        if (Membrane.Type.CellWall) {
+            // Reset engulf mode if the new membrane doesn't allow it
+            EngulfMode = false;
+        }
 
         SetupMicrobeHitpoints();
     }

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -193,13 +193,16 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
     public bool EngulfMode
     {
         get => engulfMode;
-        set {
-            if (!Membrane.Type.CellWall) {
+        set
+        {
+            if (!Membrane.Type.CellWall)
+            {
                 engulfMode = value;
-            } else {
+            }
+            else
+            {
                 engulfMode = false;
             }
-            
         }
     }
 

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -193,7 +193,14 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
     public bool EngulfMode
     {
         get => engulfMode;
-        set => engulfMode = value;
+        set {
+            if (!Membrane.Type.CellWall) {
+                engulfMode = value;
+            } else {
+                engulfMode = false;
+            }
+            
+        }
     }
 
     [JsonIgnore]
@@ -386,11 +393,6 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
         Membrane.Type = Species.MembraneType;
         Membrane.Tint = Species.Colour;
         Membrane.Dirty = true;
-        if (Membrane.Type.CellWall)
-        {
-            // Reset engulf mode if the new membrane doesn't allow it
-            EngulfMode = false;
-        }
 
         SetupMicrobeHitpoints();
     }

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -386,7 +386,8 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI
         Membrane.Type = Species.MembraneType;
         Membrane.Tint = Species.Colour;
         Membrane.Dirty = true;
-        if (Membrane.Type.CellWall) {
+        if (Membrane.Type.CellWall)
+        {
             // Reset engulf mode if the new membrane doesn't allow it
             EngulfMode = false;
         }

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -576,7 +576,8 @@ public class MicrobeAI
             if ((microbe.Translation - targetPosition).LengthSquared() <= 300 + microbe.EngulfSize * 3.0f
                 && microbe.Compounds.GetCompoundAmount(atp) >= 1.0f
                 && !microbe.EngulfMode &&
-                microbe.EngulfSize > Constants.ENGULF_SIZE_RATIO_REQ * prey.EngulfSize)
+                microbe.EngulfSize > Constants.ENGULF_SIZE_RATIO_REQ * prey.EngulfSize
+                && !microbe.Membrane.Type.CellWall)
             {
                 microbe.EngulfMode = true;
                 ticksSinceLastToggle = 0;
@@ -656,7 +657,8 @@ public class MicrobeAI
             microbe.EngulfSize * 3.0f
             && microbe.Compounds.GetCompoundAmount(atp) >= 1.0f
             && !microbe.EngulfMode &&
-            microbe.EngulfSize > Constants.ENGULF_SIZE_RATIO_REQ * chunk.Size)
+            microbe.EngulfSize > Constants.ENGULF_SIZE_RATIO_REQ * chunk.Size
+            && !microbe.Membrane.Type.CellWall)
         {
             microbe.EngulfMode = true;
             ticksSinceLastToggle = 0;

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -576,8 +576,7 @@ public class MicrobeAI
             if ((microbe.Translation - targetPosition).LengthSquared() <= 300 + microbe.EngulfSize * 3.0f
                 && microbe.Compounds.GetCompoundAmount(atp) >= 1.0f
                 && !microbe.EngulfMode &&
-                microbe.EngulfSize > Constants.ENGULF_SIZE_RATIO_REQ * prey.EngulfSize
-                && !microbe.Membrane.Type.CellWall)
+                microbe.EngulfSize > Constants.ENGULF_SIZE_RATIO_REQ * prey.EngulfSize)
             {
                 microbe.EngulfMode = true;
                 ticksSinceLastToggle = 0;
@@ -657,8 +656,7 @@ public class MicrobeAI
             microbe.EngulfSize * 3.0f
             && microbe.Compounds.GetCompoundAmount(atp) >= 1.0f
             && !microbe.EngulfMode &&
-            microbe.EngulfSize > Constants.ENGULF_SIZE_RATIO_REQ * chunk.Size
-            && !microbe.Membrane.Type.CellWall)
+            microbe.EngulfSize > Constants.ENGULF_SIZE_RATIO_REQ * chunk.Size)
         {
             microbe.EngulfMode = true;
             ticksSinceLastToggle = 0;

--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -123,7 +123,7 @@ public class PlayerMicrobeInput : Node
 
         if (toggleEngulf.ReadTrigger())
         {
-            if (stage.Player != null)
+            if (stage.Player != null && !stage.Player.Membrane.Type.CellWall)
             {
                 stage.Player.EngulfMode = !stage.Player.EngulfMode;
             }

--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -123,7 +123,7 @@ public class PlayerMicrobeInput : Node
 
         if (toggleEngulf.ReadTrigger())
         {
-            if (stage.Player != null && !stage.Player.Membrane.Type.CellWall)
+            if (stage.Player != null)
             {
                 stage.Player.EngulfMode = !stage.Player.EngulfMode;
             }


### PR DESCRIPTION
I wasn't sure where to put the information about engulfing in the tooltip so I put a red "can not engulf" in the modifiers section for the four cell wall type membranes.

<img width="523" alt="Screenshot 2020-10-24 at 19 13 34" src="https://user-images.githubusercontent.com/2828594/97089057-106f4880-162d-11eb-9424-9ad7590be5a0.png">

closes #1726