### PR TITLE
Make moving organelles in same session free

### DIFF
--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -680,7 +680,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
         if (AddOrganelle(ActiveActionName))
         {
-            // Only trigger tutorial if something was really placed
+            // Only trigger tutorial if an organelle was really placed
             TutorialState.SendEvent(TutorialEventType.MicrobeEditorOrganellePlaced, EventArgs.Empty, this);
         }
     }
@@ -1799,9 +1799,10 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
         if (!IsMoveTargetValid(newLocation, newRotation, organelle))
             return false;
 
-        // If it was already moved this session, it is free to move again
-        // Also free if not moved (but can be rotated)
-        int cost = (organelle.MovedThisSession || oldLocation == newLocation) ? 0 : Constants.ORGANELLE_MOVE_COST;
+        // If the organelle was already moved this session, added (placed) this session,
+        // or not moved (but can be rotated), then moving it is free
+        bool isFreeToMove = organelle.MovedThisSession || oldLocation == newLocation || organelle.PlacedThisSession;
+        int cost = isFreeToMove ? 0 : Constants.ORGANELLE_MOVE_COST;
 
         var action = new MicrobeEditorAction(this, cost,
             DoOrganelleMoveAction, UndoOrganelleMoveAction,

--- a/src/microbe_stage/editor/OrganellePopupMenu.cs
+++ b/src/microbe_stage/editor/OrganellePopupMenu.cs
@@ -175,11 +175,12 @@ public class OrganellePopupMenu : PopupPanel
 
         var mpLabel = moveButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
 
+        // The organelle is free to move if it was added (placed) this session or already moved this session
+        bool isFreeToMove = SelectedOrganelle != null && (SelectedOrganelle.MovedThisSession ||
+            SelectedOrganelle.PlacedThisSession);
         mpLabel.Text = string.Format(CultureInfo.CurrentCulture,
             TranslationServer.Translate("MP_COST"),
-            (SelectedOrganelle != null && SelectedOrganelle.MovedThisSession) ?
-                "-0" :
-                "-" + Constants.ORGANELLE_MOVE_COST.ToString(CultureInfo.CurrentCulture));
+            isFreeToMove ? "-0" : "-" + Constants.ORGANELLE_MOVE_COST.ToString(CultureInfo.CurrentCulture));
 
         moveButton.Disabled = !EnableMoveOption;
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes moving an organelle free to move if it was placed during this session. Once the session ends, it costs mutation points to end that same organelle during the following sessions.

**Related Issues**

Closes #2104 

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
