### PR TITLE
Disallow trailing and preceeding spaces in species names

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -649,6 +649,11 @@ public static class Constants
     public const float COMPOUND_DENSITY_CATEGORY_AN_ABUNDANCE = 500f;
 
     /// <summary>
+    ///   Regex for species name validation.
+    /// </summary>
+    public const string SPECIES_NAME_REGEX = "^(?<genus>[^ ]+) (?<epithet>[^ ]+)$";
+
+    /// <summary>
     ///   The duration for which a save is considered recently performed.
     /// </summary>
     /// <remarks>

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Godot;
 using Newtonsoft.Json;
 
@@ -572,11 +573,11 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
             editedSpecies.FormattedName);
 
         // Update name
-        var splits = NewName.Split(" ");
-        if (splits.Length == 2)
+        var match = Regex.Match(NewName, Constants.SPECIES_NAME_REGEX);
+        if (match.Success)
         {
-            editedSpecies.Genus = splits[0];
-            editedSpecies.Epithet = splits[1];
+            editedSpecies.Genus = match.Groups["genus"].Value;
+            editedSpecies.Epithet = match.Groups["epithet"].Value;
 
             GD.Print("MicrobeEditor: edited species name is now ",
                 editedSpecies.FormattedName);

--- a/src/microbe_stage/editor/MicrobeEditor.tscn
+++ b/src/microbe_stage/editor/MicrobeEditor.tscn
@@ -2031,6 +2031,7 @@ rect_min_size = Vector2( 240, 27 )
 focus_mode = 1
 mouse_filter = 1
 size_flags_vertical = 4
+max_length = 100
 placeholder_text = "SPECIES_NAME_DOT_DOT_DOT"
 __meta__ = {
 "_edit_use_anchors_": false

--- a/src/microbe_stage/editor/MicrobeEditorGUI.cs
+++ b/src/microbe_stage/editor/MicrobeEditorGUI.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Godot;
 using Newtonsoft.Json;
 
@@ -2028,7 +2029,7 @@ public class MicrobeEditorGUI : Control, ISaveLoadedTracked
 
     private void OnSpeciesNameTextChanged(string newText)
     {
-        if (newText.Split(" ").Length != 2)
+        if (!Regex.IsMatch(newText, Constants.SPECIES_NAME_REGEX))
         {
             speciesNameEdit.Set("custom_colors/font_color", new Color(1.0f, 0.3f, 0.3f));
         }
@@ -2046,7 +2047,7 @@ public class MicrobeEditorGUI : Control, ISaveLoadedTracked
         editor.NewName = newText;
 
         // Only defocus if the name is valid to indicate invalid namings to the player
-        if (newText.Split(" ").Length == 2)
+        if (Regex.IsMatch(newText, Constants.SPECIES_NAME_REGEX))
         {
             speciesNameEdit.ReleaseFocus();
         }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Used regex to validate user input.
Added maxlength of 100 to lineedit.

**Related Issues**

closes #2730

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
