### PR TITLE
Loading screen thrive logo spinner jitters

### DIFF
--- a/src/engine/LoadingScreen.cs
+++ b/src/engine/LoadingScreen.cs
@@ -24,6 +24,9 @@ public class LoadingScreen : Control
     [Export]
     public NodePath RandomizeTipTimerPath;
 
+    [Export]
+    public NodePath SpinnerPath;
+
     /// <summary>
     ///   How fast the loading indicator spins
     /// </summary>
@@ -149,8 +152,7 @@ public class LoadingScreen : Control
         loadingDescriptionLabel = GetNode<Label>(LoadingDescriptionPath);
         tipLabel = GetNode<Label>(TipLabelPath);
         randomizeTipTimer = GetNode<Timer>(RandomizeTipTimerPath);
-
-        spinner = GetNode<Control>("HBoxContainer/Spinner");
+        spinner = GetNode<Control>(SpinnerPath);
 
         UpdateMessage();
         UpdateDescription();

--- a/src/engine/LoadingScreen.tscn
+++ b/src/engine/LoadingScreen.tscn
@@ -119,6 +119,7 @@ __meta__ = {
 }
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer"]
+margin_left = 8.0
 margin_top = 8.0
 margin_right = 86.0
 margin_bottom = 56.0

--- a/src/engine/LoadingScreen.tscn
+++ b/src/engine/LoadingScreen.tscn
@@ -39,6 +39,7 @@ LoadingMessagePath = NodePath("HBoxContainer/VBoxContainer/LoadingMessage")
 LoadingDescriptionPath = NodePath("HBoxContainer/VBoxContainer/LoadingDescription")
 TipLabelPath = NodePath("TipLabel")
 RandomizeTipTimerPath = NodePath("TipTimer")
+SpinnerPath = NodePath("HBoxContainer/Spinner/TextureRect")
 
 [node name="ColorRect" type="ColorRect" parent="."]
 anchor_right = 1.0
@@ -118,7 +119,6 @@ __meta__ = {
 }
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer"]
-margin_left = 8.0
 margin_top = 8.0
 margin_right = 86.0
 margin_bottom = 56.0
@@ -149,7 +149,6 @@ margin_left = 101.0
 margin_right = 165.0
 margin_bottom = 64.0
 rect_min_size = Vector2( 64, 64 )
-rect_pivot_offset = Vector2( 32, 32 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -158,6 +157,7 @@ __meta__ = {
 margin_right = 64.0
 margin_bottom = 64.0
 rect_min_size = Vector2( 64, 64 )
+rect_pivot_offset = Vector2( 32, 32 )
 texture = ExtResource( 3 )
 expand = true
 stretch_mode = 6


### PR DESCRIPTION
**Brief Description of What This PR Does**

Solution was to directly rotate the TextureRect within the MarginContainer.
Rotating the MarginContainer results in jitter. Not sure why.

**Related Issues**

closes #2780

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
