### PR TITLE
Improve editor entry fade in

### DIFF
--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -187,7 +187,7 @@ public class MainMenu : Node
 
     private void OnIntroEnded()
     {
-        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, IsReturningToMenu ?
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, IsReturningToMenu ?
             0.3f :
             0.5f, false);
         TransitionManager.Instance.StartTransitions(null, string.Empty);
@@ -231,13 +231,13 @@ public class MainMenu : Node
 
         if (Settings.Instance.PlayMicrobeIntroVideo)
         {
-            TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.5f);
+            TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.5f);
             TransitionManager.Instance.AddCutscene("res://assets/videos/microbe_intro2.webm");
         }
         else
         {
             // People who disable the cutscene are impatient anyway so use a reduced fade time
-            TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.2f);
+            TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.2f);
         }
 
         TransitionManager.Instance.StartTransitions(this, nameof(OnMicrobeIntroEnded));
@@ -256,7 +256,7 @@ public class MainMenu : Node
         // Ignore mouse event on the button to prevent it being clicked twice
         freebuildButton.MouseFilter = Control.MouseFilterEnum.Ignore;
 
-        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.15f, false);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.15f, false);
         TransitionManager.Instance.StartTransitions(this, nameof(OnFreebuildFadeInEnded));
     }
 

--- a/src/general/PauseMenu.cs
+++ b/src/general/PauseMenu.cs
@@ -124,7 +124,7 @@ public class PauseMenu : ControlWithInput
         // Unpause the game
         GetTree().Paused = false;
 
-        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.1f, false);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.1f, false);
         TransitionManager.Instance.StartTransitions(this, nameof(OnSwitchToMenu));
     }
 

--- a/src/gui_common/Cutscene.cs
+++ b/src/gui_common/Cutscene.cs
@@ -5,32 +5,40 @@
 /// </summary>
 public class Cutscene : CanvasLayer, ITransition
 {
-    public VideoPlayer CutsceneVideoPlayer;
-    public Vector2 FrameSize;
+    private VideoPlayer cutsceneVideoPlayer;
+    private Vector2 frameSize;
+    private Control controlNode;
 
     [Signal]
     public delegate void OnFinishedSignal();
 
-    public Control ControlNode { get; private set; }
-
     public bool Skippable { get; set; } = true;
+
+    public bool Visible
+    {
+        get => controlNode.Visible;
+        set => controlNode.Visible = value;
+    }
+
+    public VideoStream Stream
+    {
+        get => cutsceneVideoPlayer.Stream;
+        set => cutsceneVideoPlayer.Stream = value;
+    }
 
     public override void _Ready()
     {
-        CutsceneVideoPlayer = GetNode<VideoPlayer>("Control/VideoPlayer");
-        ControlNode = GetNode<Control>("Control");
+        controlNode = GetNode<Control>("Control");
+        cutsceneVideoPlayer = GetNode<VideoPlayer>("Control/VideoPlayer");
 
-        FrameSize = CutsceneVideoPlayer.RectSize;
+        frameSize = cutsceneVideoPlayer.RectSize;
 
-        CutsceneVideoPlayer.Connect("finished", this, nameof(OnFinished));
-
-        ControlNode.Hide();
+        cutsceneVideoPlayer.Connect("finished", this, nameof(OnFinished));
     }
 
     public void OnStarted()
     {
-        ControlNode.Show();
-        CutsceneVideoPlayer.Play();
+        cutsceneVideoPlayer.Play();
     }
 
     public void OnFinished()

--- a/src/gui_common/Cutscene.cs
+++ b/src/gui_common/Cutscene.cs
@@ -6,7 +6,6 @@
 public class Cutscene : CanvasLayer, ITransition
 {
     private VideoPlayer cutsceneVideoPlayer;
-    private Vector2 frameSize;
     private Control controlNode;
 
     [Signal]
@@ -30,8 +29,6 @@ public class Cutscene : CanvasLayer, ITransition
     {
         controlNode = GetNode<Control>("Control");
         cutsceneVideoPlayer = GetNode<VideoPlayer>("Control/VideoPlayer");
-
-        frameSize = cutsceneVideoPlayer.RectSize;
 
         cutsceneVideoPlayer.Connect("finished", this, nameof(OnFinished));
     }

--- a/src/gui_common/ITransition.cs
+++ b/src/gui_common/ITransition.cs
@@ -1,10 +1,11 @@
-﻿using Godot;
-
+﻿/// <summary>
+///   Interface for all screen transitions.
+/// </summary>
 public interface ITransition
 {
-    Control ControlNode { get; }
-
     bool Skippable { get; set; }
+
+    bool Visible { get; set; }
 
     void OnStarted();
     void OnFinished();

--- a/src/gui_common/ScreenFade.cs
+++ b/src/gui_common/ScreenFade.cs
@@ -17,12 +17,12 @@ public class ScreenFade : CanvasLayer, ITransition
     public enum FadeType
     {
         /// <summary>
-        ///   Screen fades in
+        ///   Screen fades to white (transparent)
         /// </summary>
         FadeIn,
 
         /// <summary>
-        ///   Screen fades out
+        ///   Screen fades to black
         /// </summary>
         FadeOut,
     }
@@ -47,11 +47,11 @@ public class ScreenFade : CanvasLayer, ITransition
             // Apply initial colors
             if (currentFadeType == FadeType.FadeIn)
             {
-                rect.Color = new Color(0, 0, 0, 0);
+                rect.Color = new Color(0, 0, 0, 1);
             }
             else if (currentFadeType == FadeType.FadeOut)
             {
-                rect.Color = new Color(0, 0, 0, 1);
+                rect.Color = new Color(0, 0, 0, 0);
             }
         }
     }
@@ -92,10 +92,10 @@ public class ScreenFade : CanvasLayer, ITransition
         switch (CurrentFadeType)
         {
             case FadeType.FadeIn:
-                FadeToBlack();
+                FadeToWhite();
                 break;
             case FadeType.FadeOut:
-                FadeToWhite();
+                FadeToBlack();
                 break;
         }
     }

