### PR TITLE
2567 crash using reproduction cheat while dead

### DIFF
--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -472,13 +472,8 @@ public class MicrobeHUD : Node
     /// </summary>
     public void ShowReproductionDialog()
     {
-        if (!editorButton.Disabled)
+        if (!editorButton.Disabled || stage?.Player == null)
             return;
-
-        if (stage?.Player == null)
-        {
-            return;
-        }
 
         GUICommon.Instance.PlayCustomSound(MicrobePickupOrganelleSound);
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Prevents the editor button being enabled while dead, even with cheats.

**Related Issues**

closes #2567

**Progress Checklist**

Note: before starting this checklist the issue should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
