### PR TITLE
Added safe check on loading species info for compatibility

### DIFF
--- a/src/microbe_stage/editor/MicrobeEditorGUI.cs
+++ b/src/microbe_stage/editor/MicrobeEditorGUI.cs
@@ -793,7 +793,16 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
                 var dataset = speciesPopulationChart.GetDataSet(entry.Key.FormattedName);
 
                 var extinctInPatch = entry.Value <= 0;
-                var extinctEverywhere = snapshot.RecordedSpeciesInfo[entry.Key].Population <= 0;
+                var extinctEverywhere = false;
+
+                // We test if the species info was recorded before using it.
+                // This is especially for compatibility with older versions, to avoid crashed due to an invalid key.
+                // TODO: Use a proper save upgrade (e.g. summing population to generate info).
+                SpeciesInfo speciesInfo;
+                if (snapshot.RecordedSpeciesInfo.TryGetValue(entry.Key, out speciesInfo))
+                {
+                    extinctEverywhere = speciesInfo.Population <= 0;
+                }
 
                 // Clamp population number so it doesn't go into the negatives
                 var population = extinctInPatch ? 0 : entry.Value;

--- a/src/microbe_stage/editor/MicrobeEditorGUI.cs
+++ b/src/microbe_stage/editor/MicrobeEditorGUI.cs
@@ -798,8 +798,7 @@ public class MicrobeEditorGUI : Node, ISaveLoadedTracked
                 // We test if the species info was recorded before using it.
                 // This is especially for compatibility with older versions, to avoid crashed due to an invalid key.
                 // TODO: Use a proper save upgrade (e.g. summing population to generate info).
-                SpeciesInfo speciesInfo;
-                if (snapshot.RecordedSpeciesInfo.TryGetValue(entry.Key, out speciesInfo))
+                if (snapshot.RecordedSpeciesInfo.TryGetValue(entry.Key, out SpeciesInfo speciesInfo))
                 {
                     extinctEverywhere = speciesInfo.Population <= 0;
                 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR hotfixes crashes due to #2427 , which occur when a dictionary was not filled in older versions.
It does not upgrade the save, so snapshot recorded previously will not display extinct species.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
