### PR TITLE
Editor speed, flagellum thrust based on flagellum orientation

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -516,6 +516,14 @@ public static class Constants
 
 #pragma warning disable CA1823 // unused fields
 
+    // Defines the thrust vectors given by the flagella, based on the flagella's orientation
+    public static readonly Vector3 VectorDown = GetVector(0);
+    public static readonly Vector3 VectorDownLeft = GetVector(1);
+    public static readonly Vector3 VectorUpLeft = GetVector(2);
+    public static readonly Vector3 VectorUp = GetVector(3);
+    public static readonly Vector3 VectorUpRight = GetVector(4);
+    public static readonly Vector3 VectorDownRight = GetVector(5);
+
     // ReSharper disable UnreachableCode
     private const uint MinimumMovePopIsHigherThanMinimumViable =
         (AUTO_EVO_MINIMUM_MOVE_POPULATION * AUTO_EVO_MINIMUM_MOVE_POPULATION_FRACTION >=
@@ -535,6 +543,46 @@ public static class Constants
     ///   Game version
     /// </summary>
     public static string Version => GameVersion;
+
+    public static Vector3 GetVector(int orientation)
+    {
+        Hex hex0 = new Hex(0, 0);
+        Hex hex1 = new Hex(0, 0);
+
+        if (orientation == 0)
+        {
+            hex1 = new Hex(0, 1);
+        }
+        else if (orientation == 5)
+        {
+            hex1 = new Hex(1, 0);
+        }
+        else if (orientation == 4)
+        {
+            hex1 = new Hex(1, -1);
+        }
+        else if (orientation == 3)
+        {
+            hex1 = new Hex(0, -1);
+        }
+        else if (orientation == 2)
+        {
+            hex1 = new Hex(-1, 0);
+        }
+        else if (orientation == 1)
+        {
+            hex1 = new Hex(-1, 1);
+        }
+
+        Vector3 hex0v = Hex.AxialToCartesian(hex0);
+        Vector3 hex1v = Hex.AxialToCartesian(hex1);
+        Vector3 hexdif = hex1v - hex0v;
+        hexdif = hexdif.Normalized();
+
+        GD.Print("hex dif: (", hexdif.x, ", ", hexdif.y, ", ", hexdif.z, ")");
+
+        return hexdif;
+    }
 
     private static string FetchVersion()
     {

--- a/src/gui_common/thrive_theme.tres
+++ b/src/gui_common/thrive_theme.tres
@@ -1,9 +1,8 @@
-[gd_resource type="Theme" load_steps=48 format=2]
+[gd_resource type="Theme" load_steps=47 format=2]
 
 [ext_resource path="res://src/gui_common/fonts/Jura-Regular-Bigger.tres" type="DynamicFont" id=1]
 [ext_resource path="res://assets/textures/gui/bevel/grab.png" type="Texture" id=2]
 [ext_resource path="res://assets/textures/gui/bevel/grabhover.png" type="Texture" id=3]
-[ext_resource path="res://assets/textures/gui/bevel/hSeparatorCentered.png" type="Texture" id=4]
 [ext_resource path="res://assets/textures/gui/bevel/checkB.png" type="Texture" id=5]
 [ext_resource path="res://assets/textures/gui/bevel/checkA.png" type="Texture" id=6]
 [ext_resource path="res://assets/textures/gui/bevel/grabdisabled.png" type="Texture" id=7]
@@ -130,7 +129,6 @@ border_width_bottom = 2
 border_color = Color( 0, 0, 0, 1 )
 
 [sub_resource type="StyleBoxTexture" id=16]
-texture = ExtResource( 4 )
 region_rect = Rect2( 0, 0, 429, 1 )
 expand_margin_left = 10.0
 expand_margin_right = 10.0

--- a/src/gui_common/thrive_theme.tres
+++ b/src/gui_common/thrive_theme.tres
@@ -1,8 +1,9 @@
-[gd_resource type="Theme" load_steps=47 format=2]
+[gd_resource type="Theme" load_steps=48 format=2]
 
 [ext_resource path="res://src/gui_common/fonts/Jura-Regular-Bigger.tres" type="DynamicFont" id=1]
 [ext_resource path="res://assets/textures/gui/bevel/grab.png" type="Texture" id=2]
 [ext_resource path="res://assets/textures/gui/bevel/grabhover.png" type="Texture" id=3]
+[ext_resource path="res://assets/textures/gui/bevel/hSeparatorCentered.png" type="Texture" id=4]
 [ext_resource path="res://assets/textures/gui/bevel/checkB.png" type="Texture" id=5]
 [ext_resource path="res://assets/textures/gui/bevel/checkA.png" type="Texture" id=6]
 [ext_resource path="res://assets/textures/gui/bevel/grabdisabled.png" type="Texture" id=7]
@@ -129,6 +130,7 @@ border_width_bottom = 2
 border_color = Color( 0, 0, 0, 1 )
 
 [sub_resource type="StyleBoxTexture" id=16]
+texture = ExtResource( 4 )
 region_rect = Rect2( 0, 0, 429, 1 )
 expand_margin_left = 10.0
 expand_margin_right = 10.0

--- a/src/gui_common/thrive_theme.tres
+++ b/src/gui_common/thrive_theme.tres
@@ -1,12 +1,6 @@
-[gd_resource type="Theme" load_steps=48 format=2]
+[gd_resource type="Theme" load_steps=42 format=2]
 
 [ext_resource path="res://src/gui_common/fonts/Jura-Regular-Bigger.tres" type="DynamicFont" id=1]
-[ext_resource path="res://assets/textures/gui/bevel/grab.png" type="Texture" id=2]
-[ext_resource path="res://assets/textures/gui/bevel/grabhover.png" type="Texture" id=3]
-[ext_resource path="res://assets/textures/gui/bevel/hSeparatorCentered.png" type="Texture" id=4]
-[ext_resource path="res://assets/textures/gui/bevel/checkB.png" type="Texture" id=5]
-[ext_resource path="res://assets/textures/gui/bevel/checkA.png" type="Texture" id=6]
-[ext_resource path="res://assets/textures/gui/bevel/grabdisabled.png" type="Texture" id=7]
 [ext_resource path="res://src/gui_common/fonts/Jura-DemiBold-Normal.tres" type="DynamicFont" id=8]
 [ext_resource path="res://src/gui_common/fonts/Lato-Regular-Small.tres" type="DynamicFont" id=10]
 
@@ -130,7 +124,6 @@ border_width_bottom = 2
 border_color = Color( 0, 0, 0, 1 )
 
 [sub_resource type="StyleBoxTexture" id=16]
-texture = ExtResource( 4 )
 region_rect = Rect2( 0, 0, 429, 1 )
 expand_margin_left = 10.0
 expand_margin_right = 10.0
@@ -384,10 +377,10 @@ CheckBox/colors/font_color_pressed = Color( 1, 1, 1, 1 )
 CheckBox/constants/check_vadjust = 0
 CheckBox/constants/hseparation = 4
 CheckBox/fonts/font = ExtResource( 8 )
-CheckBox/icons/checked = ExtResource( 5 )
+CheckBox/icons/checked = null
 CheckBox/icons/radio_checked = null
 CheckBox/icons/radio_unchecked = null
-CheckBox/icons/unchecked = ExtResource( 6 )
+CheckBox/icons/unchecked = null
 CheckBox/styles/disabled = SubResource( 6 )
 CheckBox/styles/focus = SubResource( 7 )
 CheckBox/styles/hover = SubResource( 8 )
@@ -492,9 +485,9 @@ HScrollBar/styles/scroll = SubResource( 15 )
 HScrollBar/styles/scroll_focus = null
 HSeparator/constants/separation = 4
 HSeparator/styles/separator = SubResource( 16 )
-HSlider/icons/grabber = ExtResource( 2 )
-HSlider/icons/grabber_disabled = ExtResource( 7 )
-HSlider/icons/grabber_highlight = ExtResource( 3 )
+HSlider/icons/grabber = null
+HSlider/icons/grabber_disabled = null
+HSlider/icons/grabber_highlight = null
 HSlider/icons/tick = null
 HSlider/styles/grabber_area = SubResource( 17 )
 HSlider/styles/grabber_area_highlight = SubResource( 18 )
@@ -584,11 +577,11 @@ PopupMenu/colors/font_color_hover = Color( 1, 1, 1, 1 )
 PopupMenu/constants/hseparation = 2
 PopupMenu/constants/vseparation = 4
 PopupMenu/fonts/font = ExtResource( 10 )
-PopupMenu/icons/checked = ExtResource( 5 )
-PopupMenu/icons/radio_checked = ExtResource( 5 )
-PopupMenu/icons/radio_unchecked = ExtResource( 6 )
+PopupMenu/icons/checked = null
+PopupMenu/icons/radio_checked = null
+PopupMenu/icons/radio_unchecked = null
 PopupMenu/icons/submenu = null
-PopupMenu/icons/unchecked = ExtResource( 6 )
+PopupMenu/icons/unchecked = null
 PopupMenu/styles/hover = SubResource( 27 )
 PopupMenu/styles/labeled_separator_left = null
 PopupMenu/styles/labeled_separator_right = null

--- a/src/gui_common/thrive_theme.tres
+++ b/src/gui_common/thrive_theme.tres
@@ -1,6 +1,12 @@
-[gd_resource type="Theme" load_steps=42 format=2]
+[gd_resource type="Theme" load_steps=48 format=2]
 
 [ext_resource path="res://src/gui_common/fonts/Jura-Regular-Bigger.tres" type="DynamicFont" id=1]
+[ext_resource path="res://assets/textures/gui/bevel/grab.png" type="Texture" id=2]
+[ext_resource path="res://assets/textures/gui/bevel/grabhover.png" type="Texture" id=3]
+[ext_resource path="res://assets/textures/gui/bevel/hSeparatorCentered.png" type="Texture" id=4]
+[ext_resource path="res://assets/textures/gui/bevel/checkB.png" type="Texture" id=5]
+[ext_resource path="res://assets/textures/gui/bevel/checkA.png" type="Texture" id=6]
+[ext_resource path="res://assets/textures/gui/bevel/grabdisabled.png" type="Texture" id=7]
 [ext_resource path="res://src/gui_common/fonts/Jura-DemiBold-Normal.tres" type="DynamicFont" id=8]
 [ext_resource path="res://src/gui_common/fonts/Lato-Regular-Small.tres" type="DynamicFont" id=10]
 
@@ -124,6 +130,7 @@ border_width_bottom = 2
 border_color = Color( 0, 0, 0, 1 )
 
 [sub_resource type="StyleBoxTexture" id=16]
+texture = ExtResource( 4 )
 region_rect = Rect2( 0, 0, 429, 1 )
 expand_margin_left = 10.0
 expand_margin_right = 10.0
@@ -377,10 +384,10 @@ CheckBox/colors/font_color_pressed = Color( 1, 1, 1, 1 )
 CheckBox/constants/check_vadjust = 0
 CheckBox/constants/hseparation = 4
 CheckBox/fonts/font = ExtResource( 8 )
-CheckBox/icons/checked = null
+CheckBox/icons/checked = ExtResource( 5 )
 CheckBox/icons/radio_checked = null
 CheckBox/icons/radio_unchecked = null
-CheckBox/icons/unchecked = null
+CheckBox/icons/unchecked = ExtResource( 6 )
 CheckBox/styles/disabled = SubResource( 6 )
 CheckBox/styles/focus = SubResource( 7 )
 CheckBox/styles/hover = SubResource( 8 )
@@ -485,9 +492,9 @@ HScrollBar/styles/scroll = SubResource( 15 )
 HScrollBar/styles/scroll_focus = null
 HSeparator/constants/separation = 4
 HSeparator/styles/separator = SubResource( 16 )
-HSlider/icons/grabber = null
-HSlider/icons/grabber_disabled = null
-HSlider/icons/grabber_highlight = null
+HSlider/icons/grabber = ExtResource( 2 )
+HSlider/icons/grabber_disabled = ExtResource( 7 )
+HSlider/icons/grabber_highlight = ExtResource( 3 )
 HSlider/icons/tick = null
 HSlider/styles/grabber_area = SubResource( 17 )
 HSlider/styles/grabber_area_highlight = SubResource( 18 )
@@ -577,11 +584,11 @@ PopupMenu/colors/font_color_hover = Color( 1, 1, 1, 1 )
 PopupMenu/constants/hseparation = 2
 PopupMenu/constants/vseparation = 4
 PopupMenu/fonts/font = ExtResource( 10 )
-PopupMenu/icons/checked = null
-PopupMenu/icons/radio_checked = null
-PopupMenu/icons/radio_unchecked = null
+PopupMenu/icons/checked = ExtResource( 5 )
+PopupMenu/icons/radio_checked = ExtResource( 5 )
+PopupMenu/icons/radio_unchecked = ExtResource( 6 )
 PopupMenu/icons/submenu = null
-PopupMenu/icons/unchecked = null
+PopupMenu/icons/unchecked = ExtResource( 6 )
 PopupMenu/styles/hover = SubResource( 27 )
 PopupMenu/styles/labeled_separator_left = null
 PopupMenu/styles/labeled_separator_right = null

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -868,8 +868,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
     /// <summary>
     ///   Calculate the forward speed of the microbe. It is merely displayed in the microbe editor.
-    ///   The code here should be kept consistent with the code in MovementComponent.CalculateForce,
-    ///   which handles the actual (in-game) speed.
+    ///   The code in MovementComponent.CalculateForce handles the actual (in-game) speed.
     /// </summary>
     public float CalculateSpeed()
     {
@@ -885,37 +884,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
             if (organelle.Definition.HasComponentFactory<MovementComponentFactory>())
             {
-                // base the direction on which way the organelle is facing.
-                // The less this direction is forward-facing, the less it contributes to the displayed speed.
-                Vector3 forceVector = new Vector3(0.0f, 0.0f, 0.0f);
-
-                // orientation 0 is flagellum tail pointed up (this is the default)
-                // every +1 corresponds to turning counterclockwise by 1 stage
-                if (organelle.Orientation == 0)
-                {
-                    forceVector = new Vector3(0.0f, 0.0f, 1.0f);
-                }
-                else if (organelle.Orientation == 1)
-                {
-                    forceVector = new Vector3(0.8645072f, 0.0f, 0.5026205f);
-                }
-                else if (organelle.Orientation == 2)
-                {
-                    forceVector = new Vector3(0.8645072f, 0.0f, -0.5026205f);
-                }
-                else if (organelle.Orientation == 3)
-                {
-                    forceVector = new Vector3(0.0f, 0.0f, -1.0f);
-                }
-                else if (organelle.Orientation == 4)
-                {
-                    forceVector = new Vector3(-0.8645072f, 0.0f, -0.5026205f);
-                }
-                else if (organelle.Orientation == 5)
-                {
-                    forceVector = new Vector3(-0.8645072f, 0.0f, 0.5026205f);
-                }
-
+                Vector3 forceVector = MovementComponent.GetForceVector(organelle.Orientation);
                 float directionFactor = forceVector.Dot(forwardsDirection);
 
                 // Flagella pointing backwards don't slow you down

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -880,10 +880,12 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
             if (organelle.Definition.HasComponentFactory<MovementComponentFactory>())
             {
-                // base the direction on which way the organelle is facing. The less this direction is forward-facing, the less it contributes to the displayed speed.
+                // base the direction on which way the organelle is facing.
+                // The less this direction is forward-facing, the less it contributes to the displayed speed.
                 Vector3 forceVector = new Vector3(0, 0, 0);
 
-                // orientation 0 is flagellum tail pointed up (this is the default); every +1 corresponds to turning counterclockwise by 1 stage
+                // orientation 0 is flagellum tail pointed up (this is the default)
+                // every +1 corresponds to turning counterclockwise by 1 stage
                 if (organelle.Orientation == 0)
                 {
                     forceVector = new Vector3(0, 0, 50);

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -880,10 +880,37 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
             if (organelle.Definition.HasComponentFactory<MovementComponentFactory>())
             {
-                Vector3 organelleDirection = (Hex.AxialToCartesian(new Hex(0, 0))
-                    - Hex.AxialToCartesian(organelle.Position)).Normalized();
+                // base the direction on which way the organelle is facing. The less this direction is forward-facing, the less it contributes to the displayed speed.
+                Vector3 forceVector = new Vector3(0, 0, 0);
 
-                float directionFactor = organelleDirection.Dot(forwardsDirection);
+                // orientation 0 is flagellum tail pointed up (this is the default); every +1 corresponds to turning counterclockwise by 1 stage
+                if (organelle.Orientation == 0)
+                {
+                    forceVector = new Vector3(0, 0, 50);
+                }
+                else if (organelle.Orientation == 1)
+                {
+                    forceVector = new Vector3(43, 0, 25);
+                }
+                else if (organelle.Orientation == 2)
+                {
+                    forceVector = new Vector3(43, 0, -25);
+                }
+                else if (organelle.Orientation == 3)
+                {
+                    forceVector = new Vector3(0, 0, -50);
+                }
+                else if (organelle.Orientation == 4)
+                {
+                    forceVector = new Vector3(-43, 0, -25);
+                }
+                else if (organelle.Orientation == 5)
+                {
+                    forceVector = new Vector3(-43, 0, 25);
+                }
+
+                forceVector = forceVector.Normalized();
+                float directionFactor = forceVector.Dot(forwardsDirection);
 
                 // Flagella pointing backwards don't slow you down
                 directionFactor = Math.Max(directionFactor, 0);

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -866,6 +866,11 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
         }
     }
 
+    /// <summary>
+    ///   Calculate the forward speed of the microbe. It is merely displayed in the microbe editor.
+    ///   The code here should be kept consistent with the code in MovementComponent.CalculateForce,
+    ///   which handles the actual (in-game) speed.
+    /// </summary>
     public float CalculateSpeed()
     {
         float microbeMass = Constants.MICROBE_BASE_MASS;
@@ -882,36 +887,35 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
             {
                 // base the direction on which way the organelle is facing.
                 // The less this direction is forward-facing, the less it contributes to the displayed speed.
-                Vector3 forceVector = new Vector3(0, 0, 0);
+                Vector3 forceVector = new Vector3(0.0f, 0.0f, 0.0f);
 
                 // orientation 0 is flagellum tail pointed up (this is the default)
                 // every +1 corresponds to turning counterclockwise by 1 stage
                 if (organelle.Orientation == 0)
                 {
-                    forceVector = new Vector3(0, 0, 50);
+                    forceVector = new Vector3(0.0f, 0.0f, 1.0f);
                 }
                 else if (organelle.Orientation == 1)
                 {
-                    forceVector = new Vector3(43, 0, 25);
+                    forceVector = new Vector3(0.8645072f, 0.0f, 0.5026205f);
                 }
                 else if (organelle.Orientation == 2)
                 {
-                    forceVector = new Vector3(43, 0, -25);
+                    forceVector = new Vector3(0.8645072f, 0.0f, -0.5026205f);
                 }
                 else if (organelle.Orientation == 3)
                 {
-                    forceVector = new Vector3(0, 0, -50);
+                    forceVector = new Vector3(0.0f, 0.0f, -1.0f);
                 }
                 else if (organelle.Orientation == 4)
                 {
-                    forceVector = new Vector3(-43, 0, -25);
+                    forceVector = new Vector3(-0.8645072f, 0.0f, -0.5026205f);
                 }
                 else if (organelle.Orientation == 5)
                 {
-                    forceVector = new Vector3(-43, 0, 25);
+                    forceVector = new Vector3(-0.8645072f, 0.0f, 0.5026205f);
                 }
 
-                forceVector = forceVector.Normalized();
                 float directionFactor = forceVector.Dot(forwardsDirection);
 
                 // Flagella pointing backwards don't slow you down

--- a/src/microbe_stage/organelle_components/MovementComponent.cs
+++ b/src/microbe_stage/organelle_components/MovementComponent.cs
@@ -27,26 +27,28 @@ public class MovementComponent : ExternallyPositionedComponent
         {
             return Constants.VectorDown;
         }
-        else if (orientation == 1)
+
+        if (orientation == 1)
         {
             return Constants.VectorDownLeft;
         }
-        else if (orientation == 2)
+
+        if (orientation == 2)
         {
             return Constants.VectorUpLeft;
         }
-        else if (orientation == 3)
+
+        if (orientation == 3)
         {
             return Constants.VectorUp;
         }
-        else if (orientation == 4)
+
+        if (orientation == 4)
         {
             return Constants.VectorUpRight;
         }
-        else
-        {
-            return Constants.VectorDownRight;
-        }
+
+        return Constants.VectorDownRight;
     }
 
     public override void Update(float elapsed)

--- a/src/microbe_stage/organelle_components/MovementComponent.cs
+++ b/src/microbe_stage/organelle_components/MovementComponent.cs
@@ -21,6 +21,34 @@ public class MovementComponent : ExternallyPositionedComponent
         Torque = torque;
     }
 
+    public static Vector3 GetForceVector(int orientation)
+    {
+        if (orientation == 0)
+        {
+            return Constants.VectorDown;
+        }
+        else if (orientation == 1)
+        {
+            return Constants.VectorDownLeft;
+        }
+        else if (orientation == 2)
+        {
+            return Constants.VectorUpLeft;
+        }
+        else if (orientation == 3)
+        {
+            return Constants.VectorUp;
+        }
+        else if (orientation == 4)
+        {
+            return Constants.VectorUpRight;
+        }
+        else
+        {
+            return Constants.VectorDownRight;
+        }
+    }
+
     public override void Update(float elapsed)
     {
         // Visual positioning code
@@ -60,35 +88,7 @@ public class MovementComponent : ExternallyPositionedComponent
     /// </summary>
     private Vector3 CalculateForce(float momentum)
     {
-        Vector3 forceVector = new Vector3(0.0f, 0.0f, 0.0f);
-
-        // orientation 0 is flagellum tail pointed up (this is the default)
-        // every +1 corresponds to turning counterclockwise by 1 stage
-        if (organelle.Orientation == 0)
-        {
-            forceVector = new Vector3(0.0f, 0.0f, 1.0f);
-        }
-        else if (organelle.Orientation == 1)
-        {
-            forceVector = new Vector3(-0.8645072f, 0.0f, 0.5026205f);
-        }
-        else if (organelle.Orientation == 2)
-        {
-            forceVector = new Vector3(-0.8645072f, 0.0f, -0.5026205f);
-        }
-        else if (organelle.Orientation == 3)
-        {
-            forceVector = new Vector3(0.0f, 0.0f, -1.0f);
-        }
-        else if (organelle.Orientation == 4)
-        {
-            forceVector = new Vector3(0.8645072f, 0.0f, -0.5026205f);
-        }
-        else if (organelle.Orientation == 5)
-        {
-            forceVector = new Vector3(0.8645072f, 0.0f, 0.5026205f);
-        }
-
+        Vector3 forceVector = GetForceVector(organelle.Orientation);
         forceVector = forceVector * momentum;
         return forceVector;
     }

--- a/src/microbe_stage/organelle_components/MovementComponent.cs
+++ b/src/microbe_stage/organelle_components/MovementComponent.cs
@@ -37,7 +37,7 @@ public class MovementComponent : ExternallyPositionedComponent
 
     protected override void CustomAttach()
     {
-        force = CalculateForce();
+        force = CalculateForce(Momentum);
 
         animation = organelle.OrganelleAnimation;
 
@@ -58,41 +58,38 @@ public class MovementComponent : ExternallyPositionedComponent
     /// <summary>
     ///   Calculate the vector of the thrust force provided by the flagellum based on its orientation.
     /// </summary>
-    private Vector3 CalculateForce()
+    private Vector3 CalculateForce(float momentum)
     {
-        Vector3 forceVector = new Vector3(0, 0, 0);
+        Vector3 forceVector = new Vector3(0.0f, 0.0f, 0.0f);
 
         // orientation 0 is flagellum tail pointed up (this is the default)
         // every +1 corresponds to turning counterclockwise by 1 stage
         if (organelle.Orientation == 0)
         {
-            forceVector = new Vector3(0, 0, 50);
+            forceVector = new Vector3(0.0f, 0.0f, 1.0f);
         }
         else if (organelle.Orientation == 1)
         {
-            forceVector = new Vector3(-43, 0, 25);
+            forceVector = new Vector3(-0.8645072f, 0.0f, 0.5026205f);
         }
         else if (organelle.Orientation == 2)
         {
-            forceVector = new Vector3(-43, 0, -25);
+            forceVector = new Vector3(-0.8645072f, 0.0f, -0.5026205f);
         }
         else if (organelle.Orientation == 3)
         {
-            forceVector = new Vector3(0, 0, -50);
+            forceVector = new Vector3(0.0f, 0.0f, -1.0f);
         }
         else if (organelle.Orientation == 4)
         {
-            forceVector = new Vector3(43, 0, -25);
+            forceVector = new Vector3(0.8645072f, 0.0f, -0.5026205f);
         }
         else if (organelle.Orientation == 5)
         {
-            forceVector = new Vector3(43, 0, 25);
+            forceVector = new Vector3(0.8645072f, 0.0f, 0.5026205f);
         }
 
-        forceVector = forceVector.Normalized();
-
-        // scale the force based on the flagellum's stats (as noted in Constants.cs)
-        forceVector = forceVector * Constants.FLAGELLA_BASE_FORCE;
+        forceVector = forceVector * momentum;
         return forceVector;
     }
 

--- a/src/microbe_stage/organelle_components/MovementComponent.cs
+++ b/src/microbe_stage/organelle_components/MovementComponent.cs
@@ -56,15 +56,43 @@ public class MovementComponent : ExternallyPositionedComponent
     }
 
     /// <summary>
-    ///   Calculate the momentum of the movement organelle based on
-    ///   angle towards middle of cell
+    ///   Calculate the vector of the thrust force provided by the movement organelle (flagellum) based on its orientation.
     /// </summary>
-    private static Vector3 CalculateForce(Hex pos, float momentum)
+    private Vector3 CalculateForce(Hex pos, float momentum)
     {
-        Vector3 organelle = Hex.AxialToCartesian(pos);
-        Vector3 middle = Hex.AxialToCartesian(new Hex(0, 0));
-        var delta = middle - organelle;
-        return delta.Normalized() * momentum;
+        Vector3 forceVector = new Vector3(0, 0, 0);
+
+        // orientation 0 is flagellum tail pointed up (this is the default); every +1 corresponds to turning counterclockwise by 1 stage
+        if (organelle.Orientation == 0)
+        {
+            forceVector = new Vector3(0, 0, 50);
+        }
+        else if (organelle.Orientation == 1)
+        {
+            forceVector = new Vector3(-43, 0, 25);
+        }
+        else if (organelle.Orientation == 2)
+        {
+            forceVector = new Vector3(-43, 0, -25);
+        }
+        else if (organelle.Orientation == 3)
+        {
+            forceVector = new Vector3(0, 0, -50);
+        }
+        else if (organelle.Orientation == 4)
+        {
+            forceVector = new Vector3(43, 0, -25);
+        }
+        else if (organelle.Orientation == 5)
+        {
+            forceVector = new Vector3(43, 0, 25);
+        }
+
+        forceVector = forceVector.Normalized();
+
+        // scale the force based on the flagellum's stats (as noted in Constants.cs)
+        forceVector = forceVector * Constants.FLAGELLA_BASE_FORCE;
+        return forceVector;
     }
 
     private void SetSpeedFactor(float speed)

--- a/src/microbe_stage/organelle_components/MovementComponent.cs
+++ b/src/microbe_stage/organelle_components/MovementComponent.cs
@@ -37,7 +37,7 @@ public class MovementComponent : ExternallyPositionedComponent
 
     protected override void CustomAttach()
     {
-        force = CalculateForce(organelle.Position, Momentum);
+        force = CalculateForce();
 
         animation = organelle.OrganelleAnimation;
 
@@ -56,13 +56,14 @@ public class MovementComponent : ExternallyPositionedComponent
     }
 
     /// <summary>
-    ///   Calculate the vector of the thrust force provided by the movement organelle (flagellum) based on its orientation.
+    ///   Calculate the vector of the thrust force provided by the flagellum based on its orientation.
     /// </summary>
-    private Vector3 CalculateForce(Hex pos, float momentum)
+    private Vector3 CalculateForce()
     {
         Vector3 forceVector = new Vector3(0, 0, 0);
 
-        // orientation 0 is flagellum tail pointed up (this is the default); every +1 corresponds to turning counterclockwise by 1 stage
+        // orientation 0 is flagellum tail pointed up (this is the default)
+        // every +1 corresponds to turning counterclockwise by 1 stage
         if (organelle.Orientation == 0)
         {
             forceVector = new Vector3(0, 0, 50);


### PR DESCRIPTION
* Updates the microbe's movement such that the thrust provided by each flagellum is based on its orientation (the direction it's facing), rather than its location relative to the center of the microbe. This makes the flagellum's behavior align with what one might intuitively expect, and allows making actual use of the ability to choose an organelle's orientation.
* Updates the microbe editor speed calculation to account for the above. This should also resolve the issue where changes to the actual speed resulting from the center of mass being changed aren't reflected in the editor's displayed speed. 

This may also close #2094 since with this change the speed calculation in the editor is no longer dependent on where the flagella are placed.