### PR TITLE
Remove button press sound on the quit buttons in main menu and pause menu

### DIFF
--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -345,7 +345,6 @@ public class MainMenu : NodeWithInput
 
     private void QuitPressed()
     {
-        GUICommon.Instance.PlayButtonPressSound();
         GetTree().Quit();
     }
 

--- a/src/general/PauseMenu.cs
+++ b/src/general/PauseMenu.cs
@@ -241,8 +241,6 @@ public class PauseMenu : ControlWithInput
 
     private void ExitPressed()
     {
-        GUICommon.Instance.PlayButtonPressSound();
-
         exitType = ExitType.QuitGame;
 
         if (SaveHelper.SavedRecently || !Settings.Instance.ShowUnsavedProgressWarning)
@@ -251,6 +249,7 @@ public class PauseMenu : ControlWithInput
         }
         else
         {
+            GUICommon.Instance.PlayButtonPressSound();
             unsavedProgressWarning.DialogText = TranslationServer.Translate("QUIT_GAME_WARNING");
             unsavedProgressWarning.PopupCenteredShrink();
         }


### PR DESCRIPTION
**Brief Description of What This PR Does**

The press sound usually gets cut off when quitting the game which sounds glitchy.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
