### PR TITLE
Added a feature to adjust volume for individual tracks in Jukebox and tweaked the volume of a few sounds

### DIFF
--- a/simulation_parameters/common/music_tracks.json
+++ b/simulation_parameters/common/music_tracks.json
@@ -5,9 +5,11 @@
                 "TrackOrder": "Sequential",
                 "Tracks": [
                     {
+                        "Volume": 0.2,
                         "ResourcePath": "res://assets/sounds/main-menu-theme-1.ogg"
                     },
                     {
+                        "Volume": 0.2,
                         "ResourcePath": "res://assets/sounds/main-menu-theme-2.ogg"
                     }
                 ]
@@ -46,6 +48,7 @@
                         "ResourcePath": "res://assets/sounds/soundeffects/microbe-ambience.ogg"
                     },
                     {
+                        "Volume": 0.1,
                         "ResourcePath": "res://assets/sounds/soundeffects/microbe-ambience2.ogg"
                     }
                 ]

--- a/src/general/Jukebox.cs
+++ b/src/general/Jukebox.cs
@@ -186,13 +186,13 @@ public class Jukebox : Node
         {
             foreach (var player in audioPlayers)
             {
-                var dbValue = GD.Linear2Db(linearVolume * player.LinearVolume);
+                var dbValue = GD.Linear2Db(linearVolume * player.BaseVolume * player.LinearVolume);
                 player.Player.VolumeDb = dbValue;
             }
         }
         else
         {
-            var dbValue = GD.Linear2Db(linearVolume * audioPlayer.LinearVolume);
+            var dbValue = GD.Linear2Db(linearVolume * audioPlayer.BaseVolume * audioPlayer.LinearVolume);
             audioPlayer.Player.VolumeDb = dbValue;
         }
     }
@@ -236,6 +236,7 @@ public class Jukebox : Node
 
             player.Player.Stream = stream;
             player.CurrentTrack = track.ResourcePath;
+            player.BaseVolume = track.Volume;
 
             changedTrack = true;
         }
@@ -572,6 +573,8 @@ public class Jukebox : Node
         ///   The current AudioPlayer volume level in linear volume range 0-1.0f
         /// </summary>
         public float LinearVolume { get; set; } = 1.0f;
+
+        public float BaseVolume { get; set; } = 1.0f;
 
         public bool StreamPaused
         {

--- a/src/general/MusicCategory.cs
+++ b/src/general/MusicCategory.cs
@@ -117,6 +117,11 @@ public class TrackList
     /// </summary>
     public class Track
     {
+        /// <summary>
+        ///   The track's base volume level in linear volume range 0-1.0f
+        /// </summary>
+        public float Volume { get; set; } = 1.0f;
+
         public string ResourcePath { get; set; }
 
         [JsonIgnore]

--- a/src/gui_common/GUICommon.cs
+++ b/src/gui_common/GUICommon.cs
@@ -125,20 +125,23 @@ public class GUICommon : NodeWithInput
     /// </summary>
     public void PlayButtonPressSound()
     {
-        PlayCustomSound(buttonPressSound);
+        PlayCustomSound(buttonPressSound, 0.2f);
     }
 
     /// <summary>
     ///   Plays the given sound non-positionally.
     /// </summary>
-    public void PlayCustomSound(AudioStream sound)
+    public void PlayCustomSound(AudioStream sound, float volume = 1.0f)
     {
+        volume = Mathf.Clamp(volume, 0.0f, 1.0f);
+
         if (AudioSource.Playing)
         {
             // Use backup player if it is available
             if (!AudioSource2.Playing)
             {
                 AudioSource2.Stream = sound;
+                AudioSource2.VolumeDb = GD.Linear2Db(volume);
                 AudioSource2.Play();
             }
 
@@ -146,6 +149,7 @@ public class GUICommon : NodeWithInput
         }
 
         AudioSource.Stream = sound;
+        AudioSource.VolumeDb = GD.Linear2Db(volume);
         AudioSource.Play();
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Added BaseVolume to the audio players in Jukebox that can be set according to an individual track volume level in the json. Especially done so the bubbly microbe ambiance can finally be bearable to hear at default sound volume settings.

`main-menu-theme-1.ogg` and `main-menu-theme-2.ogg` volume is also tweaked as they are a bit too loud which could cause discomfort for new players booting up Thrive for the first time.

Other than those, the button press sound volume is decreased too, as they might become distracting while repeatedly clicking on stuff.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
