### PR TITLE
Fixed SimulationParameters missing the initial call to apply translations

### DIFF
--- a/src/engine/Settings.cs
+++ b/src/engine/Settings.cs
@@ -565,6 +565,9 @@ public class Settings
 
             settings.ApplyAll(true);
 
+            // Simulation parameters need to apply the initial translation
+            SimulationParameters.Instance.ApplyTranslations();
+
             return settings;
         }
         catch (Exception e)


### PR DESCRIPTION
probably caused after the PR refactoring how translations are applied

basically the SimulationParameters class didn't apply translations at all without this...