### PR TITLE
Retool Toxin mechanics and AI

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -165,7 +165,7 @@ public static class Constants
     /// <summary>
     ///   The minimum amount of oxytoxy (or any agent) needed to be able to shoot.
     /// </summary>
-    public const float MINIMUM_AGENT_EMISSION_AMOUNT = 1;
+    public const float MINIMUM_AGENT_EMISSION_AMOUNT = 1.0f;
 
     /// <summary>
     ///   The time (in seconds) it takes a cloud being absorbed to halve its compounds.

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -130,7 +130,7 @@ public static class Constants
     /// </summary>
     public const float AGENT_EMISSION_IMPULSE_STRENGTH = 20.0f;
 
-    public const float OXYTOXY_DAMAGE = 10.0f;
+    public const float OXYTOXY_DAMAGE = 30.0f;
 
     /// <summary>
     ///   Delay when a toxin hits or expires until it is destroyed. This is used to give some time for the effect to
@@ -165,7 +165,7 @@ public static class Constants
     /// <summary>
     ///   The minimum amount of oxytoxy (or any agent) needed to be able to shoot.
     /// </summary>
-    public const float MINIMUM_AGENT_EMISSION_AMOUNT = 1.0f;
+    public const float MINIMUM_AGENT_EMISSION_AMOUNT = 2.0f;
 
     /// <summary>
     ///   The time (in seconds) it takes a cloud being absorbed to halve its compounds.

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -163,9 +163,9 @@ public static class Constants
     public const float AGENT_EMISSION_COOLDOWN = 2.0f;
 
     /// <summary>
-    ///   The minimum amount of oxytoxy (or any agent) needed to be able to shoot.
+    ///   The maximum amount of oxytoxy (or any agent) fired in one shot.
     /// </summary>
-    public const float MINIMUM_AGENT_EMISSION_AMOUNT = 2.0f;
+    public const float MAXIMUM_AGENT_EMISSION_AMOUNT = 2.0f;
 
     /// <summary>
     ///   The time (in seconds) it takes a cloud being absorbed to halve its compounds.

--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -44,7 +44,7 @@
             "atp": 8
         },
         "outputs": {
-            "oxytoxy": 1
+            "oxytoxy": 1.5
         }
     },
     "bacterial_oxytoxySynthesis": {
@@ -54,7 +54,7 @@
             "atp": 5
         },
         "outputs": {
-            "oxytoxy": 0.1
+            "oxytoxy": 0.15
         }
     },
     "chemoSynthesis": {

--- a/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
@@ -69,6 +69,12 @@ public class HeterotrophicFoodSource : FoodSource
         // Pili are much more useful if the microbe can close to melee
         pilusScore *= predatorSpeed;
 
+        // predators are less likely to use toxin against larger prey, unless they are opportunistic
+        if (preySize > predatorSize)
+        {
+            oxytoxyScore *= microbeSpecies.Opportunism / Constants.MAX_SPECIES_OPPORTUNISM;
+        }
+
         // Intentionally don't penalize for osmoregulation cost to encourage larger monsters
         return behaviorScore * (pilusScore + engulfScore + predatorSize + oxytoxyScore);
     }

--- a/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
@@ -69,7 +69,7 @@
         pilusScore *= predatorSpeed;
 
         // predators are less likely to use toxin against larger prey, unless they are opportunistic
-        if (preySize > predatorSize)
+        if (preyHexSize > microbeSpeciesHexSize)
         {
             oxytoxyScore *= microbeSpecies.Opportunism / Constants.MAX_SPECIES_OPPORTUNISM;
         }

