### PR TITLE
Added check for git merge conflict markers to check_formatting

### DIFF
--- a/check_formatting.rb
+++ b/check_formatting.rb
@@ -31,7 +31,7 @@ DEFAULT_CHECKS = %w[compile files inspectcode cleanupcode duplicatecode localiza
 
 LOCALE_TEMP_SUFFIX = '.temp_check'
 TRAILING_SPACE = /(?<=\S)[\t ]+$/.freeze
-GIT_MERGE_CONFLICT_MARKERS = /^<{7} [^\s\\]*$/.freeze
+GIT_MERGE_CONFLICT_MARKERS = /^<{7}\s+\S+\s*$/.freeze
 NODE_NAME_REGEX = /\[node\s+name="([^"]+)"/.freeze
 NODE_NAME_UPPERCASE_REQUIRED_LENGTH = 25
 NODE_NAME_UPPERCASE_ACRONYM_ALLOWED_LENGTH = 4


### PR DESCRIPTION
**Brief Description of What This PR Does**

It has happened to me before that I accidently commited only paritally resolved merge conflicts, espeacally with .tscn files.
This PR adds a check for `<<<<<<< HEAD` for non-compiled files. I haven't added this check to compiled files (.cs, .csproj) because the build process will fail anyways.
