### PR TITLE
Fix health and atp progress bar filler texture

### DIFF
--- a/assets/textures/gui/bevel/AtpBar.png
+++ b/assets/textures/gui/bevel/AtpBar.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c5da92bdbb4a06fe493fe0afb689619018f2baef2b1a5686fa83e3715e31911
-size 2193
+oid sha256:ed52649dd71a47f148f201cd31537f47e3cade7e5fb8c9cc42f635cc95c648a9
+size 3387

--- a/assets/textures/gui/bevel/HealthBar.png
+++ b/assets/textures/gui/bevel/HealthBar.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6500f120cc7273027e8dc10945416010fca6922d6b1c39ef7db2894e6c5e233f
-size 2794
+oid sha256:de5d53675a18c32069a7c0e9b3ef532f55d24e51bfebccb5ebc5ce363e346d5a
+size 4396

--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -1858,21 +1858,17 @@ texture_progress = ExtResource( 64 )
 fill_mode = 4
 tint_under = Color( 0, 0, 0, 0.752941 )
 tint_progress = Color( 0.960784, 0.270588, 0.478431, 1 )
-radial_initial_angle = 211.0
-radial_fill_degrees = 197.0
+radial_initial_angle = 237.0
+radial_fill_degrees = 126.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="HitpointIcon" type="TextureRect" parent="MicrobeHUD/BottomRight/HealthBar"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -45.5403
-margin_top = 99.249
-margin_right = -25.5403
-margin_bottom = 119.249
+margin_left = 21.46
+margin_top = 197.749
+margin_right = 41.46
+margin_bottom = 217.749
 texture = ExtResource( 61 )
 expand = true
 __meta__ = {
@@ -1884,10 +1880,10 @@ anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = -203.756
+margin_left = -202.756
 margin_top = -201.525
-margin_right = -94.756
-margin_bottom = -45.525
+margin_right = 6.24402
+margin_bottom = 7.47501
 step = 0.1
 value = 100.0
 texture_under = ExtResource( 63 )
@@ -1895,21 +1891,17 @@ texture_progress = ExtResource( 63 )
 fill_mode = 4
 tint_under = Color( 0, 0, 0, 0.752941 )
 tint_progress = Color( 0.439216, 0.956863, 0.137255, 1 )
-radial_initial_angle = 205.0
-radial_fill_degrees = 210.0
+radial_initial_angle = 237.0
+radial_fill_degrees = 129.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="ATPIcon" type="TextureRect" parent="MicrobeHUD/BottomRight/ATPBar"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -36.0
-margin_top = 78.5
-margin_right = -16.0
-margin_bottom = 98.5
+margin_left = 18.5
+margin_top = 156.5
+margin_right = 38.5
+margin_bottom = 176.5
 texture = ExtResource( 60 )
 expand = true
 __meta__ = {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Changed textures size to the full circle size. This is needed for circular texture progress to show as exprected.

**Related Issues**

closes #1661

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
