### PR TITLE
Mention homebrew in setup instructions and fix capitalization

### DIFF
--- a/doc/setup_instructions.md
+++ b/doc/setup_instructions.md
@@ -43,13 +43,15 @@ To clone the Thrive repository properly you need Git with Git LFS.
 
 You need at least Git LFS version 2.8.0, old versions do not work.
 
-On Linux and mac use your package manager to install git. Git lfs is
-likely available as a package named `git-lfs`. If it is not install it
-manually. After installing remember to run `git lfs install` in terminal.
+On Linux use your package manager to install Git. On Mac install the
+package manager [homebrew](https://brew.sh/) if you don't already have
+it, and use it to install Git. On Mac and Linux Git LFS is likely available
+as a package named `git-lfs`. If it is not install it manually. After
+installing remember to run `git lfs install` in terminal.
 
 On Windows install Git with the official installer from:
 https://git-scm.com/download/win You can use this installer to also
-install git lfs for you. After installing you need to run `git lfs
+install Git LFS for you. After installing you need to run `git lfs
 install` in command prompt. You'll probably want to turn autocrlf on
 with the command `git config --global core.autocrlf true`. If you don't,
 there is a risk that you accidentally commit Windows-style line
@@ -66,7 +68,7 @@ have to deleted all your cloned folders to avoid errors, and reboot
 your computer to have everything detect that Git is now in a different
 place.
 
-If you haven't used git before you can read a free online book to learn
+If you haven't used Git before you can read a free online book to learn
 it here https://git-scm.com/book/en/v2 or if you prefer video learning
 these two are recommended https://www.youtube.com/watch?v=SWYqp7iY_Tc
 https://www.youtube.com/watch?v=HVsySz-h9r4


### PR DESCRIPTION
Mentions installing homebrew on macos and links to the site. I've also fixed the capitalization of Git and Git LFS in two places. Closes #2317 