### PR TITLE
Add an empty DynamicFont to compound and environment panels' expand/collapse buttons

### DIFF
--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -85,6 +85,7 @@
 [ext_resource path="res://assets/textures/gui/bevel/parts/membraneAmoeba.png" type="Texture" id=83]
 [ext_resource path="res://src/microbe_stage/PlayerHoverInfo.cs" type="Script" id=84]
 [ext_resource path="res://src/gui_common/fonts/Jura-Regular-HugePlus.tres" type="DynamicFont" id=85]
+[ext_resource path="res://src/gui_common/fonts/EmptyFont.tres" type="DynamicFont" id=86]
 
 [sub_resource type="Theme" id=1]
 default_font = ExtResource( 80 )
@@ -117,8 +118,6 @@ region_rect = Rect2( 0, 0, 20, 20 )
 [sub_resource type="StyleBoxTexture" id=5]
 texture = ExtResource( 43 )
 region_rect = Rect2( 0, 0, 20, 20 )
-
-[sub_resource type="DynamicFont" id=38]
 
 [sub_resource type="ButtonGroup" id=6]
 
@@ -690,7 +689,7 @@ size_flags_vertical = 4
 custom_styles/hover = SubResource( 3 )
 custom_styles/pressed = SubResource( 4 )
 custom_styles/normal = SubResource( 5 )
-custom_fonts/font = SubResource( 38 )
+custom_fonts/font = ExtResource( 86 )
 toggle_mode = true
 pressed = true
 action_mode = 0
@@ -708,7 +707,7 @@ size_flags_vertical = 4
 custom_styles/hover = SubResource( 7 )
 custom_styles/pressed = SubResource( 8 )
 custom_styles/normal = SubResource( 9 )
-custom_fonts/font = SubResource( 38 )
+custom_fonts/font = ExtResource( 86 )
 toggle_mode = true
 action_mode = 0
 group = SubResource( 6 )
@@ -1153,7 +1152,7 @@ size_flags_vertical = 4
 custom_styles/hover = SubResource( 3 )
 custom_styles/pressed = SubResource( 4 )
 custom_styles/normal = SubResource( 5 )
-custom_fonts/font = SubResource( 38 )
+custom_fonts/font = ExtResource( 86 )
 toggle_mode = true
 pressed = true
 action_mode = 0
@@ -1171,7 +1170,7 @@ size_flags_vertical = 4
 custom_styles/hover = SubResource( 16 )
 custom_styles/pressed = SubResource( 17 )
 custom_styles/normal = SubResource( 18 )
-custom_fonts/font = SubResource( 38 )
+custom_fonts/font = ExtResource( 86 )
 toggle_mode = true
 action_mode = 0
 group = SubResource( 15 )

--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=123 format=2]
+[gd_scene load_steps=124 format=2]
 
 [ext_resource path="res://src/microbe_stage/MicrobeStage.cs" type="Script" id=1]
 [ext_resource path="res://src/microbe_stage/MicrobeCamera.tscn" type="PackedScene" id=2]
@@ -117,6 +117,8 @@ region_rect = Rect2( 0, 0, 20, 20 )
 [sub_resource type="StyleBoxTexture" id=5]
 texture = ExtResource( 43 )
 region_rect = Rect2( 0, 0, 20, 20 )
+
+[sub_resource type="DynamicFont" id=38]
 
 [sub_resource type="ButtonGroup" id=6]
 
