### PR TITLE
Fixed crash with Duplicate Player cheat after loading

### DIFF
--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -1316,13 +1316,16 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
         }
     }
 
-    public void OnDestroyed()
+    public override void _ExitTree()
     {
         if (IsPlayerMicrobe)
-        {
             CheatManager.OnPlayerDuplicationCheatUsed -= OnPlayerDuplicationCheat;
-        }
 
+        base._ExitTree();
+    }
+
+    public void OnDestroyed()
+    {
         Colony?.RemoveFromColony(this);
 
         AliveMarker.Alive = false;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes an ObjectDisposed exception when using the DuplicatePlayer cheat after loading.

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
