### PR TITLE
Removed WasListeningForInput

### DIFF
--- a/src/engine/input/key_mapping/InputEventItem.cs
+++ b/src/engine/input/key_mapping/InputEventItem.cs
@@ -176,7 +176,6 @@ public class InputEventItem : Node
                 {
                     GetTree().SetInputAsHandled();
 
-                    InputGroupList.WasListeningForInput = true;
                     WaitingForInput = false;
 
                     // Rebind canceled, alert the InputManager so it can resume getting input
@@ -281,7 +280,6 @@ public class InputEventItem : Node
     {
         WaitingForInput = false;
         JustAdded = false;
-        InputGroupList.WasListeningForInput = false;
 
         // Update the godot InputMap
         GroupList?.ControlsChanged();

--- a/src/engine/input/key_mapping/InputGroupList.cs
+++ b/src/engine/input/key_mapping/InputGroupList.cs
@@ -15,8 +15,6 @@ public class InputGroupList : VBoxContainer
     [Export]
     public NodePath ResetInputsDialog;
 
-    private static bool wasListeningForInput;
-
     private IEnumerable<InputGroupItem> activeInputGroupList;
 
     private InputEventItem latestDialogCaller;
@@ -32,21 +30,6 @@ public class InputGroupList : VBoxContainer
     ///   Fired whenever some inputs were redefined.
     /// </summary>
     public event ControlsChangedDelegate OnControlsChanged;
-
-    /// <summary>
-    ///   If I was listening for inputs.
-    ///   Used by the pause menu to not close whenever escape is pressed if the user was redefining keys
-    /// </summary>
-    public static bool WasListeningForInput
-    {
-        get
-        {
-            var result = wasListeningForInput;
-            wasListeningForInput = false;
-            return result;
-        }
-        internal set => wasListeningForInput = value;
-    }
 
     public PackedScene InputEventItemScene { get; private set; }
     public PackedScene InputGroupItemScene { get; private set; }

--- a/src/general/OptionsMenu.cs
+++ b/src/general/OptionsMenu.cs
@@ -552,12 +552,6 @@ public class OptionsMenu : ControlWithInput
         if (!Visible)
             return false;
 
-        if (InputGroupList.WasListeningForInput)
-        {
-            // Listening for Inputs, should not do anything and should not pass through
-            return true;
-        }
-
         if (!Exit())
         {
             // We are prevented from exiting, consume this input


### PR DESCRIPTION
**Brief Description of What This PR Does**

WasListeningForInput can be safely removed as the InputGroupList consumes the ui-cancel event. (And is the cause of #2732)

**Related Issues**

Fixes #2732

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
