### PR TITLE
Reposition undo and redo tutorial to the screen center

### DIFF
--- a/src/tutorial/microbe_editor/MicrobeEditorTutorialGUI.tscn
+++ b/src/tutorial/microbe_editor/MicrobeEditorTutorialGUI.tscn
@@ -140,21 +140,21 @@ text = "EDITOR_TUTORIAL_CELL_TEXT"
 autowrap = true
 
 [node name="UndoTutorial" parent="." instance=ExtResource( 4 )]
-anchor_left = 1.0
+anchor_left = 0.5
 anchor_top = 0.5
-anchor_right = 1.0
+anchor_right = 0.5
 anchor_bottom = 0.5
-margin_left = -403.0
-margin_top = -134.0
-margin_right = -113.0
-margin_bottom = 216.0
+margin_left = -145.0
+margin_top = -175.0
+margin_right = 145.0
+margin_bottom = 175.0
 rect_min_size = Vector2( 290, 350 )
 rect_pivot_offset = Vector2( 145, 171 )
 theme = null
 script = ExtResource( 7 )
-WindowTitle = "TUTORIAL"
 ShowDelay = 0.0
 Resizable = true
+WindowTitle = "TUTORIAL"
 
 [node name="ScrollContainer" type="ScrollContainer" parent="UndoTutorial"]
 anchor_right = 1.0
@@ -182,28 +182,28 @@ autowrap = true
 visible = false
 
 [node name="RedoTutorial" parent="." instance=ExtResource( 4 )]
-anchor_left = 1.0
+anchor_left = 0.5
 anchor_top = 0.5
-anchor_right = 1.0
+anchor_right = 0.5
 anchor_bottom = 0.5
-margin_left = -455.0
-margin_top = -125.0
-margin_right = -85.0
-margin_bottom = 245.0
+margin_left = -185.0
+margin_top = -185.0
+margin_right = 185.0
+margin_bottom = 185.0
 rect_min_size = Vector2( 370, 370 )
 rect_pivot_offset = Vector2( 185, 185 )
 theme = null
 script = ExtResource( 7 )
-WindowTitle = "TUTORIAL"
 Resizable = true
+WindowTitle = "TUTORIAL"
 
 [node name="ScrollContainer" type="ScrollContainer" parent="RedoTutorial"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 15.0
 margin_top = 15.0
-margin_right = 355.0
-margin_bottom = 355.0
+margin_right = -15.0
+margin_bottom = -15.0
 rect_min_size = Vector2( 340, 340 )
 scroll_horizontal_enabled = false
 __meta__ = {
@@ -211,8 +211,8 @@ __meta__ = {
 }
 
 [node name="Label" type="Label" parent="RedoTutorial/ScrollContainer"]
-margin_right = 710.0
-margin_bottom = 710.0
+margin_right = 340.0
+margin_bottom = 340.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_fonts/font = ExtResource( 5 )


### PR DESCRIPTION
**Brief Description of What This PR Does**

So that they are the center of the player's focus, making it easier to read what the tutorial is about. The player can and should still see the hex that is being undone afterwards due to the slight delay of which the subsequent redo tut will pop up.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
