### PR TITLE
Added new event for input map changing

### DIFF
--- a/src/engine/input/key_mapping/InputDataList.cs
+++ b/src/engine/input/key_mapping/InputDataList.cs
@@ -12,6 +12,9 @@ public class InputDataList : ICloneable
         Data = data;
     }
 
+    /// <summary>
+    ///   Triggered when (possibly) changed inputs are applied to the Godot input map
+    /// </summary>
     public static event EventHandler InputsRemapped;
 
     /// <summary>

--- a/src/engine/input/key_mapping/InputDataList.cs
+++ b/src/engine/input/key_mapping/InputDataList.cs
@@ -12,6 +12,8 @@ public class InputDataList : ICloneable
         Data = data;
     }
 
+    public static event EventHandler InputsRemapped;
+
     /// <summary>
     ///   The key map, key is the godot action name and the list contains the keys that are used to trigger that action
     /// </summary>
@@ -54,5 +56,7 @@ public class InputDataList : ICloneable
                 InputMap.ActionAddEvent(action.Key, inputEvent.ToInputEvent());
             }
         }
+
+        InputsRemapped?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/gui_common/CustomRichTextLabel.cs
+++ b/src/gui_common/CustomRichTextLabel.cs
@@ -52,6 +52,16 @@ public class CustomRichTextLabel : RichTextLabel
         }
     }
 
+    public override void _EnterTree()
+    {
+        InputDataList.InputsRemapped += OnInputsRemapped;
+    }
+
+    public override void _ExitTree()
+    {
+        InputDataList.InputsRemapped -= OnInputsRemapped;
+    }
+
     public override void _Ready()
     {
         // Make sure bbcode is enabled
@@ -305,5 +315,10 @@ public class CustomRichTextLabel : RichTextLabel
         }
 
         return output;
+    }
+
+    private void OnInputsRemapped(object sender, EventArgs arsg)
+    {
+        ParseCustomTags();
     }
 }

--- a/src/gui_common/CustomRichTextLabel.cs
+++ b/src/gui_common/CustomRichTextLabel.cs
@@ -54,11 +54,13 @@ public class CustomRichTextLabel : RichTextLabel
 
     public override void _EnterTree()
     {
+        base._EnterTree();
         InputDataList.InputsRemapped += OnInputsRemapped;
     }
 
     public override void _ExitTree()
     {
+        base._ExitTree();
         InputDataList.InputsRemapped -= OnInputsRemapped;
     }
 

--- a/src/gui_common/KeyPrompt.cs
+++ b/src/gui_common/KeyPrompt.cs
@@ -41,6 +41,7 @@ public class KeyPrompt : TextureRect
 
         // TODO: should this rather happen in _Ready and unregister happen in dispose?
         KeyPromptHelper.IconsChanged += OnIconsChanged;
+        InputDataList.InputsRemapped += OnIconsChanged;
         Refresh();
     }
 
@@ -49,6 +50,7 @@ public class KeyPrompt : TextureRect
         base._ExitTree();
 
         KeyPromptHelper.IconsChanged -= OnIconsChanged;
+        InputDataList.InputsRemapped -= OnIconsChanged;
     }
 
     /// <summary>


### PR DESCRIPTION
**Brief Description of What This PR Does**

`InputDataList` now contains an input map change event for any keybind dependent things to listen to since that's where any modified keybinds are applied to the InputMap. Registered said event to the `KeyPrompt`'s `OnIconsChanged` callback.

**Related Issues**

Fixes #2485 
Fixes #2361

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