--- a/src/gui_common/ScreenFade.cs
+++ b/src/gui_common/ScreenFade.cs
@@ -5,11 +5,11 @@
 /// </summary>
 public class ScreenFade : CanvasLayer, ITransition
 {
-    public ColorRect Rect;
-    public Tween Fader;
+    private ColorRect rect;
+    private Tween fader;
+    private Control controlNode;
 
-    public float FadeDuration;
-    public FadeType FadeTransition;
+    private FadeType currentFadeType;
 
     [Signal]
     public delegate void OnFinishedSignal();
@@ -27,21 +27,45 @@ public class ScreenFade : CanvasLayer, ITransition
         FadeOut,
     }
 
-    public Control ControlNode { get; private set; }
-
     public bool Skippable { get; set; } = true;
+
+    public bool Visible
+    {
+        get => controlNode.Visible;
+        set => controlNode.Visible = value;
+    }
+
+    public float FadeDuration { get; set; }
+
+    public FadeType CurrentFadeType
+    {
+        get => currentFadeType;
+        set
+        {
+            currentFadeType = value;
+
+            // Apply initial colors
+            if (currentFadeType == FadeType.FadeIn)
+            {
+                rect.Color = new Color(0, 0, 0, 0);
+            }
+            else if (currentFadeType == FadeType.FadeOut)
+            {
+                rect.Color = new Color(0, 0, 0, 1);
+            }
+        }
+    }
 
     public override void _Ready()
     {
-        ControlNode = GetNode<Control>("Control");
-        Rect = GetNode<ColorRect>("Control/Rect");
-        Fader = GetNode<Tween>("Control/Fader");
-        Fader.Connect("tween_all_completed", this, "OnFinished");
+        controlNode = GetNode<Control>("Control");
+        rect = GetNode<ColorRect>("Control/Rect");
+        fader = GetNode<Tween>("Control/Fader");
 
-        // Keep this node running even while paused
+        fader.Connect("tween_all_completed", this, "OnFinished");
+
+        // Keep this node running while paused
         PauseMode = PauseModeEnum.Process;
-
-        ControlNode.Hide();
     }
 
     public void FadeToBlack()
