### PR TITLE
Made MP bar flash if insufficient point to switch membrane type

### DIFF
--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -175,12 +175,6 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
     /// </summary>
     private Vector3? mousePanningStart;
 
-    [Signal]
-    public delegate void InvalidPlacementOfHex();
-
-    [Signal]
-    public delegate void InsufficientMPToPlaceHex();
-
     /// <summary>
     /// The Symmetry setting of the Microbe Editor.
     /// </summary>
@@ -1496,15 +1490,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
         if (!IsValidPlacement(organelle))
         {
             // Play Sound
-            EmitSignal(nameof(InvalidPlacementOfHex));
-            return;
-        }
-
-        // Skip placing if the player can't afford the organelle
-        if (organelle.Definition.MPCost > MutationPoints && !FreeBuilding)
-        {
-            // Flash the MP bar and play sound
-            EmitSignal(nameof(InsufficientMPToPlaceHex));
+            gui.OnInvalidHexLocationSelected();
             return;
         }
 
@@ -1871,7 +1857,11 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
     {
         // A sanity check to not let an action proceed if we don't have enough mutation points
         if (MutationPoints < action.Cost)
+        {
+            // Flash the MP bar and play sound
+            gui.OnInsufficientMp();
             return;
+        }
 
         history.AddAction(action);
 

--- a/src/microbe_stage/editor/MicrobeEditor.tscn
+++ b/src/microbe_stage/editor/MicrobeEditor.tscn
@@ -5375,8 +5375,6 @@ CellEditorClosingWordsPath = NodePath("../TutorialGUI/CellEditorClosingWords")
 visible = false
 theme = ExtResource( 53 )
 HelpCategory = "MicrobeEditor"
-[connection signal="InsufficientMPToPlaceHex" from="." to="MicrobeEditorGUI" method="OnInsufficientMPToPlaceHex"]
-[connection signal="InvalidPlacementOfHex" from="." to="MicrobeEditorGUI" method="OnInvalidHexLocationSelected"]
 [connection signal="mouse_entered" from="MicrobeEditorGUI/TopLeft" to="MicrobeEditorGUI" method="OnMouseEnter"]
 [connection signal="mouse_exited" from="MicrobeEditorGUI/TopLeft" to="MicrobeEditorGUI" method="OnMouseExit"]
 [connection signal="mouse_entered" from="MicrobeEditorGUI/TopLeft/HBoxContainer/ReportButton" to="MicrobeEditorGUI" method="OnMouseEnter"]

--- a/src/microbe_stage/editor/MicrobeEditorGUI.cs
+++ b/src/microbe_stage/editor/MicrobeEditorGUI.cs
@@ -852,13 +852,14 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
         GUICommon.Instance.PlayCustomSound(UnableToPlaceHexSound);
     }
 
-    internal void OnInsufficientMPToPlaceHex()
+    internal void OnInsufficientMp()
     {
         if (selectedEditorTab != EditorTab.CellEditor)
             return;
 
-        AnimationPlayer animationPlayer = mutationPointsBar.GetNode<AnimationPlayer>("FlashAnimation");
+        var animationPlayer = mutationPointsBar.GetNode<AnimationPlayer>("FlashAnimation");
         animationPlayer.Play("FlashBar");
+
         GUICommon.Instance.PlayCustomSound(UnableToPlaceHexSound);
     }
 


### PR DESCRIPTION
Removed insufficient mp and invalid placement signals in favor of direct method calls. Also removed mp check in `PlaceIfPossible` because there's already the same check in `EnqueueAction`, which is where I've moved the mp bar flash method call to (and is a generic method where various editor actions go through).

Closes #2060 