### PR TITLE
Created a system for safely keeping game object references across frames

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -32,6 +32,7 @@
     <Compile Include="src\engine\ChildObjectCache.cs" />
     <Compile Include="src\engine\ChromaticFilter.cs" />
     <Compile Include="src\engine\ControlHelpers.cs" />
+    <Compile Include="src\engine\EntityReference.cs" />
     <Compile Include="src\engine\FeatureInformation.cs" />
     <Compile Include="src\engine\FileDropHandler.cs" />
     <Compile Include="src\engine\FullScreenToggle.cs" />
@@ -272,6 +273,7 @@
     <Compile Include="src\saving\serializers\CallbackConverter.cs" />
     <Compile Include="src\saving\serializers\CompoundCloudPlaneConverter.cs" />
     <Compile Include="src\saving\serializers\DynamicDeserializeObjectConverter.cs" />
+    <Compile Include="src\saving\serializers\EntityReferenceConverter.cs" />
     <Compile Include="src\saving\serializers\GodotColorConverter.cs" />
     <Compile Include="src\saving\serializers\GodotBasisConverter.cs" />
     <Compile Include="src\saving\serializers\NodeConverter.cs" />

--- a/doc/style_guide.md
+++ b/doc/style_guide.md
@@ -278,6 +278,17 @@ Godot usage
   `QueueFree`. You can instead call `DetachAndQueueFree`
   instead to detach them from parents automatically.
 
+- To support keeping references to game objects, we have `IEntity` interface
+  that all game objects need to implement. To keep references to these
+  entities, use the `EntityReference<T>` class. That class will
+  automatically clear the reference when the entity is destroyed. To
+  make this work all entity types need to properly implement the
+  `OnDestroyed` method and all code destroying entities must call that
+  method before freeing the Godot Node. Normal references can be used
+  for a single frame, and in fact if a single `EntityReference` needs
+  to be used multiple times, it is preferred to read out the value
+  from it to a local variable first.
+
 - The order of Godot overridden methods in a class should be in the
   following order: (class constructor), _Ready, _ExitTree, _Process,
   _Input, _UnhandledInput, (other callbacks)