@@ -56,18 +80,16 @@ public class ScreenFade : CanvasLayer, ITransition
 
     public void FadeTo(Color initial, Color final)
     {
-        Rect.Color = initial;
+        rect.Color = initial;
 
-        Fader.InterpolateProperty(Rect, "color", initial, final, FadeDuration);
+        fader.InterpolateProperty(rect, "color", initial, final, FadeDuration);
 
-        Fader.Start();
+        fader.Start();
     }
 
     public void OnStarted()
     {
-        ControlNode.Show();
-
-        switch (FadeTransition)
+        switch (CurrentFadeType)
         {
             case FadeType.FadeIn:
                 FadeToBlack();

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -293,7 +293,7 @@ public class MicrobeHUD : Node
     {
         // Fade out for that smooth satisfying transition
         stage.TransitionFinished = false;
-        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, longerDuration ? 1.0f : 0.3f);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, longerDuration ? 1.0f : 0.3f);
         TransitionManager.Instance.StartTransitions(stage, nameof(MicrobeStage.OnFinishTransitioning));
     }
 
@@ -476,7 +476,7 @@ public class MicrobeHUD : Node
             PauseButtonPressed();
         }
 
-        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.3f, false);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.3f, false);
         TransitionManager.Instance.StartTransitions(stage, nameof(MicrobeStage.MoveToEditor));
 
         stage.MovingToEditor = true;

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -1312,9 +1312,17 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
     private void InitEditorFresh()
     {
+        MutationPoints = Constants.BASE_MUTATION_POINTS;
+        editedMicrobeOrganelles = new OrganelleLayout<OrganelleTemplate>(
+            OnOrganelleAdded, OnOrganelleRemoved);
+
+        organelleRot = 0;
+
         targetPatch = null;
 
         playerPatchOnEntry = CurrentGame.GameWorld.Map.CurrentPatch;
+
+        canStillMove = true;
 
         // For now we only show a loading screen if auto-evo is not ready yet
         if (!CurrentGame.GameWorld.IsAutoEvoFinished())
@@ -1341,14 +1349,6 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
             // Make sure freebuilding doesn't get stuck on
             FreeBuilding = false;
         }
-
-        MutationPoints = Constants.BASE_MUTATION_POINTS;
-        editedMicrobeOrganelles = new OrganelleLayout<OrganelleTemplate>(
-            OnOrganelleAdded, OnOrganelleRemoved);
-
-        organelleRot = 0;
-
-        canStillMove = true;
 
         var playerSpecies = CurrentGame.GameWorld.PlayerSpecies;
 

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -182,6 +182,11 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
     private bool microbePreviewMode;
 
     /// <summary>
+    ///   True if auto save should trigger ASAP
+    /// </summary>
+    private bool wantsToSave;
+
+    /// <summary>
     ///   Where the user started panning with the mouse
     ///   Null if the user is not panning with the mouse
     /// </summary>
@@ -600,10 +605,17 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
                 return;
             }
 
-            if (!TransitionFinished)
-                return;
-
             OnEditorReady();
+        }
+
+        // Save if wanted
+        if (TransitionFinished && wantsToSave)
+        {
+            // Auto save after editor entry is complete
+            if (!CurrentGame.FreeBuild)
+                SaveHelper.AutoSave(this);
+
+            wantsToSave = false;
         }
 
         UpdateEditor(delta);
@@ -1246,6 +1258,9 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
         if (!IsLoadedFromSave)
         {
+            // Auto save is wanted once possible
+            wantsToSave = true;
+
             InitEditorFresh();
 
             Symmetry = 0;
@@ -1298,6 +1313,10 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
     private void InitEditorFresh()
     {
+        targetPatch = null;
+
+        playerPatchOnEntry = CurrentGame.GameWorld.Map.CurrentPatch;
+
         // For now we only show a loading screen if auto-evo is not ready yet
         if (!CurrentGame.GameWorld.IsAutoEvoFinished())
         {
@@ -1305,10 +1324,6 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
             LoadingScreen.Instance.Show(TranslationServer.Translate("LOADING_MICROBE_EDITOR"),
                 MainGameState.MicrobeEditor,
                 CurrentGame.GameWorld.GetAutoEvoRun().Status);
-        }
-        else if (!TransitionFinished)
-        {
-            ready = false;
         }
         else
         {
@@ -1333,10 +1348,6 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
             OnOrganelleAdded, OnOrganelleRemoved);
 
         organelleRot = 0;
-
-        targetPatch = null;
-
-        playerPatchOnEntry = CurrentGame.GameWorld.Map.CurrentPatch;
 
         canStillMove = true;
 
@@ -2250,9 +2261,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
         gui.UpdateReportTabStatistics(CurrentPatch);
 
-        // Auto save after editor entry is complete
-        if (!CurrentGame.FreeBuild)
-            SaveHelper.AutoSave(this);
+        FadeOut();
     }
 
     private void OnLoadedEditorReady()
@@ -2268,6 +2277,8 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
         CurrentGame.GameWorld.ResetAutoEvoRun();
 
         gui.UpdateReportTabStatistics(CurrentPatch);
+
+        FadeOut();
     }
 
     private void ApplyAutoEvoResults()
