### PR TITLE
Disallow quick save before transitioning is finished #1909

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -430,6 +430,12 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
     [RunOnKeyDown("g_quick_save")]
     public void QuickSave()
     {
+        if (!TransitionFinished)
+        {
+            GD.Print("quick save is disabled while transitioning");
+            return;
+        }
+
         GD.Print("quick saving microbe stage");
         SaveHelper.QuickSave(this);
     }


### PR DESCRIPTION
Added a check on TransitionFinished.
Not sure if an extra check on autosave is needed.

fixes #1909