--- a/src/engine/EntityReference.cs
+++ b/src/engine/EntityReference.cs
@@ -1,0 +1,147 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+/// <summary>
+///   Allows safely keeping references to game entities across multiple frames. Needs to be used instead of raw
+///   references as those can't clear themselves when the entity is disposed
+/// </summary>
+/// <typeparam name="T">The entity type</typeparam>
+public class EntityReference<T>
+    where T : class, IEntity
+{
+    // TODO: should this be somehow set to null when we detect that the alive marker is no longer alive
+    // Currently set to clear on fetch
+    private T currentInstance;
+    private AliveMarker currentAliveMarker;
+
+    public EntityReference(T value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    ///   Creates a reference that doesn't refer to anything
+    /// </summary>
+    public EntityReference()
+    {
+    }
+
+    /// <summary>
+    ///   Gets the referenced entity if it is still alive
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     If you need to access one object a bunch of times it's better to get the value from here once per frame
+    ///     and keep a normal reference around.
+    ///   </para>
+    /// </remarks>
+    public T Value
+    {
+        get
+        {
+            if (currentAliveMarker == null)
+                return null;
+
+            if (currentAliveMarker.Alive)
+                return currentInstance;
+
+            // Clear these references to let objects get garbage collected
+            currentInstance = null;
+            currentAliveMarker = null;
+            return null;
+        }
+        set
+        {
+            if (currentInstance == value)
+                return;
+
+            if (value == null)
+            {
+                currentInstance = null;
+                currentAliveMarker = null;
+            }
+            else
+            {
+                var marker = value.AliveMarker;
+
+                if (marker.Alive)
+                {
+                    currentInstance = value;
+                    currentAliveMarker = marker;
+                }
+                else
+                {
+                    currentInstance = null;
+                    currentAliveMarker = null;
+                }
+            }
+        }
+    }
+
+    [JsonIgnore]
+    public bool IsAlive => currentAliveMarker is { Alive: true };
+
+    public static implicit operator T(EntityReference<T> value)
+    {
+        return value.Value;
+    }
+
+    public static bool operator ==(EntityReference<T> lhs, EntityReference<T> rhs)
+    {
+        return Equals(lhs, rhs);
+    }
+
+    public static bool operator !=(EntityReference<T> lhs, EntityReference<T> rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    public static bool operator ==(EntityReference<T> lhs, T rhs)
+    {
+        if (lhs == null)
+            return rhs == null;
+
+        return lhs.Value == rhs;
+    }
+
+    public static bool operator !=(EntityReference<T> lhs, T rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    public void ClearIfNotAlive()
+    {
+        if (IsAlive)
+            return;
+
+        Value = null;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (obj == null)
+        {
+            return false;
+        }
+
+        if (GetType() != obj.GetType())
+        {
+            return false;
+        }
+
+        return Equals((EntityReference<T>)obj);
+    }
+
+    public bool Equals(EntityReference<T> obj)
+    {
+        return ReferenceEquals(Value, obj.Value);
+    }
+
+    public override int GetHashCode()
+    {
+        if (currentInstance == null)
+            return 19;
+
+        return EqualityComparer<T>.Default.GetHashCode(currentInstance);
+    }
+}

--- a/src/engine/NodeHelpers.cs
+++ b/src/engine/NodeHelpers.cs
@@ -6,6 +6,15 @@
 public static class NodeHelpers
 {
     /// <summary>
+    ///   Properly destroys a game entity. In addition to the normal Godot Free, Destroy must be called
+    /// </summary>
+    public static void DestroyDetachAndQueueFree(this IEntity entity)
+    {
+        entity.OnDestroyed();
+        entity.EntityNode.DetachAndQueueFree();
+    }
+
+    /// <summary>
     ///   Safely frees a Node. Detaches from parent if attached to not leave disposed objects in scene tree.
     ///   This should always be preferred over Free, except when multiple children should be deleted.
     ///   For that see <see cref="NodeHelpers.FreeChildren"/>

--- a/src/general/IEntity.cs
+++ b/src/general/IEntity.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Godot;
+using Newtonsoft.Json;
 
 /// <summary>
 ///   All game entities implement this interface to provide support for needed operations regarding them
@@ -16,6 +17,12 @@ public interface IEntity
     /// </remarks>
     [JsonIgnore]
     AliveMarker AliveMarker { get; }
+
+    /// <summary>
+    ///   The Node that this entity is in the game world as
+    /// </summary>
+    [JsonIgnore]
+    Node EntityNode { get; }
 
     void OnDestroyed();
 

--- a/src/microbe_stage/AgentProjectile.cs
+++ b/src/microbe_stage/AgentProjectile.cs
@@ -13,7 +13,7 @@ public class AgentProjectile : RigidBody, ITimedLife
     public float TimeToLiveRemaining { get; set; }
     public float Amount { get; set; }
     public AgentProperties Properties { get; set; }
-    public Node Emitter { get; set; }
+    public EntityReference<IEntity> Emitter { get; set; } = new EntityReference<IEntity>();
 
     [JsonProperty]
     private float? FadeTimeRemaining { get; set; }
@@ -28,7 +28,11 @@ public class AgentProjectile : RigidBody, ITimedLife
     {
         particles = GetNode<Particles>("Particles");
 
-        AddCollisionExceptionWith(Emitter);
+        var emitterNode = Emitter.Value?.EntityNode;
+
+        if (emitterNode != null)
+            AddCollisionExceptionWith(emitterNode);
+
         Connect("body_shape_entered", this, nameof(OnContactBegin));
     }
 

--- a/src/microbe_stage/FloatingChunk.cs
+++ b/src/microbe_stage/FloatingChunk.cs
@@ -54,7 +54,7 @@ public class FloatingChunk : RigidBody, ISpawned, ISaveLoadedTracked
     public int DespawnRadiusSquared { get; set; }
 
     [JsonIgnore]
-    public Node SpawnedNode => this;
+    public Node EntityNode => this;
 
     /// <summary>
     ///   Determines how big this chunk is for engulfing calculations. Set to &lt;= 0 to disable
@@ -369,8 +369,7 @@ public class FloatingChunk : RigidBody, ISpawned, ISaveLoadedTracked
 
         if (dissolveEffectValue >= 1)
         {
-            OnDestroyed();
-            this.DetachAndQueueFree();
+            this.DestroyDetachAndQueueFree();
         }
     }
 
@@ -461,8 +460,7 @@ public class FloatingChunk : RigidBody, ISpawned, ISaveLoadedTracked
         }
         else if (!isParticles)
         {
-            OnDestroyed();
-            this.DetachAndQueueFree();
+            this.DestroyDetachAndQueueFree();
         }
     }
 }

