### PR TITLE
Fixed rightclicking on the input mapping x

### DIFF
--- a/src/engine/input/key_mapping/InputEventItem.cs
+++ b/src/engine/input/key_mapping/InputEventItem.cs
@@ -129,8 +129,7 @@ public class InputEventItem : Node
             return;
 
         // Hacky custom button press detection
-        if ((@event is InputEventMouseButton inputMouse) && inputMouse.ButtonIndex == (int)ButtonList.Left &&
-            xButton.IsHovered())
+        if (@event is InputEventMouseButton && xButton.IsHovered())
         {
             Delete();
             return;


### PR DESCRIPTION
- When adding an input you're asked to press something
- there is a cross to undo the operation
- clicking on it with left click removes it
- clicking on it with right click will remove it only if you have something already set with right click

now without useless commits :D