### PR TITLE
Iron chunks normals

### DIFF
--- a/CIConfiguration.yml
+++ b/CIConfiguration.yml
@@ -11,7 +11,7 @@ jobs:
       shared:
         .git/lfs: v2-lfs
         .import: v2-import
-        builds: v2-builds
+        builds: v1-builds
     steps:
       # This is here to reimport assets, but this build would fail due to missing nuget packages
       # if C# was compiled here

--- a/CIConfiguration.yml
+++ b/CIConfiguration.yml
@@ -5,13 +5,13 @@ jobs:
     image: thrive/godot-ci:v10
     cache:
       loadFrom:
-        - v1-{Branch}-build
-        - v1-master-build
-      writeTo: v1-{Branch}-build
+        - v2-{Branch}-build
+        - v2-master-build
+      writeTo: v2-{Branch}-build
       shared:
         .git/lfs: v2-lfs
-        .import: v1-import
-        builds: v1-builds
+        .import: v2-import
+        builds: v2-builds
     steps:
       # This is here to reimport assets, but this build would fail due to missing nuget packages
       # if C# was compiled here

--- a/CIConfiguration.yml
+++ b/CIConfiguration.yml
@@ -5,12 +5,12 @@ jobs:
     image: thrive/godot-ci:v10
     cache:
       loadFrom:
-        - v2-{Branch}-build
-        - v2-master-build
+        - v3-{Branch}-build
+        - v3-master-build
       writeTo: v2-{Branch}-build
       shared:
         .git/lfs: v2-lfs
-        .import: v2-import
+        .import: v3-import
         builds: v1-builds
     steps:
       # This is here to reimport assets, but this build would fail due to missing nuget packages

