### PR TITLE
Fixed mouse hover detection on bound cells

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -565,7 +565,7 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
 
         foreach (Microbe entry in microbes)
         {
-            var distance = (entry.Translation - Camera.CursorWorldPos).Length();
+            var distance = (entry.GlobalTransform.origin - Camera.CursorWorldPos).Length();
 
             // Find only cells that have the mouse
             // position within their membrane


### PR DESCRIPTION
**Brief Description of What This PR Does**

Since bound cells are reparented to the player's microbe node, the `Translation` is no longer relative to the common world node (`DynamicallySpawned`) so the distance calculation no longer works. To workaround this, a `GlobalTransform` is used so it'll be independent of the local translation.

Doesn't seem to break anything so far from a quick testing.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
