### PR TITLE
Rigidly slider will now correctly say "+0" for health, and "+0%" movement, instead of "0" health, "0%" movement (Closes 2134))

### DIFF
--- a/src/microbe_stage/editor/MicrobeEditorGUI.cs
+++ b/src/microbe_stage/editor/MicrobeEditorGUI.cs
@@ -899,10 +899,10 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
         float healthChange = convertedRigidity * Constants.MEMBRANE_RIGIDITY_HITPOINTS_MODIFIER;
         float mobilityChange = -1 * convertedRigidity * Constants.MEMBRANE_RIGIDITY_MOBILITY_MODIFIER;
 
-        healthModifier.ModifierValue = ((healthChange > 0) ? "+" : string.Empty)
+        healthModifier.ModifierValue = ((healthChange >= 0) ? "+" : string.Empty)
             + healthChange.ToString("F0", CultureInfo.CurrentCulture);
 
-        mobilityModifier.ModifierValue = ((mobilityChange > 0) ? "+" : string.Empty)
+        mobilityModifier.ModifierValue = ((mobilityChange >= 0) ? "+" : string.Empty)
             + mobilityChange.ToString("P0", CultureInfo.CurrentCulture);
 
         healthModifier.AdjustValueColor(healthChange);


### PR DESCRIPTION
A simple fix, I should have thought about this case when I fixed issue 2124.

closes #2134