### PR TITLE
Tweaked iron chunk's dissolve effect cutoff threshold

### DIFF
--- a/shaders/IronChunk.shader
+++ b/shaders/IronChunk.shader
@@ -15,12 +15,11 @@ void fragment() {
     vec4 normalMap = texture(normalTexture, UV);
     vec4 dissolveTex = texture(dissolveTexture, UV);
 
-    float cutoff = dot(dissolveTex.rgb, vec3(0.4, 0.4, 0.4)) -
-        float(-0.5 + clamp(dissolveValue, 0, 1));
+    float cutoff = dot(dissolveTex.rgb, vec3(0.3, 0.3, 0.3)) -
+        float(-0.4 + clamp(dissolveValue, 0, 1));
 
     vec3 dissolveOutline = vec3(round(1.0 - float(cutoff - outlineWidth))) *
         growColor.rgb;
-
 
     ALBEDO = mainTex.rgb;
     NORMALMAP = normalMap.xyz;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Iron chunks now dissolve earlier without slight delay after engulfment.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
