### PR TITLE
Improve rigidity slider handling

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -111,6 +111,7 @@
     <Compile Include="src\general\SceneDisplayer.cs" />
     <Compile Include="src\microbe_stage\AgentProjectile.cs" />
     <Compile Include="src\microbe_stage\BiomeConditions.cs" />
+    <Compile Include="src\microbe_stage\editor\MicrobeEditorActionHistory.cs" />
     <Compile Include="src\microbe_stage\editor\MicrobeEditorCheatMenu.cs" />
     <Compile Include="src\microbe_stage\MicrobeCheatMenu.cs" />
     <Compile Include="src\microbe_stage\ChunkConfiguration.cs" />

--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -113,6 +113,7 @@
     <Compile Include="src\microbe_stage\BiomeConditions.cs" />
     <Compile Include="src\microbe_stage\editor\MicrobeEditorActionHistory.cs" />
     <Compile Include="src\microbe_stage\editor\MicrobeEditorCheatMenu.cs" />
+    <Compile Include="src\microbe_stage\editor\MicrobeRigidityChangeAction.cs" />
     <Compile Include="src\microbe_stage\MicrobeCheatMenu.cs" />
     <Compile Include="src\microbe_stage\ChunkConfiguration.cs" />
     <Compile Include="src\microbe_stage\ColonyCompoundBag.cs" />

--- a/src/general/ActionHistory.cs
+++ b/src/general/ActionHistory.cs
@@ -45,7 +45,7 @@ public class ActionHistory<T>
             return false;
 
         var action = actions[--actionIndex];
-        action.PreformUndo();
+        action.PerformUndo();
         return true;
     }
 

