### PR TITLE
Softlock with pause on a new game

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -39,6 +39,7 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
     private GuidanceLine guidanceLine;
     private Vector3? guidancePosition;
     private PauseMenu pauseMenu;
+    private bool transitionFinished;
 
     /// <summary>
     ///   Used to control how often compound position info is sent to the tutorial
@@ -68,7 +69,6 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
     ///   True if auto save should trigger ASAP
     /// </summary>
     private bool wantsToSave;
-    private bool transitionFinished;
 
     [JsonProperty]
     [AssignOnlyChildItemsOnDeserialize]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Blocked pausing until tutorial opens, to avoid softlock.

**Related Issues**

closes Revolutionary-Games/Thrive#2603

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
