### PR TITLE
Fade on respawn

### DIFF
--- a/src/microbe_stage/MicrobeCamera.cs
+++ b/src/microbe_stage/MicrobeCamera.cs
@@ -144,7 +144,10 @@ public class MicrobeCamera : Camera, IGodotEarlyNodeResolve, ISaveLoadedTracked
         ObjectToFollow = objectToFollow;
 
         if (jump && ObjectToFollow != null)
-            Translation = new Vector3(ObjectToFollow.Transform.origin.x, CameraHeight, ObjectToFollow.Transform.origin.z);
+        {
+            Translation = new Vector3(ObjectToFollow.Transform.origin.x, CameraHeight,
+                ObjectToFollow.Transform.origin.z);
+        }
     }
 
     public void ResolveNodeReferences()

--- a/src/microbe_stage/MicrobeCamera.cs
+++ b/src/microbe_stage/MicrobeCamera.cs
@@ -7,11 +7,6 @@ using Newtonsoft.Json;
 public class MicrobeCamera : Camera, IGodotEarlyNodeResolve, ISaveLoadedTracked
 {
     /// <summary>
-    ///   Object the camera positions itself over
-    /// </summary>
-    public Spatial ObjectToFollow;
-
-    /// <summary>
     ///   Background plane that is moved farther away from the camera when zooming out
     /// </summary>
     [JsonIgnore]
@@ -64,6 +59,11 @@ public class MicrobeCamera : Camera, IGodotEarlyNodeResolve, ISaveLoadedTracked
 
     private Vector3 cursorWorldPos = new Vector3(0, 0, 0);
     private bool cursorDirty = true;
+
+    /// <summary>
+    ///   Object the camera positions itself over
+    /// </summary>
+    public Spatial ObjectToFollow { get; private set; }
 
     /// <summary>
     ///   How high the camera is above the followed object
@@ -131,6 +131,19 @@ public class MicrobeCamera : Camera, IGodotEarlyNodeResolve, ISaveLoadedTracked
     {
         InputManager.UnregisterReceiver(this);
         base._ExitTree();
+    }
+
+    /// <summary>
+    ///   Sets the object to follow
+    /// </summary>
+    /// <param name="objectToFollow">The new object to follow</param>
+    /// <param name="jump">If true the camera will not interpolate to the new object</param>
+    public void SetObjectToFollow(Spatial objectToFollow, bool jump)
+    {
+        ObjectToFollow = objectToFollow;
+
+        if (jump && ObjectToFollow != null)
+            Translation = new Vector3(ObjectToFollow.Transform.origin.x, CameraHeight, ObjectToFollow.Transform.origin.z);
     }
 
     public void ResolveNodeReferences()

--- a/src/microbe_stage/MicrobeCamera.cs
+++ b/src/microbe_stage/MicrobeCamera.cs
@@ -63,6 +63,7 @@ public class MicrobeCamera : Camera, IGodotEarlyNodeResolve, ISaveLoadedTracked
     /// <summary>
     ///   Object the camera positions itself over
     /// </summary>
+    [JsonIgnore]
     public Spatial ObjectToFollow { get; private set; }
 
     /// <summary>

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -68,6 +68,7 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
     [JsonProperty]
     private bool gameOver;
 
+    [JsonProperty]
     private bool respawnFadeStarted;
 
     [JsonProperty]
@@ -494,7 +495,7 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
     [RunOnKeyDown("g_quick_save")]
     public void QuickSave()
     {
-        if (!TransitionFinished)
+        if (!TransitionFinished || respawnFadeStarted)
         {
             GD.Print("quick save is disabled while transitioning");
             return;

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -683,6 +683,7 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
         {
             gameOver = true;
             TransitionManager.Instance.CancelTransitionPressed();
+            TutorialState.HideAll();
         }
         else
         {

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -452,7 +452,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
         microbeScene = GD.Load<PackedScene>("res://src/microbe_stage/Microbe.tscn");
 
         if (!IsLoadedFromSave)
-            camera.ObjectToFollow = cameraFollow;
+            camera.SetObjectToFollow(cameraFollow, true);
 
         tutorialGUI.Visible = true;
         gui.Init(this);

--- a/src/microbe_stage/gui/ExtinctionBox.tscn
+++ b/src/microbe_stage/gui/ExtinctionBox.tscn
@@ -13,7 +13,7 @@ bg_color = Color( 0, 0, 0, 0.196078 )
 resource_name = "FadeIn"
 length = 0.5
 tracks/0/type = "value"
-tracks/0/path = NodePath(".:modulate")
+tracks/0/path = NodePath("Fade:modulate")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -34,10 +34,58 @@ script = ExtResource( 4 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-ExtinctionMenuPath = NodePath("ExtinctionBoxMenu")
-LoadMenuPath = NodePath("LoadMenu")
+ExtinctionMenuPath = NodePath("Fade/ExtinctionBoxMenu")
+LoadMenuPath = NodePath("Fade/LoadMenu")
 
-[node name="ExtinctionBoxMenu" type="VBoxContainer" parent="." groups=[
+[node name="Rect" type="ColorRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+color = Color( 0, 0, 0, 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Fade" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="LoadMenu" type="VBoxContainer" parent="Fade"]
+anchor_left = 0.1
+anchor_top = 0.1
+anchor_right = 0.9
+anchor_bottom = 0.9
+rect_min_size = Vector2( 1000, 600 )
+size_flags_horizontal = 4
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="SaveList" parent="Fade/LoadMenu" instance=ExtResource( 5 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 1024.0
+margin_bottom = 559.0
+size_flags_vertical = 3
+AutoRefreshOnFirstVisible = false
+
+[node name="Back" type="Button" parent="Fade/LoadMenu"]
+margin_left = 462.0
+margin_top = 563.0
+margin_right = 562.0
+margin_bottom = 600.0
+rect_min_size = Vector2( 100, 37 )
+size_flags_horizontal = 4
+theme = ExtResource( 3 )
+text = "BACK"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ExtinctionBoxMenu" type="VBoxContainer" parent="Fade" groups=[
 "MenuItem",
 ]]
 anchor_right = 1.0
@@ -51,7 +99,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="PanelContainer" type="PanelContainer" parent="ExtinctionBoxMenu"]
+[node name="PanelContainer" type="PanelContainer" parent="Fade/ExtinctionBoxMenu"]
 margin_top = 160.0
 margin_right = 1280.0
 margin_bottom = 460.0
@@ -63,21 +111,21 @@ __meta__ = {
 "_edit_use_anchors_": true
 }
 
-[node name="MarginContainer" type="MarginContainer" parent="ExtinctionBoxMenu/PanelContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="Fade/ExtinctionBoxMenu/PanelContainer"]
 margin_right = 1280.0
 margin_bottom = 300.0
 mouse_filter = 2
 custom_constants/margin_right = 150
 custom_constants/margin_left = 150
 
-[node name="VBoxContainer" type="VBoxContainer" parent="ExtinctionBoxMenu/PanelContainer/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Fade/ExtinctionBoxMenu/PanelContainer/MarginContainer"]
 margin_left = 150.0
 margin_right = 1130.0
 margin_bottom = 300.0
 mouse_filter = 2
 alignment = 1
 
-[node name="Title" type="Label" parent="ExtinctionBoxMenu/PanelContainer/MarginContainer/VBoxContainer"]
+[node name="Title" type="Label" parent="Fade/ExtinctionBoxMenu/PanelContainer/MarginContainer/VBoxContainer"]
 margin_top = 103.0
 margin_right = 980.0
 margin_bottom = 169.0
@@ -87,7 +135,7 @@ text = "EXTINCTION_CAPITAL"
 align = 1
 valign = 1
 
-[node name="Message" type="Label" parent="ExtinctionBoxMenu/PanelContainer/MarginContainer/VBoxContainer"]
+[node name="Message" type="Label" parent="Fade/ExtinctionBoxMenu/PanelContainer/MarginContainer/VBoxContainer"]
 margin_top = 173.0
 margin_right = 980.0
 margin_bottom = 197.0
@@ -97,7 +145,7 @@ align = 1
 valign = 1
 autowrap = true
 
-[node name="LoadGame" type="Button" parent="ExtinctionBoxMenu"]
+[node name="LoadGame" type="Button" parent="Fade/ExtinctionBoxMenu"]
 margin_left = 515.0
 margin_top = 470.0
 margin_right = 765.0
@@ -106,7 +154,7 @@ rect_min_size = Vector2( 250, 40 )
 size_flags_horizontal = 4
 text = "LOAD_GAME"
 
-[node name="ReturnToMenu" type="Button" parent="ExtinctionBoxMenu"]
+[node name="ReturnToMenu" type="Button" parent="Fade/ExtinctionBoxMenu"]
 margin_left = 515.0
 margin_top = 520.0
 margin_right = 765.0
@@ -115,39 +163,10 @@ rect_min_size = Vector2( 250, 40 )
 size_flags_horizontal = 4
 text = "RETURN_TO_MENU"
 
-[node name="LoadMenu" type="VBoxContainer" parent="."]
-visible = false
-margin_left = 140.0
-margin_top = 60.0
-margin_right = 1140.0
-margin_bottom = 660.0
-rect_min_size = Vector2( 1000, 600 )
-
-[node name="SaveList" parent="LoadMenu" instance=ExtResource( 5 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_right = 1000.0
-margin_bottom = 559.0
-size_flags_vertical = 3
-AutoRefreshOnFirstVisible = false
-
-[node name="Back" type="Button" parent="LoadMenu"]
-margin_left = 450.0
-margin_top = 563.0
-margin_right = 550.0
-margin_bottom = 600.0
-rect_min_size = Vector2( 100, 37 )
-size_flags_horizontal = 4
-theme = ExtResource( 3 )
-text = "BACK"
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 autoplay = "FadeIn"
 anims/FadeIn = SubResource( 2 )
 
-[connection signal="pressed" from="ExtinctionBoxMenu/LoadGame" to="." method="OpenLoadGamePressed"]
-[connection signal="pressed" from="ExtinctionBoxMenu/ReturnToMenu" to="." method="ReturnToMenuPressed"]
-[connection signal="pressed" from="LoadMenu/Back" to="." method="CloseLoadPressed"]
+[connection signal="pressed" from="Fade/LoadMenu/Back" to="." method="CloseLoadPressed"]
+[connection signal="pressed" from="Fade/ExtinctionBoxMenu/LoadGame" to="." method="OpenLoadGamePressed"]
+[connection signal="pressed" from="Fade/ExtinctionBoxMenu/ReturnToMenu" to="." method="ReturnToMenuPressed"]


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR adds a fade out/in effect when respawning. The camera no longer jumps to the respawn location. If the player is extinct the screen does not fade in anymore.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
