### PR TITLE
Comment out Tool attribute in custom dialogs

### DIFF
--- a/src/gui_common/CustomDialog.cs
+++ b/src/gui_common/CustomDialog.cs
@@ -43,6 +43,7 @@ using Godot;
 ///     TODO: see https://github.com/Revolutionary-Games/Thrive/issues/2751
 ///   </para>
 /// </remarks>
+
 // [Tool]
 public class CustomDialog : Popup, ICustomPopup
 {

--- a/src/gui_common/CustomDialog.cs
+++ b/src/gui_common/CustomDialog.cs
@@ -38,9 +38,12 @@ using Godot;
 ///     This uses Tool attribute to make this class be run in the Godot editor for live feedback as this class
 ///     handles UI visuals extensively through code. Not necessary but very helpful when editing scenes involving
 ///     any custom dialogs.
+///     NOTE: should always be commented in master branch to avoid Godot breaking exported properties. Uncomment this
+///     only locally if needed.
+///     TODO: see https://github.com/Revolutionary-Games/Thrive/issues/2751
 ///   </para>
 /// </remarks>
-[Tool]
+// [Tool]
 public class CustomDialog : Popup, ICustomPopup
 {
     private string windowTitle;

--- a/src/gui_common/CustomDialog.cs
+++ b/src/gui_common/CustomDialog.cs
@@ -40,11 +40,10 @@ using Godot;
 ///     any custom dialogs.
 ///     NOTE: should always be commented in master branch to avoid Godot breaking exported properties. Uncomment this
 ///     only locally if needed.
-///     TODO: see https://github.com/Revolutionary-Games/Thrive/issues/2751
 ///   </para>
 /// </remarks>
-
-// [Tool]
+/// TODO: see https://github.com/Revolutionary-Games/Thrive/issues/2751
+/// [Tool]
 public class CustomDialog : Popup, ICustomPopup
 {
     private string windowTitle;

--- a/src/gui_common/dialogs/CustomConfirmationDialog.cs
+++ b/src/gui_common/dialogs/CustomConfirmationDialog.cs
@@ -3,6 +3,7 @@
 /// <summary>
 ///   A custom reimplementation of ConfirmationDialog and AcceptDialog combined into one.
 /// </summary>
+
 // [Tool]
 public class CustomConfirmationDialog : CustomDialog
 {

--- a/src/gui_common/dialogs/CustomConfirmationDialog.cs
+++ b/src/gui_common/dialogs/CustomConfirmationDialog.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///   A custom reimplementation of ConfirmationDialog and AcceptDialog combined into one.
 /// </summary>
-[Tool]
+// [Tool]
 public class CustomConfirmationDialog : CustomDialog
 {
     [Export]

--- a/src/gui_common/dialogs/CustomConfirmationDialog.cs
+++ b/src/gui_common/dialogs/CustomConfirmationDialog.cs
@@ -3,8 +3,8 @@
 /// <summary>
 ///   A custom reimplementation of ConfirmationDialog and AcceptDialog combined into one.
 /// </summary>
-
-// [Tool]
+/// TODO: see https://github.com/Revolutionary-Games/Thrive/issues/2751
+/// [Tool]
 public class CustomConfirmationDialog : CustomDialog
 {
     [Export]

--- a/src/gui_common/dialogs/ErrorDialog.cs
+++ b/src/gui_common/dialogs/ErrorDialog.cs
@@ -4,7 +4,8 @@ using Godot;
 /// <summary>
 ///   A dialog popup dedicated for showing error and Exception messages.
 /// </summary>
-[Tool]
+
+// [Tool]
 public class ErrorDialog : CustomDialog
 {
     private string errorMessage;

--- a/src/gui_common/dialogs/ErrorDialog.cs
+++ b/src/gui_common/dialogs/ErrorDialog.cs
@@ -4,8 +4,8 @@ using Godot;
 /// <summary>
 ///   A dialog popup dedicated for showing error and Exception messages.
 /// </summary>
-
-// [Tool]
+/// TODO: see https://github.com/Revolutionary-Games/Thrive/issues/2751
+/// [Tool]
 public class ErrorDialog : CustomDialog
 {
     private string errorMessage;

--- a/src/gui_common/dialogs/LicensesDisplay.cs
+++ b/src/gui_common/dialogs/LicensesDisplay.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Godot;
 
-[Tool]
+// [Tool]
 public class LicensesDisplay : CustomDialog
 {
     private List<(string Heading, string File)> licensesToShow;

--- a/src/gui_common/dialogs/LicensesDisplay.cs
+++ b/src/gui_common/dialogs/LicensesDisplay.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Godot;
 
+// TODO: see https://github.com/Revolutionary-Games/Thrive/issues/2751
 // [Tool]
 public class LicensesDisplay : CustomDialog
 {

--- a/src/gui_common/dialogs/TutorialDialog.cs
+++ b/src/gui_common/dialogs/TutorialDialog.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///   A window dialog for tutorials with custom behaviors such as show (pop-up) delay and animation.
 /// </summary>
-[Tool]
+// [Tool]
 public class TutorialDialog : CustomDialog
 {
     private Tween tween;

--- a/src/gui_common/dialogs/TutorialDialog.cs
+++ b/src/gui_common/dialogs/TutorialDialog.cs
@@ -3,8 +3,8 @@
 /// <summary>
 ///   A window dialog for tutorials with custom behaviors such as show (pop-up) delay and animation.
 /// </summary>
-
-// [Tool]
+/// TODO: see https://github.com/Revolutionary-Games/Thrive/issues/2751
+/// [Tool]
 public class TutorialDialog : CustomDialog
 {
     private Tween tween;

--- a/src/gui_common/dialogs/TutorialDialog.cs
+++ b/src/gui_common/dialogs/TutorialDialog.cs
@@ -3,6 +3,7 @@
 /// <summary>
 ///   A window dialog for tutorials with custom behaviors such as show (pop-up) delay and animation.
 /// </summary>
+
 // [Tool]
 public class TutorialDialog : CustomDialog
 {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Commented out `Tool` attribute in custom dialogs to workaround a bug where Godot breaks some of the exported properties #2751.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