--- a/src/microbe_stage/AgentProjectile.cs
+++ b/src/microbe_stage/AgentProjectile.cs
@@ -53,7 +53,7 @@ public class AgentProjectile : RigidBody, ITimedLife
             {
                 // If more stuff needs to be damaged we
                 // could make an IAgentDamageable interface.
-                microbe.GetMicrobeFromShape(bodyShape).Damage(Constants.OXYTOXY_DAMAGE, Properties.AgentType);
+                microbe.GetMicrobeFromShape(bodyShape).Damage(Constants.OXYTOXY_DAMAGE * Amount, Properties.AgentType);
             }
         }
 

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -868,7 +868,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
                 var direction = new Vector3(random.Next(0.0f, 1.0f) * 2 - 1,
                     0, random.Next(0.0f, 1.0f) * 2 - 1);
 
-                SpawnHelpers.SpawnAgent(props, 10.0f, Constants.EMITTED_AGENT_LIFETIME,
+                SpawnHelpers.SpawnAgent(props, 1.0f, Constants.EMITTED_AGENT_LIFETIME,
                     Translation, direction, GetStageAsParent(),
                     agentScene, this);
 

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -640,11 +640,11 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
         float amountAvailable = Compounds.GetCompoundAmount(agentType);
 
         // Emit as much as you have, but don't start the cooldown if that's zero
-        float amountEmitted = Math.Min(amountAvailable / Constants.MINIMUM_AGENT_EMISSION_AMOUNT, 1.0f);
+        float amountEmitted = Math.Min(amountAvailable / Constants.MAXIMUM_AGENT_EMISSION_AMOUNT, 1.0f);
         if (amountEmitted < MathUtils.EPSILON)
             return;
 
-        Compounds.TakeCompound(agentType, amountEmitted * Constants.MINIMUM_AGENT_EMISSION_AMOUNT);
+        Compounds.TakeCompound(agentType, amountEmitted * Constants.MAXIMUM_AGENT_EMISSION_AMOUNT);
 
         // The cooldown time is inversely proportional to the amount of agent vacuoles.
         AgentEmissionCooldown = Constants.AGENT_EMISSION_COOLDOWN / AgentVacuoleCount;
@@ -863,7 +863,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
 
             var agentScene = SpawnHelpers.LoadAgentScene();
 
-            while (amount > Constants.MINIMUM_AGENT_EMISSION_AMOUNT)
+            while (amount > Constants.MAXIMUM_AGENT_EMISSION_AMOUNT)
             {
                 var direction = new Vector3(random.Next(0.0f, 1.0f) * 2 - 1,
                     0, random.Next(0.0f, 1.0f) * 2 - 1);
@@ -872,7 +872,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
                     Translation, direction, GetStageAsParent(),
                     agentScene, this);
 
-                amount -= Constants.MINIMUM_AGENT_EMISSION_AMOUNT;
+                amount -= Constants.MAXIMUM_AGENT_EMISSION_AMOUNT;
                 ++createdAgents;
 
                 if (createdAgents >= Constants.MAX_EMITTED_AGENTS_ON_DEATH)

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -567,9 +567,8 @@ public class MicrobeAI
         var sizeRatio = microbe.EngulfSize / targetMicrobe.EngulfSize;
 
         return targetMicrobe.Species != microbe.Species && (
-            (SpeciesOpportunism > Constants.MAX_SPECIES_OPPORTUNISM * 0.5 && CanShootToxin() &&
-                sizeRatio > 1 / Constants.ENGULF_SIZE_RATIO_REQ) ||
-            (sizeRatio >= Constants.ENGULF_SIZE_RATIO_REQ));
+            (SpeciesOpportunism > Constants.MAX_SPECIES_OPPORTUNISM * 0.5 && CanShootToxin())
+            || (sizeRatio >= Constants.ENGULF_SIZE_RATIO_REQ));
     }
 
     private bool CanShootToxin()

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -390,7 +390,7 @@ public class MicrobeAI
         microbe.State = engulf ? Microbe.MicrobeState.Engulf : Microbe.MicrobeState.Normal;
         targetPosition = target;
         microbe.LookAtPoint = targetPosition;
