### PR TITLE
Update CustomConfirmationDialog's strings on locale change

### DIFF
--- a/src/gui_common/CustomDialog.cs
+++ b/src/gui_common/CustomDialog.cs
@@ -169,6 +169,12 @@ public class CustomDialog : Popup, ICustomPopup
 
                 break;
             }
+
+            case NotificationTranslationChanged:
+            {
+                translatedWindowTitle = TranslationServer.Translate(windowTitle);
+                break;
+            }
         }
     }
 

--- a/src/gui_common/dialogs/CustomConfirmationDialog.cs
+++ b/src/gui_common/dialogs/CustomConfirmationDialog.cs
@@ -116,6 +116,8 @@ public class CustomConfirmationDialog : CustomDialog
             UpdateLabel();
             UpdateButtons();
         }
+
+        base._Notification(what);
     }
 
     private void UpdateLabel()

--- a/src/gui_common/dialogs/CustomConfirmationDialog.cs
+++ b/src/gui_common/dialogs/CustomConfirmationDialog.cs
@@ -109,6 +109,15 @@ public class CustomConfirmationDialog : CustomDialog
         UpdateButtons();
     }
 
+    public override void _Notification(int what)
+    {
+        if (what == NotificationTranslationChanged)
+        {
+            UpdateLabel();
+            UpdateButtons();
+        }
+    }
+
     private void UpdateLabel()
     {
         dialogLabel.Text = TranslationServer.Translate(dialogText);


### PR DESCRIPTION
**Brief Description of What This PR Does**

Made them react to language change.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
