### PR TITLE
Fixed rare crash with invalid shape ids and removed useless lock

### DIFF
--- a/src/engine/NodeHelpers.cs
+++ b/src/engine/NodeHelpers.cs
@@ -97,25 +97,13 @@ public static class NodeHelpers
     /// </remarks>
     public static void ReParent(this Node node, Node newParent)
     {
-        // TODO: remove this lock from here. This shouldn't even help at all, unless Godot runs physics callbacks
-        // concurrently. I'm pretty sure that is not the case so this shouldn't even help at all as this won't prevent
-        // the same thread from going in here at all. If it turns out that Godot *does* run physics callbacks from
-        // multiple threads, we need to investigate all of our callbacks and move to using Invoke for any that do
-        // non-thread safe operations or ones that affect Godot node trees.
-        // After reading through the callbacks, this *might* be caused by re-parenting happening during a physics
-        // callback causing a nested call for contact end callbacks as the re-parenting operation removes the node
-        // from a scene, which presumably triggers the end contact callbacks.
-        // https://github.com/Revolutionary-Games/Thrive/issues/2504
-        lock (node.GetParent())
+        if (node.GetParent() == null)
         {
-            if (node.GetParent() == null)
-            {
-                GD.PrintErr("Node needs parent to be re-parented");
-                return;
-            }
-
-            node.GetParent().RemoveChild(node);
-            newParent.AddChild(node);
+            GD.PrintErr("Node needs parent to be re-parented");
+            return;
         }
+
+        node.GetParent().RemoveChild(node);
+        newParent.AddChild(node);
     }
 }

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -2495,23 +2495,10 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
 
         if (body is Microbe microbe)
         {
-            Microbe hitMicrobe;
-
-            // The two microbes stopped contact because they bound, but re-parenting is not complete yet.
-            // Due to shape re-parenting localShape is no longer valid and we should remove the touchedMicrobe
-            // from the colony master (to whom we made contact).
-            // TODO: is it *really* necessary to check if the parent nodes are microbe instances. This seems very
-            // hacky thing to me - hhyyrylainen
+            // GetMicrobeFromShape returns null when it was provided an invalid shape id.
+            // This can happen when re-parenting is in progress.
             // https://github.com/Revolutionary-Games/Thrive/issues/2504
-            if (Colony != null && Colony == microbe.Colony &&
-                !(microbe.GetParent() is Microbe && GetParent() is Microbe))
-            {
-                hitMicrobe = this;
-            }
-            else
-            {
-                hitMicrobe = GetMicrobeFromShape(localShape);
-            }
+            var hitMicrobe = GetMicrobeFromShape(localShape) ?? this;
 
             // TODO: should this also check for pilus before removing the collision?
             hitMicrobe.touchedMicrobes.Remove(microbe);


### PR DESCRIPTION
Follow up to #2391

- Removed the weird check in `OnContactEnd`.
- Removed useless lock in `ReParent`.

I've messed up with debugging in `ReParent`. I've seen a NullPointer exception on the `node.GetParent().RemoveChild(node);` line and have checked the output of `node.GetParent()`, which returned null, therefore I concluded that this had to be a threading problem, but this was wrong. The null exception actually happened in `OnContactEnd` which `RemoveChild` seems to call internally. My IDE couldn't follow the internal godot call and therefore showed my an exception on the `RemoveChild` line. The child has been removed successfully which lead to `node.GetParent()` being null, which confused me.