### PR TITLE
Balance photosynthesis

### DIFF
--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -34,7 +34,7 @@
             "sunlight": 1
         },
         "outputs": {
-            "glucose": 0.1
+            "glucose": 0.75
         }
     },
     "oxytoxySynthesis": {
@@ -115,7 +115,7 @@
             "sunlight": 1
         },
         "outputs": {
-            "glucose": 0.02
+            "glucose": 0.015
         }
     },
     "iron_chemolithoautotrophy": {

--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -34,7 +34,7 @@
             "sunlight": 1
         },
         "outputs": {
-            "glucose": 0.75
+            "glucose": 0.6
         }
     },
     "oxytoxySynthesis": {

--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -34,7 +34,7 @@
             "sunlight": 1
         },
         "outputs": {
-            "glucose": 0.6
+            "glucose": 0.08
         }
     },
     "oxytoxySynthesis": {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Nerfs both photosynthesizing organelles to make plant-predators less of a dominant strategy. Previously, a player could reach a self-sufficient predator in 4 eukaryotic generations, assuming a little extra ATP coming from bacteria parts:
1) nucleus
2) 2 mitochondria
3) 1 chloroplast
4) toxin or flagella/spike

With this change 1 chloroplast can't quite support 2 mitochondria by itself, so this process takes another generation or two, and comes at the cost of a noticeably slower cell instead of just one extra organelle, unless the player trys out some more advanced mechanics like membranes. 

**Related Issues**

No related issues

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
