### PR TITLE
Quick save slot rotation doesn't work

### DIFF
--- a/src/saving/InProgressSave.cs
+++ b/src/saving/InProgressSave.cs
@@ -239,7 +239,7 @@ public class InProgressSave : IDisposable
 
                 foreach (var name in SaveHelper.CreateListOfSaves(SaveHelper.SaveOrder.FileSystem))
                 {
-                    var match = Regex.Match(name, "^save_(\\d)+\\." + Constants.SAVE_EXTENSION);
+                    var match = Regex.Match(name, "^save_(\\d+)\\." + Constants.SAVE_EXTENSION);
 
                     if (match.Success)
                     {
@@ -256,13 +256,13 @@ public class InProgressSave : IDisposable
 
             case SaveInformation.SaveType.AutoSave:
             {
-                return GetNextNameForSaveType("^auto_save_(\\d)+\\." + Constants.SAVE_EXTENSION, "auto_save",
+                return GetNextNameForSaveType("^auto_save_(\\d+)\\." + Constants.SAVE_EXTENSION, "auto_save",
                     Settings.Instance.MaxAutoSaves);
             }
 
             case SaveInformation.SaveType.QuickSave:
             {
-                return GetNextNameForSaveType("^quick_save_(\\d)+\\." + Constants.SAVE_EXTENSION, "quick_save",
+                return GetNextNameForSaveType("^quick_save_(\\d+)\\." + Constants.SAVE_EXTENSION, "quick_save",
                     Settings.Instance.MaxQuickSaves);
             }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

The + behind the regex capture group separates the digits in different groups.
The + within the capture group reads a 10 as 10 and not as 1 and 0.

So quick save rotation was broken for save names > 9.

**Related Issues**

closes #2719

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
