### PR TITLE
Some tooltip ux improvements and small refactorings

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -74,7 +74,7 @@
     <Compile Include="src\gui_common\ControlHighlight.cs" />
     <Compile Include="src\gui_common\CollapsibleList.cs" />
     <Compile Include="src\gui_common\Cutscene.cs" />
-    <Compile Include="src\gui_common\Fade.cs" />
+    <Compile Include="src\gui_common\ScreenFade.cs" />
     <Compile Include="src\gui_common\GUICommon.cs" />
     <Compile Include="src\gui_common\IconProgressBar.cs" />
     <Compile Include="src\gui_common\ITransition.cs" />

--- a/src/engine/input/key_mapping/InputActionItem.cs
+++ b/src/engine/input/key_mapping/InputActionItem.cs
@@ -92,8 +92,8 @@ public class InputActionItem : VBoxContainer
         inputEventsContainer = GetNode<HBoxContainer>(InputEventsContainerPath);
         addInputEvent = GetNode<Button>(AddInputEventPath);
 
-        ToolTipHelper.RegisterToolTipForControl(
-            addInputEvent, tooltipCallbacks, ToolTipManager.Instance.GetToolTip("addInputButton", "options"));
+        addInputEvent.RegisterToolTipForControl(
+            ToolTipManager.Instance.GetToolTip("addInputButton", "options"), tooltipCallbacks);
 
         inputActionHeader.Text = DisplayName;
 

--- a/src/general/PauseMenu.cs
+++ b/src/general/PauseMenu.cs
@@ -124,7 +124,7 @@ public class PauseMenu : ControlWithInput
         // Unpause the game
         GetTree().Paused = false;
 
-        TransitionManager.Instance.AddScreenFade(Fade.FadeType.FadeIn, 0.3f, false);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.3f, false);
         TransitionManager.Instance.StartTransitions(this, nameof(OnSwitchToMenu));
     }
 

--- a/src/gui_common/GUICommon.cs
+++ b/src/gui_common/GUICommon.cs
@@ -80,6 +80,24 @@ public class GUICommon : Node
         tween.Start();
     }
 
+    public void ModulateFadeIn(Control control, float duration)
+    {
+        // Make sure the control is visible
+        control.Show();
+        control.Modulate = new Color(1, 1, 1, 0);
+
+        tween.InterpolateProperty(control, "modulate:a", 0, 1, duration, Tween.TransitionType.Sine, Tween.EaseType.In);
+        tween.Start();
+    }
+
+    public void ModulateFadeOut(Control control, float duration)
+    {
+        control.Modulate = new Color(1, 1, 1, 1);
+
+        tween.InterpolateProperty(control, "modulate:a", 1, 0, duration, Tween.TransitionType.Sine, Tween.EaseType.In);
+        tween.Start();
+    }
+
     /// <summary>
     ///   Creates an icon for the given compound.
     /// </summary>

--- a/src/gui_common/MainMenu.cs
+++ b/src/gui_common/MainMenu.cs
@@ -133,8 +133,8 @@ public class MainMenu : Node
         SwitchMenu();
 
         // Easter egg message
-        ToolTipHelper.RegisterToolTipForControl(
-            thriveLogo, toolTipCallbacks, ToolTipManager.Instance.GetToolTip("thriveLogoEasterEgg", "mainMenu"));
+        thriveLogo.RegisterToolTipForControl(
+            ToolTipManager.Instance.GetToolTip("thriveLogoEasterEgg", "mainMenu"), toolTipCallbacks);
 
         if (OS.GetCurrentVideoDriver() == OS.VideoDriver.Gles2 && !IsReturningToMenu)
             gles2Popup.PopupCenteredMinsize();

--- a/src/gui_common/MainMenu.cs
+++ b/src/gui_common/MainMenu.cs
@@ -191,7 +191,7 @@ public class MainMenu : Node
 
     private void OnIntroEnded()
     {
-        TransitionManager.Instance.AddScreenFade(Fade.FadeType.FadeOut, 0.5f, false);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.5f, false);
         TransitionManager.Instance.StartTransitions(null, string.Empty);
 
         // Start music after the video
@@ -229,13 +229,13 @@ public class MainMenu : Node
 
         if (Settings.Instance.PlayMicrobeIntroVideo)
         {
-            TransitionManager.Instance.AddScreenFade(Fade.FadeType.FadeIn, 0.5f);
+            TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.5f);
             TransitionManager.Instance.AddCutscene("res://assets/videos/microbe_intro2.webm");
         }
         else
         {
             // People who disable the cutscene are impatient anyway so use a reduced fade time
-            TransitionManager.Instance.AddScreenFade(Fade.FadeType.FadeIn, 0.2f);
+            TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.2f);
         }
 
         TransitionManager.Instance.StartTransitions(this, nameof(OnMicrobeIntroEnded));
@@ -254,7 +254,7 @@ public class MainMenu : Node
         // Ignore mouse event on the button to prevent it being clicked twice
         freebuildButton.MouseFilter = Control.MouseFilterEnum.Ignore;
 
