### PR TITLE
Fix uploader API json use for new DevCenter

### DIFF
--- a/scripts/uploader.rb
+++ b/scripts/uploader.rb
@@ -37,9 +37,9 @@ class DevBuildUploader
 
   def headers
     if @access_key
-      { 'X-Access-Code' => @access_key }
+      { 'X-Access-Code' => @access_key, 'Content-Type' => 'application/json' }
     else
-      {}
+      { 'Content-Type' => 'application/json' }
     end
   end
 
@@ -95,7 +95,7 @@ class DevBuildUploader
                         objects: group.map do |i|
                           { sha3: i, size: object_size(i) }
                         end
-                      })
+                      }.to_json)
       end
 
       data['upload'].each do |upload|
@@ -120,7 +120,7 @@ class DevBuildUploader
                         build_size: File.size(build[:file]),
                         required_objects: build[:dehydrated_objects],
                         build_zip_hash: build[:build_zip_hash]
-                      })
+                      }.to_json)
       end
 
       onError "failed to receive upload url, response: #{data}" unless data['upload_url']
@@ -153,7 +153,7 @@ class DevBuildUploader
                     headers: headers, body: {
                       build_hash: version,
                       build_platform: platform
-                    })
+                    }.to_json)
     end
 
     return unless data['upload']
@@ -173,7 +173,7 @@ class DevBuildUploader
                         objects: group.map do |i|
                                    { sha3: i, size: object_size(i) }
                                  end
-                      })
+                      }.to_json)
       end
 
       data['upload'].each do |upload|
@@ -193,7 +193,7 @@ class DevBuildUploader
   # Does the whole upload process
   def upload(file, url, token)
     file_size = (File.size(file).to_f / 2**20).round(2)
-    puts "Uploading file #{file} " + 
+    puts "Uploading file #{file} " +
          "with size of #{file_size} MiB"
     put_file file, url
 
@@ -202,7 +202,7 @@ class DevBuildUploader
       HTTParty.post(URI.join(@base_url, '/api/v1/devbuild/finish'),
                     headers: headers, body: {
                       token: token
-                    })
+                    }.to_json)
     end
   end
 
@@ -219,7 +219,7 @@ class DevBuildUploader
     (1..@retries).each do |i|
       begin
         response = yield
-        
+
         if response.code == 503
           puts "Error 503: waiting #{time_to_wait} seconds..."
           sleep(time_to_wait)

--- a/upload_devbuilds.rb
+++ b/upload_devbuilds.rb
@@ -26,7 +26,7 @@ OptionParser.new do |opts|
   opts.on('--url devcenterurl', 'Custom URL to upload to') do |url|
     @options[:url] = url
   end
-  opts.on('-j', '--parallel count', 'How many parallel uploads to do') do |p|
+  opts.on('-j', '--parallel count', Integer, 'How many parallel uploads to do') do |p|
     @options[:parallel_upload] = p
   end
 end.parse!


### PR DESCRIPTION
the uploader script did some weird non-json stuff so it wouldn't work with the new devcenter so these changes are required.

I'll probably hold off on merging this before the new devcenter is close to ready to deploy to production.