### PR TITLE
1880 exception collection was modified in auto evo

### DIFF
--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -306,8 +306,12 @@ public class AutoEvoRun
 
         foreach (var entry in map.Patches)
         {
+            // TODO: No one should be allowed to update the SpeciesInPatch.
+            // If this happens, the root cause must be addressed.
+
             // Iterate over a copy to be secure from changes to the dictionary.
-            foreach (var speciesEntry in entry.Value.SpeciesInPatch.ToList())
+            var speciesInPatchCopy = entry.Value.SpeciesInPatch.ToList();
+            foreach (var speciesEntry in speciesInPatchCopy)
             {
                 if (alreadyHandledSpecies.Contains(speciesEntry.Key))
                     continue;
@@ -329,6 +333,25 @@ public class AutoEvoRun
                     steps.Enqueue(new FindBestMigration(map, speciesEntry.Key, random,
                         autoEvoConfiguration.MoveAttemptsPerSpecies,
                         autoEvoConfiguration.AllowNoMigration));
+                }
+            }
+
+            // Verify the length.
+            if (speciesInPatchCopy.Count != entry.Value.SpeciesInPatch.Count)
+            {
+                GD.PrintErr("Auto-evo: Issue #1880 occured (Collection was modified).");
+            }
+            else
+            {
+                // Check that each entry is still the same.
+                foreach (var speciesEntry in speciesInPatchCopy)
+                {
+                    if (!entry.Value.SpeciesInPatch.TryGetValue(speciesEntry.Key, out long value)
+                        || speciesEntry.Value != value)
+                    {
+                        GD.PrintErr("Auto-evo: Issue #1880 occured (Collection was modified).");
+                        break;
+                    }
                 }
             }
 

--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -306,6 +306,7 @@ public class AutoEvoRun
 
         foreach (var entry in map.Patches)
         {
+            // Iterate over a copy to be secure from changes to the dictionary.
             foreach (var speciesEntry in entry.Value.SpeciesInPatch.ToList())
             {
                 if (alreadyHandledSpecies.Contains(speciesEntry.Key))

--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -306,7 +306,7 @@ public class AutoEvoRun
 
         foreach (var entry in map.Patches)
         {
-            foreach (var speciesEntry in entry.Value.SpeciesInPatch)
+            foreach (var speciesEntry in entry.Value.SpeciesInPatch.ToList())
             {
                 if (alreadyHandledSpecies.Contains(speciesEntry.Key))
                     continue;


### PR DESCRIPTION
**Brief Description of What This PR Does**

The exception from the issue is pretty old. I could not reproduce it, but I think it is dangerous to iterate over a global editable dictionary in a thread.
As GatherInfo is only called once per AutoEvo run, the ToList() is not a big addition.

**Related Issues**

closes #1880

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
