### PR TITLE
Fixed critical error in the german localization

### DIFF
--- a/locale/de.po
+++ b/locale/de.po
@@ -2288,7 +2288,7 @@ msgstr "{0} mit Population: {1}"
 #: ../src/microbe_stage/editor/OrganellePopupMenu.cs:163
 #: ../src/microbe_stage/editor/OrganellePopupMenu.cs:179
 msgid "MP_COST"
-msgstr "{0] MP"
+msgstr "{0} MP"
 
 #: ../src/microbe_stage/editor/OrganellePopupMenu.tscn:228
 msgid "DELETE"


### PR DESCRIPTION
There was a really bad bug in the german localization, which caused a crash when opening the editor.
P.S.: I haven't checked any other languages