### PR TITLE
Key prompts stuck after disabling tutorial in editor

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -573,6 +573,11 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
         HUD.OnEnterStageTransition(false);
         HUD.HideReproductionDialog();
 
+        if (!CurrentGame.TutorialState.Enabled)
+        {
+            tutorialGUI.EventReceiver?.OnTutorialDisabled();
+        }
+
         StartMusic();
 
         // Reset locale to assure the stage's language.


### PR DESCRIPTION
**Brief Description of What This PR Does**

The microbe stage tutorials were not informed about the disabling within the editor. For the popup dialogs this only works because they close automatically when leaving the stage.
So added a check in ReturnFromEditor and if Tutorials are disabled informed the tutorialGui.

**Related Issues**

closes #2075

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
