### PR TITLE
Added support for basic load after dropping a save file on the game

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -26,6 +26,7 @@
     <Compile Include="src\engine\ChromaticFilter.cs" />
     <Compile Include="src\engine\ControlHelpers.cs" />
     <Compile Include="src\engine\FeatureInformation.cs" />
+    <Compile Include="src\engine\FileDropHandler.cs" />
     <Compile Include="src\engine\FullScreenToggle.cs" />
     <Compile Include="src\engine\GodotFileStream.cs" />
     <Compile Include="src\engine\GuidanceLine.cs" />

--- a/project.godot
+++ b/project.godot
@@ -43,6 +43,7 @@ ScreenShotTaker="*res://src/engine/ScreenShotTaker.cs"
 FullScreenToggle="*res://src/engine/FullScreenToggle.cs"
 Jukebox="*res://src/general/Jukebox.cs"
 TemporaryLoadedNodeDeleter="*res://src/saving/TemporaryLoadedNodeDeleter.cs"
+FileDropHandler="*res://src/engine/FileDropHandler.cs"
 PostStartupActions="*res://src/engine/PostStartupActions.cs"
 
 [debug]

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -504,6 +504,8 @@ public static class Constants
 
     public const string SAVE_FOLDER = "user://saves";
 
+    public const string EXPLICIT_PATH_PREFIX = "file://";
+
     public const string SCREENSHOT_FOLDER = "user://screenshots";
 
     public const string LOGS_FOLDER_NAME = "logs";

--- a/src/engine/FileDropHandler.cs
+++ b/src/engine/FileDropHandler.cs
@@ -8,7 +8,7 @@ public class FileDropHandler : Node
 {
     public override void _Ready()
     {
-        GetTree().Connect("files_dropped", this, "OnFilesDropped");
+        GetTree().Connect("files_dropped", this, nameof(OnFilesDropped));
     }
 
     private void OnFilesDropped(string[] files, int screen)
@@ -64,7 +64,7 @@ public class FileDropHandler : Node
                 return;
             }
 
-            if (info.ThriveVersion == Constants.Version)
+            if (info.ThriveVersion != Constants.Version)
             {
                 // TODO: would be nice to show a confirmation dialog here
                 GD.Print("The dropped save version is not exactly the same as current game version");

--- a/src/engine/FileDropHandler.cs
+++ b/src/engine/FileDropHandler.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Godot;
+
+/// <summary>
+///   Handles signal from Godot when files are dragged and dropped onto the game window
+/// </summary>
+public class FileDropHandler : Node
+{
+    public override void _Ready()
+    {
+        GetTree().Connect("files_dropped", this, "OnFilesDropped");
+    }
+
+    private void OnFilesDropped(string[] files, int screen)
+    {
+        foreach (var file in files)
+        {
+            GD.Print("Detected file drop \"", file, "\" on screen ", screen);
+            HandleFileDrop(file, screen);
+        }
+    }
+
+    private void HandleFileDrop(string file, int screen)
+    {
+        // Currently nothing depends on this (this might be the game window index, at least on Linux this doesn't seem
+        // to change when the monitor is changed the drag happens on...)
+        _ = screen;
+
+        // For now just the load save functionality is done, but in the future this might be extended to allow
+        // other code to dynamically register listeners here
+
+        if (file.EndsWith(Constants.SAVE_EXTENSION, StringComparison.InvariantCulture))
+        {
+            if (!file.StartsWith(Constants.EXPLICIT_PATH_PREFIX, StringComparison.InvariantCulture))
+                file = Constants.EXPLICIT_PATH_PREFIX + file;
+
+            // TODO: could add a dialog to ask if the save should be loaded now or copied to the saves folder
+            HandleLoadSaveFromDrop(file);
+        }
+        else
+        {
+            GD.Print("Unknown file type to handle on drop");
+        }
+    }
+
+    private void HandleLoadSaveFromDrop(string file)
+    {
+        GD.Print("Trying to load dropped save file...");
+
+        // TODO: would be nice to have some kind of popup box showing the errors from here to the user
+        try
+        {
+            var info = Save.LoadJustInfoFromSave(file);
+
+            if (info.Type == SaveInformation.SaveType.Invalid)
+            {
+                GD.PrintErr("Given file (", file, ") is not a valid Thrive save");
+                return;
+            }
+
+            if (SaveHelper.IsKnownIncompatible(info.ThriveVersion))
+            {
+                GD.Print("Dropped save file is known incompatible, not loading it");
+                return;
+            }
+
+            if (info.ThriveVersion == Constants.Version)
+            {
+                // TODO: would be nice to show a confirmation dialog here
+                GD.Print("The dropped save version is not exactly the same as current game version");
+            }
+
+            SaveHelper.LoadSave(file);
+        }
+        catch (Exception e)
+        {
+            GD.PrintErr("Exception while trying to load dropped save: ", e);
+        }
+    }
+}

--- a/src/saving/SaveFileInfo.cs
+++ b/src/saving/SaveFileInfo.cs
@@ -1,4 +1,5 @@
-﻿using Godot;
+﻿using System;
+using Godot;
 
 /// <summary>
 ///   Info about a save file on disk
@@ -41,6 +42,10 @@ public class SaveFileInfo
 
     public static string SaveNameToPath(string name)
     {
+        // If the name begins with the file protocol it's already a full path
+        if (name.StartsWith(Constants.EXPLICIT_PATH_PREFIX, StringComparison.InvariantCulture))
+            return name.Substring(Constants.EXPLICIT_PATH_PREFIX.Length);
+
         return PathUtils.Join(Constants.SAVE_FOLDER, name);
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**
Allows loading a save file by dragging it from a folder onto the game.

Follow up issues to polish this up
- https://github.com/Revolutionary-Games/Thrive/issues/2424
- https://github.com/Revolutionary-Games/Thrive/issues/2423

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

closes #1427 

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
