### PR TITLE
Straggling Balance Changes

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -217,7 +217,7 @@ public static class Constants
     /// <summary>
     ///   Amount of health per second regenerated
     /// </summary>
-    public const float REGENERATION_RATE = 1.0f;
+    public const float REGENERATION_RATE = 1.5f;
 
     /// <summary>
     ///   How often in seconds ATP damage is checked and applied if cell has no ATP
@@ -263,7 +263,7 @@ public static class Constants
     /// <summary>
     ///   The speed reduction when a cell is in engulfing mode.
     /// </summary>
-    public const float ENGULFING_MOVEMENT_DIVISION = 2.0f;
+    public const float ENGULFING_MOVEMENT_DIVISION = 1.7f;
 
     /// <summary>
     ///   The speed reduction when a cell is being engulfed.

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -61,7 +61,7 @@ public static class Constants
     /// </remarks>
     public const float BASE_MOVEMENT_ATP_COST = 1.0f;
 
-    public const float FLAGELLA_ENERGY_COST = 7.1f;
+    public const float FLAGELLA_ENERGY_COST = 7.0f;
 
     public const float FLAGELLA_BASE_FORCE = 75.7f;
 
@@ -450,7 +450,7 @@ public static class Constants
     /// <summary>
     ///   How much auto-evo affects the player species compared to the normal amount
     /// </summary>
-    public const float AUTO_EVO_PLAYER_STRENGTH_FRACTION = 0.8f;
+    public const float AUTO_EVO_PLAYER_STRENGTH_FRACTION = 0.35f;
 
     public const int EDITOR_TIME_JUMP_MILLION_YEARS = 100;
 
@@ -626,27 +626,27 @@ public static class Constants
     /// <summary>
     ///   Minimum amount for the little category in the hover info.
     /// </summary>
-    public const float COMPOUND_DENSITY_CATEGORY_LITTLE = 5f;
+    public const float COMPOUND_DENSITY_CATEGORY_LITTLE = 10f;
 
     /// <summary>
     ///   Minimum amount for the some category in the hover info.
     /// </summary>
-    public const float COMPOUND_DENSITY_CATEGORY_SOME = 20f;
+    public const float COMPOUND_DENSITY_CATEGORY_SOME = 50f;
 
     /// <summary>
     ///   Minimum amount for the fair amount category in the hover info.
     /// </summary>
-    public const float COMPOUND_DENSITY_CATEGORY_FAIR_AMOUNT = 50f;
+    public const float COMPOUND_DENSITY_CATEGORY_FAIR_AMOUNT = 200f;
 
     /// <summary>
     ///   Minimum amount for the quite a bit category in the hover info.
     /// </summary>
-    public const float COMPOUND_DENSITY_CATEGORY_QUITE_A_BIT = 200f;
+    public const float COMPOUND_DENSITY_CATEGORY_QUITE_A_BIT = 400f;
 
     /// <summary>
     ///   Minimum amount for the an abundance category in the hover info.
     /// </summary>
-    public const float COMPOUND_DENSITY_CATEGORY_AN_ABUNDANCE = 500f;
+    public const float COMPOUND_DENSITY_CATEGORY_AN_ABUNDANCE = 600f;
 
     /// <summary>
     ///   Regex for species name validation.

--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -3,7 +3,7 @@
         "name": "RESPIRATION",
         "inputs": {
             "oxygen": 1,
-            "glucose": 0.2
+            "glucose": 0.18
         },
         "outputs": {
             "atp": 87
@@ -21,7 +21,7 @@
     "glycolysis_cytoplasm": {
         "name": "CYTOPLASM_GLYCOLYSIS",
         "inputs": {
-            "glucose": 0.012
+            "glucose": 0.011
         },
         "outputs": {
             "atp": 3
@@ -61,20 +61,20 @@
         "name": "CHEMO_SYNTHESIS",
         "inputs": {
             "carbondioxide": 0.09,
-            "hydrogensulfide": 0.12
+            "hydrogensulfide": 0.14
         },
         "outputs": {
-            "glucose": 0.08
+            "glucose": 0.09
         }
     },
     "bacterial_ChemoSynthesis": {
         "name": "CHEMO_SYNTHESIS",
         "inputs": {
             "carbondioxide": 0.09,
-            "hydrogensulfide": 0.06
+            "hydrogensulfide": 0.07
         },
         "outputs": {
-            "glucose": 0.03
+            "glucose": 0.04
         }
     },
     "nitrogenFixing": {
@@ -102,7 +102,7 @@
         "name": "RESPIRATION",
         "inputs": {
             "oxygen": 1,
-            "glucose": 0.15
+            "glucose": 0.12
         },
         "outputs": {
             "atp": 38

--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -201,7 +201,7 @@
                             "convexShapePath": "res://assets/models/Iron4.shape"
                         }
                     ],
-                    "density": 0.00005,
+                    "density": 0.00003,
                     "dissolves": true,
                     "radius": 1,
                     "chunkScale": 1,
@@ -286,13 +286,13 @@
                     "deleteOnTouch": false,
                     "compounds": {
                         "ammonia": {
-                            "amount": 200
+                            "amount": 50
                         },
                         "phosphates": {
-                            "amount": 200
+                            "amount": 50
                         },
                         "glucose": {
-                            "amount": 200
+                            "amount": 100
                         }
                     }
                 },
@@ -304,7 +304,7 @@
                             "convexShapePath": "res://assets/models/Iron5.shape"
                         }
                     ],
-                    "density": 0.00005,
+                    "density": 0.00008,
                     "dissolves": true,
                     "radius": 10,
                     "chunkScale": 1,
@@ -451,7 +451,7 @@
                             "convexShapePath": "res://assets/models/Iron5.shape"
                         }
                     ],