-        TransitionManager.Instance.AddScreenFade(Fade.FadeType.FadeIn, 0.3f, false);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.3f, false);
         TransitionManager.Instance.StartTransitions(this, nameof(OnFreebuildFadeInEnded));
     }
 

--- a/src/gui_common/ScreenFade.cs
+++ b/src/gui_common/ScreenFade.cs
@@ -1,9 +1,9 @@
-﻿using Godot;
+using Godot;
 
 /// <summary>
-///   Controls the screen fade
+///   Controls the screen fade transition
 /// </summary>
-public class Fade : CanvasLayer, ITransition
+public class ScreenFade : CanvasLayer, ITransition
 {
     public ColorRect Rect;
     public Tween Fader;

--- a/src/gui_common/ScreenFade.cs
+++ b/src/gui_common/ScreenFade.cs
@@ -1,4 +1,4 @@
-using Godot;
+﻿using Godot;
 
 /// <summary>
 ///   Controls the screen fade transition

--- a/src/gui_common/ScreenFade.tscn
+++ b/src/gui_common/ScreenFade.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=2 format=2]
 
-[ext_resource path="res://src/gui_common/Fade.cs" type="Script" id=1]
+[ext_resource path="res://src/gui_common/ScreenFade.cs" type="Script" id=1]
 
-[node name="Fade" type="CanvasLayer"]
+[node name="ScreenFade" type="CanvasLayer"]
 layer = 10
 script = ExtResource( 1 )
 

--- a/src/gui_common/TransitionManager.cs
+++ b/src/gui_common/TransitionManager.cs
@@ -21,7 +21,7 @@ public class TransitionManager : NodeWithInput
     {
         instance = this;
 
-        screenFadeScene = GD.Load<PackedScene>("res://src/gui_common/Fade.tscn");
+        screenFadeScene = GD.Load<PackedScene>("res://src/gui_common/ScreenFade.tscn");
         cutsceneScene = GD.Load<PackedScene>("res://src/gui_common/Cutscene.tscn");
     }
 
@@ -59,10 +59,10 @@ public class TransitionManager : NodeWithInput
     /// <param name="allowSkipping">
     ///   Allow the user to skip this
     /// </param>
-    public void AddScreenFade(Fade.FadeType type, float fadeDuration, bool allowSkipping = true)
+    public void AddScreenFade(ScreenFade.FadeType type, float fadeDuration, bool allowSkipping = true)
     {
         // Instantiate scene
-        var screenFade = (Fade)screenFadeScene.Instance();
+        var screenFade = (ScreenFade)screenFadeScene.Instance();
         AddChild(screenFade);
 
         screenFade.Skippable = allowSkipping;

--- a/src/gui_common/charts/line/LineChart.cs
+++ b/src/gui_common/charts/line/LineChart.cs
@@ -229,7 +229,7 @@ public class LineChart : VBoxContainer
                 toolTip.Description = $"{point.Value.x} {XAxisName}\n{point.Value.y} {YAxisName}";
                 toolTip.DisplayDelay = 0;
 
-                ToolTipHelper.RegisterToolTipForControl(point, toolTipCallbacks, toolTip);
+                point.RegisterToolTipForControl(toolTip, toolTipCallbacks);
                 ToolTipManager.Instance.AddToolTip(toolTip, "chartMarkers" + ChartName + data.Key);
             }
         }
@@ -396,7 +396,7 @@ public class LineChart : VBoxContainer
             toolTip.DisplayName = data.Key;
             toolTip.Description = data.Key;
 
-            ToolTipHelper.RegisterToolTipForControl(icon, toolTipCallbacks, toolTip);
+            icon.RegisterToolTipForControl(toolTip, toolTipCallbacks);
             ToolTipManager.Instance.AddToolTip(toolTip, "chartLegend" + ChartName + data.Key);
         }
     }

--- a/src/gui_common/tooltip/DefaultToolTip.cs
+++ b/src/gui_common/tooltip/DefaultToolTip.cs
@@ -58,6 +58,10 @@ public class DefaultToolTip : Control, ICustomToolTip
         set => Visible = value;
     }
 
+    public ToolTipPositioning Positioning { get; private set; } = ToolTipPositioning.LastMousePosition;
+
+    public bool HideOnMousePress { get; private set; } = true;
+
     public Node ToolTipNode => this;
 
     public override void _Ready()
@@ -74,7 +78,7 @@ public class DefaultToolTip : Control, ICustomToolTip
 
     public void OnDisplay()
     {
-        ToolTipHelper.TooltipFadeIn(tween, this);
+        GUICommon.Instance.ModulateFadeIn(this, Constants.TOOLTIP_FADE_SPEED);
     }
 
     public void OnHide()

--- a/src/gui_common/tooltip/DefaultToolTip.cs
+++ b/src/gui_common/tooltip/DefaultToolTip.cs
@@ -13,8 +13,6 @@ public class DefaultToolTip : Control, ICustomToolTip
     /// </summary>
     private Label descriptionLabel;
 
-    private Tween tween;
-
     private string description;
 
     public Vector2 Position
