### PR TITLE
Consumed event while rebinding

### DIFF
--- a/src/engine/input/InputManager.cs
+++ b/src/engine/input/InputManager.cs
@@ -17,11 +17,6 @@ public class InputManager : Node
     private static InputManager staticInstance;
 
     /// <summary>
-    ///   A bool indicating whether a rebinding is in progress
-    /// </summary>
-    public static bool RebindingIsActive { get; set; }
-
-    /// <summary>
     ///   A list of all loaded attributes
     /// </summary>
     /// <remarks>
@@ -42,6 +37,12 @@ public class InputManager : Node
 
         StartTimer();
     }
+
+
+    /// <summary>
+    ///   A bool indicating whether a rebinding is in progress
+    /// </summary>
+    public static bool RebindingIsActive { get; set; }
 
     /// <summary>
     ///   Adds the instance to the list of objects receiving input.

--- a/src/engine/input/InputManager.cs
+++ b/src/engine/input/InputManager.cs
@@ -15,7 +15,12 @@ using Godot;
 public class InputManager : Node
 {
     private static InputManager staticInstance;
-    private static bool rebindingIsActive = false;
+
+    /// <summary>
+    /// A bool indicating whether a rebinding is in progress
+    /// </summary>
+    public static bool RebindingIsActive
+    { get; set; }
 
     /// <summary>
     ///   A list of all loaded attributes
@@ -94,11 +99,6 @@ public class InputManager : Node
             attribute.Key.FocusLost();
     }
 
-    public static void SetRebindingActive(bool isRebinding)
-    {
-        rebindingIsActive = isRebinding;
-    }
-
     /// <summary>
     ///   Calls all OnProcess methods of all input attributes
     /// </summary>
@@ -117,6 +117,9 @@ public class InputManager : Node
     /// <param name="event">The event the user fired</param>
     public override void _UnhandledInput(InputEvent @event)
     {
+        if (RebindingIsActive)
+            return;
+
         OnInput(true, @event);
     }
 
@@ -128,8 +131,9 @@ public class InputManager : Node
     /// <param name="event">The event the user fired</param>
     public override void _Input(InputEvent @event)
     {
-        if (rebindingIsActive)
+        if (RebindingIsActive)
             return;
+
         OnInput(false, @event);
     }
 

--- a/src/engine/input/InputManager.cs
+++ b/src/engine/input/InputManager.cs
@@ -17,10 +17,9 @@ public class InputManager : Node
     private static InputManager staticInstance;
 
     /// <summary>
-    /// A bool indicating whether a rebinding is in progress
+    ///   A bool indicating whether a rebinding is in progress
     /// </summary>
-    public static bool RebindingIsActive
-    { get; set; }
+    public static bool RebindingIsActive { get; set; }
 
     /// <summary>
     ///   A list of all loaded attributes

--- a/src/engine/input/InputManager.cs
+++ b/src/engine/input/InputManager.cs
@@ -15,6 +15,7 @@ using Godot;
 public class InputManager : Node
 {
     private static InputManager staticInstance;
+    private static bool rebindingIsActive = false;
 
     /// <summary>
     ///   A list of all loaded attributes
@@ -93,6 +94,11 @@ public class InputManager : Node
             attribute.Key.FocusLost();
     }
 
+    public static void SetRebindingActive(bool isRebinding)
+    {
+        rebindingIsActive = isRebinding;
+    }
+
     /// <summary>
     ///   Calls all OnProcess methods of all input attributes
     /// </summary>
@@ -122,6 +128,8 @@ public class InputManager : Node
     /// <param name="event">The event the user fired</param>
     public override void _Input(InputEvent @event)
     {
+        if (rebindingIsActive)
+            return;
         OnInput(false, @event);
     }
 

--- a/src/engine/input/InputManager.cs
+++ b/src/engine/input/InputManager.cs
@@ -116,9 +116,6 @@ public class InputManager : Node
     /// <param name="event">The event the user fired</param>
     public override void _UnhandledInput(InputEvent @event)
     {
-        if (RebindingIsActive)
-            return;
-
         OnInput(true, @event);
     }
 
@@ -130,9 +127,6 @@ public class InputManager : Node
     /// <param name="event">The event the user fired</param>
     public override void _Input(InputEvent @event)
     {
-        if (RebindingIsActive)
-            return;
-
         OnInput(false, @event);
     }
 
@@ -230,6 +224,10 @@ public class InputManager : Node
 
     private void OnInput(bool unhandledInput, InputEvent @event)
     {
+        // Ignore input while rebinding
+        if (RebindingIsActive)
+            return;
+
         // Ignore mouse motion
         // TODO: support mouse movement input as well
         if (@event is InputEventMouseMotion)

--- a/src/engine/input/InputManager.cs
+++ b/src/engine/input/InputManager.cs
@@ -39,7 +39,7 @@ public class InputManager : Node
     }
 
     /// <summary>
-    ///   A bool indicating whether a rebinding is in progress
+    ///   Indicates whether a rebinding is in progress
     /// </summary>
     public static bool RebindingIsActive { get; set; }
 

--- a/src/engine/input/InputManager.cs
+++ b/src/engine/input/InputManager.cs
@@ -38,7 +38,6 @@ public class InputManager : Node
         StartTimer();
     }
 
-
     /// <summary>
     ///   A bool indicating whether a rebinding is in progress
     /// </summary>

--- a/src/engine/input/key_mapping/InputEventItem.cs
+++ b/src/engine/input/key_mapping/InputEventItem.cs
@@ -265,8 +265,8 @@ public class InputEventItem : Node
         // Consume current input even so it is only used for rebinding
         GetTree().SetInputAsHandled();
 
