### PR TITLE
Removed vertical spacings on the line graphs y axis

### DIFF
--- a/src/gui_common/charts/line/LineChart.tscn
+++ b/src/gui_common/charts/line/LineChart.tscn
@@ -119,7 +119,7 @@ custom_constants/separation = 0
 margin_bottom = 697.0
 size_flags_vertical = 3
 theme = SubResource( 1 )
-custom_constants/separation = 5
+custom_constants/separation = 0
 
 [node name="Line" type="VSeparator" parent="VBoxContainer/HBoxContainer/MarginContainer/ChartContainer/Ordinate"]
 margin_right = 4.0

--- a/src/microbe_stage/editor/MicrobeEditor.tscn
+++ b/src/microbe_stage/editor/MicrobeEditor.tscn
@@ -3981,10 +3981,10 @@ size_flags_horizontal = 3
 custom_styles/separator = SubResource( 29 )
 
 [node name="ColorPicker" type="ColorPicker" parent="MicrobeEditorGUI/CellEditor/LeftPanel/MainPanel/VBoxContainer/MarginContainer/VBoxContainer/Appearance/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer2"]
-margin_left = 152.0
-margin_top = 175.0
-margin_right = 455.0
-margin_bottom = 650.0
+margin_left = 160.0
+margin_top = 183.0
+margin_right = 463.0
+margin_bottom = 658.0
 theme = SubResource( 31 )
 edit_alpha = false
 


### PR DESCRIPTION
Made a mistake by adding vertical spacings on the y axis labels (since only the x axis needs it), it doesn't look visually appealing and is not very useful so I removed it.