### PR TITLE
Added toggle fullscreen button (alt+enter)

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -24,6 +24,7 @@
     <Compile Include="src\engine\ChildObjectCache.cs" />
     <Compile Include="src\engine\ChromaticFilter.cs" />
     <Compile Include="src\engine\FeatureInformation.cs" />
+    <Compile Include="src\engine\FullScreenToggle.cs" />
     <Compile Include="src\engine\GodotFileStream.cs" />
     <Compile Include="src\engine\GuidanceLine.cs" />
     <Compile Include="src\engine\IAssignableSetting.cs" />

--- a/project.godot
+++ b/project.godot
@@ -41,6 +41,7 @@ ToolTipManager="*res://src/gui_common/tooltip/ToolTipManager.tscn"
 TransitionManager="*res://src/gui_common/TransitionManager.cs"
 CursorLoader="*res://src/engine/CursorLoader.cs"
 ScreenShotTaker="*res://src/engine/ScreenShotTaker.cs"
+FullScreenToggle="*res://src/engine/FullScreenToggle.cs"
 Jukebox="*res://src/general/Jukebox.cs"
 TemporaryLoadedNodeDeleter="*res://src/saving/TemporaryLoadedNodeDeleter.cs"
 PostStartupActions="*res://src/engine/PostStartupActions.cs"
@@ -231,6 +232,11 @@ e_pan_mouse={
 e_reset_camera={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":67,"unicode":0,"echo":false,"script":null)
+ ]
+}
+toggle_fullscreen={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":true,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"unicode":0,"echo":false,"script":null)
  ]
 }
 

--- a/src/engine/FullScreenToggle.cs
+++ b/src/engine/FullScreenToggle.cs
@@ -1,0 +1,21 @@
+﻿using Godot;
+
+/// <summary>
+///   Toggles fullscreen mode on a key press
+/// </summary>
+public class FullScreenToggle : NodeWithInput
+{
+    public override void _Ready()
+    {
+        // Keep this node running while paused
+        PauseMode = PauseModeEnum.Process;
+    }
+
+    [RunOnKeyDown("toggle_fullscreen", OnlyUnhandled = false)]
+    public void ToggleFullScreenPressed()
+    {
+        GD.Print("Toggling fullscreen with keypress");
+        Settings.Instance.FullScreen.Value = !Settings.Instance.FullScreen.Value;
+        Settings.Instance.ApplyWindowSettings();
+    }
+}


### PR DESCRIPTION
I didn't do anything regarding the options menu. Not sure if this should do anything regarding that. It's pretty easy to press the fullscreen checkbox once if it is out of sync with the actual window windowed mode. And the usual expectation probably is that the DirectX key combination, that this tries to emulate, doesn't cause permanent changes in the options.