### PR TITLE
Auto-evo data caching and other speedups

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -29,6 +29,7 @@
     <Compile Include="src\auto-evo\simulation\food_source\MarineSnowFoodSource.cs" />
     <Compile Include="src\auto-evo\simulation\food_source\HeterotrophicFoodSource.cs" />
     <Compile Include="src\auto-evo\simulation\food_source\EnvironmentalFoodSource.cs" />
+    <Compile Include="src\auto-evo\simulation\SimulationCache.cs" />
     <Compile Include="src\auto-evo\steps\IncreaseBiodiversity.cs" />
     <Compile Include="src\auto-evo\steps\RemoveInvalidMigrations.cs" />
     <Compile Include="src\engine\CheatManager.cs" />

--- a/src/auto-evo/simulation/PopulationSimulation.cs
+++ b/src/auto-evo/simulation/PopulationSimulation.cs
@@ -14,10 +14,12 @@
         private static readonly Compound Glucose = SimulationParameters.Instance.GetCompound("glucose");
         private static readonly Compound HydrogenSulfide = SimulationParameters.Instance.GetCompound("hydrogensulfide");
         private static readonly Compound Iron = SimulationParameters.Instance.GetCompound("iron");
+        private static readonly Compound Sunlight = SimulationParameters.Instance.GetCompound("sunlight");
 
         public static void Simulate(SimulationConfiguration parameters)
         {
             var random = new Random();
+            var cache = new SimulationCache();
 
             var speciesToSimulate = CopyInitialPopulationsToResults(parameters);
 
@@ -31,7 +33,7 @@
 
             while (parameters.StepsLeft > 0)
             {
-                RunSimulationStep(parameters, speciesToSimulate, patchesToSimulate, random);
+                RunSimulationStep(parameters, speciesToSimulate, patchesToSimulate, random, cache);
                 --parameters.StepsLeft;
             }
         }
@@ -115,31 +117,31 @@
         }
 
         private static void RunSimulationStep(SimulationConfiguration parameters, List<Species> species,
-            IEnumerable<KeyValuePair<int, Patch>> patchesToSimulate, Random random)
+            IEnumerable<KeyValuePair<int, Patch>> patchesToSimulate, Random random, SimulationCache cache)
         {
             foreach (var entry in patchesToSimulate)
             {
                 // Simulate the species in each patch taking into account the already computed populations
                 SimulatePatchStep(parameters.Results, entry.Value,
-                    species.Where(item => parameters.Results.GetPopulationInPatch(item, entry.Value) > 0).ToList(),
-                    random);
+                    species.Where(item => parameters.Results.GetPopulationInPatch(item, entry.Value) > 0),
+                    random, cache);
             }
         }
 
         /// <summary>
         ///   The heart of the simulation that handles the processed parameters and calculates future populations.
         /// </summary>
