### PR TITLE
Fixed cells still existing long after it has died

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -129,6 +129,7 @@
     <Compile Include="src\microbe_stage\MicrobeHUD.cs" />
     <Compile Include="src\microbe_stage\MicrobeStage.cs" />
     <Compile Include="src\microbe_stage\NucleusMesh.cs" />
+    <Compile Include="src\microbe_stage\particles\CellBurstEffect.cs" />
     <Compile Include="src\microbe_stage\PlacedOrganelle.cs" />
     <Compile Include="src\microbe_stage\PlayerMicrobeInput.cs" />
     <Compile Include="src\microbe_stage\ProcessList.cs" />

--- a/assets/textures/dissolve_noise.tres
+++ b/assets/textures/dissolve_noise.tres
@@ -1,7 +1,7 @@
 [gd_resource type="NoiseTexture" load_steps=2 format=2]
 
 [sub_resource type="OpenSimplexNoise" id=1]
-octaves = 6
+period = 15.0
 persistence = 1.0
 lacunarity = 4.0
 

--- a/shaders/IronChunk.shader
+++ b/shaders/IronChunk.shader
@@ -14,7 +14,7 @@ void fragment() {
     vec4 dissolveTex = texture(dissolveTexture, UV);
 
     float cutoff = dot(dissolveTex.rgb, vec3(0.4, 0.4, 0.4)) -
-        float(-0.4 + clamp(dissolveValue, 0, 1));
+        float(-0.5 + clamp(dissolveValue, 0, 1));
 
     vec3 dissolveOutline = vec3(round(1.0 - float(cutoff - outlineWidth))) *
         growColor.rgb;

--- a/shaders/IronChunk.shader
+++ b/shaders/IronChunk.shader
@@ -13,8 +13,8 @@ void fragment() {
     vec4 mainTex = texture(texture, UV);
     vec4 dissolveTex = texture(dissolveTexture, UV);
 
-    float cutoff = dot(dissolveTex.rgb, vec3(0.3, 0.3, 0.3)) -
-        float(-0.8 + clamp(dissolveValue, 0, 1));
+    float cutoff = dot(dissolveTex.rgb, vec3(0.4, 0.4, 0.4)) -
+        float(-0.4 + clamp(dissolveValue, 0, 1));
 
     vec3 dissolveOutline = vec3(round(1.0 - float(cutoff - outlineWidth))) *
         growColor.rgb;

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -369,7 +369,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
         engulfAudio = GetNode<AudioStreamPlayer3D>("EngulfAudio");
         movementAudio = GetNode<AudioStreamPlayer3D>("MovementAudio");
 
-        cellBurstEffectScene = GD.Load<PackedScene>("res://src/microbe_stage/particles/CellBurst.tscn");
+        cellBurstEffectScene = GD.Load<PackedScene>("res://src/microbe_stage/particles/CellBurstEffect.tscn");
 
         if (IsPlayerMicrobe)
         {
@@ -1716,13 +1716,12 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
         {
             deathParticlesSpawned = true;
 
-            var cellBurstEffectParticles = (Particles)cellBurstEffectScene.Instance();
-            var cellBurstEffectMaterial = (ParticlesMaterial)cellBurstEffectParticles.ProcessMaterial;
+            var cellBurstEffectParticles = (CellBurstEffect)cellBurstEffectScene.Instance();
+            cellBurstEffectParticles.Translation = Translation;
+            cellBurstEffectParticles.Host = this;
+            cellBurstEffectParticles.AddToGroup(Constants.TIMED_GROUP);
 
-            cellBurstEffectMaterial.EmissionSphereRadius = Radius / 2;
-            cellBurstEffectMaterial.LinearAccel = Radius / 2;
-            cellBurstEffectParticles.OneShot = true;
-            AddChild(cellBurstEffectParticles);
+            GetParent().AddChild(cellBurstEffectParticles);
 
             // Hide the particles if being engulfed since they are
             // supposed to be already "absorbed" by the engulfing cell
@@ -1739,7 +1738,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
 
         Membrane.DissolveEffectValue += delta * Constants.MEMBRANE_DISSOLVE_SPEED;
 
-        if (Membrane.DissolveEffectValue >= 6)
+        if (Membrane.DissolveEffectValue >= 1)
         {
             this.DetachAndQueueFree();
         }

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -1718,7 +1718,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
 
             var cellBurstEffectParticles = (CellBurstEffect)cellBurstEffectScene.Instance();
             cellBurstEffectParticles.Translation = Translation;
-            cellBurstEffectParticles.Host = this;
+            cellBurstEffectParticles.CellRadius = Radius;
             cellBurstEffectParticles.AddToGroup(Constants.TIMED_GROUP);
 
             GetParent().AddChild(cellBurstEffectParticles);

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -1718,7 +1718,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
 
             var cellBurstEffectParticles = (CellBurstEffect)cellBurstEffectScene.Instance();
             cellBurstEffectParticles.Translation = Translation;
-            cellBurstEffectParticles.CellRadius = Radius;
+            cellBurstEffectParticles.Radius = Radius;
             cellBurstEffectParticles.AddToGroup(Constants.TIMED_GROUP);
 
             GetParent().AddChild(cellBurstEffectParticles);

--- a/src/microbe_stage/particles/CellBurstEffect.cs
+++ b/src/microbe_stage/particles/CellBurstEffect.cs
@@ -1,0 +1,24 @@
+﻿using Godot;
+
+public class CellBurstEffect : Particles, ITimedLife
+{
+    public float TimeToLiveRemaining { get; set; }
+
+    public Microbe Host;
+
+    public override void _Ready()
+    {
+        TimeToLiveRemaining = Lifetime;
+
+        var material = (ParticlesMaterial)ProcessMaterial;
+
+        material.EmissionSphereRadius = Host.Radius / 2;
+        material.LinearAccel = Host.Radius / 2;
+        OneShot = true;
+    }
+
+    public void OnTimeOver()
+    {
+        this.DetachAndQueueFree();
+    }
+}

--- a/src/microbe_stage/particles/CellBurstEffect.cs
+++ b/src/microbe_stage/particles/CellBurstEffect.cs
@@ -2,9 +2,9 @@
 
 public class CellBurstEffect : Particles, ITimedLife
 {
-    public float TimeToLiveRemaining { get; set; }
-
     public Microbe Host;
+
+    public float TimeToLiveRemaining { get; set; }
 
     public override void _Ready()
     {

--- a/src/microbe_stage/particles/CellBurstEffect.cs
+++ b/src/microbe_stage/particles/CellBurstEffect.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 public class CellBurstEffect : Spatial, ITimedLife
 {
     [JsonProperty]
-    public float CellRadius;
+    public float Radius;
 
     private Particles particles;
 
@@ -20,8 +20,8 @@ public class CellBurstEffect : Spatial, ITimedLife
 
         var material = (ParticlesMaterial)particles.ProcessMaterial;
 
-        material.EmissionSphereRadius = CellRadius / 2;
-        material.LinearAccel = CellRadius / 2;
+        material.EmissionSphereRadius = Radius / 2;
+        material.LinearAccel = Radius / 2;
         particles.OneShot = true;
     }
 

--- a/src/microbe_stage/particles/CellBurstEffect.cs
+++ b/src/microbe_stage/particles/CellBurstEffect.cs
@@ -1,20 +1,28 @@
 ﻿using Godot;
+using Newtonsoft.Json;
 
-public class CellBurstEffect : Particles, ITimedLife
+[JSONAlwaysDynamicType]
+[SceneLoadedClass("res://src/microbe_stage/particles/CellBurstEffect.tscn", UsesEarlyResolve = false)]
+public class CellBurstEffect : Spatial, ITimedLife
 {
-    public Microbe Host;
+    [JsonProperty]
+    public float CellRadius;
+
+    private Particles particles;
 
     public float TimeToLiveRemaining { get; set; }
 
     public override void _Ready()
     {
-        TimeToLiveRemaining = Lifetime;
+        particles = GetNode<Particles>("Particles");
 
-        var material = (ParticlesMaterial)ProcessMaterial;
+        TimeToLiveRemaining = particles.Lifetime;
 
-        material.EmissionSphereRadius = Host.Radius / 2;
-        material.LinearAccel = Host.Radius / 2;
-        OneShot = true;
+        var material = (ParticlesMaterial)particles.ProcessMaterial;
+
+        material.EmissionSphereRadius = CellRadius / 2;
+        material.LinearAccel = CellRadius / 2;
+        particles.OneShot = true;
     }
 
     public void OnTimeOver()

--- a/src/microbe_stage/particles/CellBurstEffect.tscn
+++ b/src/microbe_stage/particles/CellBurstEffect.tscn
@@ -55,7 +55,10 @@ albedo_texture = ExtResource( 1 )
 [sub_resource type="QuadMesh" id=9]
 material = SubResource( 8 )
 
-[node name="CellBurstEffect" type="Particles"]
+[node name="CellBurstEffect" type="Spatial"]
+script = ExtResource( 2 )
+
+[node name="Particles" type="Particles" parent="."]
 amount = 300
 lifetime = 5.0
 explosiveness = 1.0
@@ -63,4 +66,3 @@ randomness = 1.0
 local_coords = false
 process_material = SubResource( 7 )
 draw_pass_1 = SubResource( 9 )
-script = ExtResource( 2 )

--- a/src/microbe_stage/particles/CellBurstEffect.tscn
+++ b/src/microbe_stage/particles/CellBurstEffect.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://assets/textures/snowflake2.png" type="Texture" id=1]
+[ext_resource path="res://src/microbe_stage/particles/CellBurstEffect.cs" type="Script" id=2]
 
 [sub_resource type="Gradient" id=1]
 offsets = PoolRealArray( 0, 0.576577, 1 )
@@ -54,7 +55,7 @@ albedo_texture = ExtResource( 1 )
 [sub_resource type="QuadMesh" id=9]
 material = SubResource( 8 )
 
-[node name="CellBurst" type="Particles"]
+[node name="CellBurstEffect" type="Particles"]
 amount = 300
 lifetime = 5.0
 explosiveness = 1.0
@@ -62,3 +63,4 @@ randomness = 1.0
 local_coords = false
 process_material = SubResource( 7 )
 draw_pass_1 = SubResource( 9 )
+script = ExtResource( 2 )

--- a/src/microbe_stage/particles/CellBurstEffect.tscn
+++ b/src/microbe_stage/particles/CellBurstEffect.tscn
@@ -18,7 +18,7 @@ _data = [ Vector2( 0, 1 ), 0.0, 0.0, 0, 0, Vector2( 1, 3.97727 ), 0.0, 0.0, 0, 0
 curve = SubResource( 3 )
 
 [sub_resource type="Curve" id=5]
-_data = [ Vector2( 0, 0 ), 0.0, 0.0, 0, 0, Vector2( 1, 1 ), 0.0, 0.0, 0, 0 ]
+_data = [ Vector2( 0, 0 ), 0.0, 0.0, 0, 0, Vector2( 0.670968, 1 ), 0.0, 0.0, 0, 0, Vector2( 1, 0 ), 0.0, 0.0, 0, 0 ]
 
 [sub_resource type="CurveTexture" id=6]
 curve = SubResource( 5 )


### PR DESCRIPTION
This mainly fixed a bug where if a cell is mouse hovered after it died, the hover panel still show species name for a while. Now it should be queue freed right after the membrane dissolve animation is complete.