### PR TITLE
Resubscribe player duplication event on microbe tree enter

### DIFF
--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -462,8 +462,6 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
             // Setup tracking running processes
             ProcessStatistics = new ProcessStatistics();
 
-            CheatManager.OnPlayerDuplicationCheatUsed += OnPlayerDuplicationCheat;
-
             GD.Print("Player Microbe spawned");
         }
 
@@ -1359,6 +1357,12 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
                 OnReproductionStatus(this, true);
             }
         }
+    }
+
+    public override void _EnterTree()
+    {
+        if (IsPlayerMicrobe)
+            CheatManager.OnPlayerDuplicationCheatUsed += OnPlayerDuplicationCheat;
     }
 
     public override void _ExitTree()


### PR DESCRIPTION
**Brief Description of What This PR Does**

Was only missing re-subscription to `OnPlayerDuplicationCheatUsed` event after microbe enters the tree as the event was unsubscribed due to the player moving to the editor and microbe stage exiting the tree. I suspect this happens after https://github.com/Revolutionary-Games/Thrive/pull/2502.

**Related Issues**

Fixes #2519 

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
