### PR TITLE
Fix blank keyprompt

### DIFF
--- a/src/gui_common/CustomRichTextLabel.cs
+++ b/src/gui_common/CustomRichTextLabel.cs
@@ -319,7 +319,7 @@ public class CustomRichTextLabel : RichTextLabel
         return output;
     }
 
-    private void OnInputsRemapped(object sender, EventArgs arsg)
+    private void OnInputsRemapped(object sender, EventArgs args)
     {
         ParseCustomTags();
     }

--- a/src/gui_common/KeyPromptHelper.cs
+++ b/src/gui_common/KeyPromptHelper.cs
@@ -67,6 +67,16 @@ public static class KeyPromptHelper
     }
 
     /// <summary>
+    ///   Mapping of current Theme to the names of blank images, valid values: "Black", "White"
+    /// </summary>
+    public static string BlankTheme => theme switch
+    {
+        "Dark" => "Black",
+        "Light" => "White",
+        _ => theme,
+    };
+
+    /// <summary>
     ///   The current primary input method for showing button prompts with
     /// </summary>
     public static ActiveInputMethod InputMethod
@@ -140,7 +150,7 @@ public static class KeyPromptHelper
     /// </summary>
     public static string GetPathForInvalidKey()
     {
-        return $"res://assets/textures/gui/xelu_prompts/Keyboard_Mouse/Blanks/Blank_{Theme}_Normal.png";
+        return $"res://assets/textures/gui/xelu_prompts/Keyboard_Mouse/Blanks/Blank_{BlankTheme}_Normal.png";
     }
 
     /// <summary>


### PR DESCRIPTION
**Brief Description of What This PR Does**
Fixes the "blank" key image path used when no proper key image is found for a button prompt

also fixed a typo I noticed in the PR I just merged

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
