### PR TITLE
Fixed AI not shooting toxins

### DIFF
--- a/src/general/Species.cs
+++ b/src/general/Species.cs
@@ -29,8 +29,8 @@ public abstract class Species : ICloneable
     public float Aggression = 100.0f;
     public float Opportunism = 100.0f;
     public float Fear = 100.0f;
-    public float Activity;
-    public float Focus;
+    public float Activity = 100.0f;
+    public float Focus = 100.0f;
 
     /// <summary>
     ///   This is the global population (the sum of population in all patches)

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -7,6 +7,11 @@ using Newtonsoft.Json;
 ///   AI for a single Microbe. This is a separate class to contain all the AI status variables as well as make the
 ///   Microbe.cs file cleaner as this AI has a lot of code.
 /// </summary>
+/// <remarks>
+///   <para>
+///     This is ran in a background thread so no state changing or scene spawning methods on Microbe may be called.
+///   </para>
+/// </remarks>
 public class MicrobeAI
 {
     private readonly Compound atp;
@@ -455,7 +460,7 @@ public class MicrobeAI
     /// <param name="allMicrobes">All microbes.</param>
     private void GetNearestPredatorItem(List<Microbe> allMicrobes)
     {
-        // Retrive the nearest predator
+        // Retrieve the nearest predator
         // For our desires lets just say all microbes bigger are potential predators
         // and later extend this to include those with toxins and pilus
         Vector3 testPosition = new Vector3(0, 0, 0);
@@ -603,7 +608,7 @@ public class MicrobeAI
             {
                 if (microbe.Compounds.GetCompoundAmount(oxytoxy) >= Constants.MINIMUM_AGENT_EMISSION_AMOUNT)
                 {
-                    microbe.EmitToxin(oxytoxy);
+                    microbe.QueueEmitToxin(oxytoxy);
                 }
             }
         }
@@ -747,7 +752,7 @@ public class MicrobeAI
             {
                 if (microbe.Compounds.GetCompoundAmount(oxytoxy) >= Constants.MINIMUM_AGENT_EMISSION_AMOUNT)
                 {
-                    microbe.EmitToxin(oxytoxy);
+                    microbe.QueueEmitToxin(oxytoxy);
                 }
             }
         }


### PR DESCRIPTION
Basically the personality values were so low that it was basically never going to happen.
Now all of the personality values start at 100.
Also fixed a bug that this uncovered: the game locked up when the AI tried to shoot toxins from a background thread. I fixed that by making a method that queues shooting a toxin on the next frame.

closes #2132