### PR TITLE
Disabled reproduction dialog at players's death

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -510,6 +510,8 @@ public class MicrobeStage : Node, ILoadableGameState, IGodotEarlyNodeResolve
     {
         GD.Print("The player has died");
 
+        HUD.HideReproductionDialog();
+
         TutorialState.SendEvent(TutorialEventType.MicrobePlayerDied, EventArgs.Empty, this);
 
         Player = null;


### PR DESCRIPTION
In function OnPlayerDied was function HideReproductionDialog, which should disable reproduction dialog.

closes #1670