### PR TITLE
Fixed nested ternary in MicrobeAI

### DIFF
--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -191,9 +191,19 @@ public class MicrobeAI
                 }
             }
 
-            var rivalThreshold = SpeciesOpportunism < Constants.MAX_SPECIES_OPPORTUNISM / 3 ? 1 :
-                SpeciesOpportunism < Constants.MAX_SPECIES_OPPORTUNISM * 2 / 3 ? 3 :
-                5;
+            int rivalThreshold;
+            if (SpeciesOpportunism < Constants.MAX_SPECIES_OPPORTUNISM / 3)
+            {
+                rivalThreshold = 1;
+            }
+            else if (SpeciesOpportunism < Constants.MAX_SPECIES_OPPORTUNISM * 2 / 3)
+            {
+                rivalThreshold = 3;
+            }
+            else
+            {
+                rivalThreshold = 5;
+            }
 
             // In rare instances, microbes will choose to be much more ambitious
             if (RollCheck(SpeciesFocus, Constants.MAX_SPECIES_FOCUS, random))


### PR DESCRIPTION
**Brief Description of What This PR Does**

fixes nested ternary (CI complains about bad indentation) in MicrobeAI

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
