### PR TITLE
1541 - Fixing lack of iron chunks in cave

### DIFF
--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -1290,7 +1290,7 @@
                             "convexShapePath": "res://assets/models/Iron4.shape"
                         }
                     ],
-                    "density": 0.0001,
+                    "density": 0.001,
                     "dissolves": true,
                     "radius": 1,
                     "chunkScale": 1,

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -68,6 +68,8 @@ public class SpawnSystem
     /// </summary>
     private int estimateEntityCount;
 
+    private Dictionary<Spawner, int> attemptsPerSpawnType;
+
     public SpawnSystem(Node root)
     {
         worldRoot = root;
@@ -232,8 +234,7 @@ public class SpawnSystem
 
         int spawned = 0;
 
-        // TODO ugly
-        Dictionary<Spawner, int> attemptsPerSpawnType = new Dictionary<Spawner, int>();
+        attemptsPerSpawnType.Clear();
         int maxAttempts = -1;
         foreach (var spawnType in spawnTypes)
         {
@@ -265,6 +266,8 @@ public class SpawnSystem
             foreach (var spawnType in spawnTypes)
             {
                 int numAttempts = attemptsPerSpawnType[spawnType];
+
+                // Already did max attempts for this type
                 if (i > numAttempts)
                     continue;
 

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -232,7 +232,19 @@ public class SpawnSystem
 
         int spawned = 0;
 
+        // TODO ugly
+        Dictionary<Spawner, int> attemptsPerSpawnType = new Dictionary<Spawner, int>();
+        int maxAttempts = -1;
         foreach (var spawnType in spawnTypes)
+        {
+            int numAttempts = Math.Min(Math.Max(spawnType.SpawnFrequency * 2, 1),
+                maxTriesPerSpawner);
+            attemptsPerSpawnType[spawnType] = numAttempts;
+            if (numAttempts > maxAttempts)
+                maxAttempts = numAttempts;
+        }
+
+        for (int i = 0; i < maxAttempts; i++)
         {
             /*
             To actually spawn a given entity for a given attempt, two
@@ -249,11 +261,13 @@ public class SpawnSystem
             numAttempts stores how many times the SpawnSystem attempts
             to spawn the given entity.
             */
-            int numAttempts = Math.Min(Math.Max(spawnType.SpawnFrequency * 2, 1),
-                maxTriesPerSpawner);
 
-            for (int i = 0; i < numAttempts; i++)
+            foreach (var spawnType in spawnTypes)
             {
+                int numAttempts = attemptsPerSpawnType[spawnType];
+                if (i > numAttempts)
+                    continue;
+
                 if (random.Next(0, numAttempts + 1) < spawnType.SpawnFrequency)
                 {
                     /*

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -239,12 +239,12 @@ public class SpawnSystem
         int maxAttempts = -1;
         foreach (var spawnType in spawnTypes)
         {
-            int numAttempts = Math.Min(Math.Max(spawnType.SpawnFrequency * 2, 1),
+            int attempts = Math.Min(Math.Max(spawnType.SpawnFrequency * 2, 1),
                 maxTriesPerSpawner);
-            attemptsPerSpawnType[spawnType] = numAttempts;
+            attemptsPerSpawnType[spawnType] = attempts;
 
-            if (numAttempts > maxAttempts)
-                maxAttempts = numAttempts;
+            if (attempts > maxAttempts)
+                maxAttempts = attempts;
         }
 
         for (int i = 0; i < maxAttempts; i++)
@@ -269,13 +269,13 @@ public class SpawnSystem
 
             foreach (var spawnType in spawnTypes)
             {
-                int numAttempts = attemptsPerSpawnType[spawnType];
+                int attempts = attemptsPerSpawnType[spawnType];
 
                 // Already did max attempts for this type
-                if (i > numAttempts)
+                if (i > attempts)
                     continue;
 
-                if (random.Next(0, numAttempts + 1) < spawnType.SpawnFrequency)
+                if (random.Next(0, attempts + 1) < spawnType.SpawnFrequency)
                 {
                     /*
                     First condition passed. Choose a location for the entity.

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -239,8 +239,7 @@ public class SpawnSystem
         int maxAttempts = -1;
         foreach (var spawnType in spawnTypes)
         {
-            int attempts = Math.Min(Math.Max(spawnType.SpawnFrequency * 2, 1),
-                maxTriesPerSpawner);
+            int attempts = Mathf.Clamp(spawnType.SpawnFrequency * 2, 1, maxTriesPerSpawner);
             attemptsPerSpawnType[spawnType] = attempts;
 
             if (attempts > maxAttempts)

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -73,6 +73,7 @@ public class SpawnSystem
     public SpawnSystem(Node root)
     {
         worldRoot = root;
+        attemptsPerSpawnType = new Dictionary<Spawner, int>();
     }
 
     // Needs no params constructor for loading saves?

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -242,6 +242,7 @@ public class SpawnSystem
             int numAttempts = Math.Min(Math.Max(spawnType.SpawnFrequency * 2, 1),
                 maxTriesPerSpawner);
             attemptsPerSpawnType[spawnType] = numAttempts;
+            
             if (numAttempts > maxAttempts)
                 maxAttempts = numAttempts;
         }

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -261,7 +261,9 @@ public class SpawnSystem
             spawn cycle, the SpawnSystem attempts to spawn each given
             entity multiple times depending on the spawnFrequency.
             numAttempts stores how many times the SpawnSystem attempts
-            to spawn the given entity.
+            to spawn the given entity. Furthermore, each attempt gives a spawn chance
+            for each spawner (up to their type limit) to still favor diversity,
+            instead of one spawner taking up all the free spawning slots.
             */
 
             foreach (var spawnType in spawnTypes)

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -242,7 +242,7 @@ public class SpawnSystem
             int numAttempts = Math.Min(Math.Max(spawnType.SpawnFrequency * 2, 1),
                 maxTriesPerSpawner);
             attemptsPerSpawnType[spawnType] = numAttempts;
-            
+
             if (numAttempts > maxAttempts)
                 maxAttempts = numAttempts;
         }


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR adress the issue of lacking iron in the cave, by two fixes:
1. Increasing small chunks density in the cave, to avoid high proportion displayed on patch map hiding sparse, very rich deposits (only affects new games as these densities are saved)
2. Reworking spawning algorithm by running an attempt per spawner, up to max, rather than up to max attempts per spawner, to favor diversity (affects all patches).

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

Resolves #1541 and resolves #1626 and resolves #1777 .

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