-        if (microbe.Compounds.GetCompoundAmount(oxytoxy) >= Constants.MINIMUM_AGENT_EMISSION_AMOUNT)
+        if (microbe.Compounds.GetCompoundAmount(oxytoxy) >= Constants.MAXIMUM_AGENT_EMISSION_AMOUNT)
         {
             LaunchToxin(target);
 
@@ -573,7 +573,7 @@ public class MicrobeAI
 
     private bool CanShootToxin()
     {
-        return microbe.Compounds.GetCompoundAmount(oxytoxy) >= Constants.MINIMUM_AGENT_EMISSION_AMOUNT;
+        return microbe.Compounds.GetCompoundAmount(oxytoxy) >= Constants.MAXIMUM_AGENT_EMISSION_AMOUNT;
     }
 
     private float DistanceFromMe(Vector3 target)

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -573,7 +573,8 @@ public class MicrobeAI
 
     private bool CanShootToxin()
     {
-        return microbe.Compounds.GetCompoundAmount(oxytoxy) >= Constants.MAXIMUM_AGENT_EMISSION_AMOUNT * SpeciesFocus / Constants.MAX_SPECIES_FOCUS;
+        return microbe.Compounds.GetCompoundAmount(oxytoxy) >=
+            Constants.MAXIMUM_AGENT_EMISSION_AMOUNT * SpeciesFocus / Constants.MAX_SPECIES_FOCUS;
     }
 
     private float DistanceFromMe(Vector3 target)

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -567,7 +567,7 @@ public class MicrobeAI
         var sizeRatio = microbe.EngulfSize / targetMicrobe.EngulfSize;
 
         return targetMicrobe.Species != microbe.Species && (
-            (SpeciesOpportunism > Constants.MAX_SPECIES_OPPORTUNISM * 0.5f && CanShootToxin())
+            (SpeciesOpportunism > Constants.MAX_SPECIES_OPPORTUNISM * 0.3f && CanShootToxin())
             || (sizeRatio >= Constants.ENGULF_SIZE_RATIO_REQ));
     }
 

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -573,7 +573,7 @@ public class MicrobeAI
 
     private bool CanShootToxin()
     {
-        return microbe.Compounds.GetCompoundAmount(oxytoxy) >= Constants.MAXIMUM_AGENT_EMISSION_AMOUNT;
+        return microbe.Compounds.GetCompoundAmount(oxytoxy) >= Constants.MAXIMUM_AGENT_EMISSION_AMOUNT * SpeciesFocus / Constants.MAX_SPECIES_FOCUS;
     }
 
     private float DistanceFromMe(Vector3 target)

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -567,7 +567,7 @@ public class MicrobeAI
         var sizeRatio = microbe.EngulfSize / targetMicrobe.EngulfSize;
 
         return targetMicrobe.Species != microbe.Species && (
-            (SpeciesOpportunism > Constants.MAX_SPECIES_OPPORTUNISM * 0.5 && CanShootToxin())
+            (SpeciesOpportunism > Constants.MAX_SPECIES_OPPORTUNISM * 0.5f && CanShootToxin())
             || (sizeRatio >= Constants.ENGULF_SIZE_RATIO_REQ));
     }
 

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -247,6 +247,7 @@ public static class SpawnHelpers
 
         worldRoot.AddChild(agent);
         agent.Translation = location + (direction * 1.5f);
+        agent.Scale = new Vector3(amount, amount, amount);
 
         agent.ApplyCentralImpulse(normalizedDirection *
             Constants.AGENT_EMISSION_IMPULSE_STRENGTH);


### PR DESCRIPTION
**Brief Description of What This PR Does**

Does 3 things:

* Makes toxin have a maximum emission of 2 instead of a minimum emission of 1. Microbes can now release toxin below fully capacity, with a proportionally smaller model and proportionally lower damage.
* Full toxin emission now deals 30 damage (albeit for double the compound cost), and generates 50% faster (and more efficiently)
* AI modified to be braver at attacking larger prey with toxin (with high enough opportunism), and to sometimes choose to use toxin at partial emission

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
