### PR TITLE
Fixed lines in graph with insufficient data being visible

### DIFF
--- a/src/gui_common/charts/line/LineChart.cs
+++ b/src/gui_common/charts/line/LineChart.cs
@@ -233,6 +233,7 @@ public class LineChart : VBoxContainer
                 {
                     // Hide the marker as its positioning won't be pretty at zero coordinate
                     point.Visible = false;
+                    data.Value.Draw = false;
                 }
 
                 point.Coordinate = point.Coordinate.LinearInterpolate(coordinate, 3.0f * delta);


### PR DESCRIPTION
A tiny fix for this small bug:
![line](https://user-images.githubusercontent.com/54026083/118362743-f4c49300-b5ba-11eb-9b5a-40f796897031.gif)
The graph line in the sunlight graph is visible where it should've been hidden.