@@ -70,8 +68,6 @@ public class DefaultToolTip : Control, ICustomToolTip
         // a different node name, so this use hard-coded path for now
         // See https://github.com/Revolutionary-Games/Thrive/issues/1855
         descriptionLabel = GetNode<Label>("MarginContainer/VBoxContainer/Description");
-
-        tween = GetNode<Tween>("Tween");
 
         UpdateDescription();
     }

--- a/src/gui_common/tooltip/DefaultToolTip.tscn
+++ b/src/gui_common/tooltip/DefaultToolTip.tscn
@@ -50,5 +50,3 @@ margin_right = 2.0
 margin_bottom = 17.0
 size_flags_horizontal = 3
 custom_fonts/font = ExtResource( 1 )
-
-[node name="Tween" type="Tween" parent="."]

--- a/src/gui_common/tooltip/DefaultToolTip.tscn
+++ b/src/gui_common/tooltip/DefaultToolTip.tscn
@@ -4,7 +4,7 @@
 [ext_resource path="res://src/gui_common/tooltip/DefaultToolTip.cs" type="Script" id=3]
 
 [sub_resource type="StyleBoxFlat" id=1]
-bg_color = Color( 0, 0.129412, 0.141176, 1 )
+bg_color = Color( 0, 0.129412, 0.141176, 0.980392 )
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1

--- a/src/gui_common/tooltip/ICustomToolTip.cs
+++ b/src/gui_common/tooltip/ICustomToolTip.cs
@@ -32,6 +32,10 @@ public interface ICustomToolTip
     /// </summary>
     Node ToolTipNode { get; }
 
+    ToolTipPositioning Positioning { get; }
+
+    bool HideOnMousePress { get; }
+
     /// <summary>
     ///   Display the tooltip in a customized way (like fade in or scale tweening)
     /// </summary>
@@ -41,4 +45,20 @@ public interface ICustomToolTip
     ///   Hide the tooltip
     /// </summary>
     void OnHide();
+}
+
+/// <summary>
+///   How the tooltip should be positioned on display.
+/// </summary>
+public enum ToolTipPositioning
+{
+    /// <summary>
+    ///   Tooltip positioned at the last cursor position after entering a tooltipable area.
+    /// </summary>
+    LastMousePosition,
+
+    /// <summary>
+    ///   Tooltip constantly positioned at the same position as the cursor.
+    /// </summary>
+    FollowMousePosition,
 }

--- a/src/gui_common/tooltip/ICustomToolTip.cs
+++ b/src/gui_common/tooltip/ICustomToolTip.cs
@@ -1,6 +1,22 @@
 ﻿using Godot;
 
 /// <summary>
+///   How the tooltip should be positioned on display.
+/// </summary>
+public enum ToolTipPositioning
+{
+    /// <summary>
+    ///   Tooltip positioned at the last cursor position after entering a tooltipable area.
+    /// </summary>
+    LastMousePosition,
+
+    /// <summary>
+    ///   Tooltip constantly positioned at the same position as the cursor.
+    /// </summary>
+    FollowMousePosition,
+}
+
+/// <summary>
 ///   Interface for all custom tooltip Control nodes
 /// </summary>
 public interface ICustomToolTip
@@ -45,20 +61,4 @@ public interface ICustomToolTip
     ///   Hide the tooltip
     /// </summary>
     void OnHide();
-}
-
-/// <summary>
-///   How the tooltip should be positioned on display.
-/// </summary>
-public enum ToolTipPositioning
-{
-    /// <summary>
-    ///   Tooltip positioned at the last cursor position after entering a tooltipable area.
-    /// </summary>
-    LastMousePosition,
-
-    /// <summary>
-    ///   Tooltip constantly positioned at the same position as the cursor.
-    /// </summary>
-    FollowMousePosition,
 }

--- a/src/gui_common/tooltip/ToolTipHelper.cs
+++ b/src/gui_common/tooltip/ToolTipHelper.cs
@@ -10,7 +10,7 @@ public static class ToolTipHelper
         "res://src/gui_common/tooltip/DefaultToolTip.tscn");
 
     /// <summary>
-    ///   Instantiates default tooltip scene
+    ///   Instantiates a default tooltip scene
     /// </summary>
     public static DefaultToolTip CreateDefaultToolTip()
     {
@@ -23,8 +23,8 @@ public static class ToolTipHelper
     /// <param name="control">The Control to register the tooltip to</param>
     /// <param name="callbackDatas">List to store the callbacks to keep them from unloading</param>
     /// <param name="tooltip">The tooltip to register with</param>
-    public static void RegisterToolTipForControl(Control control, List<ToolTipCallbackData> callbackDatas,
-        ICustomToolTip tooltip)
+    public static void RegisterToolTipForControl(this Control control, ICustomToolTip tooltip,
+        List<ToolTipCallbackData> callbackDatas)
     {
         // Skip if already registered
         if (callbackDatas.Find(match => match.ToolTip == tooltip) != null)
@@ -38,21 +38,5 @@ public static class ToolTipHelper
         control.Connect("tree_exiting", toolTipCallbackData, nameof(ToolTipCallbackData.OnMouseExit));
 
         callbackDatas.Add(toolTipCallbackData);
-    }
-
-    /// <summary>
-    ///   Used to fade in the tooltip on display
-    /// </summary>
-    /// <param name="tween">The tooltip's tween node</param>
-    /// <param name="control">The tooltip's control node</param>
-    public static void TooltipFadeIn(Tween tween, Control control)
-    {
-        control.Show();
-        control.Modulate = new Color(1, 1, 1, 0);
-
-        tween.InterpolateProperty(control, "modulate", new Color(1, 1, 1, 0), new Color(1, 1, 1, 1),
-            Constants.TOOLTIP_FADE_SPEED, Tween.TransitionType.Sine, Tween.EaseType.In);
-
-        tween.Start();
     }
 }