--- a/assets/models/Iceshard1.tscn
+++ b/assets/models/Iceshard1.tscn
@@ -1,7 +1,6 @@
 [gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://assets/models/Iceshard1.mesh" type="ArrayMesh" id=1]
-[ext_resource path="res://shaders/Iceshard1.shader" type="Shader" id=2]
 
 [node name="iceshard1" type="MeshInstance"]
 transform = Transform( 100, 0, 0, 0, 100, 0, 0, 0, 100, 0, 0, 0 )

--- a/assets/models/Iceshard1.tscn
+++ b/assets/models/Iceshard1.tscn
@@ -1,6 +1,7 @@
 [gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://assets/models/Iceshard1.mesh" type="ArrayMesh" id=1]
+[ext_resource path="res://shaders/Iceshard1.shader" type="Shader" id=2]
 
 [node name="iceshard1" type="MeshInstance"]
 transform = Transform( 100, 0, 0, 0, 100, 0, 0, 0, 100, 0, 0, 0 )

--- a/assets/models/IronMaterial.material
+++ b/assets/models/IronMaterial.material
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:95cc8b5790fd5c13e015eac392ad0ebbe715bdc871e45aebb7a40cd6dbc5d894
-size 374
+oid sha256:adccd0142febf3ee97748e47f7760503015a7bb3c1ffb8e20256fd73fdbfcae7
+size 400

--- a/assets/models/IronMaterial.material
+++ b/assets/models/IronMaterial.material
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:adccd0142febf3ee97748e47f7760503015a7bb3c1ffb8e20256fd73fdbfcae7
-size 400
+oid sha256:95cc8b5790fd5c13e015eac392ad0ebbe715bdc871e45aebb7a40cd6dbc5d894
+size 374

--- a/assets/models/IronMaterial.material
+++ b/assets/models/IronMaterial.material
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:adc6f0152c87794b18dabc9265529b034f3e7d64629fa7f9bc2ebd3677c1731b
-size 403
+oid sha256:403d07a08d110e11d40935c13ab7c8a1ad401cf1a59945cae78b1d1698e33bfe
+size 402

--- a/assets/models/IronMaterial.material
+++ b/assets/models/IronMaterial.material
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:adccd0142febf3ee97748e47f7760503015a7bb3c1ffb8e20256fd73fdbfcae7
-size 400
+oid sha256:adc6f0152c87794b18dabc9265529b034f3e7d64629fa7f9bc2ebd3677c1731b
+size 403

--- a/assets/textures/iron_01.png
+++ b/assets/textures/iron_01.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd9fd4d8b6aee3c7770d47b4398f32e85a8020c0741d2e3deac147af254bcece
-size 1494741
+oid sha256:c58ff962fe22c2b463319a73e44b9fcc31483e797e0cb00665e566299672a06e
+size 1423886

--- a/assets/textures/iron_01.png
+++ b/assets/textures/iron_01.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c58ff962fe22c2b463319a73e44b9fcc31483e797e0cb00665e566299672a06e
-size 1423886
+oid sha256:dd9fd4d8b6aee3c7770d47b4398f32e85a8020c0741d2e3deac147af254bcece
+size 1494741

--- a/assets/textures/iron_bump.png.import
+++ b/assets/textures/iron_bump.png.import
@@ -2,26 +2,28 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/iron_bump.png-1261ba14aff12a85b13c6e01a8de3aac.stex"
+path.s3tc="res://.import/iron_bump.png-1261ba14aff12a85b13c6e01a8de3aac.s3tc.stex"
+path.etc2="res://.import/iron_bump.png-1261ba14aff12a85b13c6e01a8de3aac.etc2.stex"
 metadata={
-"vram_texture": false
+"imported_formats": [ "s3tc", "etc2" ],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/textures/iron_bump.png"
-dest_files=[ "res://.import/iron_bump.png-1261ba14aff12a85b13c6e01a8de3aac.stex" ]
+dest_files=[ "res://.import/iron_bump.png-1261ba14aff12a85b13c6e01a8de3aac.s3tc.stex", "res://.import/iron_bump.png-1261ba14aff12a85b13c6e01a8de3aac.etc2.stex" ]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/lossy_quality=0.7
 compress/hdr_mode=0
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
+flags/repeat=true
 flags/filter=true
-flags/mipmaps=false
+flags/mipmaps=true
 flags/anisotropic=false
 flags/srgb=2
 process/fix_alpha_border=true
@@ -30,5 +32,5 @@ process/HDR_as_SRGB=false
 process/invert_color=false
 stream=false
 size_limit=0
-detect_3d=true
+detect_3d=false
 svg/scale=1.0

--- a/assets/textures/iron_bump.png.import
+++ b/assets/textures/iron_bump.png.import
@@ -2,28 +2,26 @@
 
 importer="texture"
 type="StreamTexture"
-path.s3tc="res://.import/iron_bump.png-1261ba14aff12a85b13c6e01a8de3aac.s3tc.stex"
-path.etc2="res://.import/iron_bump.png-1261ba14aff12a85b13c6e01a8de3aac.etc2.stex"
+path="res://.import/iron_bump.png-1261ba14aff12a85b13c6e01a8de3aac.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://assets/textures/iron_bump.png"
-dest_files=[ "res://.import/iron_bump.png-1261ba14aff12a85b13c6e01a8de3aac.s3tc.stex", "res://.import/iron_bump.png-1261ba14aff12a85b13c6e01a8de3aac.etc2.stex" ]
+dest_files=[ "res://.import/iron_bump.png-1261ba14aff12a85b13c6e01a8de3aac.stex" ]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/lossy_quality=0.7
 compress/hdr_mode=0
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=true
+flags/repeat=0
 flags/filter=true
-flags/mipmaps=true
+flags/mipmaps=false
 flags/anisotropic=false
 flags/srgb=2
 process/fix_alpha_border=true
@@ -32,5 +30,5 @@ process/HDR_as_SRGB=false
 process/invert_color=false
 stream=false
 size_limit=0
-detect_3d=false
+detect_3d=true
 svg/scale=1.0

--- a/shaders/IronChunk.shader
+++ b/shaders/IronChunk.shader
@@ -1,8 +1,8 @@
 shader_type spatial;
 render_mode depth_draw_alpha_prepass;
 
-uniform sampler2D Texture : hint_albedo;
-uniform sampler2D Normals;
+uniform sampler2D albedo : hint_albedo;
+uniform sampler2D normals;
 
 uniform sampler2D dissolveTexture : hint_albedo;
 uniform float dissolveValue : hint_range(0, 1);
@@ -11,8 +11,8 @@ uniform float outlineWidth;
 uniform vec4 growColor : hint_color;
 
 void fragment() {
-    vec4 mainTex = texture(Texture, UV);
-    vec4 normalmap = texture(Normals, UV);
+    vec4 mainTex = texture(albedo, UV);
+    vec4 normalmap = texture(normals, UV);
     vec4 dissolveTex = texture(dissolveTexture, UV);
 
     float cutoff = dot(dissolveTex.rgb, vec3(0.4, 0.4, 0.4)) -

--- a/shaders/IronChunk.shader
+++ b/shaders/IronChunk.shader
@@ -24,7 +24,7 @@ void fragment() {
 
     ALBEDO = mainTex.rgb;
     NORMALMAP = normalMap.xyz;
-    METALLIC= 0.9 * (((ALBEDO.r + ALBEDO.g + ALBEDO.b) / 3.0) * -1.0 + 1.0);
+    METALLIC = 0.9 * (((ALBEDO.r + ALBEDO.g + ALBEDO.b) / 3.0) * -1.0 + 1.0);
     ROUGHNESS = 0.85;
     ALPHA = round(cutoff) * mainTex.a;
     EMISSION = dissolveOutline;

--- a/shaders/IronChunk.shader
+++ b/shaders/IronChunk.shader
@@ -1,8 +1,8 @@
 shader_type spatial;
 render_mode depth_draw_alpha_prepass;
 
-uniform sampler2D albedo : hint_albedo;
-uniform sampler2D normals;
+uniform sampler2D albedoTexture : hint_albedo;
+uniform sampler2D normalTexture;
 
 uniform sampler2D dissolveTexture : hint_albedo;
 uniform float dissolveValue : hint_range(0, 1);
@@ -11,8 +11,8 @@ uniform float outlineWidth;
 uniform vec4 growColor : hint_color;
 
 void fragment() {
-    vec4 mainTex = texture(albedo, UV);
-    vec4 normalmap = texture(normals, UV);
+    vec4 mainTex = texture(albedoTexture, UV);
+    vec4 normalMap = texture(normalTexture, UV);
     vec4 dissolveTex = texture(dissolveTexture, UV);
 
     float cutoff = dot(dissolveTex.rgb, vec3(0.4, 0.4, 0.4)) -
@@ -23,7 +23,7 @@ void fragment() {
 
 
     ALBEDO = mainTex.rgb;
-    NORMALMAP = normalmap.xyz;
+    NORMALMAP = normalMap.xyz;
     METALLIC= 0.9 * (((ALBEDO.r + ALBEDO.g + ALBEDO.b) / 3.0) * -1.0 + 1.0);
     ROUGHNESS = 0.85;
     ALPHA = round(cutoff) * mainTex.a;

--- a/shaders/IronChunk.shader
+++ b/shaders/IronChunk.shader
@@ -1,8 +1,7 @@
 shader_type spatial;
 render_mode depth_draw_alpha_prepass;
 
-uniform sampler2D Texture : hint_albedo;
-uniform sampler2D Normals;
+uniform sampler2D texture : hint_albedo;
 
 uniform sampler2D dissolveTexture : hint_albedo;
 uniform float dissolveValue : hint_range(0, 1);
@@ -11,8 +10,7 @@ uniform float outlineWidth;
 uniform vec4 growColor : hint_color;
 
 void fragment() {
-    vec4 mainTex = texture(Texture, UV);
-    vec4 normalmap = texture(Normals, UV);
+    vec4 mainTex = texture(texture, UV);
     vec4 dissolveTex = texture(dissolveTexture, UV);
 
     float cutoff = dot(dissolveTex.rgb, vec3(0.4, 0.4, 0.4)) -
@@ -21,11 +19,9 @@ void fragment() {
     vec3 dissolveOutline = vec3(round(1.0 - float(cutoff - outlineWidth))) *
         growColor.rgb;
 
+    // TODO: Radioactive chunk effect
 
     ALBEDO = mainTex.rgb;
-    NORMALMAP = normalmap.xyz;
-    METALLIC= 0.9 * (((ALBEDO.r + ALBEDO.g + ALBEDO.b) / 3.0) * -1.0 + 1.0);
-    ROUGHNESS = 0.85;
     ALPHA = round(cutoff) * mainTex.a;
     EMISSION = dissolveOutline;
 }

--- a/shaders/IronChunk.shader
+++ b/shaders/IronChunk.shader
@@ -1,7 +1,8 @@
 shader_type spatial;
 render_mode depth_draw_alpha_prepass;
 
-uniform sampler2D texture : hint_albedo;
+uniform sampler2D Texture : hint_albedo;
+uniform sampler2D Normals;
 
 uniform sampler2D dissolveTexture : hint_albedo;
 uniform float dissolveValue : hint_range(0, 1);
@@ -10,7 +11,8 @@ uniform float outlineWidth;
 uniform vec4 growColor : hint_color;
 
 void fragment() {
-    vec4 mainTex = texture(texture, UV);
+    vec4 mainTex = texture(Texture, UV);
+    vec4 normalmap = texture(Normals, UV);
     vec4 dissolveTex = texture(dissolveTexture, UV);
 
     float cutoff = dot(dissolveTex.rgb, vec3(0.4, 0.4, 0.4)) -
@@ -19,9 +21,11 @@ void fragment() {
     vec3 dissolveOutline = vec3(round(1.0 - float(cutoff - outlineWidth))) *
         growColor.rgb;
 
-    // TODO: Radioactive chunk effect
 
     ALBEDO = mainTex.rgb;
+    NORMALMAP = normalmap.xyz;
+    METALLIC= 0.9 * (((ALBEDO.r + ALBEDO.g + ALBEDO.b) / 3.0) * -1.0 + 1.0);
+    ROUGHNESS = 0.85;
     ALPHA = round(cutoff) * mainTex.a;
     EMISSION = dissolveOutline;
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Changes the Iron Chunk shader to use normal mapping along with METALLIC and ROUGHNESS.

**Related Issues**

no related issue, just noticed unused files

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
