### PR TITLE
fix back button main menu while animating

### DIFF
--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -101,7 +101,7 @@ public class MainMenu : NodeWithInput
 
         if (slide)
         {
-            guiAnimations.Play("MenuSlide");
+            PlayGUIAnimation("MenuSlide");
         }
         else
         {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Stops animation before playing.
Uses existing method 
```c#
    private void PlayGUIAnimation(string animation)
    {
        if (guiAnimations.IsPlaying())
            guiAnimations.Stop();

        guiAnimations.Play(animation);
    }
```

**Related Issues**

closes #2655

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
