### PR TITLE
Removed extra space between badges and the screenshot in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This is the code repository for Thrive. For more information, visit
 </a>
 [![Developer Wiki](https://img.shields.io/badge/-Developer%20Wiki-red)](https://wiki.revolutionarygamesstudio.com/)
 [![Discord](https://discord.com/api/guilds/228300288023461893/widget.png)](https://discord.gg/FZxDQ4H)
-
 <br>
 <br>
 <img src="https://randomthrivefiles.b-cdn.net/screenshots/github_screenshot_1.png" alt="game screenshot" width="900px">

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is the code repository for Thrive. For more information, visit
 </a>
 [![Developer Wiki](https://img.shields.io/badge/-Developer%20Wiki-red)](https://wiki.revolutionarygamesstudio.com/)
 [![Discord](https://discord.com/api/guilds/228300288023461893/widget.png)](https://discord.gg/FZxDQ4H)
-<br>
+
 <br>
 <img src="https://randomthrivefiles.b-cdn.net/screenshots/github_screenshot_1.png" alt="game screenshot" width="900px">
 


### PR DESCRIPTION
A minor change, thought it would be good to remove it to make the readme more symmetrical/clean. It's kinda bothering me for a while now :P