-        // rebinding is done so we alert the InputManager that he can resume getting input
-        InputManager.SetRebindingActive(false);
+        // Rebinding is done so we alert the InputManager that it can resume getting input
+        InputManager.RebindingIsActive = false;
     }
 
     /// <summary>
@@ -299,7 +299,7 @@ public class InputEventItem : Node
         WaitingForInput = true;
         button.Text = TranslationServer.Translate("PRESS_KEY_DOT_DOT_DOT");
         xButton.Visible = true;
-        InputManager.SetRebindingActive(true);
+        InputManager.RebindingIsActive = true;
     }
 
     private void UpdateButtonText()

--- a/src/engine/input/key_mapping/InputEventItem.cs
+++ b/src/engine/input/key_mapping/InputEventItem.cs
@@ -264,7 +264,7 @@ public class InputEventItem : Node
         // Update the button text
         UpdateButtonText();
 
-        // Consume current input even so it is only used for rebinding
+        // Consume current input event so it is only used for rebinding
         GetTree().SetInputAsHandled();
 
         // Rebinding is done so we alert the InputManager that it can resume getting input
@@ -302,7 +302,7 @@ public class InputEventItem : Node
         button.Text = TranslationServer.Translate("PRESS_KEY_DOT_DOT_DOT");
         xButton.Visible = true;
 
-        // Signal to the input manager that a rebinding has started and it should ignore other input
+        // Signal to the input manager that a rebinding has started and it should ignore input untill the rebind is finished
         InputManager.RebindingIsActive = true;
     }
 

--- a/src/engine/input/key_mapping/InputEventItem.cs
+++ b/src/engine/input/key_mapping/InputEventItem.cs
@@ -184,6 +184,9 @@ public class InputEventItem : Node
         var old = AssociatedEvent;
         AssociatedEvent = new SpecifiedInputKey((InputEventWithModifiers)@event);
 
+        // Consume current input event so it is only used for rebinding
+        GetTree().SetInputAsHandled();
+
         // Check conflicts, and don't proceed if there is a conflict
         if (CheckNewKeyConflicts(@event, groupList, old))
             return;
@@ -223,9 +226,6 @@ public class InputEventItem : Node
 
             // If there are conflicts detected reset the changes and ask the user.
             groupList.ShowInputConflictDialog(this, conflict, (InputEventWithModifiers)@event);
-
-            // No other node should react to this input since the rebinding is still active after the dialog is closed
-            GetTree().SetInputAsHandled();
             return true;
         }
 
@@ -264,9 +264,6 @@ public class InputEventItem : Node
         // Update the button text
         UpdateButtonText();
 
-        // Consume current input event so it is only used for rebinding
-        GetTree().SetInputAsHandled();
-
         // Rebinding is done so we alert the InputManager that it can resume getting input
         InputManager.RebindingIsActive = false;
     }
@@ -302,7 +299,8 @@ public class InputEventItem : Node
         button.Text = TranslationServer.Translate("PRESS_KEY_DOT_DOT_DOT");
         xButton.Visible = true;
 
-        // Signal to the input manager that a rebinding has started and it should ignore input untill the rebind is finished
+        // Signal to the input manager that a rebinding has started
+        // and it should ignore input untill the rebind is finished
         InputManager.RebindingIsActive = true;
     }
 

--- a/src/engine/input/key_mapping/InputEventItem.cs
+++ b/src/engine/input/key_mapping/InputEventItem.cs
@@ -223,6 +223,8 @@ public class InputEventItem : Node
 
             // If there are conflicts detected reset the changes and ask the user.
             groupList.ShowInputConflictDialog(this, conflict, (InputEventWithModifiers)@event);
+
+            // No other node should react to this input since the rebinding is still active after the dialog is closed
             GetTree().SetInputAsHandled();
             return true;
         }
@@ -299,6 +301,8 @@ public class InputEventItem : Node
         WaitingForInput = true;
         button.Text = TranslationServer.Translate("PRESS_KEY_DOT_DOT_DOT");
         xButton.Visible = true;
+
+        // Signal to the input manager that a rebinding has started and it should ignore other input
         InputManager.RebindingIsActive = true;
     }
 

--- a/src/engine/input/key_mapping/InputEventItem.cs
+++ b/src/engine/input/key_mapping/InputEventItem.cs
@@ -223,6 +223,7 @@ public class InputEventItem : Node
 
             // If there are conflicts detected reset the changes and ask the user.
             groupList.ShowInputConflictDialog(this, conflict, (InputEventWithModifiers)@event);
+            GetTree().SetInputAsHandled();
             return true;
         }
 
@@ -260,6 +261,12 @@ public class InputEventItem : Node
 
         // Update the button text
         UpdateButtonText();
+
+        // Consume current input even so it is only used for rebinding
+        GetTree().SetInputAsHandled();
+
+        // rebinding is done so we alert the InputManager that he can resume getting input
+        InputManager.SetRebindingActive(false);
     }
 
     /// <summary>
@@ -292,6 +299,7 @@ public class InputEventItem : Node
         WaitingForInput = true;
         button.Text = TranslationServer.Translate("PRESS_KEY_DOT_DOT_DOT");
         xButton.Visible = true;
+        InputManager.SetRebindingActive(true);
     }
 
     private void UpdateButtonText()

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -430,6 +430,12 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
     [RunOnKeyDown("g_quick_save")]
     public void QuickSave()
     {
+        if (!TransitionFinished)
+        {
+            GD.Print("quick save is disabled while transitioning");
+            return;
+        }
+
         GD.Print("quick saving microbe stage");
         SaveHelper.QuickSave(this);
     }


### PR DESCRIPTION
This seems to solve the bug. 
Toggling the fps rebinding works and it also works with assigning f9 to it.

fixes #1903 