-        private static void SimulatePatchStep(RunResults populations, Patch patch, List<Species> genericSpecies,
-            Random random)
+        private static void SimulatePatchStep(RunResults populations, Patch patch, IEnumerable<Species> genericSpecies,
+            Random random, SimulationCache cache)
         {
             _ = random;
 
-            // Skip if there aren't any species in this patch
-            if (genericSpecies.Count < 1)
-                return;
-
             // This algorithm version is for microbe species
             var species = genericSpecies.Select(s => (MicrobeSpecies)s).ToList();
+
+            // Skip if there aren't any species in this patch
+            if (species.Count < 1)
+                return;
 
             var energyBySpecies = new Dictionary<MicrobeSpecies, float>();
             foreach (var currentSpecies in species)
@@ -149,7 +151,7 @@
 
             var niches = new List<FoodSource>
             {
-                new EnvironmentalFoodSource(patch, "sunlight", Constants.AUTO_EVO_SUNLIGHT_ENERGY_AMOUNT),
+                new EnvironmentalFoodSource(patch, Sunlight, Constants.AUTO_EVO_SUNLIGHT_ENERGY_AMOUNT),
                 new CompoundFoodSource(patch, Glucose),
                 new CompoundFoodSource(patch, HydrogenSulfide),
                 new CompoundFoodSource(patch, Iron),
@@ -175,7 +177,8 @@
                 {
                     // Softly enforces https://en.wikipedia.org/wiki/Competitive_exclusion_principle
                     // by exaggerating fitness differences
-                    var thisSpeciesFitness = Mathf.Max(Mathf.Pow(niche.FitnessScore(currentSpecies), 2.5f), 0.0f);
+                    var thisSpeciesFitness =
+                        Mathf.Max(Mathf.Pow(niche.FitnessScore(currentSpecies, cache), 2.5f), 0.0f);
                     fitnessBySpecies[currentSpecies] = thisSpeciesFitness;
                     totalNicheFitness += thisSpeciesFitness;
                 }
@@ -195,8 +198,7 @@
 
             foreach (var currentSpecies in species)
             {
-                var energyBalanceInfo = ProcessSystem.ComputeEnergyBalance(currentSpecies.Organelles,
-                    patch.Biome, currentSpecies.MembraneType);
+                var energyBalanceInfo = cache.GetEnergyBalanceForSpecies(currentSpecies, patch);
 
                 // Modify populations based on energy
                 var newPopulation = (long)(energyBySpecies[currentSpecies]

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -5,6 +5,12 @@
     /// <summary>
     ///   Caches some information in auto-evo runs to speed them up
     /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     Some information will get outdated when data that the auto-evo relies on changes. If in the future
+    ///     caching is moved to a higher level in the auto-evo, that needs to be considered.
+    ///   </para>
+    /// </remarks>
     public class SimulationCache
     {
         private readonly Dictionary<(MicrobeSpecies, Patch), EnergyBalanceInfo> cachedEnergyBalances = new();

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -1,0 +1,27 @@
+﻿namespace AutoEvo
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    ///   Caches some information in auto-evo runs to speed them up
+    /// </summary>
+    public class SimulationCache
+    {
+        private readonly Dictionary<(MicrobeSpecies, Patch), EnergyBalanceInfo> cachedEnergyBalances = new();
+
+        public EnergyBalanceInfo GetEnergyBalanceForSpecies(MicrobeSpecies species, Patch patch)
+        {
+            var key = (species, patch);
+
+            if (cachedEnergyBalances.TryGetValue(key, out var cached))
+            {
+                return cached;
+            }
+
+            cached = ProcessSystem.ComputeEnergyBalance(species.Organelles, patch.Biome, species.MembraneType);
+
+            cachedEnergyBalances.Add(key, cached);
+            return cached;
+        }
+    }
+}

--- a/src/auto-evo/simulation/SimulationConfiguration.cs
+++ b/src/auto-evo/simulation/SimulationConfiguration.cs
@@ -20,7 +20,7 @@
         /// <summary>
         ///   Results of the run are stored here
         /// </summary>
-        public RunResults Results { get; set; } = new RunResults();
+        public RunResults Results { get; set; } = new();
 
         /// <summary>
         ///   List of species to ignore in the map for simulation.
@@ -32,7 +32,7 @@
         ///   </para>
         /// </remarks>
         /// <value>The excluded species.</value>
-        public List<Species> ExcludedSpecies { get; set; } = new List<Species>();
+        public List<Species> ExcludedSpecies { get; set; } = new();
 
         /// <summary>
         ///   List of extra species to simulate in addition to the ones in the map.
@@ -44,22 +44,33 @@
         ///   </para>
         /// </remarks>
         /// <value>The extra species.</value>
-        public List<Species> ExtraSpecies { get; set; } = new List<Species>();
+        public List<Species> ExtraSpecies { get; set; } = new();
 
         /// <summary>
         ///   Migrations to apply before running the simulation.
         /// </summary>
-        public List<Tuple<Species, SpeciesMigration>> Migrations { get; set; } =
-            new List<Tuple<Species, SpeciesMigration>>();
+        public List<Tuple<Species, SpeciesMigration>> Migrations { get; set; } = new();
 
         /// <summary>
         ///   If not empty, only the specified patches are ran
         /// </summary>
-        /// <remarks>
-        ///    <para>
-        ///      TODO: change migration finding and mutation finding to only simulate patches they need
-        ///    </para>
-        /// </remarks>
         public ISet<Patch> PatchesToRun { get; set; } = new HashSet<Patch>();
+
+        /// <summary>
+        ///   Sets the patches to be simulated to be ones where the species is present (population > 0)
+        /// </summary>
+        /// <param name="species">The species to check for in the <see cref="OriginalMap"/> patches</param>
+        public void SetPatchesToRunBySpeciesPresence(Species species)
+        {
+            PatchesToRun.Clear();
+
+            foreach (var patchEntry in OriginalMap.Patches)
+            {
+                if (patchEntry.Value.GetSpeciesPopulation(species) > 0)
+                {
+                    PatchesToRun.Add(patchEntry.Value);
+                }
+            }
+        }
     }
 }

--- a/src/auto-evo/simulation/food_source/FoodSource.cs
+++ b/src/auto-evo/simulation/food_source/FoodSource.cs
@@ -12,7 +12,7 @@ public abstract class FoodSource
     /// </summary>
     /// <param name="microbe">The species to be evaluated.</param>
     /// <param name="simulationCache">
-    ///   Cache that should be used to reduce amount of times expensive computations are ran
+    ///   Cache that should be used to reduce amount of times expensive computations are run
     /// </param>
     /// <returns>
     ///   A float to represent score. Scores are only compared against other scores from the same FoodSource,

--- a/src/auto-evo/simulation/food_source/FoodSource.cs
+++ b/src/auto-evo/simulation/food_source/FoodSource.cs
@@ -1,4 +1,6 @@
-﻿public abstract class FoodSource
+﻿using AutoEvo;
+
+public abstract class FoodSource
 {
     private readonly Compound glucose = SimulationParameters.Instance.GetCompound("glucose");
     private readonly Compound atp = SimulationParameters.Instance.GetCompound("atp");
@@ -9,11 +11,14 @@
     ///   Provides a fitness metric to determine population adjustments for species in a patch.
     /// </summary>
     /// <param name="microbe">The species to be evaluated.</param>
+    /// <param name="simulationCache">
+    ///   Cache that should be used to reduce amount of times expensive computations are ran
+    /// </param>
     /// <returns>
     ///   A float to represent score. Scores are only compared against other scores from the same FoodSource,
     ///   so different implementations do not need to worry about scale.
     /// </returns>
-    public abstract float FitnessScore(Species microbe);
+    public abstract float FitnessScore(Species microbe, SimulationCache simulationCache);
 
     protected float EnergyGenerationScore(MicrobeSpecies species, Compound compound)
     {

--- a/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
@@ -1,12 +1,14 @@
-﻿public class HeterotrophicFoodSource : FoodSource
+﻿using AutoEvo;
+
+public class HeterotrophicFoodSource : FoodSource
 {
     private readonly Compound oxytoxy = SimulationParameters.Instance.GetCompound("oxytoxy");
 
-    private MicrobeSpecies prey;
-    private Patch patch;
-    private float preyHexSize;
-    private float preySpeed;
-    private float totalEnergy;
+    private readonly MicrobeSpecies prey;
+    private readonly Patch patch;
+    private readonly float preyHexSize;
+    private readonly float preySpeed;
+    private readonly float totalEnergy;
 
     public HeterotrophicFoodSource(Patch patch, MicrobeSpecies prey)
     {
@@ -18,7 +20,7 @@
         totalEnergy = population * prey.Organelles.Count * Constants.AUTO_EVO_PREDATION_ENERGY_MULTIPLIER;
     }
 
-    public override float FitnessScore(Species species)
+    public override float FitnessScore(Species species, SimulationCache simulationCache)
     {
         var microbeSpecies = (MicrobeSpecies)species;
 
@@ -32,9 +34,7 @@
 
         var microbeSpeciesHexSize = microbeSpecies.BaseHexSize;
         var predatorSpeed = microbeSpecies.BaseSpeed;
-        predatorSpeed += ProcessSystem
-            .ComputeEnergyBalance(microbeSpecies.Organelles.Organelles, patch.Biome,
-                microbeSpecies.MembraneType).FinalBalance;
+        predatorSpeed += simulationCache.GetEnergyBalanceForSpecies(microbeSpecies, patch).FinalBalance;
 
         // It's great if you can engulf this prey, but only if you can catch it
         var engulfScore = 0.0f;

--- a/src/auto-evo/simulation/food_source/MarineSnowFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/MarineSnowFoodSource.cs
@@ -1,16 +1,16 @@
-﻿public class MarineSnowFoodSource : FoodSource
+﻿using AutoEvo;
+
+public class MarineSnowFoodSource : FoodSource
 {
     private readonly Compound glucose = SimulationParameters.Instance.GetCompound("glucose");
 
-    private Patch patch;
-    private BiomeConditions biomeConditions;
-    private float totalEnergy;
-    private float chunkSize;
+    private readonly Patch patch;
+    private readonly float totalEnergy;
+    private readonly float chunkSize;
 
     public MarineSnowFoodSource(Patch patch)
     {
         this.patch = patch;
-        biomeConditions = patch.Biome;
 
         if (patch.Biome.Chunks.TryGetValue("marineSnow", out ChunkConfiguration chunk))
         {
@@ -19,14 +19,15 @@
         }
     }
 
-    public override float FitnessScore(Species species)
+    public override float FitnessScore(Species species, SimulationCache simulationCache)
     {
         var microbeSpecies = (MicrobeSpecies)species;
 
         var predatorSpeed = microbeSpecies.BaseSpeed;
-        predatorSpeed += ProcessSystem
-            .ComputeEnergyBalance(microbeSpecies.Organelles.Organelles, patch.Biome,
-                microbeSpecies.MembraneType).FinalBalance;
+
+        var energyBalance = simulationCache.GetEnergyBalanceForSpecies(microbeSpecies, patch);
+
+        predatorSpeed += energyBalance.FinalBalance;
 
         var score = predatorSpeed * species.Behaviour.Activity;
 
@@ -37,9 +38,7 @@
             score *= Constants.AUTO_EVO_CHUNK_LEAK_MULTIPLIER;
         }
 
-        score /= ProcessSystem.ComputeEnergyBalance(
-            microbeSpecies.Organelles.Organelles,
-            biomeConditions, microbeSpecies.MembraneType).FinalBalanceStationary;
+        score /= energyBalance.FinalBalanceStationary;
 
         return score;
     }

--- a/src/auto-evo/simulation/food_source/MarineSnowFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/MarineSnowFoodSource.cs
@@ -23,11 +23,9 @@ public class MarineSnowFoodSource : FoodSource
     {
         var microbeSpecies = (MicrobeSpecies)species;
 
-        var predatorSpeed = microbeSpecies.BaseSpeed;
-
         var energyBalance = simulationCache.GetEnergyBalanceForSpecies(microbeSpecies, patch);
 
-        predatorSpeed += energyBalance.FinalBalance;
+        var predatorSpeed = microbeSpecies.BaseSpeed + energyBalance.FinalBalance;
 
         var score = predatorSpeed * species.Behaviour.Activity;
 

--- a/src/auto-evo/steps/FindBestMigration.cs
+++ b/src/auto-evo/steps/FindBestMigration.cs
@@ -36,6 +36,8 @@
         {
             var config = new SimulationConfiguration(map, Constants.AUTO_EVO_VARIANT_SIMULATION_STEPS);
 
+            config.SetPatchesToRunBySpeciesPresence(species);
+
             PopulationSimulation.Simulate(config);
 
             var population = config.Results.GetGlobalPopulation(species);
@@ -52,6 +54,11 @@
                 return new AttemptResult(null, -1);
 
             var config = new SimulationConfiguration(map, Constants.AUTO_EVO_VARIANT_SIMULATION_STEPS);
+
+            config.SetPatchesToRunBySpeciesPresence(species);
+            config.PatchesToRun.Add(migration.From);
+            config.PatchesToRun.Add(migration.To);
+
             config.Migrations.Add(new Tuple<Species, SpeciesMigration>(species, migration));
 
             // TODO: this could be faster to just simulate the source and

--- a/src/auto-evo/steps/FindBestMutation.cs
+++ b/src/auto-evo/steps/FindBestMutation.cs
@@ -14,7 +14,7 @@
         private readonly float splitThresholdFraction;
         private readonly int splitThresholdAmount;
 
-        private readonly Mutations mutations = new Mutations();
+        private readonly Mutations mutations = new();
 
         public FindBestMutation(PatchMap map, Species species, int mutationsToTry, bool allowNoMutation,
             float splitThresholdFraction, int splitThresholdAmount)
@@ -43,6 +43,8 @@
         {
             var config = new SimulationConfiguration(map, Constants.AUTO_EVO_VARIANT_SIMULATION_STEPS);
 
+            config.SetPatchesToRunBySpeciesPresence(species);
+
             PopulationSimulation.Simulate(config);
 
             return new AttemptResult(null, config.Results.GetPopulationInPatches(species));
@@ -55,6 +57,7 @@
 
             var config = new SimulationConfiguration(map, Constants.AUTO_EVO_VARIANT_SIMULATION_STEPS);
 
+            config.SetPatchesToRunBySpeciesPresence(species);
             config.ExcludedSpecies.Add(species);
             config.ExtraSpecies.Add(mutated);
 

--- a/src/general/GameWorld.cs
+++ b/src/general/GameWorld.cs
@@ -104,14 +104,20 @@ public class GameWorld
         {
             // Make sure there is an existing run, as that isn't saved, so when loading we need to create the run to
             // store things in it. Creating the run here doesn't interfere with it being started
+
+            // We skip starting a run if the list of external effects would be empty anyway, as is the case
+            // when loading a save made in the editor
+            if (value == null || value.Count < 1)
+            {
+                autoEvo?.ExternalEffects.Clear();
+                return;
+            }
+
             CreateRunIfMissing();
 
             var effects = autoEvo.ExternalEffects;
 
             effects.Clear();
-
-            if (value == null)
-                return;
 
             effects.AddRange(value);
         }

--- a/src/microbe_stage/Patch.cs
+++ b/src/microbe_stage/Patch.cs
@@ -159,10 +159,10 @@ public class Patch
 
     public long GetSpeciesPopulation(Species species)
     {
-        if (!currentSnapshot.SpeciesInPatch.ContainsKey(species))
+        if (!currentSnapshot.SpeciesInPatch.TryGetValue(species, out var population))
             return 0;
 
-        return currentSnapshot.SpeciesInPatch[species];
+        return population;
     }
 
     public float GetTotalChunkCompoundAmount(Compound compound)


### PR DESCRIPTION
**Brief Description of What This PR Does**

added caching of energy balances and made migrations and mutations only simulate the patches they need. In my testing the first change cut down the total run time by 10 times and then the second change about halved it, so I think these changes in total made a 20-fold reduction in auto-evo processing time

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #2451

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
