### PR TITLE
Fix compound amount label not updating on language change

### DIFF
--- a/src/gui_common/CompoundAmount.cs
+++ b/src/gui_common/CompoundAmount.cs
@@ -149,6 +149,8 @@ public class CompoundAmount : HBoxContainer
         {
             if (icon != null)
                 UpdateTooltip();
+
+            UpdateLabel();
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds `UpdateLabel` call to the CompoundAmount translation changed notification so it correctly displays the correct format based on the current locale.

**Related Issues**

Fixes #2433 

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
