### PR TITLE
Increase Migration Rate

### DIFF
--- a/simulation_parameters/common/auto-evo_parameters.json
+++ b/simulation_parameters/common/auto-evo_parameters.json
@@ -8,7 +8,7 @@
     "SpeciesSplitByMutationThresholdPopulationAmount": 200,
     "BiodiversityAttemptFillChance": 0.7,
     "UseBiodiversityForceSplit": false,
-    "BiodiversityFromNeighbourPatchChance": 0.3,
+    "BiodiversityFromNeighbourPatchChance": 0.55,
     "BiodiversityNearbyPatchIsFreePopulation": true,
     "NewBiodiversityIncreasingSpeciesPopulation": 100,
     "BiodiversitySplitIsMutated": true


### PR DESCRIPTION
**Brief Description of What This PR Does**

Increases odds that species from auto-evo move to other patches. Under this branch the AI will normally have species at the surface by round 12, so that a player who rushes to the surface early will only have a few rounds of getting to be the only species.


**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
