### PR TITLE
Normalize personality attributes

### DIFF
--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -53,6 +53,12 @@ public class MicrobeAI
     [JsonIgnore]
     private Dictionary<Compound, float> compoundsSearchWeights;
 
+    private float speciesAggressionNormalized;
+    private float speciesFearNormalized;
+    private float speciesActivityNormalized;
+    private float speciesFocusNormalized;
+    private float speciesOpportunismNormalized;
+
     public MicrobeAI(Microbe microbe)
     {
         this.microbe = microbe ?? throw new ArgumentException("no microbe given", nameof(microbe));
@@ -65,13 +71,13 @@ public class MicrobeAI
 
         previouslyAbsorbedCompounds = new Dictionary<Compound, float>(microbe.TotalAbsorbedCompounds);
         compoundsSearchWeights = new Dictionary<Compound, float>();
-    }
 
-    private float SpeciesAggressionNormalized => microbe.Species.Aggression / Constants.MAX_SPECIES_AGGRESSION;
-    private float SpeciesFearNormalized => microbe.Species.Fear / Constants.MAX_SPECIES_FEAR;
-    private float SpeciesActivityNormalized => microbe.Species.Activity / Constants.MAX_SPECIES_ACTIVITY;
-    private float SpeciesFocusNormalized => microbe.Species.Focus / Constants.MAX_SPECIES_FOCUS;
-    private float SpeciesOpportunismNormalized => microbe.Species.Opportunism / Constants.MAX_SPECIES_OPPORTUNISM;
+        speciesAggressionNormalized = microbe.Species.Aggression / Constants.MAX_SPECIES_AGGRESSION;
+        speciesFearNormalized = microbe.Species.Fear / Constants.MAX_SPECIES_FEAR;
+        speciesActivityNormalized = microbe.Species.Activity / Constants.MAX_SPECIES_ACTIVITY;
+        speciesFocusNormalized = microbe.Species.Focus / Constants.MAX_SPECIES_FOCUS;
+        speciesOpportunismNormalized = microbe.Species.Opportunism / Constants.MAX_SPECIES_OPPORTUNISM;
+    }
 
     public void Think(float delta, Random random, MicrobeAICommonData data)
     {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Currently the AI checks the personality attributes by comparing them to the maximum values, resulting in extraneous calculations every think interval. This normalizes the values relative to maximums, so the calculations are only done once on instantiation. This leaves behind a bunch of magic numbers that are more obvious candidates for being moved out as constants, but given how arbitrary a lot of them are I chose to abstain from taking that extra step now.

Should have no gameplay effects, but it will need some solid regression testing.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
