### PR TITLE
Cloud visual tweaks and fixed flickering

### DIFF
--- a/shaders/CompoundCloudPlane.shader
+++ b/shaders/CompoundCloudPlane.shader
@@ -11,31 +11,43 @@ uniform vec4 colour3 : hint_color  = vec4(0, 0, 0, 0);
 uniform vec4 colour4 : hint_color  = vec4(0, 0, 0, 0);
 
 uniform vec2 UVOffset = vec2(0, 0);
+uniform vec2 NoiseUVOffset = vec2(0, 0);
 
-// Setting this too high makes the clouds invisible
-const float CLOUD_DISSIPATION = 2.0;
+// Setting this too low makes the clouds invisible
+const float CLOUD_DISSIPATION = 0.9f;
 
 // Should be the same as its counterpart in CompoundCloudPlane.cs
-const float CLOUD_MAX_INTENSITY_SHOWN = 1000f;
+const float CLOUD_MAX_INTENSITY_SHOWN = 1000.f;
+
+const float NOISE_ZERO_OFFSET = 0.5f;
+
+// Needs to match the value in CompoundCloudPlane.cs
+const float NOISE_UV_SCALE = 2.5f;
 
 float getIntensity(float value){
-    return min(0.8 * atan(0.003f * CLOUD_MAX_INTENSITY_SHOWN * value), 1.0f);
+    return min(0.9 * atan(0.003f * CLOUD_MAX_INTENSITY_SHOWN * value), 1.0f);
+    // return min(0.008 * CLOUD_MAX_INTENSITY_SHOWN * value, 1.0f);
+    // return min(value * 0.9f, 1.0f);
 }
 
 void fragment(){
     vec4 concentrations = texture(densities, UV + UVOffset);
     
-    float cloud1 = getIntensity(concentrations.r) * pow(texture(noise, UV + UVOffset).r, 
-        CLOUD_DISSIPATION);
+//    float cloud1 = max(getIntensity(concentrations.r) * (texture(noise, UV + UVOffset).r - NOISE_ZERO_OFFSET) * CLOUD_DISSIPATION, 0.f);
+//
+//    float cloud2 = max(getIntensity(concentrations.g) * (texture(noise, UV + UVOffset + 0.2f).r - NOISE_ZERO_OFFSET) * CLOUD_DISSIPATION, 0.f);
+//
+//    float cloud3 = max(getIntensity(concentrations.b) * (texture(noise, UV + UVOffset + 0.4f).r - NOISE_ZERO_OFFSET) * CLOUD_DISSIPATION, 0.f);
+//
+//    float cloud4 = max(getIntensity(concentrations.a) * (texture(noise, UV + UVOffset + 0.6f).r - NOISE_ZERO_OFFSET) * CLOUD_DISSIPATION, 0.f);
+    
+    float cloud1 = getIntensity(concentrations.r) * max(texture(noise, UV * NOISE_UV_SCALE + NoiseUVOffset).r - NOISE_ZERO_OFFSET, 0.0f) * CLOUD_DISSIPATION;
         
-    float cloud2 = getIntensity(concentrations.g) * pow(texture(noise, UV + UVOffset + 0.2f).r, 
-        CLOUD_DISSIPATION);
+    float cloud2 = getIntensity(concentrations.g) * max(texture(noise, UV * NOISE_UV_SCALE + NoiseUVOffset + 0.2f).r - NOISE_ZERO_OFFSET, 0.0f) * CLOUD_DISSIPATION;
         
-    float cloud3 = getIntensity(concentrations.b) * pow(texture(noise, UV + UVOffset + 0.4f).r, 
-        CLOUD_DISSIPATION);
+    float cloud3 = getIntensity(concentrations.b) * max(texture(noise, UV * NOISE_UV_SCALE + NoiseUVOffset + 0.4f).r - NOISE_ZERO_OFFSET, 0.0f) * CLOUD_DISSIPATION;
         
-    float cloud4 = getIntensity(concentrations.a) * pow(texture(noise, UV + UVOffset + 0.6f).r, 
-        CLOUD_DISSIPATION);
+    float cloud4 = getIntensity(concentrations.a) * max(texture(noise, UV * NOISE_UV_SCALE + NoiseUVOffset + 0.6f).r - NOISE_ZERO_OFFSET, 0.0f) * CLOUD_DISSIPATION;
     
     vec4 colour =
         // first

--- a/shaders/CompoundCloudPlane.shader
+++ b/shaders/CompoundCloudPlane.shader
@@ -11,21 +11,25 @@ uniform vec4 colour3 : hint_color  = vec4(0, 0, 0, 0);
 uniform vec4 colour4 : hint_color  = vec4(0, 0, 0, 0);
 
 uniform vec2 UVOffset = vec2(0, 0);
-uniform vec2 NoiseUVOffset = vec2(0, 0);
 
 // Setting this too low makes the clouds invisible
 const float CLOUD_DISSIPATION = 0.9f;
 
+const float DENSITY_MULTIPLIER = 0.95f;
+
 // Should be the same as its counterpart in CompoundCloudPlane.cs
 const float CLOUD_MAX_INTENSITY_SHOWN = 1000.f;
 
-const float NOISE_ZERO_OFFSET = 0.5f;
+// This needs to be less than 0.5 otherwise large cloud areas (due to the noise texture 
+// not being very high resolution) are invisible
+const float NOISE_ZERO_OFFSET = 0.45f;
 
 // Needs to match the value in CompoundCloudPlane.cs
+// TODO: implement this or increase the perlin noise texture size to give the clouds more detail
 const float NOISE_UV_SCALE = 2.5f;
 
 float getIntensity(float value){
-    return min(0.9 * atan(0.003f * CLOUD_MAX_INTENSITY_SHOWN * value), 1.0f);
+    return min(DENSITY_MULTIPLIER * atan(0.006f * CLOUD_MAX_INTENSITY_SHOWN * value), 1.0f);
     // return min(0.008 * CLOUD_MAX_INTENSITY_SHOWN * value, 1.0f);
     // return min(value * 0.9f, 1.0f);
 }
@@ -33,21 +37,17 @@ float getIntensity(float value){
 void fragment(){
     vec4 concentrations = texture(densities, UV + UVOffset);
     
-//    float cloud1 = max(getIntensity(concentrations.r) * (texture(noise, UV + UVOffset).r - NOISE_ZERO_OFFSET) * CLOUD_DISSIPATION, 0.f);
-//
-//    float cloud2 = max(getIntensity(concentrations.g) * (texture(noise, UV + UVOffset + 0.2f).r - NOISE_ZERO_OFFSET) * CLOUD_DISSIPATION, 0.f);
-//
-//    float cloud3 = max(getIntensity(concentrations.b) * (texture(noise, UV + UVOffset + 0.4f).r - NOISE_ZERO_OFFSET) * CLOUD_DISSIPATION, 0.f);
-//
-//    float cloud4 = max(getIntensity(concentrations.a) * (texture(noise, UV + UVOffset + 0.6f).r - NOISE_ZERO_OFFSET) * CLOUD_DISSIPATION, 0.f);
-    
-    float cloud1 = getIntensity(concentrations.r) * max(texture(noise, UV * NOISE_UV_SCALE + NoiseUVOffset).r - NOISE_ZERO_OFFSET, 0.0f) * CLOUD_DISSIPATION;
+    float cloud1 = getIntensity(concentrations.r) * max(texture(noise, UV + UVOffset).r - 
+        NOISE_ZERO_OFFSET, 0.0f) * CLOUD_DISSIPATION;
         
-    float cloud2 = getIntensity(concentrations.g) * max(texture(noise, UV * NOISE_UV_SCALE + NoiseUVOffset + 0.2f).r - NOISE_ZERO_OFFSET, 0.0f) * CLOUD_DISSIPATION;
+    float cloud2 = getIntensity(concentrations.g) * max(texture(noise, UV + UVOffset + 0.2f).r - 
+        NOISE_ZERO_OFFSET, 0.0f) * CLOUD_DISSIPATION;
         
-    float cloud3 = getIntensity(concentrations.b) * max(texture(noise, UV * NOISE_UV_SCALE + NoiseUVOffset + 0.4f).r - NOISE_ZERO_OFFSET, 0.0f) * CLOUD_DISSIPATION;
+    float cloud3 = getIntensity(concentrations.b) * max(texture(noise, UV + UVOffset + 0.4f).r - 
+        NOISE_ZERO_OFFSET, 0.0f) * CLOUD_DISSIPATION;
         
-    float cloud4 = getIntensity(concentrations.a) * max(texture(noise, UV * NOISE_UV_SCALE + NoiseUVOffset + 0.6f).r - NOISE_ZERO_OFFSET, 0.0f) * CLOUD_DISSIPATION;
+    float cloud4 = getIntensity(concentrations.a) * max(texture(noise, UV + UVOffset + 0.6f).r - 
+        NOISE_ZERO_OFFSET, 0.0f) * CLOUD_DISSIPATION;
     
     vec4 colour =
         // first

--- a/shaders/CompoundCloudPlane.shader
+++ b/shaders/CompoundCloudPlane.shader
@@ -1,4 +1,5 @@
 shader_type spatial;
+render_mode blend_add;
 render_mode unshaded;
 
 uniform sampler2D densities;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -46,6 +46,9 @@ public static class Constants
     // Should be the same as its counterpart in shaders/CompoundCloudPlane.shader
     public const float CLOUD_MAX_INTENSITY_SHOWN = 1000;
 
+    // Should be the same as its counterpart in shaders/CompoundCloudPlane.shader
+    public const float CLOUD_NOISE_UV_OFFSET_MULTIPLIER = 2.5f;
+
     public const int MEMBRANE_RESOLUTION = 10;
 
     /// <summary>

--- a/src/microbe_stage/CompoundCloudPlane.cs
+++ b/src/microbe_stage/CompoundCloudPlane.cs
@@ -721,5 +721,13 @@ public class CompoundCloudPlane : CSGMesh, ISaveLoadedTracked
         var material = (ShaderMaterial)Material;
         material.SetShaderParam("UVOffset", new Vector2(position.x / (float)Constants.CLOUD_SQUARES_PER_SIDE,
             position.y / (float)Constants.CLOUD_SQUARES_PER_SIDE));
+
+        // Noise texture follows the world position with a modifier to make the noise texture repeat more often
+        // material.SetShaderParam("NoiseUVOffset",
+        //     new Vector2((position.x / (float)Constants.CLOUD_WIDTH) * Constants.CLOUD_NOISE_UV_OFFSET_MULTIPLIER,
+        //         (position.y / (float)Constants.CLOUD_HEIGHT) * Constants.CLOUD_NOISE_UV_OFFSET_MULTIPLIER));
+        material.SetShaderParam("NoiseUVOffset",
+            new Vector2(position.x * Constants.CLOUD_NOISE_UV_OFFSET_MULTIPLIER,
+                position.y * Constants.CLOUD_NOISE_UV_OFFSET_MULTIPLIER));
     }
 }

--- a/src/microbe_stage/CompoundCloudPlane.cs
+++ b/src/microbe_stage/CompoundCloudPlane.cs
@@ -719,6 +719,8 @@ public class CompoundCloudPlane : CSGMesh, ISaveLoadedTracked
     private void SetMaterialUVForPosition()
     {
         var material = (ShaderMaterial)Material;
+
+        // No clue how this math ends up with the right UV offsets - hhyyrylainen
         material.SetShaderParam("UVOffset", new Vector2(position.x / (float)Constants.CLOUD_SQUARES_PER_SIDE,
             position.y / (float)Constants.CLOUD_SQUARES_PER_SIDE));
 

--- a/src/microbe_stage/CompoundCloudPlane.cs
+++ b/src/microbe_stage/CompoundCloudPlane.cs
@@ -723,13 +723,5 @@ public class CompoundCloudPlane : CSGMesh, ISaveLoadedTracked
         // No clue how this math ends up with the right UV offsets - hhyyrylainen
         material.SetShaderParam("UVOffset", new Vector2(position.x / (float)Constants.CLOUD_SQUARES_PER_SIDE,
             position.y / (float)Constants.CLOUD_SQUARES_PER_SIDE));
-
-        // Noise texture follows the world position with a modifier to make the noise texture repeat more often
-        // material.SetShaderParam("NoiseUVOffset",
-        //     new Vector2((position.x / (float)Constants.CLOUD_WIDTH) * Constants.CLOUD_NOISE_UV_OFFSET_MULTIPLIER,
-        //         (position.y / (float)Constants.CLOUD_HEIGHT) * Constants.CLOUD_NOISE_UV_OFFSET_MULTIPLIER));
-        material.SetShaderParam("NoiseUVOffset",
-            new Vector2(position.x * Constants.CLOUD_NOISE_UV_OFFSET_MULTIPLIER,
-                position.y * Constants.CLOUD_NOISE_UV_OFFSET_MULTIPLIER));
     }
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixed the flickering with Godot 3.3 also attempted to do some visual overhaul but my knowledge about the cloud system was inadequate to get that working (https://github.com/Revolutionary-Games/Thrive/issues/2286)

Looks like this:
![2021-06-01_13 35 48 2413](https://user-images.githubusercontent.com/3796411/120310091-a9aabf80-c2de-11eb-96e6-a6505fc93eb4.png)


**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

fixes #2275
might also help with #1700 but more testing on that is needed

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
