### PR TITLE
fixes #2099 When re-entering load menu and pressing load game crashes

### DIFF
--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -126,7 +126,6 @@ public class SaveList : ScrollContainer
             savesList.AddChild(item);
         }
 
-        EmitSignal(nameof(OnItemsChanged));
         loadingItem.Visible = false;
         refreshing = false;
     }
@@ -153,6 +152,7 @@ public class SaveList : ScrollContainer
         loadingItem.Visible = true;
         readSavesList = new Task<List<string>>(() => SaveHelper.CreateListOfSaves());
         TaskExecutor.Instance.AddTask(readSavesList);
+        EmitSignal(nameof(OnItemsChanged));
     }
 
     private void OnSubItemSelectedChanged()
@@ -181,6 +181,7 @@ public class SaveList : ScrollContainer
         SaveHelper.DeleteSave(saveToBeDeleted);
         saveToBeDeleted = null;
 
+        Refresh();
         EmitSignal(nameof(OnItemsChanged));
     }
 

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -126,6 +126,7 @@ public class SaveList : ScrollContainer
             savesList.AddChild(item);
         }
 
+        EmitSignal(nameof(OnItemsChanged));
         loadingItem.Visible = false;
         refreshing = false;
     }
@@ -180,7 +181,6 @@ public class SaveList : ScrollContainer
         SaveHelper.DeleteSave(saveToBeDeleted);
         saveToBeDeleted = null;
 
-        Refresh();
         EmitSignal(nameof(OnItemsChanged));
     }
 

--- a/src/saving/SaveManagerGUI.cs
+++ b/src/saving/SaveManagerGUI.cs
@@ -252,6 +252,8 @@ public class SaveManagerGUI : Control
     private void OnBackButton()
     {
         GUICommon.Instance.PlayButtonPressSound();
+        Selected.ForEach(item => item.Selected = false);
+        RefreshList();
         EmitSignal(nameof(OnBackPressed));
     }
 }

--- a/src/saving/SaveManagerGUI.cs
+++ b/src/saving/SaveManagerGUI.cs
@@ -105,7 +105,7 @@ public class SaveManagerGUI : Control
 
         if (!getTotalSaveCountTask.IsCompleted)
             return;
-
+        
         var info = getTotalSaveCountTask.Result;
         currentAutoSaveCount = getAutoSaveCountTask.Result.count;
         currentQuickSaveCount = getQuickSaveCountTask.Result.count;
@@ -142,8 +142,6 @@ public class SaveManagerGUI : Control
 
     private void RefreshList()
     {
-        selectedDirty = true;
-
         saveList.Refresh();
         RefreshSaveCounts();
     }
@@ -153,6 +151,7 @@ public class SaveManagerGUI : Control
         if (refreshing)
             return;
 
+        selectedDirty = true;
         saveCountRefreshed = true;
         refreshing = true;
 
@@ -252,7 +251,6 @@ public class SaveManagerGUI : Control
     private void OnBackButton()
     {
         GUICommon.Instance.PlayButtonPressSound();
-        RefreshList();
         EmitSignal(nameof(OnBackPressed));
     }
 }

--- a/src/saving/SaveManagerGUI.cs
+++ b/src/saving/SaveManagerGUI.cs
@@ -252,7 +252,6 @@ public class SaveManagerGUI : Control
     private void OnBackButton()
     {
         GUICommon.Instance.PlayButtonPressSound();
-        Selected.ForEach(item => item.Selected = false);
         RefreshList();
         EmitSignal(nameof(OnBackPressed));
     }

--- a/src/saving/SaveManagerGUI.cs
+++ b/src/saving/SaveManagerGUI.cs
@@ -89,7 +89,7 @@ public class SaveManagerGUI : Control
         deleteSelectedConfirmDialog = GetNode<ConfirmationDialog>(DeleteSelectedConfirmDialogPath);
         deleteOldConfirmDialog = GetNode<ConfirmationDialog>(DeleteOldConfirmDialogPath);
 
-        saveList.Connect(nameof(SaveList.OnItemsChanged), this, nameof(RefreshList));
+        saveList.Connect(nameof(SaveList.OnItemsChanged), this, nameof(RefreshSaveCounts));
     }
 
     public override void _Process(float delta)
@@ -143,7 +143,6 @@ public class SaveManagerGUI : Control
     private void RefreshList()
     {
         saveList.Refresh();
-        RefreshSaveCounts();
     }
 
     private void RefreshSaveCounts()

--- a/src/saving/SaveManagerGUI.cs
+++ b/src/saving/SaveManagerGUI.cs
@@ -105,7 +105,7 @@ public class SaveManagerGUI : Control
 
         if (!getTotalSaveCountTask.IsCompleted)
             return;
-        
+
         var info = getTotalSaveCountTask.Result;
         currentAutoSaveCount = getAutoSaveCountTask.Result.count;
         currentQuickSaveCount = getQuickSaveCountTask.Result.count;


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR fixes #2099. The game was crashing when selecting a saved game, returning to the main menu, enter again in the load game screen and clicking Load.

The problem that I found is that every time we enter the load menu the saveList it is refreshed and the SaveManagerUI it is not and that cause the variable wich contains the selected save file not to be updated so it have a null object.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
