### PR TITLE
Fixed ghost drift

### DIFF
--- a/src/microbe_stage/Microbe.tscn
+++ b/src/microbe_stage/Microbe.tscn
@@ -25,7 +25,7 @@ resource_local_to_scene = true
 
 [node name="Microbe" type="RigidBody"]
 process_priority = 1
-collision_layer = 3
+collision_layer = 2
 collision_mask = 3
 contact_monitor = true
 can_sleep = false


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes the ghost drift bug.

The ghost drift bug occured because the organelles dynamically create a ShapeOwner and attach it to the microbe. The orgenelles of one microbe collide with the organelles of the other microbe. It seems like the `AddCollisionExceptionWith` does not handle this very well.

This fix works by removing the "Common" collision layer from microbes. I thought that this might break some collisions, but I have not noticed any broken collisions, but more collision testing would be required before merging.

**Related Issues**

Closes #2308

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
