### PR TITLE
Fix glucose decay

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -396,6 +396,7 @@ public static class Constants
     public const float AUTO_EVO_COMPOUND_ENERGY_AMOUNT = 600;
 
     public const float GLUCOSE_REDUCTION_RATE = 0.8f;
+    public const float GLUCOSE_MIN = 0.00000f;
 
     public const int MAX_SPAWNS_PER_FRAME = 2;
     public const int MAX_DESPAWNS_PER_FRAME = 2;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -396,7 +396,7 @@ public static class Constants
     public const float AUTO_EVO_COMPOUND_ENERGY_AMOUNT = 600;
 
     public const float GLUCOSE_REDUCTION_RATE = 0.8f;
-    public const float GLUCOSE_MIN = 0.00000f;
+    public const float GLUCOSE_MIN = 0.0f;
 
     public const int MAX_SPAWNS_PER_FRAME = 2;
     public const int MAX_DESPAWNS_PER_FRAME = 2;

--- a/src/general/IWorldEffect.cs
+++ b/src/general/IWorldEffect.cs
@@ -1,16 +1,16 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 /// <summary>
 ///   Time dependent effects running on a world
 /// </summary>
 public interface IWorldEffect
 {
-    /// <summary>
-    ///   Called when added to a world. The best time to do dynamic casts
-    /// </summary>
-    void OnRegisterToWorld();
+	/// <summary>
+	///   Called when added to a world. The best time to do dynamic casts
+	/// </summary>
+	void OnRegisterToWorld();
 
-    void OnTimePassed(double elapsed, double totalTimePassed);
+	void OnTimePassed(double elapsed, double totalTimePassed);
 }
 
 /// <summary>
@@ -19,40 +19,44 @@ public interface IWorldEffect
 [JSONDynamicTypeAllowed]
 public class GlucoseReductionEffect : IWorldEffect
 {
-    [JsonProperty]
-    private GameWorld targetWorld;
+	[JsonProperty]
+	private GameWorld targetWorld;
 
-    public GlucoseReductionEffect(GameWorld targetWorld)
-    {
-        this.targetWorld = targetWorld;
-    }
+	public GlucoseReductionEffect(GameWorld targetWorld)
+	{
+		this.targetWorld = targetWorld;
+	}
 
-    public void OnRegisterToWorld()
-    {
-    }
+	public void OnRegisterToWorld()
+	{
+	}
 
-    public void OnTimePassed(double elapsed, double totalTimePassed)
-    {
-        foreach (var key in targetWorld.Map.Patches.Keys)
-        {
-            var patch = targetWorld.Map.Patches[key];
+	public void OnTimePassed(double elapsed, double totalTimePassed)
+	{
+		foreach (var key in targetWorld.Map.Patches.Keys)
+		{
+			var patch = targetWorld.Map.Patches[key];
 
-            Compound glucose = null;
+			// If there are microbes to be eating up the primordial soup, reduce the milk
+			if (patch.SpeciesInPatch.Keys.Count > 0)
+			{
+				Compound glucose = null;
 
-            foreach (var compound in patch.Biome.Compounds.Keys)
-            {
-                if (compound.InternalName == "glucose")
-                {
-                    glucose = compound;
-                }
-            }
+				foreach (var compound in patch.Biome.Compounds.Keys)
+				{
+					if (compound.InternalName == "glucose")
+					{
+						glucose = compound;
+					}
+				}
 
-            if (glucose != null)
-            {
-                var toMod = patch.Biome.Compounds[glucose];
-                toMod.Density = Math.Max(toMod.Density * Constants.GLUCOSE_REDUCTION_RATE, Constants.GLUCOSE_MIN);
-                patch.Biome.Compounds[glucose] = toMod;
-            }
-        }
-    }
+				if (glucose != null)
+				{
+					var toMod = patch.Biome.Compounds[glucose];
+					toMod.Density = Math.Max(toMod.Density * Constants.GLUCOSE_REDUCTION_RATE, Constants.GLUCOSE_MIN);
+					patch.Biome.Compounds[glucose] = toMod;
+				}
+			}
+		}
+	}
 }