--- a/src/gui_common/tooltip/ToolTipManager.cs
+++ b/src/gui_common/tooltip/ToolTipManager.cs
@@ -79,7 +79,7 @@ public class ToolTipManager : CanvasLayer
         // Adjust position and size
         if (MainToolTip.ToolTipVisible)
         {
-            var mousePos = lastMousePosition;
+            Vector2 mousePos;
 
             switch (MainToolTip.Positioning)
             {

--- a/src/gui_common/tooltip/ToolTipManager.cs
+++ b/src/gui_common/tooltip/ToolTipManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Godot;
 
 /// <summary>
@@ -78,17 +79,43 @@ public class ToolTipManager : CanvasLayer
         // Adjust position and size
         if (MainToolTip.ToolTipVisible)
         {
+            var mousePos = lastMousePosition;
+
+            switch (MainToolTip.Positioning)
+            {
+                case ToolTipPositioning.LastMousePosition:
+                    mousePos = lastMousePosition;
+                    break;
+                case ToolTipPositioning.FollowMousePosition:
+                    mousePos = GetViewport().GetMousePosition();
+                    break;
+                default:
+                    throw new Exception("Invalid tooltip positioning type");
+            }
+
             var screenSize = GetViewport().GetVisibleRect().Size;
 
             // Clamp tooltip position so it doesn't go offscreen
-            var adjustedPosition = new Vector2(
-                Mathf.Clamp(lastMousePosition.x + Constants.TOOLTIP_OFFSET, 0, screenSize.x -
+            MainToolTip.Position = new Vector2(
+                Mathf.Clamp(mousePos.x + Constants.TOOLTIP_OFFSET, 0, screenSize.x -
                     MainToolTip.Size.x),
-                Mathf.Clamp(lastMousePosition.y + Constants.TOOLTIP_OFFSET, 0, screenSize.y -
+                Mathf.Clamp(mousePos.y + Constants.TOOLTIP_OFFSET, 0, screenSize.y -
                     MainToolTip.Size.y));
 
-            MainToolTip.Position = adjustedPosition;
             MainToolTip.Size = Vector2.Zero;
+        }
+    }
+
+    public override void _Input(InputEvent @event)
+    {
+        if (MainToolTip == null)
+            return;
+
+        if (@event is InputEventMouseButton mouseButton &&
+            mouseButton.Pressed && MainToolTip.HideOnMousePress)
+        {
+            MainToolTip.OnHide();
+            displayTimer = MainToolTip.DisplayDelay;
         }
     }
 

--- a/src/gui_common/tooltip/ToolTipManager.tscn
+++ b/src/gui_common/tooltip/ToolTipManager.tscn
@@ -26,7 +26,7 @@
 [ext_resource path="res://src/gui_common/fonts/Lato-Bold-AlmostSmall.tres" type="DynamicFont" id=27]
 [ext_resource path="res://src/gui_common/fonts/Jura-DemiBold-Normal.tres" type="DynamicFont" id=29]
 
-[sub_resource type="StyleBoxFlat" id=1]
+[sub_resource type="StyleBoxFlat" id=2]
 bg_color = Color( 0, 0.129412, 0.141176, 1 )
 border_width_left = 1
 border_width_top = 1
@@ -38,8 +38,8 @@ corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
-[sub_resource type="StyleBoxFlat" id=2]
-bg_color = Color( 0, 0.129412, 0.141176, 1 )
+[sub_resource type="StyleBoxFlat" id=1]
+bg_color = Color( 0, 0.129412, 0.141176, 0.980392 )
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
@@ -81,7 +81,7 @@ DescriptionLabelPath = NodePath("../../general/menuButton/MarginContainer/VBoxCo
 
 [node name="helpButton" parent="GroupHolder/general" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
+custom_styles/panel = SubResource( 2 )
 Description = "OPEN_HELP_SCREEN"
 DescriptionLabelPath = NodePath("../../general/helpButton/MarginContainer/VBoxContainer/Description")
 
@@ -103,31 +103,31 @@ DescriptionLabelPath = NodePath("../../../GroupHolder/editor/finishButton/Margin
 
 [node name="symmetryButton" parent="GroupHolder/editor" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
+custom_styles/panel = SubResource( 2 )
 Description = "CHANGE_THE_SYMMETRY"
 DescriptionLabelPath = NodePath("../../../GroupHolder/editor/symmetryButton/MarginContainer/VBoxContainer/Description")
 
 [node name="undoButton" parent="GroupHolder/editor" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
+custom_styles/panel = SubResource( 2 )
 Description = "UNDO_THE_LAST_ACTION"
 DescriptionLabelPath = NodePath("../undoButton/MarginContainer/VBoxContainer/Description")
 
 [node name="redoButton" parent="GroupHolder/editor" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
+custom_styles/panel = SubResource( 2 )
 Description = "REDO_THE_LAST_ACTION"
 DescriptionLabelPath = NodePath("../../../GroupHolder/editor/redoButton/MarginContainer/VBoxContainer/Description")
 
 [node name="newCellButton" parent="GroupHolder/editor" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
+custom_styles/panel = SubResource( 2 )
 Description = "CREATE_A_NEW_MICROBE"
 DescriptionLabelPath = NodePath("../../../GroupHolder/editor/newCellButton/MarginContainer/VBoxContainer/Description")
 
 [node name="timeIndicator" parent="GroupHolder/editor" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
+custom_styles/panel = SubResource( 2 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../../GroupHolder/editor/timeIndicator/MarginContainer/VBoxContainer/Description")
 
@@ -137,7 +137,7 @@ margin_right = 350.0
 margin_bottom = 238.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -333,7 +333,7 @@ margin_right = 350.0
 margin_bottom = 379.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -585,7 +585,7 @@ margin_right = 350.0
 margin_bottom = 423.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -878,7 +878,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -1178,7 +1178,7 @@ margin_right = 350.0
 margin_bottom = 214.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -1517,7 +1517,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -1834,7 +1834,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -2121,7 +2121,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -2420,7 +2420,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -2703,7 +2703,7 @@ margin_right = 350.0
 margin_bottom = 91.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -2829,7 +2829,7 @@ margin_right = 350.0
 margin_bottom = 91.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -2955,7 +2955,7 @@ margin_right = 350.0
 margin_bottom = 507.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -3157,7 +3157,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -3444,7 +3444,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -3744,7 +3744,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -4036,7 +4036,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -4320,7 +4320,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -4637,7 +4637,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -4838,7 +4838,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -5153,7 +5153,7 @@ margin_right = 350.0
 margin_bottom = 121.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -5284,7 +5284,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -5544,7 +5544,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -5800,7 +5800,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -6127,7 +6127,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -6454,7 +6454,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -6815,7 +6815,7 @@ margin_right = 350.0
 margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
-custom_styles/panel = SubResource( 2 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -7177,61 +7177,51 @@ mouse_filter = 2
 
 [node name="cytoplasm" parent="GroupHolder/processesProduction" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../processesProduction/cytoplasm/MarginContainer/VBoxContainer/Description")
 
 [node name="metabolosome" parent="GroupHolder/processesProduction" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../processesProduction/metabolosome/MarginContainer/VBoxContainer/Description")
 
 [node name="chromatophore" parent="GroupHolder/processesProduction" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../processesProduction/chromatophore/MarginContainer/VBoxContainer/Description")
 
 [node name="chemoSynthesizingProteins" parent="GroupHolder/processesProduction" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../processesProduction/chemoSynthesizingProteins/MarginContainer/VBoxContainer/Description")
 
 [node name="rusticyanin" parent="GroupHolder/processesProduction" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../processesProduction/rusticyanin/MarginContainer/VBoxContainer/Description")
 
 [node name="nitrogenase" parent="GroupHolder/processesProduction" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../processesProduction/nitrogenase/MarginContainer/VBoxContainer/Description")
 
 [node name="oxytoxyProteins" parent="GroupHolder/processesProduction" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../processesProduction/oxytoxyProteins/MarginContainer/VBoxContainer/Description")
 
 [node name="mitochondrion" parent="GroupHolder/processesProduction" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../processesProduction/mitochondrion/MarginContainer/VBoxContainer/Description")
 
 [node name="nitrogenfixingplastid" parent="GroupHolder/processesProduction" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../processesProduction/nitrogenfixingplastid/MarginContainer/VBoxContainer/Description")
 
 [node name="oxytoxy" parent="GroupHolder/processesProduction" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../processesProduction/oxytoxy/MarginContainer/VBoxContainer/Description")
 
@@ -7242,60 +7232,50 @@ mouse_filter = 2
 
 [node name="osmoregulation" parent="GroupHolder/processesConsumption" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../../GroupHolder/processesConsumption/osmoregulation/MarginContainer/VBoxContainer/Description")
 
 [node name="baseMovement" parent="GroupHolder/processesConsumption" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../../GroupHolder/processesConsumption/baseMovement/MarginContainer/VBoxContainer/Description")
 
 [node name="chromatophore" parent="GroupHolder/processesConsumption" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../../GroupHolder/processesConsumption/chromatophore/MarginContainer/VBoxContainer/Description")
 
 [node name="chemoSynthesizingProteins" parent="GroupHolder/processesConsumption" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../../GroupHolder/processesConsumption/chemoSynthesizingProteins/MarginContainer/VBoxContainer/Description")
 
 [node name="rusticyanin" parent="GroupHolder/processesConsumption" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../../GroupHolder/processesConsumption/rusticyanin/MarginContainer/VBoxContainer/Description")
 
 [node name="nitrogenase" parent="GroupHolder/processesConsumption" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../../GroupHolder/processesConsumption/nitrogenase/MarginContainer/VBoxContainer/Description")
 
 [node name="oxytoxyProteins" parent="GroupHolder/processesConsumption" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../../GroupHolder/processesConsumption/oxytoxyProteins/MarginContainer/VBoxContainer/Description")
 
 [node name="flagellum" parent="GroupHolder/processesConsumption" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../../GroupHolder/processesConsumption/flagellum/MarginContainer/VBoxContainer/Description")
 
 [node name="nitrogenfixingplastid" parent="GroupHolder/processesConsumption" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../../GroupHolder/processesConsumption/nitrogenfixingplastid/MarginContainer/VBoxContainer/Description")
 
 [node name="oxytoxy" parent="GroupHolder/processesConsumption" instance=ExtResource( 1 )]
 visible = false
-custom_styles/panel = SubResource( 1 )
 DisplayDelay = 0.3
 DescriptionLabelPath = NodePath("../../../GroupHolder/processesConsumption/oxytoxy/MarginContainer/VBoxContainer/Description")

--- a/src/gui_common/tooltip/microbe_editor/SelectionMenuToolTip.cs
+++ b/src/gui_common/tooltip/microbe_editor/SelectionMenuToolTip.cs
@@ -82,13 +82,17 @@ public class SelectionMenuToolTip : Control, ICustomToolTip
     }
 
     [Export]
-    public float DisplayDelay { get; set; } = 0.3f;
+    public float DisplayDelay { get; set; } = 0.0f;
 
     public bool ToolTipVisible
     {
         get => Visible;
         set => Visible = value;
     }
+
+    public ToolTipPositioning Positioning { get; private set; } = ToolTipPositioning.FollowMousePosition;
+
+    public bool HideOnMousePress { get; private set; } = false;
 
     public Node ToolTipNode => this;
 
@@ -332,7 +336,7 @@ public class SelectionMenuToolTip : Control, ICustomToolTip
 
     public void OnDisplay()
     {
-        ToolTipHelper.TooltipFadeIn(tween, this);
+        Show();
     }
 
     public void OnHide()

--- a/src/gui_common/tooltip/microbe_editor/SelectionMenuToolTip.cs
+++ b/src/gui_common/tooltip/microbe_editor/SelectionMenuToolTip.cs
@@ -37,8 +37,6 @@ public class SelectionMenuToolTip : Control, ICustomToolTip
     private VBoxContainer modifierInfoList;
     private VBoxContainer processList;
 
-    private Tween tween;
-
     private string displayName;
     private string description;
 
@@ -103,8 +101,6 @@ public class SelectionMenuToolTip : Control, ICustomToolTip
         descriptionLabel = GetNode<Label>(DescriptionLabelPath);
         modifierInfoList = GetNode<VBoxContainer>(ModifierListPath);
         processList = GetNode<VBoxContainer>(ProcessListPath);
-
-        tween = GetNode<Tween>("Tween");
 
         UpdateName();
         UpdateDescription();

--- a/src/gui_common/tooltip/microbe_editor/SelectionMenuToolTip.tscn
+++ b/src/gui_common/tooltip/microbe_editor/SelectionMenuToolTip.tscn
@@ -145,5 +145,3 @@ margin_bottom = 123.0
 size_flags_horizontal = 3
 custom_fonts/font = ExtResource( 2 )
 autowrap = true
-
-[node name="Tween" type="Tween" parent="."]

--- a/src/gui_common/tooltip/microbe_editor/SelectionMenuToolTip.tscn
+++ b/src/gui_common/tooltip/microbe_editor/SelectionMenuToolTip.tscn
@@ -10,8 +10,8 @@
 [ext_resource path="res://src/gui_common/fonts/Jura-DemiBold-Smaller.tres" type="DynamicFont" id=8]
 [ext_resource path="res://src/gui_common/thrive_theme.tres" type="Theme" id=9]
 
-[sub_resource type="StyleBoxFlat" id=4]
-bg_color = Color( 0, 0.129412, 0.141176, 1 )
+[sub_resource type="StyleBoxFlat" id=1]
+bg_color = Color( 0, 0.129412, 0.141176, 0.980392 )
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
@@ -22,10 +22,10 @@ corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
-[sub_resource type="Theme" id=3]
+[sub_resource type="Theme" id=2]
 default_font = ExtResource( 6 )
 
-[sub_resource type="StyleBoxTexture" id=5]
+[sub_resource type="StyleBoxTexture" id=3]
 texture = ExtResource( 5 )
 region_rect = Rect2( 0, 0, 429, 1 )
 
@@ -35,7 +35,7 @@ margin_bottom = 155.0
 rect_min_size = Vector2( 350, 0 )
 mouse_filter = 2
 theme = ExtResource( 9 )
-custom_styles/panel = SubResource( 4 )
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 7 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -123,7 +123,7 @@ margin_top = 57.0
 margin_right = 318.0
 margin_bottom = 57.0
 mouse_filter = 2
-theme = SubResource( 3 )
+theme = SubResource( 2 )
 
 [node name="ModifierList" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
 margin_top = 72.0
@@ -136,7 +136,7 @@ margin_top = 87.0
 margin_right = 318.0
 margin_bottom = 91.0
 mouse_filter = 2
-custom_styles/separator = SubResource( 5 )
+custom_styles/separator = SubResource( 3 )
 
 [node name="Description" type="Label" parent="MarginContainer/VBoxContainer"]
 margin_top = 106.0

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -279,7 +279,7 @@ public class MicrobeHUD : Node
     {
         // Fade out for that smooth satisfying transition
         stage.TransitionFinished = false;
-        TransitionManager.Instance.AddScreenFade(Fade.FadeType.FadeOut, 0.3f);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.3f);
         TransitionManager.Instance.StartTransitions(stage, nameof(MicrobeStage.OnFinishTransitioning));
     }
 
@@ -458,7 +458,7 @@ public class MicrobeHUD : Node
             PauseButtonPressed();
         }
 
-        TransitionManager.Instance.AddScreenFade(Fade.FadeType.FadeIn, 0.3f, false);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.3f, false);
         TransitionManager.Instance.StartTransitions(stage, nameof(MicrobeStage.MoveToEditor));
     }
 

--- a/src/microbe_stage/editor/MicrobeEditor.tscn
+++ b/src/microbe_stage/editor/MicrobeEditor.tscn
@@ -3794,10 +3794,10 @@ size_flags_horizontal = 3
 custom_styles/separator = SubResource( 29 )
 
 [node name="ColorPicker" type="ColorPicker" parent="MicrobeEditorGUI/CellEditor/LeftPanel/MainPanel/VBoxContainer/MarginContainer/VBoxContainer/Appearance/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer2"]
-margin_left = 24.0
-margin_top = 47.0
-margin_right = 381.0
-margin_bottom = 496.0
+margin_left = 28.0
+margin_top = 51.0
+margin_right = 385.0
+margin_bottom = 500.0
 theme = SubResource( 30 )
 edit_alpha = false
 

--- a/src/microbe_stage/editor/MicrobeEditorGUI.cs
+++ b/src/microbe_stage/editor/MicrobeEditorGUI.cs
@@ -498,36 +498,34 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
     {
         foreach (Control organelleSelection in organelleSelectionElements)
         {
-            ToolTipHelper.RegisterToolTipForControl(
-                organelleSelection, tooltipCallbacks, ToolTipManager.Instance.GetToolTip(
-                    organelleSelection.Name, "organelleSelection"));
+            organelleSelection.RegisterToolTipForControl(ToolTipManager.Instance.GetToolTip(
+                organelleSelection.Name, "organelleSelection"), tooltipCallbacks);
         }
 
         foreach (Control membraneSelection in membraneSelectionElements)
         {
-            ToolTipHelper.RegisterToolTipForControl(
-                membraneSelection, tooltipCallbacks, ToolTipManager.Instance.GetToolTip(
-                    membraneSelection.Name, "membraneSelection"));
+            membraneSelection.RegisterToolTipForControl(ToolTipManager.Instance.GetToolTip(
+                membraneSelection.Name, "membraneSelection"), tooltipCallbacks);
         }
 
-        ToolTipHelper.RegisterToolTipForControl(
-            rigiditySlider, tooltipCallbacks, ToolTipManager.Instance.GetToolTip("rigiditySlider", "editor"));
-        ToolTipHelper.RegisterToolTipForControl(
-            helpButton, tooltipCallbacks, ToolTipManager.Instance.GetToolTip("helpButton"));
-        ToolTipHelper.RegisterToolTipForControl(
-            symmetryButton, tooltipCallbacks, ToolTipManager.Instance.GetToolTip("symmetryButton", "editor"));
-        ToolTipHelper.RegisterToolTipForControl(
-            undoButton, tooltipCallbacks, ToolTipManager.Instance.GetToolTip("undoButton", "editor"));
-        ToolTipHelper.RegisterToolTipForControl(
-            redoButton, tooltipCallbacks, ToolTipManager.Instance.GetToolTip("redoButton", "editor"));
-        ToolTipHelper.RegisterToolTipForControl(
-            newCellButton, tooltipCallbacks, ToolTipManager.Instance.GetToolTip("newCellButton", "editor"));
-        ToolTipHelper.RegisterToolTipForControl(
-            timeIndicator, tooltipCallbacks, ToolTipManager.Instance.GetToolTip("timeIndicator", "editor"));
-        ToolTipHelper.RegisterToolTipForControl(
-            finishButton, tooltipCallbacks, ToolTipManager.Instance.GetToolTip("finishButton", "editor"));
-        ToolTipHelper.RegisterToolTipForControl(
-            menuButton, tooltipCallbacks, ToolTipManager.Instance.GetToolTip("menuButton"));
+        rigiditySlider.RegisterToolTipForControl(
+            ToolTipManager.Instance.GetToolTip("rigiditySlider", "editor"), tooltipCallbacks);
+        helpButton.RegisterToolTipForControl(
+            ToolTipManager.Instance.GetToolTip("helpButton"), tooltipCallbacks);
+        symmetryButton.RegisterToolTipForControl(
+            ToolTipManager.Instance.GetToolTip("symmetryButton", "editor"), tooltipCallbacks);
+        undoButton.RegisterToolTipForControl(
+            ToolTipManager.Instance.GetToolTip("undoButton", "editor"), tooltipCallbacks);
+        redoButton.RegisterToolTipForControl(
+            ToolTipManager.Instance.GetToolTip("redoButton", "editor"), tooltipCallbacks);
+        newCellButton.RegisterToolTipForControl(
+            ToolTipManager.Instance.GetToolTip("newCellButton", "editor"), tooltipCallbacks);
+        timeIndicator.RegisterToolTipForControl(
+            ToolTipManager.Instance.GetToolTip("timeIndicator", "editor"), tooltipCallbacks);
+        finishButton.RegisterToolTipForControl(
+            ToolTipManager.Instance.GetToolTip("finishButton", "editor"), tooltipCallbacks);
+        menuButton.RegisterToolTipForControl(
+            ToolTipManager.Instance.GetToolTip("menuButton"), tooltipCallbacks);
     }
 
     public override void _Process(float delta)
@@ -692,7 +690,7 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
         {
             var tooltip = ToolTipManager.Instance.GetToolTip(subBar.Name, "processesProduction");
 
-            ToolTipHelper.RegisterToolTipForControl(subBar, processesTooltipCallbacks, tooltip);
+            subBar.RegisterToolTipForControl(tooltip, processesTooltipCallbacks);
 
             tooltip.Description =
                 $"{SimulationParameters.Instance.GetOrganelleType(subBar.Name).Name}: " +
@@ -703,7 +701,7 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
         {
             var tooltip = ToolTipManager.Instance.GetToolTip(subBar.Name, "processesConsumption");
 
-            ToolTipHelper.RegisterToolTipForControl(subBar, processesTooltipCallbacks, tooltip);
+            subBar.RegisterToolTipForControl(tooltip, processesTooltipCallbacks);
 
             string displayName;
 

--- a/src/microbe_stage/editor/MicrobeEditorGUI.cs
+++ b/src/microbe_stage/editor/MicrobeEditorGUI.cs
@@ -487,7 +487,7 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
         ApplySelectionMenuTab();
 
         // Fade out for that smooth satisfying transition
-        TransitionManager.Instance.AddScreenFade(Fade.FadeType.FadeOut, 0.5f);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.5f);
         TransitionManager.Instance.StartTransitions(editor, nameof(MicrobeEditor.OnFinishTransitioning));
     }
 
@@ -923,7 +923,7 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
         // To prevent being clicked twice
         finishButton.MouseFilter = Control.MouseFilterEnum.Ignore;
 
-        TransitionManager.Instance.AddScreenFade(Fade.FadeType.FadeIn, 0.5f, false);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.5f, false);
         TransitionManager.Instance.StartTransitions(editor, nameof(MicrobeEditor.OnFinishEditing));
     }
 
@@ -931,7 +931,7 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
     {
         GUICommon.Instance.PlayButtonPressSound();
 
-        TransitionManager.Instance.AddScreenFade(Fade.FadeType.FadeIn, 0.5f, false);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.5f, false);
         TransitionManager.Instance.StartTransitions(editor, nameof(MicrobeEditor.OnFinishEditing));
     }
 

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -232,7 +232,7 @@ public class SaveList : ScrollContainer
     {
         GUICommon.Instance.PlayButtonPressSound();
 
-        TransitionManager.Instance.AddScreenFade(Fade.FadeType.FadeIn, 0.3f, true);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.3f, true);
         TransitionManager.Instance.StartTransitions(this, nameof(LoadSave));
     }
 

--- a/src/saving/SaveListItem.cs
+++ b/src/saving/SaveListItem.cs
@@ -242,7 +242,7 @@ public class SaveListItem : PanelContainer
             return;
         }
 
-        TransitionManager.Instance.AddScreenFade(Fade.FadeType.FadeIn, 0.3f, true);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.3f, true);
         TransitionManager.Instance.StartTransitions(this, nameof(LoadSave));
     }
 


### PR DESCRIPTION
While playing Thrive, I kept noticing the organelle tooltip display delay I added feels slow, kind of annoying if you want to quickly compare different stats imo. So to make it feel a bit good, I opt to removing the delay and fade in, also made it follow the mouse cursor (which is how I want it originally but somehow tempted to change it). For the DefaultToolTip, it now hides on mouse press.