--- a/src/general/ActionHistory.cs
+++ b/src/general/ActionHistory.cs
@@ -10,14 +10,14 @@ public class ActionHistory<T>
     where T : ReversibleAction
 {
     [JsonProperty]
-    private List<T> actions = new List<T>();
+    protected List<T> actions = new List<T>();
 
     /// <summary>
     ///   marks the last action that has been done (not undone, but
     ///   possibly redone), is 0 if there is none.
     /// </summary>
     [JsonProperty]
-    private int actionIndex;
+    protected int actionIndex;
 
     public bool CanRedo()
     {
@@ -45,7 +45,7 @@ public class ActionHistory<T>
             return false;
 
         var action = actions[--actionIndex];
-        action.Undo();
+        action.PreformUndo();
         return true;
     }
 

--- a/src/general/ReversibleAction.cs
+++ b/src/general/ReversibleAction.cs
@@ -27,7 +27,7 @@ public abstract class ReversibleAction
     /// <summary>
     ///   Undoes this action
     /// </summary>
-    public void PreformUndo()
+    public void PerformUndo()
     {
         if (!Performed)
             throw new InvalidOperationException("cannot undo not performed action");

--- a/src/general/ReversibleAction.cs
+++ b/src/general/ReversibleAction.cs
@@ -27,7 +27,7 @@ public abstract class ReversibleAction
     /// <summary>
     ///   Undoes this action
     /// </summary>
-    public void Undo()
+    public void PreformUndo()
     {
         if (!Performed)
             throw new InvalidOperationException("cannot undo not performed action");

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -835,7 +835,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
         var newRigidity = rigidity / Constants.MEMBRANE_RIGIDITY_SLIDER_TO_VALUE_RATIO;
         var prevRigidity = Rigidity;
 
-        var action = new MicrobeEditorAction(this, cost, DoRigidityChangeAction, UndoRigidityChangeAction,
+        var action = new MicrobeRigidityChangeAction(this, cost, DoRigidityChangeAction, UndoRigidityChangeAction,
             new RigidityChangeActionData(newRigidity, prevRigidity));
 
         EnqueueAction(action);

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -75,6 +75,8 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
     [JsonProperty]
     private float rigidity;
 
+    private float initialRigidity;
+
     /// <summary>
     ///   Where the player wants to move after editing
     /// </summary>
@@ -806,6 +808,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
     public void SetRigidity(int rigidity)
     {
         int intRigidity = (int)Math.Round(Rigidity * Constants.MEMBRANE_RIGIDITY_SLIDER_TO_VALUE_RATIO);
+        int intInitialRigidity = (int)Math.Round(initialRigidity * Constants.MEMBRANE_RIGIDITY_SLIDER_TO_VALUE_RATIO);
 
         if (MovingOrganelle != null)
         {
@@ -817,7 +820,8 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
         if (intRigidity == rigidity)
             return;
 
-        int cost = Math.Abs(rigidity - intRigidity) * Constants.MEMBRANE_RIGIDITY_COST_PER_STEP;
+        int cost = (Math.Abs(rigidity - intInitialRigidity) - Math.Abs(intRigidity - intInitialRigidity))
+            * Constants.MEMBRANE_RIGIDITY_COST_PER_STEP;
 
         if (cost > MutationPoints)
         {
@@ -1383,7 +1387,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
         // bar can take it into account (the bar is updated when
         // organelles are added)
         Membrane = species.MembraneType;
-        Rigidity = species.MembraneRigidity;
+        initialRigidity = Rigidity = species.MembraneRigidity;
         Colour = species.Colour;
 
         // Get the species organelles to be edited. This also updates the placeholder hexes

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -58,7 +58,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
     ///   Where all user actions will  be registered
     /// </summary>
     [JsonProperty]
-    private ActionHistory<MicrobeEditorAction> history;
+    private MicrobeEditorActionHistory history;
 
     private Material invalidMaterial;
     private Material validMaterial;
@@ -1160,7 +1160,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
         if (!IsLoadedFromSave)
         {
-            history = new ActionHistory<MicrobeEditorAction>();
+            history = new MicrobeEditorActionHistory();
 
             // Start a new game if no game has been started
             if (CurrentGame == null)

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -75,8 +75,6 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
     [JsonProperty]
     private float rigidity;
 
-    private float initialRigidity;
-
     /// <summary>
     ///   Where the player wants to move after editing
     /// </summary>
@@ -808,7 +806,6 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
     public void SetRigidity(int rigidity)
     {
         int intRigidity = (int)Math.Round(Rigidity * Constants.MEMBRANE_RIGIDITY_SLIDER_TO_VALUE_RATIO);
-        int intInitialRigidity = (int)Math.Round(initialRigidity * Constants.MEMBRANE_RIGIDITY_SLIDER_TO_VALUE_RATIO);
 
         if (MovingOrganelle != null)
         {
@@ -820,8 +817,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
         if (intRigidity == rigidity)
             return;
 
-        int cost = (Math.Abs(rigidity - intInitialRigidity) - Math.Abs(intRigidity - intInitialRigidity))
-            * Constants.MEMBRANE_RIGIDITY_COST_PER_STEP;
+        int cost = Math.Abs(rigidity - intRigidity) * Constants.MEMBRANE_RIGIDITY_COST_PER_STEP;
 
         if (cost > MutationPoints)
         {
@@ -1387,7 +1383,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
         // bar can take it into account (the bar is updated when
         // organelles are added)
         Membrane = species.MembraneType;
-        initialRigidity = Rigidity = species.MembraneRigidity;
+        Rigidity = species.MembraneRigidity;
         Colour = species.Colour;
 
         // Get the species organelles to be edited. This also updates the placeholder hexes

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -751,7 +751,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
                 // Update rigidity slider in case it was disabled
                 // TODO: could come up with a bit nicer design here
                 int intRigidity = (int)Math.Round(Rigidity * Constants.MEMBRANE_RIGIDITY_SLIDER_TO_VALUE_RATIO);
-                gui.UpdateRigiditySlider(intRigidity, MutationPoints);
+                gui.UpdateRigiditySlider(intRigidity);
 
                 // Re-enable undo/redo button
                 UpdateUndoRedoButtons();
@@ -813,7 +813,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
         if (MovingOrganelle != null)
         {
             gui.OnActionBlockedWhileMoving();
-            gui.UpdateRigiditySlider(intRigidity, MutationPoints);
+            gui.UpdateRigiditySlider(intRigidity);
             return;
         }
 
@@ -828,7 +828,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
             int stepsLeft = MutationPoints / Constants.MEMBRANE_RIGIDITY_COST_PER_STEP;
             if (stepsLeft < 1)
             {
-                gui.UpdateRigiditySlider(intRigidity, MutationPoints);
+                gui.UpdateRigiditySlider(intRigidity);
                 return;
             }
 
@@ -2223,8 +2223,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
     private void OnRigidityChanged()
     {
-        gui.UpdateRigiditySlider((int)Math.Round(Rigidity * Constants.MEMBRANE_RIGIDITY_SLIDER_TO_VALUE_RATIO),
-            MutationPoints);
+        gui.UpdateRigiditySlider((int)Math.Round(Rigidity * Constants.MEMBRANE_RIGIDITY_SLIDER_TO_VALUE_RATIO));
 
         gui.UpdateSpeed(CalculateSpeed());
         gui.UpdateHitpoints(CalculateHitpoints());

--- a/src/microbe_stage/editor/MicrobeEditorAction.cs
+++ b/src/microbe_stage/editor/MicrobeEditorAction.cs
@@ -9,47 +9,47 @@ using Newtonsoft.Json;
 /// </remarks>
 public class MicrobeEditorAction : ReversibleAction
 {
-    [JsonProperty]
-    public readonly int Cost;
-
-    [JsonProperty]
-    public readonly Action<MicrobeEditorAction> Redo;
-
-    [JsonProperty]
-    public readonly Action<MicrobeEditorAction> Undo;
-
-    [JsonProperty]
-    public readonly MicrobeEditor Editor;
-
     /// <summary>
     ///   Action specific data
     /// </summary>
     [JsonProperty]
-    public IMicrobeEditorActionData Data;
+    public readonly IMicrobeEditorActionData Data;
+
+    [JsonProperty]
+    protected readonly Action<MicrobeEditorAction> redo;
+
+    [JsonProperty]
+    protected readonly Action<MicrobeEditorAction> undo;
+
+    [JsonProperty]
+    protected readonly MicrobeEditor editor;
 
     public MicrobeEditorAction(MicrobeEditor editor, int cost,
         Action<MicrobeEditorAction> redo,
         Action<MicrobeEditorAction> undo, IMicrobeEditorActionData data = null)
     {
-        Editor = editor;
+        this.editor = editor;
         Cost = cost;
-        Redo = redo;
-        Undo = undo;
+        this.redo = redo;
+        this.undo = undo;
         Data = data;
     }
+
+    [JsonProperty]
+    public int Cost { get; protected set; }
 
     [JsonIgnore]
     public bool IsMoveAction => Data is MoveActionData;
 
     public override void DoAction()
     {
-        Editor.ChangeMutationPoints(-Cost);
-        Redo(this);
+        editor.ChangeMutationPoints(-Cost);
+        redo(this);
     }
 
     public override void UndoAction()
     {
-        Editor.ChangeMutationPoints(Cost);
-        Undo(this);
+        editor.ChangeMutationPoints(Cost);
+        undo(this);
     }
 }

--- a/src/microbe_stage/editor/MicrobeEditorAction.cs
+++ b/src/microbe_stage/editor/MicrobeEditorAction.cs
@@ -12,29 +12,29 @@ public class MicrobeEditorAction : ReversibleAction
     [JsonProperty]
     public readonly int Cost;
 
+    [JsonProperty]
+    public readonly Action<MicrobeEditorAction> Redo;
+
+    [JsonProperty]
+    public readonly Action<MicrobeEditorAction> Undo;
+
+    [JsonProperty]
+    public readonly MicrobeEditor Editor;
+
     /// <summary>
     ///   Action specific data
     /// </summary>
     [JsonProperty]
     public IMicrobeEditorActionData Data;
 
-    [JsonProperty]
-    private readonly Action<MicrobeEditorAction> redo;
-
-    [JsonProperty]
-    private readonly Action<MicrobeEditorAction> undo;
-
-    [JsonProperty]
-    private readonly MicrobeEditor editor;
-
     public MicrobeEditorAction(MicrobeEditor editor, int cost,
         Action<MicrobeEditorAction> redo,
         Action<MicrobeEditorAction> undo, IMicrobeEditorActionData data = null)
     {
-        this.editor = editor;
+        Editor = editor;
         Cost = cost;
-        this.redo = redo;
-        this.undo = undo;
+        Redo = redo;
+        Undo = undo;
         Data = data;
     }
 
@@ -43,13 +43,13 @@ public class MicrobeEditorAction : ReversibleAction
 
     public override void DoAction()
     {
-        editor.ChangeMutationPoints(-Cost);
-        redo(this);
+        Editor.ChangeMutationPoints(-Cost);
+        Redo(this);
     }
 
     public override void UndoAction()
     {
-        editor.ChangeMutationPoints(Cost);
-        undo(this);
+        Editor.ChangeMutationPoints(Cost);
+        Undo(this);
     }
 }

--- a/src/microbe_stage/editor/MicrobeEditorActionHistory.cs
+++ b/src/microbe_stage/editor/MicrobeEditorActionHistory.cs
@@ -1,0 +1,24 @@
+﻿public class MicrobeEditorActionHistory : ActionHistory<MicrobeEditorAction>
+{
+    public new void AddAction(MicrobeEditorAction action)
+    {
+        // If action is RigidityChange, try to combine it with the previous one.
+        if (CanUndo())
+        {
+            RigidityChangeActionData data = action.Data as RigidityChangeActionData;
+            RigidityChangeActionData previousData = actions[actionIndex - 1].Data as RigidityChangeActionData;
+            if (data != null && previousData != null)
+            {
+                data.PreviousRigidity = previousData.PreviousRigidity;
+                MicrobeEditorAction combinedAction = new MicrobeEditorAction(action.Editor,
+                    action.Cost + actions[actionIndex - 1].Cost, action.Redo, action.Undo, action.Data);
+
+                Undo();
+                base.AddAction(combinedAction);
+                return;
+            }
+        }
+
+        base.AddAction(action);
+    }
+}

--- a/src/microbe_stage/editor/MicrobeEditorActionHistory.cs
+++ b/src/microbe_stage/editor/MicrobeEditorActionHistory.cs
@@ -5,16 +5,9 @@
         // If action is RigidityChange, try to combine it with the previous one.
         if (CanUndo())
         {
-            RigidityChangeActionData data = action.Data as RigidityChangeActionData;
-            RigidityChangeActionData previousData = actions[actionIndex - 1].Data as RigidityChangeActionData;
-            if (data != null && previousData != null)
+            if (action is MicrobeRigidityChangeAction && actions[actionIndex - 1] is MicrobeRigidityChangeAction)
             {
-                data.PreviousRigidity = previousData.PreviousRigidity;
-                MicrobeEditorAction combinedAction = new MicrobeEditorAction(action.Editor,
-                    action.Cost + actions[actionIndex - 1].Cost, action.Redo, action.Undo, action.Data);
-
-                Undo();
-                base.AddAction(combinedAction);
+                ((MicrobeRigidityChangeAction)actions[actionIndex - 1]).Combine((MicrobeRigidityChangeAction)action);
                 return;
             }
         }

--- a/src/microbe_stage/editor/MicrobeEditorActionHistory.cs
+++ b/src/microbe_stage/editor/MicrobeEditorActionHistory.cs
@@ -5,9 +5,10 @@
         // If action is RigidityChange, try to combine it with the previous one.
         if (CanUndo())
         {
-            if (action is MicrobeRigidityChangeAction && actions[actionIndex - 1] is MicrobeRigidityChangeAction)
+            if (action is MicrobeRigidityChangeAction newAction
+                && actions[actionIndex - 1] is MicrobeRigidityChangeAction previousAction)
             {
-                ((MicrobeRigidityChangeAction)actions[actionIndex - 1]).Combine((MicrobeRigidityChangeAction)action);
+                previousAction.Combine(newAction);
                 return;
             }
         }

--- a/src/microbe_stage/editor/MicrobeEditorGUI.cs
+++ b/src/microbe_stage/editor/MicrobeEditorGUI.cs
@@ -1281,8 +1281,7 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
         UpdateMembraneButtons(membrane.InternalName);
         SetMembraneTooltips(membrane);
 
-        UpdateRigiditySlider((int)Math.Round(rigidity * Constants.MEMBRANE_RIGIDITY_SLIDER_TO_VALUE_RATIO),
-            editor.MutationPoints);
+        UpdateRigiditySlider((int)Math.Round(rigidity * Constants.MEMBRANE_RIGIDITY_SLIDER_TO_VALUE_RATIO));
     }
 
     internal void UpdateMembraneButtons(string membrane)
@@ -1294,17 +1293,8 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
         }
     }
 
-    internal void UpdateRigiditySlider(int value, int mutationPoints)
+    internal void UpdateRigiditySlider(int value)
     {
-        if (mutationPoints >= Constants.MEMBRANE_RIGIDITY_COST_PER_STEP && editor.MovingOrganelle == null)
-        {
-            rigiditySlider.Editable = true;
-        }
-        else
-        {
-            rigiditySlider.Editable = false;
-        }
-
         rigiditySlider.Value = value;
         SetRigiditySliderTooltip(value);
     }

--- a/src/microbe_stage/editor/MicrobeRigidityChangeAction.cs
+++ b/src/microbe_stage/editor/MicrobeRigidityChangeAction.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+public class MicrobeRigidityChangeAction : MicrobeEditorAction
+{
+    public MicrobeRigidityChangeAction(MicrobeEditor editor, int cost,
+        Action<MicrobeEditorAction> redo, Action<MicrobeEditorAction> undo, RigidityChangeActionData data = null)
+        : base(editor, cost, redo, undo, data)
+    {
+    }
+
+    public void Combine(MicrobeRigidityChangeAction newAction)
+    {
+        newAction.Perform();
+        ((RigidityChangeActionData)Data).NewRigidity = ((RigidityChangeActionData)newAction.Data).NewRigidity;
+        Cost += newAction.Cost;
+    }
+}


### PR DESCRIPTION
**Brief Description of What This PR Does**

Disabling the slide prevents sliding back and makes it a must to use undo. And if the player added something else after that, he can only undo all those things before he can use the slide bar again. So I just deleted that section of code.

Rigidity changes are combined.

**Related Issues**

Fixes #1496

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
