### PR TITLE
Make ATP damage noise stop once cell is dead #1813

### DIFF
--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -524,7 +524,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
     /// </summary>
     public void Damage(float amount, string source)
     {
-        if (amount == 0)
+        if (amount == 0 || Dead)
             return;
 
         if (string.IsNullOrEmpty(source))


### PR DESCRIPTION
This fix skip the function Damage when cell is dead

Fixes #1813 