### PR TITLE
Added a save breakage point for 0.5.3.1 and fixed some version comparison problems

### DIFF
--- a/src/general/VersionUtils.cs
+++ b/src/general/VersionUtils.cs
@@ -48,7 +48,11 @@ public static class VersionUtils
         // Compare the numeric versions
         try
         {
-            int versionDiff = Version.Parse(aSplit[0]).CompareTo(Version.Parse(bSplit[0]));
+            // parse and make a trailing zero missing insignificant
+            var parsedA = NormalizeVersion(Version.Parse(aSplit[0]));
+            var parsedB = NormalizeVersion(Version.Parse(bSplit[0]));
+
+            int versionDiff = parsedA.CompareTo(parsedB);
             if (versionDiff != 0)
             {
                 return versionDiff;
@@ -67,6 +71,12 @@ public static class VersionUtils
             return bSplit.Length - aSplit.Length;
         }
 
+        // Versions are equal if the splits are the same (or if either had no suffix)
+        if (aSplit.Equals(bSplit) || aSplit.Length < 2 || bSplit.Length < 2)
+        {
+            return 0;
+        }
+
         // Compare predefined suffixes
         int aSuffixIndex = Array.IndexOf(Suffixes, aSplit[1].ToLowerInvariant());
         int bSuffixIndex = Array.IndexOf(Suffixes, bSplit[1].ToLowerInvariant());
@@ -79,6 +89,19 @@ public static class VersionUtils
         return string.Compare(aSplit[1], bSplit[1], CultureInfo.InvariantCulture, CompareOptions.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    ///   Normalizes version so that the revision number is 0 if there weren't enough numbers
+    /// </summary>
+    public static Version NormalizeVersion(Version version)
+    {
+        if (version.Revision == -1)
+        {
+            return new Version(version.Major, version.Minor, version.Build, 0);
+        }
+
+        return version;
+    }
+
     // TODO: Use actual unit tests instead
     // https://github.com/Revolutionary-Games/Thrive/issues/1571
     public static bool TestCompare()
@@ -88,6 +111,10 @@ public static class VersionUtils
             && Compare("1.2.3-rc1", "1.2.4-pre-alpha") < 0
             && Compare("3.2.1-pre-alpha", "1.2.3") > 0
             && Compare("1.2.3-alpha", "1.2.3-potato") < 0
+            && Compare("1.2.3", "1.2.3.0") == 0
+            && Compare("1.2.3.1", "1.2.3.0") > 0
+            && Compare("0.5.3.1-alpha", "0.5.3.1") < 1
+            && Compare("0.5.3.1-alpha", "0.5.3") > 0
             ;
     }
 }

--- a/src/saving/SaveHelper.cs
+++ b/src/saving/SaveHelper.cs
@@ -15,7 +15,8 @@ public static class SaveHelper
     /// </summary>
     private static readonly List<string> KnownSaveIncompatibilityPoints = new List<string>
     {
-        "0.5.3",
+        "0.5.3.0",
+        "0.5.3.1",
     };
 
     public enum SaveOrder


### PR DESCRIPTION
Checked that the "unit test" that is in the version utils still works (and also added some other cases).

Adds a save breakage point required by: https://github.com/Revolutionary-Games/Thrive/pull/2046