### PR TITLE
Update Godot version to 3.3.3

### DIFF
--- a/CIConfiguration.yml
+++ b/CIConfiguration.yml
@@ -2,7 +2,7 @@ version: 1
 
 jobs:
   build:
-    image: thrive/godot-ci:v10
+    image: thrive/godot-ci:v11
     cache:
       loadFrom:
         - v3-{Branch}-build
@@ -30,7 +30,7 @@ jobs:
           name: Upload devbuilds
           command: ./upload_devbuilds.rb
   jetbrains:
-    image: thrive/godot-ci:v10
+    image: thrive/godot-ci:v11
     cache:
       loadFrom:
         - v1-{Branch}-jetbrains

--- a/check_formatting.rb
+++ b/check_formatting.rb
@@ -610,7 +610,7 @@ end
 def run_inspect_code
   return if skip_jetbrains?
 
-  params = [inspect_code_executable, 'Thrive.sln', '-o=inspect_results.xml']
+  params = [inspect_code_executable, 'Thrive.sln', '-o=inspect_results.xml', '--build']
 
   params.append "--include=#{@includes.join(';')}" if @includes
 

--- a/doc/setup_instructions.md
+++ b/doc/setup_instructions.md
@@ -24,7 +24,7 @@ Prerequisites
 Godot mono version
 ------------------
 
-The currently used Godot version is __3.3.2 mono__. The regular version
+The currently used Godot version is __3.3.3 mono__. The regular version
 will not work. You can download Godot here: https://godotengine.org/download/
 if it is still the latest stable version. If a new version of Godot has
 been released but Thrive has not been updated yet, you need to look

--- a/doc/setup_instructions.md
+++ b/doc/setup_instructions.md
@@ -451,7 +451,7 @@ sudo npm install -g jsonlint
 Download from:
 https://www.jetbrains.com/resharper/download/#section=commandline
 unzip and add to PATH. Currently used version is:
-JetBrains.ReSharper.CommandLineTools.2021.2
+JetBrains.ReSharper.CommandLineTools.2021.2.1
 
 NOTE: there is more documentation on the install process here:
 https://www.jetbrains.com/help/resharper/InspectCode.html

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -10,7 +10,7 @@ RUN wget https://download.jetbrains.com/resharper/dotUltimate.2021.2/JetBrains.R
     -O jetbrains.zip && unzip jetbrains.zip -d /usr/bin && rm -rf jetbrains.zip && chmod +x /usr/bin/*.sh
 
 # Godot install
-ENV GODOT_VERSION "3.3.2"
+ENV GODOT_VERSION "3.3.3"
 
 RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/mono/Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64.zip \
     && wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/mono/Godot_v${GODOT_VERSION}-stable_mono_export_templates.tpz \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -6,7 +6,7 @@ RUN git lfs install
 RUN gem install os colorize rubyzip json sha3 httparty parallel nokogiri
 
 # Jetbrains CLI tools
-RUN wget https://download.jetbrains.com/resharper/dotUltimate.2021.2/JetBrains.ReSharper.CommandLineTools.2021.2.zip \
+RUN wget https://download.jetbrains.com/resharper/dotUltimate.2021.2.1/JetBrains.ReSharper.CommandLineTools.2021.2.1.zip \
     -O jetbrains.zip && unzip jetbrains.zip -d /usr/bin && rm -rf jetbrains.zip && chmod +x /usr/bin/*.sh
 
 # Godot install

--- a/scripts/godot_version.rb
+++ b/scripts/godot_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 # Defines the godot version the install scripts use
-GODOT_VERSION = '3.3.2'
+GODOT_VERSION = '3.3.3'
 GODOT_VERSION_FULL = "#{GODOT_VERSION}.stable.mono"


### PR DESCRIPTION
Updates Godot to 3.3.3 which released today. The release notes can be found here [here](https://godotengine.org/article/maintenance-release-godot-3-3-3). I Played a quick game and everything seems to be working.