### PR TITLE
Fixed editor button not enabled after loading a save with full reproduction progress

### DIFF
--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -123,7 +123,6 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
     [JsonProperty]
     private Color flashColour = new Color(0, 0, 0, 0);
 
-    [JsonProperty]
     private bool allOrganellesDivided;
 
     [JsonProperty]

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -123,6 +123,18 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
     [JsonProperty]
     private Color flashColour = new Color(0, 0, 0, 0);
 
+    /// <summary>
+    ///   True once all organelles are divided to not continuously run code that is triggered
+    ///   when a cell is ready to reproduce.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     This is not saved so that the player cell can enable the editor when loading a save
+    ///     where the player is ready to reproduce. If more code is added to be ran just once based
+    ///     on this flag, it needs to be made sure that that code re-running after loading a save is
+    ///     not a problem.
+    ///   </para>
+    /// </remarks>
     private bool allOrganellesDivided;
 
     [JsonProperty]


### PR DESCRIPTION
Removes the `[JsonProperty]` attribute from `allOrganellesDivided` flag so the microbe code has a chance to run the `HandleReproduction` method once and notify the gui to activate the editor button after spawning from save. Previously its state was kept true already and the gui isn't aware that the player microbe is ready to split. So far I haven't seen any side effects from removing it.

Fixes #1351 