### PR TITLE
Made AI move for Run and Rumble if immobile

### DIFF
--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -367,7 +367,7 @@ public class MicrobeAI
     // For doing run and tumble
     private void RunAndTumble(Random random)
     {
-        // If this microbe is actually immobile, just initialize by moving in a random direction.
+        // If this microbe is currently stationary, just initialize by moving in a random direction.
         // Used to get newly spawned microbes to move.
         if (microbe.MovementDirection.Length() == 0)
         {

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -367,6 +367,14 @@ public class MicrobeAI
     // For doing run and tumble
     private void RunAndTumble(Random random)
     {
+        // If this microbe is actually immobile, just initialize by moving in a random direction.
+        // Used to get newly spawned microbes to move.
+        if (microbe.MovementDirection.Length() == 0)
+        {
+            MoveWithRandomTurn(0, 2 * Mathf.Pi, random);
+            return;
+        }
+
         // Run and tumble
         // A biased random walk, they turn more if they are picking up less compounds.
         // The scientifically accurate algorithm has been flipped to account for the compound

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -371,7 +371,7 @@ public class MicrobeAI
         // Used to get newly spawned microbes to move.
         if (microbe.MovementDirection.Length() == 0)
         {
-            MoveWithRandomTurn(0, 2 * Mathf.Pi, random);
+            MoveWithRandomTurn(0, Mathf.Pi, random);
             return;
         }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR modifies run and rumble to make immobile microbe move randomly (as they don't have any input to compute gradient from).
This makes newly spawned microbes move immediately (as they would previously only have 50% chance to move per step).
Note that this does not affect sessile organisms.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

Closes #889 .

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
