### PR TITLE
Sort translation progress keys

### DIFF
--- a/scripts/update_translation_progress.rb
+++ b/scripts/update_translation_progress.rb
@@ -87,14 +87,14 @@ def run
   base_path = detect_thrive_folder
 
   progress = {}
-  stats = { TranslationProgress: progress }
 
   Dir["#{base_path}locale/**/*.po"].each do |f|
-    # Dir["#{base_path}locale/**/frm.po"].each do |f|
     value = calculate_stats_for f
     puts "Progress of #{f}: #{value * 100}%"
     progress[File.basename(f, File.extname(f))] = value
   end
+
+  stats = { TranslationProgress: progress.sort_by { |k, _v| k }.to_h }
 
   json_file = "#{base_path}simulation_parameters/common/translations_info.json"
 


### PR DESCRIPTION
to ensure consistent order of the translation progress values

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here.
-->
noticed that a recent PR (seemingly) reordered a bunch of the values, this should guarantee consistent order of the values.

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
