### PR TITLE
Enable check to require using inline variables in out declarations

### DIFF
--- a/Thrive.sln.DotSettings
+++ b/Thrive.sln.DotSettings
@@ -43,6 +43,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceUsingStatementBraces/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=IdentifierTypo/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InlineOutVariableDeclaration/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=JoinNullCheckWithUsage/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=JoinNullCheckWithUsageWhenPossible/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MergeCastWithTypeCheck/@EntryIndexedValue">WARNING</s:String>

--- a/src/microbe_stage/CompoundCloudSystem.cs
+++ b/src/microbe_stage/CompoundCloudSystem.cs
@@ -167,8 +167,7 @@ public class CompoundCloudSystem : Node, ISaveLoadedTracked
     {
         foreach (var cloud in clouds)
         {
-            int x, y;
-            if (cloud.ContainsPosition(worldPosition, out x, out y))
+            if (cloud.ContainsPosition(worldPosition, out var x, out var y))
             {
                 // Within cloud
 
@@ -187,8 +186,7 @@ public class CompoundCloudSystem : Node, ISaveLoadedTracked
     {
         foreach (var cloud in clouds)
         {
-            int x, y;
-            if (cloud.ContainsPosition(worldPosition, out x, out y))
+            if (cloud.ContainsPosition(worldPosition, out var x, out var y))
             {
                 // Within cloud
 
@@ -212,8 +210,7 @@ public class CompoundCloudSystem : Node, ISaveLoadedTracked
 
         foreach (var cloud in clouds)
         {
-            int x, y;
-            if (cloud.ContainsPosition(worldPosition, out x, out y))
+            if (cloud.ContainsPosition(worldPosition, out var x, out var y))
             {
                 cloud.GetCompoundsAt(x, y, result);
             }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes `out string stuff` the form that should be used, if not used, CI should fail.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