@@ -2305,6 +2316,15 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
     private void UpdatePatchBackgroundImage()
     {
         camera.SetBackground(SimulationParameters.Instance.GetBackground(CurrentPatch.BiomeTemplate.Background));
+    }
+
+    /// <summary>
+    ///   Starts a fade out transition
+    /// </summary>
+    private void FadeOut()
+    {
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.5f);
+        TransitionManager.Instance.StartTransitions(this, nameof(OnFinishTransitioning));
     }
 
     private void SaveGame(string name)

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -608,10 +608,9 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
             OnEditorReady();
         }
 
-        // Save if wanted
+        // Auto save after editor entry is complete
         if (TransitionFinished && wantsToSave)
         {
-            // Auto save after editor entry is complete
             if (!CurrentGame.FreeBuild)
                 SaveHelper.AutoSave(this);
 
@@ -2261,7 +2260,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
         gui.UpdateReportTabStatistics(CurrentPatch);
 
-        FadeOut();
+        FadeIn();
     }
 
     private void OnLoadedEditorReady()
@@ -2278,7 +2277,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
         gui.UpdateReportTabStatistics(CurrentPatch);
 
-        FadeOut();
+        FadeIn();
     }
 
     private void ApplyAutoEvoResults()
@@ -2319,11 +2318,11 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
     }
 
     /// <summary>
-    ///   Starts a fade out transition
+    ///   Starts a fade in transition
     /// </summary>
-    private void FadeOut()
+    private void FadeIn()
     {
-        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.5f);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.5f);
         TransitionManager.Instance.StartTransitions(this, nameof(OnFinishTransitioning));
     }
 

--- a/src/microbe_stage/editor/MicrobeEditorGUI.cs
+++ b/src/microbe_stage/editor/MicrobeEditorGUI.cs
@@ -1176,7 +1176,7 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
         // To prevent being clicked twice
         finishButton.MouseFilter = Control.MouseFilterEnum.Ignore;
 
-        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.3f, false);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.3f, false);
         TransitionManager.Instance.StartTransitions(editor, nameof(MicrobeEditor.OnFinishEditing));
     }
 
@@ -1184,7 +1184,7 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
     {
         GUICommon.Instance.PlayButtonPressSound();
 
-        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.3f, false);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.3f, false);
         TransitionManager.Instance.StartTransitions(editor, nameof(MicrobeEditor.OnFinishEditing));
     }
 

--- a/src/microbe_stage/editor/MicrobeEditorGUI.cs
+++ b/src/microbe_stage/editor/MicrobeEditorGUI.cs
@@ -553,10 +553,6 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
         ApplySelectionMenuTab();
 
         UpdateMutationPointsBar();
-
-        // Fade out for that smooth satisfying transition
-        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.5f);
-        TransitionManager.Instance.StartTransitions(editor, nameof(MicrobeEditor.OnFinishTransitioning));
     }
 
     public void SetMap(PatchMap map)

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -229,7 +229,7 @@ public class SaveList : ScrollContainer
     {
         GUICommon.Instance.PlayButtonPressSound();
 
-        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.3f, true);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.3f, true);
         TransitionManager.Instance.StartTransitions(this, nameof(LoadSave));
     }
 

--- a/src/saving/SaveListItem.cs
+++ b/src/saving/SaveListItem.cs
@@ -242,7 +242,7 @@ public class SaveListItem : PanelContainer
             return;
         }
 
-        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeIn, 0.3f, true);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.3f, true);
         TransitionManager.Instance.StartTransitions(this, nameof(LoadSave));
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This changes the fading out transition to only be started after the editor is ready. Fades in games are usually used to hide in-progress loading/process for a smoother experience so to see the auto-evo run finishes after screen fade in completed is probably a bit jarring and make the fades slightly ineffective.

Auto-saves should still work correctly with this (performed after the fade in has finished).

Also did a bit of minor refactoring on transition related scripts.

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