--- a/src/general/IWorldEffect.cs
+++ b/src/general/IWorldEffect.cs
@@ -34,29 +34,17 @@ public class GlucoseReductionEffect : IWorldEffect
 
     public void OnTimePassed(double elapsed, double totalTimePassed)
     {
+        var glucose = SimulationParameters.Instance.GetCompound("glucose");
         foreach (var key in targetWorld.Map.Patches.Keys)
         {
             var patch = targetWorld.Map.Patches[key];
 
             // If there are microbes to be eating up the primordial soup, reduce the milk
-            if (patch.SpeciesInPatch.Keys.Count > 0)
+            if (patch.SpeciesInPatch.Count > 0)
             {
-                Compound glucose = null;
-
-                foreach (var compound in patch.Biome.Compounds.Keys)
-                {
-                    if (compound.InternalName == "glucose")
-                    {
-                        glucose = compound;
-                    }
-                }
-
-                if (glucose != null)
-                {
-                    var toMod = patch.Biome.Compounds[glucose];
-                    toMod.Density = Math.Max(toMod.Density * Constants.GLUCOSE_REDUCTION_RATE, Constants.GLUCOSE_MIN);
-                    patch.Biome.Compounds[glucose] = toMod;
-                }
+                var glucoseValue = patch.Biome.Compounds[glucose];
+                glucoseValue.Density = Math.Max(glucoseValue.Density * Constants.GLUCOSE_REDUCTION_RATE, Constants.GLUCOSE_MIN);
+                patch.Biome.Compounds[glucose] = glucoseValue;
             }
         }
     }

--- a/src/general/IWorldEffect.cs
+++ b/src/general/IWorldEffect.cs
@@ -37,14 +37,21 @@ public class GlucoseReductionEffect : IWorldEffect
         {
             var patch = targetWorld.Map.Patches[key];
 
+            Compound glucose = null;
+
             foreach (var compound in patch.Biome.Compounds.Keys)
             {
                 if (compound.InternalName == "glucose")
                 {
-                    var data = patch.Biome.Compounds[compound];
-
-                    data.Density *= Constants.GLUCOSE_REDUCTION_RATE;
+                    glucose = compound;
                 }
+            }
+
+            if (glucose != null)
+            {
+                var toMod = patch.Biome.Compounds[glucose];
+                toMod.Density *= Constants.GLUCOSE_REDUCTION_RATE;
+                patch.Biome.Compounds[glucose] = toMod;
             }
         }
     }

--- a/src/general/IWorldEffect.cs
+++ b/src/general/IWorldEffect.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using Newtonsoft.Json;
 
 /// <summary>
 ///   Time dependent effects running on a world

--- a/src/general/IWorldEffect.cs
+++ b/src/general/IWorldEffect.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using System;
 
 /// <summary>
 ///   Time dependent effects running on a world

--- a/src/general/IWorldEffect.cs
+++ b/src/general/IWorldEffect.cs
@@ -50,7 +50,7 @@ public class GlucoseReductionEffect : IWorldEffect
             if (glucose != null)
             {
                 var toMod = patch.Biome.Compounds[glucose];
-                toMod.Density *= Constants.GLUCOSE_REDUCTION_RATE;
+                toMod.Density = Math.Max(toMod.Density * Constants.GLUCOSE_REDUCTION_RATE, Constants.GLUCOSE_MIN);
                 patch.Biome.Compounds[glucose] = toMod;
             }
         }

--- a/src/general/IWorldEffect.cs
+++ b/src/general/IWorldEffect.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System;
 
 /// <summary>
@@ -6,12 +6,12 @@ using System;
 /// </summary>
 public interface IWorldEffect
 {
-	/// <summary>
-	///   Called when added to a world. The best time to do dynamic casts
-	/// </summary>
-	void OnRegisterToWorld();
+    /// <summary>
+    ///   Called when added to a world. The best time to do dynamic casts
+    /// </summary>
+    void OnRegisterToWorld();
 
-	void OnTimePassed(double elapsed, double totalTimePassed);
+    void OnTimePassed(double elapsed, double totalTimePassed);
 }
 
 /// <summary>
