### PR TITLE
2314 Crash on PartialAdvectCenter

### DIFF
--- a/src/microbe_stage/CompoundCloudPlane.cs
+++ b/src/microbe_stage/CompoundCloudPlane.cs
@@ -616,10 +616,10 @@ public class CompoundCloudPlane : CSGMesh, ISaveLoadedTracked
                     // NOTE: we add modulo to avoid overflow due to large time steps
                     // This makes this function a duplicate of PartialAdvectEdges
                     // TODO: check for refactorization (and in general of the whole file) --Maxonovien
-                    q0 = MathUtils.PositiveModulo(q0, Size);
-                    q1 = MathUtils.PositiveModulo(q1, Size);
-                    r0 = MathUtils.PositiveModulo(r0, Size);
-                    r1 = MathUtils.PositiveModulo(r1, Size);
+                    q0 = q0.PositiveModulo(Size);
+                    q1 = q1.PositiveModulo(Size);
+                    r0 = r0.PositiveModulo(Size);
+                    r1 = r1.PositiveModulo(Size);
 
                     Density[q0, r0] += OldDensity[x, y] * s0 * t0;
                     Density[q0, r1] += OldDensity[x, y] * s0 * t1;

--- a/src/microbe_stage/CompoundCloudPlane.cs
+++ b/src/microbe_stage/CompoundCloudPlane.cs
@@ -614,7 +614,7 @@ public class CompoundCloudPlane : CSGMesh, ISaveLoadedTracked
                         out var s1, out var s0, out var t1, out var t0);
 
                     // NOTE: we add modulo to avoid overflow due to large time steps
-                    // This makes this function a duplicate of PartialAdvectCenter
+                    // This makes this function a duplicate of PartialAdvectEdges
                     // TODO: check for refactorization (and in general of the whole file) --Maxonovien
                     q0 = MathUtils.PositiveModulo(q0, Size);
                     q1 = MathUtils.PositiveModulo(q1, Size);

--- a/src/microbe_stage/CompoundCloudPlane.cs
+++ b/src/microbe_stage/CompoundCloudPlane.cs
@@ -613,6 +613,14 @@ public class CompoundCloudPlane : CSGMesh, ISaveLoadedTracked
                     CalculateMovementFactors(dx, dy, out var q0, out var q1, out var r0, out var r1,
                         out var s1, out var s0, out var t1, out var t0);
 
+                    // NOTE: we add modulo to avoid overflow due to large time steps
+                    // This makes this function a duplicate of PartialAdvectCenter
+                    // TODO: check for refactorization (and in general of the whole file) --Maxonovien
+                    q0 = MathUtils.PositiveModulo(q0, Size);
+                    q1 = MathUtils.PositiveModulo(q1, Size);
+                    r0 = MathUtils.PositiveModulo(r0, Size);
+                    r1 = MathUtils.PositiveModulo(r1, Size);
+
                     Density[q0, r0] += OldDensity[x, y] * s0 * t0;
                     Density[q0, r1] += OldDensity[x, y] * s0 * t1;
                     Density[q1, r0] += OldDensity[x, y] * s1 * t0;


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR fixes possible crashes when updating cloud centers, by adding a modulo on the grid access.

Note that this duplicates the update method for edges. I still left all as is, because that would probably involve a long and error-prone refactor, while this is intended to be a hotfix.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

Closes #2314.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
