### PR TITLE
Make absorption not work for non-useful compounds in a cell #1655

### DIFF
--- a/src/microbe_stage/CompoundCloudPlane.cs
+++ b/src/microbe_stage/CompoundCloudPlane.cs
@@ -471,6 +471,7 @@ public class CompoundCloudPlane : CSGMesh, ISaveApplyable
             if (Compounds[i] == null)
                 break;
 
+            // Skip if compound is non-useful
             if (!storage.IsUseful(Compounds[i]))
                 continue;
 

--- a/src/microbe_stage/CompoundCloudPlane.cs
+++ b/src/microbe_stage/CompoundCloudPlane.cs
@@ -471,6 +471,9 @@ public class CompoundCloudPlane : CSGMesh, ISaveApplyable
             if (Compounds[i] == null)
                 break;
 
+            if (!storage.IsUseful(Compounds[i]))
+                continue;
+
             // Overestimate of how much compounds we get
             float generousAmount = HackyAdress(Density[localX, localY], i) *
                 Constants.SKIP_TRYING_TO_ABSORB_RATIO;


### PR DESCRIPTION
I think it's better to use CompoundsBag.IsUseful, instead of pass the useful list to the function. But if you prefer a different way, tell me.