### PR TITLE
Fixed the black ambient light in GLES2 making things seem invisible

### DIFF
--- a/default_env.tres
+++ b/default_env.tres
@@ -3,5 +3,5 @@
 [sub_resource type="ProceduralSky" id=1]
 
 [resource]
-background_mode = 2
 background_sky = SubResource( 1 )
+ambient_light_color = Color( 0.627451, 0.627451, 0.627451, 1 )


### PR DESCRIPTION
It turns out the ambient light from the background's procedural sky doesn't seem to work with GLES2 in older Intel gpus and thus only produced black color. This is fixed by changing the background mode to Clear Color and lightening the color of ambient light.

Reference: https://godotengine.org/qa/88624/all-meshes-black-in-gles2

Closes #1576 