### PR TITLE
Fixed save upgrade not upgrading dictionary keys containing JSON 

### DIFF
--- a/assets/sounds/extinct2.ogg.import
+++ b/assets/sounds/extinct2.ogg.import
@@ -1,0 +1,15 @@
+[remap]
+
+importer="ogg_vorbis"
+type="AudioStreamOGGVorbis"
+path="res://.import/extinct2.ogg-6122e9d17446baa4f9ae52089e919650.oggstr"
+
+[deps]
+
+source_file="res://assets/sounds/extinct2.ogg"
+dest_files=[ "res://.import/extinct2.ogg-6122e9d17446baa4f9ae52089e919650.oggstr" ]
+
+[params]
+
+loop=true
+loop_offset=0

--- a/assets/sounds/extinct2.ogg.import
+++ b/assets/sounds/extinct2.ogg.import
@@ -11,5 +11,5 @@ dest_files=[ "res://.import/extinct2.ogg-6122e9d17446baa4f9ae52089e919650.oggstr
 
 [params]
 
-loop=true
+loop=false
 loop_offset=0


### PR DESCRIPTION
**Brief Description of What This PR Does**

when making the save upgrader I didn't remember that we put JSON in object keys, so this upgrades those as well.
also includes the import settings for the extinction track which was missing from the PR that added that.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

closes #2532

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
