### PR TITLE
Fixed microbe stage opening tutorial closing itself instantly

### DIFF
--- a/src/engine/ControlHelpers.cs
+++ b/src/engine/ControlHelpers.cs
@@ -21,8 +21,10 @@ public static class ControlHelpers
                 // "Refresh" the popup to correct its size
                 popup.RectSize = Vector2.Zero;
 
+                var parentRect = popup.GetViewport().GetVisibleRect();
+
                 // Re-center it
-                popup.PopupCentered();
+                popup.RectPosition = parentRect.Position + (parentRect.Size - popup.RectSize) / 2;
             });
         }
     }


### PR DESCRIPTION
Fixed a regression from the previous UI fixes PR causing the microbe stage welcome message dialog to instantly close itself, missed this in previous testing. Seems to be caused by the double `PopupCentered` call in `PopupCenteredShrink` used for re-centering, so it's now replaced with code directly changing the popup's RectPosition property.