--- a/src/microbe_stage/ISpawned.cs
+++ b/src/microbe_stage/ISpawned.cs
@@ -1,6 +1,4 @@
-﻿using Godot;
-
-/// <summary>
+﻿/// <summary>
 ///   All nodes that can be spawned with the spawn system must implement this interface
 /// </summary>
 public interface ISpawned : IEntity
@@ -10,10 +8,4 @@ public interface ISpawned : IEntity
     ///   greater than this, it is despawned.
     /// </summary>
     int DespawnRadiusSquared { get; set; }
-
-    /// <summary>
-    ///   The Node that was spawned for this entity, used to tag it
-    ///   for detecting despawning.
-    /// </summary>
-    Node SpawnedNode { get; }
 }

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -75,7 +75,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
     private bool previousEngulfMode;
 
     [JsonProperty]
-    private Microbe hostileEngulfer;
+    private EntityReference<Microbe> hostileEngulfer = new EntityReference<Microbe>();
 
     [JsonProperty]
     private bool wasBeingEngulfed;
@@ -351,7 +351,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
     public bool IsForPreviewOnly { get; set; }
 
     [JsonIgnore]
-    public Node SpawnedNode => this;
+    public Node EntityNode => this;
 
     [JsonIgnore]
     public List<TweakedProcess> ActiveProcesses
@@ -2062,21 +2062,13 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
         }
 
         // Check whether we should not be being engulfed anymore
-        if (hostileEngulfer != null)
+        var hostile = hostileEngulfer.Value;
+        if (hostile != null)
         {
-            try
+            // Dead things can't engulf us
+            if (hostile.Dead)
             {
-                // Dead things can't engulf us
-                if (hostileEngulfer.Dead)
-                {
-                    hostileEngulfer = null;
-                    IsBeingEngulfed = false;
-                }
-            }
-            catch (ObjectDisposedException)
-            {
-                // Something that's disposed can't engulf us
-                hostileEngulfer = null;
+                hostileEngulfer.Value = null;
                 IsBeingEngulfed = false;
             }
         }
@@ -2110,7 +2102,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
         // Apply engulf effect (which will cause damage in their process call) to the cells we are engulfing
         foreach (var microbe in attemptingToEngulf)
         {
-            microbe.hostileEngulfer = this;
+            microbe.hostileEngulfer.Value = this;
             microbe.IsBeingEngulfed = true;
         }
     }
@@ -2122,13 +2114,13 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
         wasBeingEngulfed = false;
         IsBeingEngulfed = false;
 
-        if (hostileEngulfer != null)
+        if (hostileEngulfer.Value != null)
         {
             // Currently unused
             // hostileEngulfer.isCurrentlyEngulfing = false;
         }
 
-        hostileEngulfer = null;
+        hostileEngulfer.Value = null;
     }
 
     private void HandleOsmoregulation(float delta)
@@ -2191,8 +2183,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
 
         if (Membrane.DissolveEffectValue >= 1)
         {
-            OnDestroyed();
-            this.DetachAndQueueFree();
+            this.DestroyDetachAndQueueFree();
         }
     }
 
@@ -2651,7 +2642,7 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
     private void StartEngulfingTarget(Microbe microbe)
     {
         AddCollisionExceptionWith(microbe);
-        microbe.hostileEngulfer = this;
+        microbe.hostileEngulfer.Value = this;
         microbe.IsBeingEngulfed = true;
     }
 
@@ -2660,6 +2651,6 @@ public class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, ISaveLoade
         if (IsInstanceValid(microbe) && (Colony == null || Colony != microbe.Colony))
             RemoveCollisionExceptionWith(microbe);
 
-        microbe.hostileEngulfer = null;
+        microbe.hostileEngulfer.Value = null;
     }
 }

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -103,7 +103,7 @@ public class SpawnSystem
         float radius = Constants.MICROBE_SPAWN_RADIUS)
     {
         entity.DespawnRadiusSquared = (int)(radius * radius);
-        entity.SpawnedNode.AddToGroup(Constants.SPAWNED_GROUP);
+        entity.EntityNode.AddToGroup(Constants.SPAWNED_GROUP);
     }
 
     /// <summary>
@@ -171,8 +171,7 @@ public class SpawnSystem
                     continue;
                 }
 
-                spawned.OnDestroyed();
-                entity.DetachAndQueueFree();
+                spawned.DestroyDetachAndQueueFree();
             }
         }
     }