-                    "density": 0.00005,
+                    "density": 0.00003,
                     "dissolves": true,
                     "radius": 10,
                     "chunkScale": 1,
@@ -683,13 +683,13 @@
                     "deleteOnTouch": false,
                     "compounds": {
                         "ammonia": {
-                            "amount": 200
+                            "amount": 50
                         },
                         "phosphates": {
-                            "amount": 200
+                            "amount": 50
                         },
                         "glucose": {
-                            "amount": 200
+                            "amount": 100
                         }
                     }
                 }
@@ -895,7 +895,7 @@
                             "convexShapePath": "res://assets/models/organelles/Rusticyanin.shape"
                         }
                     ],
-                    "density": 0.00002,
+                    "density": 0.00006,
                     "dissolves": true,
                     "radius": 1,
                     "chunkScale": 1,
@@ -906,13 +906,13 @@
                     "deleteOnTouch": false,
                     "compounds": {
                         "ammonia": {
-                            "amount": 200
+                            "amount": 50
                         },
                         "phosphates": {
-                            "amount": 200
+                            "amount": 50
                         },
                         "glucose": {
-                            "amount": 200
+                            "amount": 100
                         }
                     }
                 }
@@ -1025,7 +1025,7 @@
                             "convexShapePath": "res://assets/models/Iron4.shape"
                         }
                     ],
-                    "density": 0.0005,
+                    "density": 0.00008,
                     "dissolves": true,
                     "radius": 1,
                     "chunkScale": 1,
@@ -1122,7 +1122,7 @@
                             "convexShapePath": "res://assets/models/organelles/Rusticyanin.shape"
                         }
                     ],
-                    "density": 0.00002,
+                    "density": 0.00004,
                     "dissolves": true,
                     "radius": 1,
                     "chunkScale": 1,
@@ -1133,13 +1133,13 @@
                     "deleteOnTouch": false,
                     "compounds": {
                         "ammonia": {
-                            "amount": 200
+                            "amount": 50
                         },
                         "phosphates": {
-                            "amount": 200
+                            "amount": 50
                         },
                         "glucose": {
-                            "amount": 200
+                            "amount": 100
                         }
                     }
                 }
@@ -1252,7 +1252,7 @@
                             "convexShapePath": "res://assets/models/Iron4.shape"
                         }
                     ],
-                    "density": 0.00005,
+                    "density": 0.00008,
                     "dissolves": true,
                     "radius": 1,
                     "chunkScale": 1,
@@ -1395,7 +1395,7 @@
                             "convexShapePath": "res://assets/models/Iron4.shape"
                         }
                     ],
-                    "density": 0.0001,
+                    "density": 0.0003,
                     "dissolves": true,
                     "radius": 1,
                     "chunkScale": 1,
@@ -1707,7 +1707,7 @@
                             "convexShapePath": "res://assets/models/Iron4.shape"
                         }
                     ],
-                    "density": 0.00005,
+                    "density": 0.00006,
                     "dissolves": true,
                     "radius": 1,
                     "chunkScale": 1,
@@ -1962,13 +1962,13 @@
                     "deleteOnTouch": false,
                     "compounds": {
                         "ammonia": {
-                            "amount": 200
+                            "amount": 50
                         },
                         "phosphates": {
-                            "amount": 200
+                            "amount": 50
                         },
                         "glucose": {
-                            "amount": 200
+                            "amount": 100
                         }
                     }
                 }

--- a/simulation_parameters/microbe_stage/organelles.json
+++ b/simulation_parameters/microbe_stage/organelles.json
@@ -328,8 +328,8 @@
     "flagellum": {
         "mpCost": 55,
         "initialComposition": {
-            "ammonia": 2,
-            "phosphates": 2
+            "ammonia": 1,
+            "phosphates": 1
         },
         "hexes": [
             {
@@ -361,8 +361,8 @@
     "vacuole": {
         "mpCost": 50,
         "initialComposition": {
-            "ammonia": 2,
-            "phosphates": 2
+            "ammonia": 1,
+            "phosphates": 1
         },
         "hexes": [
             {
@@ -424,8 +424,8 @@
     "oxytoxy": {
         "mpCost": 70,
         "initialComposition": {
-            "ammonia": 2,
-            "phosphates": 2
+            "ammonia": 1,
+            "phosphates": 1
         },
         "hexes": [
             {
@@ -458,8 +458,8 @@
     "bindingAgent": {
         "mpCost": 55,
         "initialComposition": {
-            "ammonia": 2,
-            "phosphates": 2
+            "ammonia": 1,
+            "phosphates": 1
         },
         "hexes": [
             {
@@ -525,8 +525,8 @@
     "cytoplasm": {
         "mpCost": 22,
         "initialComposition": {
-            "ammonia": 2,
-            "phosphates": 2
+            "ammonia": 1,
+            "phosphates": 1
         },
         "hexes": [
             {

--- a/simulation_parameters/microbe_stage/organelles.json
+++ b/simulation_parameters/microbe_stage/organelles.json
@@ -48,7 +48,7 @@
         },
         "prokaryoteChance": 2,
         "chanceToCreate": 0.5,
-        "mass": 0.09,
+        "mass": 0.08,
         "displayScene": "res://assets/models/organelles/Rusticyanin.tscn",
         "name": "RUSTICYANIN",
         "productionColour": "#3293f7",


### PR DESCRIPTION
**Brief Description of What This PR Does**
Some changes that didn't make it into the balance pass before it was merged.

Slightly Decreased engulfment mode speed penalty
Tweaked compound density requirements for inspection categories
Very slightly decreased flagellum ATP cost
Reduced impact of autoevo on the player for the time being

I am not entirely happy with the current state of autoevo's effects on the player, but it will have to due for now.
**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
