### PR TITLE
Fixed crash when trying to return to main menu

### DIFF
--- a/src/engine/SceneManager.cs
+++ b/src/engine/SceneManager.cs
@@ -63,7 +63,7 @@ public class SceneManager : Node
     /// </summary>
     public void ReturnToMenu()
     {
-        var scene = LoadScene("res://src/gui_common/MainMenu.tscn");
+        var scene = LoadScene("res://src/general/MainMenu.tscn");
 
         var mainMenu = (MainMenu)scene.Instance();
 


### PR DESCRIPTION
SceneManager was still referring to the old MainMenu scene path when loading the scene causing the game to crash.