### PR TITLE
Applied balance changes

### DIFF
--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -3,16 +3,16 @@
         "name": "RESPIRATION",
         "inputs": {
             "oxygen": 1,
-            "glucose": 0.1
+            "glucose": 0.2
         },
         "outputs": {
-            "atp": 90
+            "atp": 87
         }
     },
     "glycolysis": {
         "name": "GLYCOLYSIS",
         "inputs": {
-            "glucose": 0.024
+            "glucose": 0.006
         },
         "outputs": {
             "atp": 2
@@ -24,7 +24,7 @@
             "glucose": 0.012
         },
         "outputs": {
-            "atp": 4
+            "atp": 3
         }
     },
     "photosynthesis": {
@@ -61,7 +61,7 @@
         "name": "CHEMO_SYNTHESIS",
         "inputs": {
             "carbondioxide": 0.09,
-            "hydrogensulfide": 0.03
+            "hydrogensulfide": 0.12
         },
         "outputs": {
             "glucose": 0.08
@@ -71,10 +71,10 @@
         "name": "CHEMO_SYNTHESIS",
         "inputs": {
             "carbondioxide": 0.09,
-            "hydrogensulfide": 0.025
+            "hydrogensulfide": 0.06
         },
         "outputs": {
-            "glucose": 0.04
+            "glucose": 0.03
         }
     },
     "nitrogenFixing": {
@@ -105,7 +105,7 @@
             "glucose": 0.15
         },
         "outputs": {
-            "atp": 40
+            "atp": 36
         }
     },
     "chromatophore_photosynthesis": {
@@ -115,7 +115,7 @@
             "sunlight": 1
         },
         "outputs": {
-            "glucose": 0.03
+            "glucose": 0.02
         }
     },
     "iron_chemolithoautotrophy": {


### PR DESCRIPTION
Chemosynthesis is now much faster. Cells will quickly metabolize hydrogen sulfide, building up "fat stores" of glucose on the side. 
Respiration has been moderately tweaked, which is what resulted in me needing to rebalance everything else as a result.
Photosynthesis has been rebalanced. eukaryotes can no longer fuel large cells with a single chloroplast, but can make due with at least two.
Cytoplasm produces slightly less ATP, so players need at least two more hexes if they want to be simple bubbles with a flagellum.

I would appreciate if someone could try this out and give me a second opinion!