### PR TITLE
Status bool in RunOnKeyChange

### DIFF
--- a/doc/input_system.md
+++ b/doc/input_system.md
@@ -25,7 +25,7 @@ The available input attributes
 | Attribute | Description | Parameters | Method parameters | Multiple |
 | --------- | ----------- | ---------- | ----------------- | -------- |
 | RunOnKey  | Fires repeatedly when the input is held down | input : string | delta : float | yes |
-| RunOnKeyChange | Fires once when the input is pressed or released | input : string | none | yes |
+| RunOnKeyChange | Fires once when the input is pressed or released | input : string | state : bool | yes |
 | RunOnKeyDown | Fires once when the input is pressed | input : string | none | yes |
 | RunOnKeyUp | Fires once when the input is released | input : string | none | yes |
 | RunOnKeyToggle | Fires once when the input is pressed and provides an alternating bool | input : string | state : bool | yes |

--- a/src/engine/input/RunOnKeyChangeAttribute.cs
+++ b/src/engine/input/RunOnKeyChangeAttribute.cs
@@ -18,7 +18,7 @@ public class RunOnKeyChangeAttribute : RunOnKeyAttribute
         if (!base.OnInput(@event) || HeldDown == before)
             return false;
 
-        return CallMethod();
+        return CallMethod(HeldDown);
     }
 
     public override void OnProcess(float delta)


### PR DESCRIPTION
**Brief Description of What This PR Does**

I have thought about the input system a bit and providing a status about the held status makes much sense to me.

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
