### PR TITLE
Apply Language Settings when return from editor #1885

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -495,8 +495,10 @@ public class MicrobeStage : Node, ILoadableGameState, IGodotEarlyNodeResolve
         HUD.HideReproductionDialog();
 
         StartMusic();
-
-        // Apply language settings (to fix bug, see #1885)
+        
+        // Apply language settings here to be sure the stage doesn't continue to use the wrong language
+        // Because the stage scene tree being unattached during editor,
+        // if language was changed while in the editor, it doesn't properly propagate
         Settings.Instance.ApplyLanguageSettings();
 
         // Auto save is wanted once possible

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -495,7 +495,7 @@ public class MicrobeStage : Node, ILoadableGameState, IGodotEarlyNodeResolve
         HUD.HideReproductionDialog();
 
         StartMusic();
-        
+
         // Apply language settings here to be sure the stage doesn't continue to use the wrong language
         // Because the stage scene tree being unattached during editor,
         // if language was changed while in the editor, it doesn't properly propagate

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -496,6 +496,9 @@ public class MicrobeStage : Node, ILoadableGameState, IGodotEarlyNodeResolve
 
         StartMusic();
 
+        // Apply language settings (to fix bug, see #1885)
+        Settings.Instance.ApplyLanguageSettings();
+
         // Auto save is wanted once possible
         wantsToSave = true;
     }


### PR DESCRIPTION
This fixes #1885
Apply language settings in OnReturnFromEditor() in MicrobeStage.cs