@@ -652,7 +654,7 @@ __meta__ = {
 
 [node name="Header" type="MarginContainer" parent="MicrobeHUD/BottomLeft/LeftPanels/EnvironmentPanel/VBoxContainer"]
 margin_right = 197.0
-margin_bottom = 35.0
+margin_bottom = 52.0
 rect_min_size = Vector2( 195, 35 )
 mouse_filter = 1
 custom_constants/margin_right = 10
@@ -663,15 +665,14 @@ custom_constants/margin_left = 10
 margin_left = 10.0
 margin_top = 5.0
 margin_right = 184.0
-margin_bottom = 35.0
+margin_bottom = 52.0
 rect_min_size = Vector2( 174, 0 )
 size_flags_horizontal = 0
 custom_constants/separation = 6
 
 [node name="Label" type="Label" parent="MicrobeHUD/BottomLeft/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer"]
-margin_top = 5.0
 margin_right = 126.0
-margin_bottom = 24.0
+margin_bottom = 47.0
 size_flags_horizontal = 3
 custom_fonts/font = ExtResource( 77 )
 text = "ENVIRONMENT"
@@ -679,9 +680,9 @@ autowrap = true
 
 [node name="EnvironmentExpandButton" type="Button" parent="MicrobeHUD/BottomLeft/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer"]
 margin_left = 132.0
-margin_top = 4.0
+margin_top = 14.0
 margin_right = 150.0
-margin_bottom = 26.0
+margin_bottom = 32.0
 rect_min_size = Vector2( 18, 18 )
 focus_mode = 0
 size_flags_horizontal = 0
@@ -689,6 +690,7 @@ size_flags_vertical = 4
 custom_styles/hover = SubResource( 3 )
 custom_styles/pressed = SubResource( 4 )
 custom_styles/normal = SubResource( 5 )
+custom_fonts/font = SubResource( 38 )
 toggle_mode = true
 pressed = true
 action_mode = 0
@@ -696,9 +698,9 @@ group = SubResource( 6 )
 
 [node name="EnvironmentCompressButton" type="Button" parent="MicrobeHUD/BottomLeft/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer"]
 margin_left = 156.0
-margin_top = 4.0
+margin_top = 14.0
 margin_right = 174.0
-margin_bottom = 26.0
+margin_bottom = 32.0
 rect_min_size = Vector2( 18, 18 )
 focus_mode = 0
 size_flags_horizontal = 0
@@ -706,22 +708,23 @@ size_flags_vertical = 4
 custom_styles/hover = SubResource( 7 )
 custom_styles/pressed = SubResource( 8 )
 custom_styles/normal = SubResource( 9 )
+custom_fonts/font = SubResource( 38 )
 toggle_mode = true
 action_mode = 0
 group = SubResource( 6 )
 
 [node name="HSeparator" type="HSeparator" parent="MicrobeHUD/BottomLeft/LeftPanels/EnvironmentPanel/VBoxContainer"]
-margin_top = 39.0
+margin_top = 56.0
 margin_right = 197.0
-margin_bottom = 43.0
+margin_bottom = 60.0
 rect_min_size = Vector2( 197, 0 )
 size_flags_horizontal = 0
 custom_styles/separator = SubResource( 10 )
 
 [node name="Body" type="MarginContainer" parent="MicrobeHUD/BottomLeft/LeftPanels/EnvironmentPanel/VBoxContainer"]
-margin_top = 47.0
+margin_top = 64.0
 margin_right = 197.0
-margin_bottom = 232.0
+margin_bottom = 249.0
 custom_constants/margin_top = 5
 custom_constants/margin_left = 22
 custom_constants/margin_bottom = 10
@@ -1129,9 +1132,9 @@ expand = true
 
 [node name="Label" type="Label" parent="MicrobeHUD/BottomLeft/LeftPanels/CompoundsPanel/VBoxContainer/Header/HBoxContainer"]
 margin_left = 41.0
-margin_top = 8.0
+margin_top = 6.0
 margin_right = 186.0
-margin_bottom = 27.0
+margin_bottom = 28.0
 rect_min_size = Vector2( 145, 0 )
 size_flags_horizontal = 3
 custom_fonts/font = ExtResource( 77 )
@@ -1140,9 +1143,9 @@ autowrap = true
 
 [node name="CompoundExpandButton" type="Button" parent="MicrobeHUD/BottomLeft/LeftPanels/CompoundsPanel/VBoxContainer/Header/HBoxContainer"]
 margin_left = 192.0
-margin_top = 6.0
+margin_top = 8.0
 margin_right = 210.0
-margin_bottom = 28.0
+margin_bottom = 26.0
 rect_min_size = Vector2( 18, 18 )
 focus_mode = 0
 size_flags_horizontal = 0
@@ -1150,6 +1153,7 @@ size_flags_vertical = 4
 custom_styles/hover = SubResource( 3 )
 custom_styles/pressed = SubResource( 4 )
 custom_styles/normal = SubResource( 5 )
+custom_fonts/font = SubResource( 38 )
 toggle_mode = true
 pressed = true
 action_mode = 0
@@ -1157,9 +1161,9 @@ group = SubResource( 15 )
 
 [node name="CompoundCompressButton" type="Button" parent="MicrobeHUD/BottomLeft/LeftPanels/CompoundsPanel/VBoxContainer/Header/HBoxContainer"]
 margin_left = 216.0
-margin_top = 6.0
+margin_top = 8.0
 margin_right = 234.0
-margin_bottom = 28.0
+margin_bottom = 26.0
 rect_min_size = Vector2( 18, 18 )
 focus_mode = 0
 size_flags_horizontal = 0
@@ -1167,6 +1171,7 @@ size_flags_vertical = 4
 custom_styles/hover = SubResource( 16 )
 custom_styles/pressed = SubResource( 17 )
 custom_styles/normal = SubResource( 18 )
+custom_fonts/font = SubResource( 38 )
 toggle_mode = true
 action_mode = 0
 group = SubResource( 15 )
@@ -1514,9 +1519,9 @@ expand = true
 
 [node name="Label" type="Label" parent="MicrobeHUD/BottomLeft/LeftPanels/AgentsPanel/VBoxContainer/Header/HBoxContainer"]
 margin_left = 39.0
-margin_top = 8.0
+margin_top = 6.0
 margin_right = 239.0
-margin_bottom = 27.0
+margin_bottom = 28.0
 size_flags_horizontal = 3
 custom_fonts/font = ExtResource( 77 )
 text = "AGENTS"
@@ -1773,7 +1778,7 @@ __meta__ = {
 
 [node name="Label" type="Label" parent="MicrobeHUD/BottomRight/PopulationData"]
 margin_right = 82.0
-margin_bottom = 33.0
+margin_bottom = 37.0
 rect_min_size = Vector2( 82, 0 )
 size_flags_horizontal = 3
 custom_styles/normal = SubResource( 28 )
@@ -1787,9 +1792,9 @@ __meta__ = {
 
 [node name="Value" type="Label" parent="MicrobeHUD/BottomRight/PopulationData"]
 margin_left = 86.0
-margin_top = 8.0
+margin_top = 9.0
 margin_right = 125.0
-margin_bottom = 25.0
+margin_bottom = 28.0
 rect_min_size = Vector2( 35, 0 )
 size_flags_horizontal = 3
 custom_styles/normal = SubResource( 28 )


### PR DESCRIPTION
**Brief Description of What This PR Does**

The new Jura font version (#2738) seems to have a bigger height than the previous, this causes these buttons to be slightly taller (due to the built-in label nodes inside of them). An empty DynamicFont is set as the custom font overrides to nullify their label nodes height and making the buttons symmetrical again.

### Before
![2021-11-06 (3)](https://user-images.githubusercontent.com/54026083/140611700-79fcf801-9e97-4cb3-b3d5-40201b3fb51c.png)

### Fixed
![2021-11-06 (2)](https://user-images.githubusercontent.com/54026083/140611722-0759c583-d825-4e62-82e8-83e74d8b2c36.png)

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