@@ -20,44 +20,44 @@ public interface IWorldEffect
 [JSONDynamicTypeAllowed]
 public class GlucoseReductionEffect : IWorldEffect
 {
-	[JsonProperty]
-	private GameWorld targetWorld;
+    [JsonProperty]
+    private GameWorld targetWorld;
 
-	public GlucoseReductionEffect(GameWorld targetWorld)
-	{
-		this.targetWorld = targetWorld;
-	}
+    public GlucoseReductionEffect(GameWorld targetWorld)
+    {
+        this.targetWorld = targetWorld;
+    }
 
-	public void OnRegisterToWorld()
-	{
-	}
+    public void OnRegisterToWorld()
+    {
+    }
 
-	public void OnTimePassed(double elapsed, double totalTimePassed)
-	{
-		foreach (var key in targetWorld.Map.Patches.Keys)
-		{
-			var patch = targetWorld.Map.Patches[key];
+    public void OnTimePassed(double elapsed, double totalTimePassed)
+    {
+        foreach (var key in targetWorld.Map.Patches.Keys)
+        {
+            var patch = targetWorld.Map.Patches[key];
 
-			// If there are microbes to be eating up the primordial soup, reduce the milk
-			if (patch.SpeciesInPatch.Keys.Count > 0)
-			{
-				Compound glucose = null;
+            // If there are microbes to be eating up the primordial soup, reduce the milk
+            if (patch.SpeciesInPatch.Keys.Count > 0)
+            {
+                Compound glucose = null;
 
-				foreach (var compound in patch.Biome.Compounds.Keys)
-				{
-					if (compound.InternalName == "glucose")
-					{
-						glucose = compound;
-					}
-				}
+                foreach (var compound in patch.Biome.Compounds.Keys)
+                {
+                    if (compound.InternalName == "glucose")
+                    {
+                        glucose = compound;
+                    }
+                }
 
-				if (glucose != null)
-				{
-					var toMod = patch.Biome.Compounds[glucose];
-					toMod.Density = Math.Max(toMod.Density * Constants.GLUCOSE_REDUCTION_RATE, Constants.GLUCOSE_MIN);
-					patch.Biome.Compounds[glucose] = toMod;
-				}
-			}
-		}
-	}
+                if (glucose != null)
+                {
+                    var toMod = patch.Biome.Compounds[glucose];
+                    toMod.Density = Math.Max(toMod.Density * Constants.GLUCOSE_REDUCTION_RATE, Constants.GLUCOSE_MIN);
+                    patch.Biome.Compounds[glucose] = toMod;
+                }
+            }
+        }
+    }
 }

--- a/src/general/IWorldEffect.cs
+++ b/src/general/IWorldEffect.cs
@@ -43,8 +43,7 @@ public class GlucoseReductionEffect : IWorldEffect
             // If there are microbes to be eating up the primordial soup, reduce the milk
             if (patch.SpeciesInPatch.Count > 0)
             {
-                EnvironmentalCompoundProperties glucoseValue;
-                if (patch.Biome.Compounds.TryGetValue(glucose, out glucoseValue))
+                if (patch.Biome.Compounds.TryGetValue(glucose, out EnvironmentalCompoundProperties glucoseValue))
                 {
                     glucoseValue.Density = Math.Max(glucoseValue.Density * Constants.GLUCOSE_REDUCTION_RATE,
                         Constants.GLUCOSE_MIN);

--- a/src/general/IWorldEffect.cs
+++ b/src/general/IWorldEffect.cs
@@ -42,9 +42,13 @@ public class GlucoseReductionEffect : IWorldEffect
             // If there are microbes to be eating up the primordial soup, reduce the milk
             if (patch.SpeciesInPatch.Count > 0)
             {
-                var glucoseValue = patch.Biome.Compounds[glucose];
-                glucoseValue.Density = Math.Max(glucoseValue.Density * Constants.GLUCOSE_REDUCTION_RATE, Constants.GLUCOSE_MIN);
-                patch.Biome.Compounds[glucose] = glucoseValue;
+                EnvironmentalCompoundProperties glucoseValue;
+                if (patch.Biome.Compounds.TryGetValue(glucose, out glucoseValue))
+                {
+                    glucoseValue.Density = Math.Max(glucoseValue.Density * Constants.GLUCOSE_REDUCTION_RATE,
+                        Constants.GLUCOSE_MIN);
+                    patch.Biome.Compounds[glucose] = glucoseValue;
+                }
             }
         }
     }

--- a/src/general/IWorldEffect.cs
+++ b/src/general/IWorldEffect.cs
@@ -35,6 +35,7 @@ public class GlucoseReductionEffect : IWorldEffect
     public void OnTimePassed(double elapsed, double totalTimePassed)
     {
         var glucose = SimulationParameters.Instance.GetCompound("glucose");
+
         foreach (var key in targetWorld.Map.Patches.Keys)
         {
             var patch = targetWorld.Map.Patches[key];


### PR DESCRIPTION
Fixes #2035 

  Glucose decay was, in fact, broken due to the quirky way C# handles dictionary modification. After a little playtesting I took the liberty to modify the algorithm to only lower glucose where there was life to be eating it up. Otherwise at the current 0.8 decay rate there's no chance to get to the mesopelagic with enough nutrients to survive and reach the sunlight zone, unless you're REALLY good. I also added a constant for a minimum glucose level, but set it to zero for now. I like the ticking timer this provides, but in a future change I could see folks wanting to take things in an easier direction.