### PR TITLE
Default font doesn't display "ž" correctly (in czech translation)

### DIFF
--- a/assets/fonts/Jura-DemiBold.ttf
+++ b/assets/fonts/Jura-DemiBold.ttf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa720099a548cb027ff3d65d3a1f4e73af449135d6ee7d6cb4cecdace7dfbc2c
-size 326140
+oid sha256:5bbfa70810312d798d40e94d70dc49b2b6dedcacc3a62229d39f00c90bed8aee
+size 154344

--- a/assets/fonts/Jura-Light.ttf
+++ b/assets/fonts/Jura-Light.ttf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fee801e80e5ceff9b97100f290862c619cd6cff237721012ab7bbbf2eacffdf0
-size 266744
+oid sha256:5d7391e4d5a5baeb29a8cad20c49d4723f2cebddbacc4dde376f5f84f16ff50e
+size 154152

--- a/assets/fonts/Jura-Medium.ttf
+++ b/assets/fonts/Jura-Medium.ttf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05673836050f9a60afa40f345b051dd2ec6a37ba6a9f0b0c6f2e936f3929de4f
-size 345824
+oid sha256:ef0abe75ce787a15e5f25450a56ca3b38545e5e158fe4b0bd00370378bef38fe
+size 154332

--- a/assets/fonts/Jura-Regular.ttf
+++ b/assets/fonts/Jura-Regular.ttf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f734203fdd1be9ad2bb8d40c90f56fc5de6ca71b96e05292e9ea4885a664e843
-size 338940
+oid sha256:441c2ec109516b30bb581b09a10e535755eaa819db9fe7b37d7c098103f8691d
+size 154416


### PR DESCRIPTION
**Brief Description of What This PR Does**

Updated jura font version from 2.5.1 to 5.106. The new version was corrected.

**Related Issues**

closes #2005

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
