### PR TITLE
Set auto-evo to again make copy of player on editor

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -121,9 +121,9 @@ public static class Constants
     public const int INITIAL_SPLIT_POPULATION_MAX = 2000;
 
     /// <summary>
-    ///   If true a mutated copy of the (player) species is created when entering the editor
+    ///   Probability that entering the editor will create a species branching off the player
     /// </summary>
-    public const bool CREATE_COPY_OF_EDITED_SPECIES = true;
+    public const float CREATE_COPY_OF_EDITED_SPECIES_CHANCE = 0.5f;
 
     /// <summary>
     ///   Max number of concurrent audio players that may be spawned per entity.

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -123,7 +123,7 @@ public static class Constants
     /// <summary>
     ///   If true a mutated copy of the (player) species is created when entering the editor
     /// </summary>
-    public const bool CREATE_COPY_OF_EDITED_SPECIES = false;
+    public const bool CREATE_COPY_OF_EDITED_SPECIES = true;
 
     /// <summary>
     ///   Max number of concurrent audio players that may be spawned per entity.

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -1491,7 +1491,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
         // Disabled warning as this is a tweak constant
         // ReSharper disable ConditionIsAlwaysTrueOrFalse HeuristicUnreachableCode
-        if (Constants.CREATE_COPY_OF_EDITED_SPECIES && new Random().NextDouble() > 0.5)
+        if (new Random().NextDouble() < Constants.CREATE_COPY_OF_EDITED_SPECIES_CHANCE)
         {
             // Create a mutated version of the current species code to compete against the player
             CreateMutatedSpeciesCopy(species);

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -1490,7 +1490,6 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 #pragma warning disable 162
 
         // Disabled warning as this is a tweak constant
-        // ReSharper disable ConditionIsAlwaysTrueOrFalse HeuristicUnreachableCode
         if (new Random().NextDouble() < Constants.CREATE_COPY_OF_EDITED_SPECIES_CHANCE)
         {
             // Create a mutated version of the current species code to compete against the player

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -1491,7 +1491,7 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
 
         // Disabled warning as this is a tweak constant
         // ReSharper disable ConditionIsAlwaysTrueOrFalse HeuristicUnreachableCode
-        if (Constants.CREATE_COPY_OF_EDITED_SPECIES)
+        if (Constants.CREATE_COPY_OF_EDITED_SPECIES && new Random().NextDouble() > 0.5)
         {
             // Create a mutated version of the current species code to compete against the player
             CreateMutatedSpeciesCopy(species);

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -1487,17 +1487,12 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
             editedMicrobeOrganelles.Add((OrganelleTemplate)organelle.Clone());
         }
 
-#pragma warning disable 162
-
         // Disabled warning as this is a tweak constant
         if (new Random().NextDouble() < Constants.CREATE_COPY_OF_EDITED_SPECIES_CHANCE)
         {
             // Create a mutated version of the current species code to compete against the player
             CreateMutatedSpeciesCopy(species);
         }
-
-        // ReSharper restore ConditionIsAlwaysTrueOrFalse HeuristicUnreachableCode
-#pragma warning restore 162
 
         NewName = species.FormattedName;
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

After some playtesting, it was clear that it's just too easy to completely outrun the other species, which still take a lot of rounds to propagate around the world. In the future we should solve this by making the player migrate slower and the AI migrate faster, but in the short term this is the only practical way to make a fun 0.5.6

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