@@ -418,8 +417,7 @@ public class SpawnSystem
             if (squaredDistance > spawned.DespawnRadiusSquared)
             {
                 entitiesDeleted++;
-                spawned.OnDestroyed();
-                entity.DetachAndQueueFree();
+                spawned.DestroyDetachAndQueueFree();
 
                 if (entitiesDeleted >= maxEntitiesToDeletePerStep)
                     break;
@@ -440,7 +438,7 @@ public class SpawnSystem
         // just fine
         entity.DespawnRadiusSquared = spawnType.SpawnRadiusSquared;
 
-        entity.SpawnedNode.AddToGroup(Constants.SPAWNED_GROUP);
+        entity.EntityNode.AddToGroup(Constants.SPAWNED_GROUP);
     }
 
     /// <summary>

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -235,7 +235,7 @@ public static class SpawnHelpers
     /// </summary>
     public static AgentProjectile SpawnAgent(AgentProperties properties, float amount,
         float lifetime, Vector3 location, Vector3 direction,
-        Node worldRoot, PackedScene agentScene, Node emitter)
+        Node worldRoot, PackedScene agentScene, IEntity emitter)
     {
         var normalizedDirection = direction.Normalized();
 
@@ -243,7 +243,7 @@ public static class SpawnHelpers
         agent.Properties = properties;
         agent.Amount = amount;
         agent.TimeToLiveRemaining = lifetime;
-        agent.Emitter = emitter;
+        agent.Emitter = new EntityReference<IEntity>(emitter);
 
         worldRoot.AddChild(agent);
         agent.Translation = location + (direction * 1.5f);

--- a/src/saving/serializers/EntityReferenceConverter.cs
+++ b/src/saving/serializers/EntityReferenceConverter.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Reflection;
+using Newtonsoft.Json;
+
+public class EntityReferenceConverter : JsonConverter
+{
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+        if (value == null)
+        {
+            writer.WriteNull();
+            return;
+        }
+
+        var objectType = value.GetType();
+
+        var genericTypes = objectType.GenericTypeArguments;
+
+        if (genericTypes.Length != 1)
+            throw new JsonException("Invalid generic types for EntityReference");
+
+        // Even though Microbe is used here, it shouldn't matter at all, as we just want to grab the property name
+        var property = objectType.GetProperty(nameof(EntityReference<Microbe>.Value));
+
+        if (property == null)
+            throw new JsonException("Value property not found in EntityReference");
+
+        var internalValue = property.GetValue(value);
+
+        if (internalValue == null)
+        {
+            writer.WriteNull();
+            return;
+        }
+
+        serializer.Serialize(writer, internalValue, genericTypes[0]);
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    {
+        ConstructorInfo constructor;
+        if (reader.TokenType == JsonToken.Null)
+        {
+            constructor = objectType.GetConstructor(BindingFlags.Public | BindingFlags.Instance, null,
+                CallingConventions.HasThis, Array.Empty<Type>(), null);
+
+            if (constructor == null)
+                throw new JsonException("could not find default constructor for EntityReference");
+
+            return constructor.Invoke(Array.Empty<object>());
+        }
+
+        var genericTypes = objectType.GenericTypeArguments;
+
+        if (genericTypes.Length != 1)
+            throw new JsonException("Invalid generic types for EntityReference");
+
+        constructor = objectType.GetConstructor(BindingFlags.Public | BindingFlags.Instance, null,
+            CallingConventions.HasThis, new[] { genericTypes[0] }, null);
+
+        if (constructor == null)
+            throw new JsonException("could not find single argument constructor for EntityReference");
+
+        return constructor.Invoke(new[] { serializer.Deserialize(reader, genericTypes[0]) });
+    }
+
+    public override bool CanConvert(Type objectType)
+    {
+        if (!objectType.IsGenericType)
+            return false;
+
+        return objectType.GetGenericTypeDefinition() == typeof(EntityReference<>);
+    }
+}

--- a/src/saving/serializers/ThriveJsonConverter.cs
+++ b/src/saving/serializers/ThriveJsonConverter.cs
@@ -58,6 +58,8 @@ public class ThriveJsonConverter : IDisposable
             // to not use this
             new BaseNodeConverter(context),
 
+            new EntityReferenceConverter(),
+
             // Converter for all types with a specific few attributes for this to be enabled
             new DefaultThriveJSONConverter(context),
         };


### PR DESCRIPTION
**Brief Description of What This PR Does**

Not fully tested, but here's a potential implementation on how we can keep references across frames without having disposed object problems.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->

closes #2029

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
