### PR TITLE
Set anchors for extinction screen's load menu to full rect

### DIFF
--- a/src/microbe_stage/gui/ExtinctionBox.tscn
+++ b/src/microbe_stage/gui/ExtinctionBox.tscn
@@ -117,11 +117,16 @@ text = "RETURN_TO_MENU"
 
 [node name="LoadMenu" type="VBoxContainer" parent="."]
 visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
 margin_left = 140.0
 margin_top = 60.0
-margin_right = 1140.0
-margin_bottom = 660.0
+margin_right = -140.0
+margin_bottom = -60.0
 rect_min_size = Vector2( 1000, 600 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="SaveList" parent="LoadMenu" instance=ExtResource( 5 )]
 anchor_right = 0.0


### PR DESCRIPTION
**Brief Description of What This PR Does**

So that it's centered properly on the screen.

## Before
![2021-10-25_15 09 33 1904](https://user-images.githubusercontent.com/54026083/138658905-34187c28-5dc6-4d84-8a19-ee668a58aea0.png)

## After
![2021-10-25_15 05 00 8509](https://user-images.githubusercontent.com/54026083/138658924-e496d142-d035-4a2a-95d1-02d327fce0d1.png)

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
