### PR TITLE
Cell Process panel (and tutorial popups) is on top of menu

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -107,6 +107,7 @@
     <Compile Include="src\gui_common\dialogs\CustomConfirmationDialog.cs" />
     <Compile Include="src\gui_common\dialogs\ErrorDialog.cs" />
     <Compile Include="src\gui_common\dialogs\LicensesDisplay.cs" />
+    <Compile Include="src\gui_common\CustomControlDialog.cs" />
     <Compile Include="src\gui_common\tooltip\DefaultToolTip.cs" />
     <Compile Include="src\gui_common\tooltip\ICustomToolTip.cs" />
     <Compile Include="src\gui_common\tooltip\microbe_editor\ModifierInfoLabel.cs" />

--- a/src/engine/ControlHelpers.cs
+++ b/src/engine/ControlHelpers.cs
@@ -28,4 +28,50 @@ public static class ControlHelpers
             });
         }
     }
+
+    /// <summary>
+    ///   Shows the control in the center of the screen and shrinks it to the minimum size.
+    /// </summary>
+    public static void ControlCenteredShrink(this Control control, bool runSizeUnstuck = true)
+    {
+        var parentRect = control.GetViewport().GetVisibleRect();
+
+        var rectSize = control.GetMinimumSize();
+        if (rectSize == default(Vector2))
+        {
+            foreach (Control child in control.GetChildren())
+            {
+                if (child != null)
+                {
+                    var pos = child.RectPosition;
+                    var min = child.GetCombinedMinimumSize();
+
+                    rectSize.x = Mathf.Max(pos.x + min.x, rectSize.x);
+                    rectSize.y = Mathf.Max(pos.y + min.y, rectSize.y);
+                }
+            }
+        }
+
+        var rectPos = parentRect.Position + (parentRect.Size - rectSize) / 2;
+
+        control.SetPosition(rectPos);
+        control.SetSize(rectSize);
+
+        control.Visible = true;
+
+        // In case the popup sizing stuck (this happens sometimes)
+        if (runSizeUnstuck)
+        {
+            Invoke.Instance.Queue(() =>
+            {
+                // "Refresh" the popup to correct its size
+                control.RectSize = Vector2.Zero;
+
+                parentRect = control.GetViewport().GetVisibleRect();
+
+                // Re-center it
+                control.RectPosition = parentRect.Position + (parentRect.Size - control.RectSize) / 2;
+            });
+        }
+    }
 }

--- a/src/gui_common/CheatMenu.cs
+++ b/src/gui_common/CheatMenu.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///   Handles the opening, closing and operations of the cheat menus
 /// </summary>
-public abstract class CheatMenu : CustomDialog
+public abstract class CheatMenu : CustomControlDialog
 {
     /// <summary>
     ///   Whether the cheat menu may be opened or not

--- a/src/gui_common/CustomControlDialog.cs
+++ b/src/gui_common/CustomControlDialog.cs
@@ -1,0 +1,569 @@
+﻿/*************************************************************************/
+/*              This file is substantially derived from:                 */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+// NO_DUPLICATE_CHECK
+
+using System;
+using Godot;
+
+public class CustomControlDialog : Control
+{
+    private string windowTitle;
+    private string translatedWindowTitle;
+
+    private bool closeHovered;
+
+    private Vector2 dragOffset;
+    private Vector2 dragOffsetFar;
+
+    private TextureButton closeButton;
+
+    private DragType dragType = DragType.None;
+
+    private StyleBox customPanel;
+    private StyleBox titleBarPanel;
+    private StyleBox closeButtonHighlight;
+
+    private Font titleFont;
+    private Color titleColor;
+
+    private int titleBarHeight;
+    private int titleHeight;
+    private int scaleBorderSize;
+    private int customMargin;
+    private bool showCloseButton = true;
+
+    [Flags]
+    private enum DragType
+    {
+        None = 0,
+        Move = 1,
+        ResizeTop = 1 << 1,
+        ResizeRight = 1 << 2,
+        ResizeBottom = 1 << 3,
+        ResizeLeft = 1 << 4,
+    }
+
+    /// <summary>
+    ///   The text displayed in the window's title bar.
+    /// </summary>
+    [Export]
+    public string WindowTitle
+    {
+        get => windowTitle;
+        set
+        {
+            if (windowTitle == value)
+                return;
+
+            windowTitle = value;
+            translatedWindowTitle = TranslationServer.Translate(value);
+
+            MinimumSizeChanged();
+            Update();
+        }
+    }
+
+    /// <summary>
+    ///   If true, the dialog window size is locked to the size of the viewport.
+    /// </summary>
+    [Export]
+    public bool FullRect { get; set; }
+
+    /// <summary>
+    ///   If true, the user can resize the window.
+    /// </summary>
+    [Export]
+    public bool Resizable { get; set; }
+
+    /// <summary>
+    ///   If true, the user can move the window around the viewport by dragging the titlebar.
+    /// </summary>
+    [Export]
+    public bool Movable { get; set; } = true;
+
+    /// <summary>
+    ///   If true, the window's position is clamped inside the screen so it doesn't go out of bounds.
+    /// </summary>
+    [Export]
+    public bool BoundToScreenArea { get; set; } = true;
+
+    [Export]
+    public bool ShowCloseButton
+    {
+        get => showCloseButton;
+        set
+        {
+            if (showCloseButton == value)
+                return;
+
+            showCloseButton = value;
+            SetupCloseButton();
+        }
+    }
+
+    public override void _EnterTree()
+    {
+        // To make popup rect readjustment react to window resizing
+        if (!GetTree().Root.IsConnected("size_changed", this, nameof(OnViewportResized)))
+            GetTree().Root.Connect("size_changed", this, nameof(OnViewportResized));
+
+        customPanel = GetStylebox("custom_panel", "WindowDialog");
+        titleBarPanel = GetStylebox("custom_titlebar", "WindowDialog");
+        titleBarHeight = GetConstant("custom_titlebar_height", "WindowDialog");
+        titleFont = GetFont("custom_title_font", "WindowDialog");
+        titleHeight = GetConstant("custom_title_height", "WindowDialog");
+        titleColor = GetColor("custom_title_color", "WindowDialog");
+        closeButtonHighlight = GetStylebox("custom_close_highlight", "WindowDialog");
+        scaleBorderSize = GetConstant("custom_scaleBorder_size", "WindowDialog");
+        customMargin = GetConstant("custom_margin", "Dialogs");
+
+        SetupCloseButton();
+        UpdateChildRects();
+    }
+
+    public override void _Notification(int what)
+    {
+        switch (what)
+        {
+            case NotificationResized:
+            {
+                UpdateChildRects();
+
+                if (FullRect)
+                    SetToFullRect();
+
+                break;
+            }
+
+            case NotificationVisibilityChanged:
+            {
+                if (Visible)
+                {
+                    OnShown();
+
+                    if (FullRect)
+                        SetToFullRect();
+                }
+                else
+                {
+                    OnHidden();
+                }
+
+                UpdateChildRects();
+                break;
+            }
+
+            case NotificationMouseExit:
+            {
+                // Reset the mouse cursor when leaving the resizable window border.
+                if (Resizable && dragType == DragType.None)
+                {
+                    if (MouseDefaultCursorShape != CursorShape.Arrow)
+                        MouseDefaultCursorShape = CursorShape.Arrow;
+                }
+
+                break;
+            }
+
+            case NotificationTranslationChanged:
+            {
+                translatedWindowTitle = TranslationServer.Translate(windowTitle);
+                break;
+            }
+        }
+    }
+
+    public override void _Draw()
+    {
+        // Draw background panels
+        DrawStyleBox(customPanel, new Rect2(
+            new Vector2(0, -titleBarHeight), new Vector2(RectSize.x, RectSize.y + titleBarHeight)));
+
+        DrawStyleBox(titleBarPanel, new Rect2(
+            new Vector2(3, -titleBarHeight + 3), new Vector2(RectSize.x - 6, titleBarHeight - 3)));
+
+        // Draw title in the title bar
+        var fontHeight = titleFont.GetHeight() - titleFont.GetDescent() * 2;
+
+        var titlePosition = new Vector2(
+            (RectSize.x - titleFont.GetStringSize(translatedWindowTitle).x) / 2, (-titleHeight + fontHeight) / 2);
+
+        DrawString(titleFont, titlePosition, translatedWindowTitle, titleColor,
+            (int)(RectSize.x - customPanel.GetMinimumSize().x));
+
+        // Draw close button highlight
+        if (closeHovered)
+        {
+            DrawStyleBox(closeButtonHighlight, closeButton.GetRect());
+        }
+    }
+
+    public override void _GuiInput(InputEvent @event)
+    {
+        // Handle title bar dragging
+        if (@event is InputEventMouseButton mouseButton && mouseButton.ButtonIndex == (int)ButtonList.Left)
+        {
+            if (mouseButton.Pressed && Movable)
+            {
+                // Begin a possible dragging operation
+                dragType = DragHitTest(new Vector2(mouseButton.Position.x, mouseButton.Position.y));
+
+                if (dragType != DragType.None)
+                    dragOffset = GetGlobalMousePosition() - RectPosition;
+
+                dragOffsetFar = RectPosition + RectSize - GetGlobalMousePosition();
+            }
+            else if (dragType != DragType.None && !mouseButton.Pressed)
+            {
+                // End a dragging operation
+                dragType = DragType.None;
+            }
+        }
+
+        if (@event is InputEventMouseMotion mouseMotion)
+        {
+            if (dragType == DragType.None)
+            {
+                HandlePreviewDrag(mouseMotion);
+            }
+            else
+            {
+                HandleActiveDrag();
+            }
+        }
+    }
+
+    /// <summary>
+    ///   This is overriden so mouse position could take the titlebar into account due to it being drawn
+    ///   outside of the normal Control's rect bounds.
+    /// </summary>
+    public override bool HasPoint(Vector2 point)
+    {
+        var rect = new Rect2(Vector2.Zero, RectSize);
+
+        // Enlarge upwards for title bar
+        var adjustedRect = new Rect2(
+            new Vector2(rect.Position.x, rect.Position.y - titleBarHeight),
+            new Vector2(rect.Size.x, rect.Size.y + titleBarHeight));
+
+        // Inflate by the resizable border thickness
+        if (Resizable)
+        {
+            adjustedRect = new Rect2(
+                new Vector2(adjustedRect.Position.x - scaleBorderSize, adjustedRect.Position.y - scaleBorderSize),
+                new Vector2(adjustedRect.Size.x + scaleBorderSize * 2, adjustedRect.Size.y + scaleBorderSize * 2));
+        }
+
+        return adjustedRect.HasPoint(point);
+    }
+
+    /// <summary>
+    ///   Overrides the minimum size to account for default elements (e.g title, close button, margin) rect size
+    ///   and for the other custom added contents on the window.
+    /// </summary>
+    public override Vector2 _GetMinimumSize()
+    {
+        var buttonWidth = closeButton?.GetCombinedMinimumSize().x;
+        var titleWidth = titleFont?.GetStringSize(TranslationServer.Translate(windowTitle)).x;
+        var buttonArea = buttonWidth + (buttonWidth / 2);
+
+        var contentSize = Vector2.Zero;
+
+        for (int i = 0; i < GetChildCount(); ++i)
+        {
+            var child = GetChildOrNull<Control>(i);
+
+            if (child == null || child == closeButton || child.IsSetAsToplevel())
+                continue;
+
+            var childMinSize = child.GetCombinedMinimumSize();
+
+            contentSize = new Vector2(
+                Mathf.Max(childMinSize.x, contentSize.x),
+                Mathf.Max(childMinSize.y, contentSize.y));
+        }
+
+        // Re-decide whether the largest rect is the default elements' or the contents'
+        return new Vector2(Mathf.Max(2 * buttonArea.GetValueOrDefault() + titleWidth.GetValueOrDefault(),
+            contentSize.x + customMargin * 2), contentSize.y + customMargin * 2);
+    }
+
+    /// <summary>
+    ///   Called after the popup is made visible.
+    /// </summary>
+    protected virtual void OnShown()
+    {
+        // TODO: implement default show animation(?)
+    }
+
+    /// <summary>
+    ///   Called after popup is made invisible.
+    /// </summary>
+    protected virtual void OnHidden()
+    {
+        // TODO: add proper close animation
+        closeHovered = false;
+    }
+
+    /// <summary>
+    ///   Evaluates what kind of drag type is being done on the window based on the current mouse position.
+    /// </summary>
+    private DragType DragHitTest(Vector2 position)
+    {
+        var result = DragType.None;
+
+        if (Resizable)
+        {
+            if (position.y < (-titleBarHeight + scaleBorderSize))
+            {
+                result = DragType.ResizeTop;
+            }
+            else if (position.y >= (RectSize.y - scaleBorderSize))
+            {
+                result = DragType.ResizeBottom;
+            }
+
+            if (position.x < scaleBorderSize)
+            {
+                result |= DragType.ResizeLeft;
+            }
+            else if (position.x >= (RectSize.x - scaleBorderSize))
+            {
+                result |= DragType.ResizeRight;
+            }
+        }
+
+        if (result == DragType.None && position.y < 0)
+            result = DragType.Move;
+
+        return result;
+    }
+
+    /// <summary>
+    ///   Updates the cursor icon while moving along the borders.
+    /// </summary>
+    private void HandlePreviewDrag(InputEventMouseMotion mouseMotion)
+    {
+        var cursor = CursorShape.Arrow;
+
+        if (Resizable)
+        {
+            var previewDragType = DragHitTest(new Vector2(mouseMotion.Position.x, mouseMotion.Position.y));
+
+            switch (previewDragType)
+            {
+                case DragType.ResizeTop:
+                case DragType.ResizeBottom:
+                    cursor = CursorShape.Vsize;
+                    break;
+                case DragType.ResizeLeft:
+                case DragType.ResizeRight:
+                    cursor = CursorShape.Hsize;
+                    break;
+                case (int)DragType.ResizeTop + DragType.ResizeLeft:
+                case (int)DragType.ResizeBottom + DragType.ResizeRight:
+                    cursor = CursorShape.Fdiagsize;
+                    break;
+                case (int)DragType.ResizeTop + DragType.ResizeRight:
+                case (int)DragType.ResizeBottom + DragType.ResizeLeft:
+                    cursor = CursorShape.Bdiagsize;
+                    break;
+            }
+        }
+
+        if (GetCursorShape() != cursor)
+            MouseDefaultCursorShape = cursor;
+    }
+
+    /// <summary>
+    ///   Updates the window position and size while in a dragging operation.
+    /// </summary>
+    private void HandleActiveDrag()
+    {
+        var globalMousePos = GetGlobalMousePosition();
+
+        var minSize = GetCombinedMinimumSize();
+
+        var newPosition = new Vector2(RectPosition);
+        var newSize = new Vector2(RectSize);
+
+        if (dragType == DragType.Move)
+        {
+            newPosition = globalMousePos - dragOffset;
+        }
+        else
+        {
+            // Handle border dragging
+
+            if (dragType.HasFlag(DragType.ResizeTop))
+            {
+                var bottom = RectPosition.y + RectSize.y;
+                var maxY = bottom - minSize.y;
+
+                newPosition.y = Mathf.Min(globalMousePos.y - dragOffset.y, maxY);
+                newSize.y = bottom - newPosition.y;
+            }
+            else if (dragType.HasFlag(DragType.ResizeBottom))
+            {
+                newSize.y = globalMousePos.y - newPosition.y + dragOffsetFar.y;
+            }
+
+            if (dragType.HasFlag(DragType.ResizeLeft))
+            {
+                var right = RectPosition.x + RectSize.x;
+                var maxX = right - minSize.x;
+
+                newPosition.x = Mathf.Min(globalMousePos.x - dragOffset.x, maxX);
+                newSize.x = right - newPosition.x;
+            }
+            else if (dragType.HasFlag(DragType.ResizeRight))
+            {
+                newSize.x = globalMousePos.x - newPosition.x + dragOffsetFar.x;
+            }
+        }
+
+        RectPosition = newPosition;
+        RectSize = newSize;
+
+        if (BoundToScreenArea)
+            FixRect();
+    }
+
+    /// <summary>
+    ///   Applies final adjustments to the window's rect.
+    /// </summary>
+    private void FixRect()
+    {
+        var screenSize = GetViewport()?.GetVisibleRect().Size;
+        var screenSizeValue = screenSize.GetValueOrDefault();
+
+        // Clamp position to ensure window stays inside the screen
+        RectPosition = new Vector2(
+            Mathf.Clamp(RectPosition.x, 0, screenSizeValue.x - RectSize.x),
+            Mathf.Clamp(RectPosition.y, titleBarHeight, screenSizeValue.y - RectSize.y));
+
+        if (Resizable)
+        {
+            // Size can't be bigger than the viewport
+            RectSize = new Vector2(
+                Mathf.Min(RectSize.x, screenSizeValue.x), Mathf.Min(RectSize.y, screenSizeValue.y - titleBarHeight));
+        }
+    }
+
+    private void SetupCloseButton()
+    {
+        if (!ShowCloseButton)
+        {
+            if (closeButton != null)
+            {
+                RemoveChild(closeButton);
+                closeButton = null;
+            }
+
+            return;
+        }
+
+        if (closeButton != null)
+            return;
+
+        var closeColor = GetColor("custom_close_color", "WindowDialog");
+
+        closeButton = new TextureButton
+        {
+            Expand = true,
+            RectMinSize = new Vector2(14, 14),
+            SelfModulate = closeColor,
+            MouseFilter = MouseFilterEnum.Pass,
+            TextureNormal = GetIcon("custom_close", "WindowDialog"),
+        };
+
+        closeButton.SetAnchorsPreset(LayoutPreset.TopRight);
+
+        closeButton.RectPosition = new Vector2(
+            -GetConstant("custom_close_h_ofs", "WindowDialog"),
+            -GetConstant("custom_close_v_ofs", "WindowDialog"));
+
+        closeButton.Connect("mouse_entered", this, nameof(OnCloseButtonMouseEnter));
+        closeButton.Connect("mouse_exited", this, nameof(OnCloseButtonMouseExit));
+        closeButton.Connect("pressed", this, nameof(OnCloseButtonPressed));
+
+        AddChild(closeButton);
+    }
+
+    private void UpdateChildRects()
+    {
+        var childPos = new Vector2(customMargin, customMargin);
+        var childSize = new Vector2(RectSize.x - customMargin * 2, RectSize.y - customMargin * 2);
+
+        for (int i = 0; i < GetChildCount(); ++i)
+        {
+            var child = GetChildOrNull<Control>(i);
+
+            if (child == null || child == closeButton || child.IsSetAsToplevel())
+                continue;
+
+            child.RectPosition = childPos;
+            child.RectSize = childSize;
+        }
+    }
+
+    private void SetToFullRect()
+    {
+        var viewportSize = GetViewport().GetVisibleRect().Size;
+
+        RectPosition = new Vector2(0, titleBarHeight);
+        RectSize = new Vector2(viewportSize.x, viewportSize.y - titleBarHeight);
+    }
+
+    private void OnCloseButtonMouseEnter()
+    {
+        closeHovered = true;
+        Update();
+    }
+
+    private void OnCloseButtonMouseExit()
+    {
+        closeHovered = false;
+        Update();
+    }
+
+    private void OnCloseButtonPressed()
+    {
+        Hide();
+    }
+
+    private void OnViewportResized()
+    {
+        if (BoundToScreenArea)
+            FixRect();
+
+        if (FullRect)
+            SetToFullRect();
+    }
+}

--- a/src/gui_common/CustomControlDialog.tscn
+++ b/src/gui_common/CustomControlDialog.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/gui_common/CustomControlDialog.cs" type="Script" id=1]
+
+[node name="CustomControlDialog" type="Control"]
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/src/gui_common/dialogs/TutorialDialog.cs
+++ b/src/gui_common/dialogs/TutorialDialog.cs
@@ -5,7 +5,7 @@
 /// </summary>
 /// TODO: see https://github.com/Revolutionary-Games/Thrive/issues/2751
 /// [Tool]
-public class TutorialDialog : CustomDialog
+public class TutorialDialog : CustomControlDialog
 {
     private Tween tween;
 

--- a/src/microbe_stage/MicrobeCheatMenu.tscn
+++ b/src/microbe_stage/MicrobeCheatMenu.tscn
@@ -5,13 +5,10 @@
 [ext_resource path="res://src/gui_common/fonts/Lato-Regular-Small.tres" type="DynamicFont" id=3]
 [ext_resource path="res://src/gui_common/CustomCheckBox.tscn" type="PackedScene" id=4]
 
-[node name="MicrobeCheatMenu" type="Popup"]
+[node name="MicrobeCheatMenu" type="Control"]
+visible = false
 theme = ExtResource( 1 )
-popup_exclusive = true
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 WindowTitle = "CHEATS"
 Resizable = true
 InfiniteCompoundsPath = NodePath("VBoxContainer/InfiniteCompounds")

--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=124 format=2]
+[gd_scene load_steps=119 format=2]
 
 [ext_resource path="res://src/microbe_stage/MicrobeStage.cs" type="Script" id=1]
 [ext_resource path="res://src/microbe_stage/MicrobeCamera.tscn" type="PackedScene" id=2]
@@ -2050,20 +2050,9 @@ __meta__ = {
 [node name="AnimationPlayer" type="AnimationPlayer" parent="MicrobeHUD/BottomRight/EditorButton"]
 anims/EditorButtonFlash = SubResource( 30 )
 
-[node name="ProcessPanel" parent="MicrobeHUD" instance=ExtResource( 58 )]
-margin_left = 8.0
-margin_top = 72.0
-margin_right = -872.0
-margin_bottom = -48.0
-
 [node name="AnimationPlayer" type="AnimationPlayer" parent="MicrobeHUD"]
 anims/HideLeftPanels = SubResource( 31 )
 anims/ShowLeftPanels = SubResource( 32 )
-
-[node name="MicrobeCheatMenu" parent="MicrobeHUD" instance=ExtResource( 73 )]
-margin_left = 10.0
-margin_top = 30.0
-margin_right = 207.0
 
 [node name="ScrollContainer" type="ScrollContainer" parent="MicrobeHUD"]
 anchor_left = 0.5
@@ -2123,6 +2112,17 @@ hint_tooltip = "TOGGLE_BINDING"
 toggle_mode = true
 ActionIcon = ExtResource( 82 )
 ActionName = "g_toggle_binding"
+
+[node name="ProcessPanel" parent="MicrobeHUD" instance=ExtResource( 58 )]
+margin_left = 8.0
+margin_top = 72.0
+margin_right = -872.0
+margin_bottom = -48.0
+
+[node name="MicrobeCheatMenu" parent="MicrobeHUD" instance=ExtResource( 73 )]
+margin_left = 10.0
+margin_top = 30.0
+margin_right = 207.0
 
 [node name="HintText" type="Label" parent="MicrobeHUD"]
 anchor_right = 1.0
@@ -2209,10 +2209,10 @@ visible = false
 [connection signal="mouse_entered" from="MicrobeHUD/BottomRight/EditorButton" to="MicrobeHUD" method="OnEditorButtonMouseEnter"]
 [connection signal="mouse_exited" from="MicrobeHUD/BottomRight/EditorButton" to="MicrobeHUD" method="OnEditorButtonMouseExit"]
 [connection signal="pressed" from="MicrobeHUD/BottomRight/EditorButton" to="MicrobeHUD" method="EditorButtonPressed"]
-[connection signal="OnClosed" from="MicrobeHUD/ProcessPanel" to="MicrobeHUD" method="OnProcessPanelClosed"]
 [connection signal="pressed" from="MicrobeHUD/ScrollContainer/HotBar/Engulfment" to="PlayerMicrobeInput" method="ToggleEngulf"]
 [connection signal="pressed" from="MicrobeHUD/ScrollContainer/HotBar/FireToxin" to="PlayerMicrobeInput" method="EmitToxin"]
 [connection signal="pressed" from="MicrobeHUD/ScrollContainer/HotBar/BindingMode" to="PlayerMicrobeInput" method="ToggleBinding"]
+[connection signal="OnClosed" from="MicrobeHUD/ProcessPanel" to="MicrobeHUD" method="OnProcessPanelClosed"]
 [connection signal="OnHelpMenuOpenRequested" from="TutorialGUI" to="MicrobeHUD" method="HelpButtonPressed"]
 [connection signal="MakeSave" from="PauseMenu" to="." method="SaveGame"]
 [connection signal="OnClosed" from="PauseMenu" to="MicrobeHUD" method="CloseMenu"]

--- a/src/microbe_stage/ProcessPanel.cs
+++ b/src/microbe_stage/ProcessPanel.cs
@@ -4,7 +4,7 @@ using Godot;
 /// <summary>
 ///   Controls the process panel contents
 /// </summary>
-public class ProcessPanel : CustomDialog
+public class ProcessPanel : CustomControlDialog
 {
     [Export]
     public NodePath ProcessListPath;

--- a/src/microbe_stage/ProcessPanel.tscn
+++ b/src/microbe_stage/ProcessPanel.tscn
@@ -4,15 +4,13 @@
 [ext_resource path="res://src/microbe_stage/ProcessList.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/microbe_stage/ProcessPanel.cs" type="Script" id=3]
 
-[node name="ProcessPanel" type="Popup"]
+[node name="ProcessPanel" type="Control"]
 process_priority = 5
+visible = false
 margin_right = 400.0
 rect_min_size = Vector2( 400, 600 )
 theme = ExtResource( 1 )
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 WindowTitle = "PROCESS_PANEL_TITLE"
 Resizable = true
 ProcessListPath = NodePath("MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer/ProcessList")

--- a/src/microbe_stage/editor/MicrobeEditorCheatMenu.tscn
+++ b/src/microbe_stage/editor/MicrobeEditorCheatMenu.tscn
@@ -5,10 +5,9 @@
 [ext_resource path="res://src/gui_common/fonts/Lato-Regular-Small.tres" type="DynamicFont" id=3]
 [ext_resource path="res://src/gui_common/CustomCheckBox.tscn" type="PackedScene" id=4]
 
-[node name="MicrobeEditorCheatMenu" type="Popup"]
-visible = true
+[node name="MicrobeEditorCheatMenu" type="Control"]
+visible = false
 theme = ExtResource( 1 )
-popup_exclusive = true
 script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false

--- a/src/tutorial/microbe_editor/MicrobeEditorTutorialGUI.cs
+++ b/src/tutorial/microbe_editor/MicrobeEditorTutorialGUI.cs
@@ -35,14 +35,14 @@ public class MicrobeEditorTutorialGUI : Control, ITutorialGUI
     [Export]
     public NodePath StaySmallTutorialPath;
 
-    private CustomDialog editorEntryReport;
-    private CustomDialog patchMap;
-    private CustomDialog cellEditorIntroduction;
-    private CustomDialog cellEditorUndo;
-    private CustomDialog cellEditorRedo;
-    private CustomDialog cellEditorClosingWords;
-    private CustomDialog autoEvoPrediction;
-    private CustomDialog staySmallTutorial;
+    private CustomControlDialog editorEntryReport;
+    private CustomControlDialog patchMap;
+    private CustomControlDialog cellEditorIntroduction;
+    private CustomControlDialog cellEditorUndo;
+    private CustomControlDialog cellEditorRedo;
+    private CustomControlDialog cellEditorClosingWords;
+    private CustomControlDialog autoEvoPrediction;
+    private CustomControlDialog staySmallTutorial;
 
     public MainGameState AssociatedGameState { get; } = MainGameState.MicrobeEditor;
     public ITutorialInput EventReceiver { get; set; }
@@ -208,14 +208,14 @@ public class MicrobeEditorTutorialGUI : Control, ITutorialGUI
 
     public override void _Ready()
     {
-        editorEntryReport = GetNode<CustomDialog>(EditorEntryReportPath);
-        patchMap = GetNode<CustomDialog>(PatchMapPath);
-        cellEditorIntroduction = GetNode<CustomDialog>(CellEditorIntroductionPath);
-        cellEditorUndo = GetNode<CustomDialog>(CellEditorUndoPath);
-        cellEditorRedo = GetNode<CustomDialog>(CellEditorRedoPath);
-        cellEditorClosingWords = GetNode<CustomDialog>(CellEditorClosingWordsPath);
-        autoEvoPrediction = GetNode<CustomDialog>(AutoEvoPredictionPath);
-        staySmallTutorial = GetNode<CustomDialog>(StaySmallTutorialPath);
+        editorEntryReport = GetNode<CustomControlDialog>(EditorEntryReportPath);
+        patchMap = GetNode<CustomControlDialog>(PatchMapPath);
+        cellEditorIntroduction = GetNode<CustomControlDialog>(CellEditorIntroductionPath);
+        cellEditorUndo = GetNode<CustomControlDialog>(CellEditorUndoPath);
+        cellEditorRedo = GetNode<CustomControlDialog>(CellEditorRedoPath);
+        cellEditorClosingWords = GetNode<CustomControlDialog>(CellEditorClosingWordsPath);
+        autoEvoPrediction = GetNode<CustomControlDialog>(AutoEvoPredictionPath);
+        staySmallTutorial = GetNode<CustomControlDialog>(StaySmallTutorialPath);
 
         CellEditorUndoHighlight = GetNode<ControlHighlight>(CellEditorUndoHighlightPath);
         AutoEvoPredictionHighlight = GetNode<ControlHighlight>(AutoEvoPredictionHighlightPath);

--- a/src/tutorial/microbe_editor/MicrobeEditorTutorialGUI.tscn
+++ b/src/tutorial/microbe_editor/MicrobeEditorTutorialGUI.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://src/tutorial/microbe_editor/MicrobeEditorTutorialGUI.cs" type="Script" id=1]
 [ext_resource path="res://src/gui_common/thrive_theme.tres" type="Theme" id=2]
 [ext_resource path="res://src/gui_common/ControlHighlight.tscn" type="PackedScene" id=3]
-[ext_resource path="res://src/gui_common/CustomDialog.tscn" type="PackedScene" id=4]
+[ext_resource path="res://src/gui_common/CustomControlDialog.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/gui_common/fonts/Lato-Regular-Smaller.tres" type="DynamicFont" id=5]
 [ext_resource path="res://src/gui_common/fonts/Lato-Bold-AlmostSmaller.tres" type="DynamicFont" id=6]
 [ext_resource path="res://src/gui_common/dialogs/TutorialDialog.cs" type="Script" id=7]
@@ -30,6 +30,7 @@ AutoEvoPredictionHighlightPath = NodePath("AutoEvoPredictionHighlight")
 StaySmallTutorialPath = NodePath("StaySmall")
 
 [node name="EditorEntryReport" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -67,6 +68,7 @@ text = "EDITOR_TUTORIAL_EDITOR_TEXT"
 autowrap = true
 
 [node name="PatchMapTutorial" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -106,6 +108,7 @@ text = "EDITOR_TUTORIAL_PATCH_TEXT"
 autowrap = true
 
 [node name="CellEditorIntro" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -141,6 +144,7 @@ text = "EDITOR_TUTORIAL_CELL_TEXT"
 autowrap = true
 
 [node name="UndoTutorial" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -184,6 +188,7 @@ autowrap = true
 visible = false
 
 [node name="RedoTutorial" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -222,6 +227,7 @@ text = "EDITOR_TUTORIAL_SELECT_ORGANELLE_TEXT"
 autowrap = true
 
 [node name="CellEditorClosingWords" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -285,6 +291,7 @@ text = "GOT_IT"
 visible = false
 
 [node name="AutoEvoPrediction" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -345,6 +352,7 @@ custom_fonts/font = ExtResource( 6 )
 text = "CLOSE"
 
 [node name="StaySmall" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -405,21 +413,13 @@ custom_fonts/font = ExtResource( 6 )
 text = "CLOSE"
 
 [connection signal="hide" from="EditorEntryReport" to="." method="OnSpecificCloseClicked" binds= [ "MicrobeEditorReport" ]]
-[connection signal="popup_hide" from="EditorEntryReport" to="." method="OnSpecificCloseClicked" binds= [ "MicrobeEditorReport" ]]
 [connection signal="hide" from="PatchMapTutorial" to="." method="OnSpecificCloseClicked" binds= [ "PatchMap" ]]
-[connection signal="popup_hide" from="PatchMapTutorial" to="." method="OnSpecificCloseClicked" binds= [ "PatchMap" ]]
 [connection signal="hide" from="CellEditorIntro" to="." method="OnSpecificCloseClicked" binds= [ "CellEditorIntroduction" ]]
-[connection signal="popup_hide" from="CellEditorIntro" to="." method="OnSpecificCloseClicked" binds= [ "CellEditorIntroduction" ]]
 [connection signal="hide" from="UndoTutorial" to="." method="OnSpecificCloseClicked" binds= [ "CellEditorUndo" ]]
-[connection signal="popup_hide" from="UndoTutorial" to="." method="OnSpecificCloseClicked" binds= [ "CellEditorUndo" ]]
 [connection signal="hide" from="RedoTutorial" to="." method="OnSpecificCloseClicked" binds= [ "CellEditorRedo" ]]
-[connection signal="popup_hide" from="RedoTutorial" to="." method="OnSpecificCloseClicked" binds= [ "CellEditorRedo" ]]
 [connection signal="hide" from="CellEditorClosingWords" to="." method="OnSpecificCloseClicked" binds= [ "CellEditorClosingWords" ]]
-[connection signal="popup_hide" from="CellEditorClosingWords" to="." method="OnSpecificCloseClicked" binds= [ "CellEditorClosingWords" ]]
 [connection signal="pressed" from="CellEditorClosingWords/ScrollContainer/VBoxContainer/Button" to="." method="OnSpecificCloseClicked" binds= [ "CellEditorClosingWords" ]]
 [connection signal="hide" from="AutoEvoPrediction" to="." method="OnSpecificCloseClicked" binds= [ "AutoEvoPrediction" ]]
-[connection signal="popup_hide" from="AutoEvoPrediction" to="." method="OnSpecificCloseClicked" binds= [ "AutoEvoPrediction" ]]
 [connection signal="pressed" from="AutoEvoPrediction/ScrollContainer/VBoxContainer/Button" to="." method="OnSpecificCloseClicked" binds= [ "AutoEvoPrediction" ]]
 [connection signal="hide" from="StaySmall" to="." method="OnSpecificCloseClicked" binds= [ "StaySmallTutorial" ]]
-[connection signal="popup_hide" from="StaySmall" to="." method="OnSpecificCloseClicked" binds= [ "StaySmallTutorial" ]]
 [connection signal="pressed" from="StaySmall/ScrollContainer/VBoxContainer/Button" to="." method="OnSpecificCloseClicked" binds= [ "StaySmallTutorial" ]]

--- a/src/tutorial/microbe_stage/MicrobeTutorialGUI.cs
+++ b/src/tutorial/microbe_stage/MicrobeTutorialGUI.cs
@@ -48,19 +48,19 @@ public class MicrobeTutorialGUI : Control, ITutorialGUI
     [Export]
     public NodePath CheckTheHelpMenuPath;
 
-    private CustomDialog microbeWelcomeMessage;
+    private CustomControlDialog microbeWelcomeMessage;
     private Control microbeMovementKeyPrompts;
     private Control microbeMovementKeyForward;
     private Control microbeMovementKeyLeft;
     private Control microbeMovementKeyRight;
     private Control microbeMovementKeyBackwards;
-    private CustomDialog microbeMovementPopup;
-    private CustomDialog glucoseTutorial;
-    private CustomDialog stayingAlive;
-    private CustomDialog reproductionTutorial;
-    private CustomDialog editorButtonTutorial;
-    private CustomDialog unbindTutorial;
-    private CustomDialog checkTheHelpMenu;
+    private CustomControlDialog microbeMovementPopup;
+    private CustomControlDialog glucoseTutorial;
+    private CustomControlDialog stayingAlive;
+    private CustomControlDialog reproductionTutorial;
+    private CustomControlDialog editorButtonTutorial;
+    private CustomControlDialog unbindTutorial;
+    private CustomControlDialog checkTheHelpMenu;
 
     [Signal]
     public delegate void OnHelpMenuOpenRequested();
@@ -85,7 +85,7 @@ public class MicrobeTutorialGUI : Control, ITutorialGUI
 
             if (value)
             {
-                microbeWelcomeMessage.PopupCenteredShrink();
+                microbeWelcomeMessage.ControlCenteredShrink();
             }
             else
             {
@@ -271,19 +271,19 @@ public class MicrobeTutorialGUI : Control, ITutorialGUI
 
     public override void _Ready()
     {
-        microbeWelcomeMessage = GetNode<CustomDialog>(MicrobeWelcomeMessagePath);
+        microbeWelcomeMessage = GetNode<CustomControlDialog>(MicrobeWelcomeMessagePath);
         microbeMovementKeyPrompts = GetNode<Control>(MicrobeMovementKeyPromptsPath);
-        microbeMovementPopup = GetNode<CustomDialog>(MicrobeMovementPopupPath);
+        microbeMovementPopup = GetNode<CustomControlDialog>(MicrobeMovementPopupPath);
         microbeMovementKeyForward = GetNode<Control>(MicrobeMovementKeyForwardPath);
         microbeMovementKeyLeft = GetNode<Control>(MicrobeMovementKeyLeftPath);
         microbeMovementKeyRight = GetNode<Control>(MicrobeMovementKeyRightPath);
         microbeMovementKeyBackwards = GetNode<Control>(MicrobeMovementKeyBackwardsPath);
-        glucoseTutorial = GetNode<CustomDialog>(GlucoseTutorialPath);
-        stayingAlive = GetNode<CustomDialog>(StayingAlivePath);
-        reproductionTutorial = GetNode<CustomDialog>(ReproductionTutorialPath);
-        editorButtonTutorial = GetNode<CustomDialog>(EditorButtonTutorialPath);
-        unbindTutorial = GetNode<CustomDialog>(UnbindTutorialPath);
-        checkTheHelpMenu = GetNode<CustomDialog>(CheckTheHelpMenuPath);
+        glucoseTutorial = GetNode<CustomControlDialog>(GlucoseTutorialPath);
+        stayingAlive = GetNode<CustomControlDialog>(StayingAlivePath);
+        reproductionTutorial = GetNode<CustomControlDialog>(ReproductionTutorialPath);
+        editorButtonTutorial = GetNode<CustomControlDialog>(EditorButtonTutorialPath);
+        unbindTutorial = GetNode<CustomControlDialog>(UnbindTutorialPath);
+        checkTheHelpMenu = GetNode<CustomControlDialog>(CheckTheHelpMenuPath);
     }
 
     public override void _Process(float delta)

--- a/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
+++ b/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://src/tutorial/microbe_stage/MicrobeTutorialGUI.cs" type="Script" id=1]
 [ext_resource path="res://src/gui_common/thrive_theme.tres" type="Theme" id=2]
 [ext_resource path="res://src/gui_common/KeyPrompt.tscn" type="PackedScene" id=3]
-[ext_resource path="res://src/gui_common/CustomDialog.tscn" type="PackedScene" id=4]
+[ext_resource path="res://src/gui_common/CustomControlDialog.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/gui_common/fonts/Lato-Regular-Smaller.tres" type="DynamicFont" id=5]
 [ext_resource path="res://src/gui_common/fonts/Lato-Bold-AlmostSmaller.tres" type="DynamicFont" id=6]
 [ext_resource path="res://src/gui_common/dialogs/TutorialDialog.cs" type="Script" id=7]
@@ -34,6 +34,7 @@ UnbindTutorialPath = NodePath("UnbindTutorial")
 CheckTheHelpMenuPath = NodePath("CheckHelpMenu")
 
 [node name="MicrobeWelcome" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -44,11 +45,9 @@ margin_right = -190.0
 margin_bottom = 118.0
 rect_min_size = Vector2( 450, 450 )
 rect_pivot_offset = Vector2( 225, 225 )
-popup_exclusive = true
 script = ExtResource( 7 )
 WindowTitle = "TUTORIAL"
 Resizable = true
-ExclusiveAllowCloseOnEscape = false
 ShowDelay = 0.0
 
 [node name="ScrollContainer" type="ScrollContainer" parent="MicrobeWelcome"]
@@ -122,6 +121,7 @@ __meta__ = {
 }
 
 [node name="ExplainingPopup" parent="MicrobeMovementTutorial" instance=ExtResource( 4 )]
+visible = false
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -204,6 +204,7 @@ rect_min_size = Vector2( 40, 40 )
 ActionName = "g_move_right"
 
 [node name="GlucoseTutorial" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -238,6 +239,7 @@ text = "MICROBE_STAGE_COLLECT_TEXT"
 autowrap = true
 
 [node name="StayingAliveTutorial" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -272,6 +274,7 @@ text = "MICROBE_STAGE_HEALTH_TEXT"
 autowrap = true
 
 [node name="ReproductionTutorial" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -310,6 +313,7 @@ text = "MICROBE_STAGE_REPRODUCE_TEXT"
 autowrap = true
 
 [node name="EditorButtonTutorial" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -348,6 +352,7 @@ text = "MICROBE_STAGE_EDITOR_BUTTON_TUTORIAL"
 autowrap = true
 
 [node name="UnbindTutorial" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -382,6 +387,7 @@ text = "MICROBE_STAGE_UNBIND_TEXT"
 autowrap = true
 
 [node name="CheckHelpMenu" parent="." instance=ExtResource( 4 )]
+visible = false
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -429,21 +435,14 @@ margin_right = 10.0
 margin_bottom = 35.0
 text = "VIEW_NOW"
 
-[connection signal="popup_hide" from="MicrobeWelcome" to="." method="OnClickedCloseAll"]
+[connection signal="hide" from="MicrobeWelcome" to="." method="OnClickedCloseAll"]
 [connection signal="toggled" from="MicrobeWelcome/ScrollContainer/VBoxContainer/HBoxContainer/CheckBox" to="." method="OnTutorialEnabledValueChanged"]
 [connection signal="pressed" from="MicrobeWelcome/ScrollContainer/VBoxContainer/Button" to="." method="OnClickedCloseAll"]
 [connection signal="hide" from="MicrobeMovementTutorial/ExplainingPopup" to="." method="OnSpecificCloseClicked" binds= [ "MicrobeMovementExplain" ]]
-[connection signal="popup_hide" from="MicrobeMovementTutorial/ExplainingPopup" to="." method="OnSpecificCloseClicked" binds= [ "MicrobeMovementExplain" ]]
 [connection signal="hide" from="GlucoseTutorial" to="." method="OnSpecificCloseClicked" binds= [ "GlucoseCollecting" ]]
-[connection signal="popup_hide" from="GlucoseTutorial" to="." method="OnSpecificCloseClicked" binds= [ "GlucoseCollecting" ]]
 [connection signal="hide" from="StayingAliveTutorial" to="." method="OnSpecificCloseClicked" binds= [ "MicrobeStayingAlive" ]]
-[connection signal="popup_hide" from="StayingAliveTutorial" to="." method="OnSpecificCloseClicked" binds= [ "MicrobeStayingAlive" ]]
 [connection signal="hide" from="ReproductionTutorial" to="." method="OnSpecificCloseClicked" binds= [ "MicrobeReproduction" ]]
-[connection signal="popup_hide" from="ReproductionTutorial" to="." method="OnSpecificCloseClicked" binds= [ "MicrobeReproduction" ]]
 [connection signal="hide" from="EditorButtonTutorial" to="." method="OnSpecificCloseClicked" binds= [ "MicrobeEditorPress" ]]
-[connection signal="popup_hide" from="EditorButtonTutorial" to="." method="OnSpecificCloseClicked" binds= [ "MicrobeEditorPress" ]]
 [connection signal="hide" from="UnbindTutorial" to="." method="OnSpecificCloseClicked" binds= [ "MicrobeUnbind" ]]
-[connection signal="popup_hide" from="UnbindTutorial" to="." method="OnSpecificCloseClicked" binds= [ "MicrobeUnbind" ]]
 [connection signal="hide" from="CheckHelpMenu" to="." method="OnSpecificCloseClicked" binds= [ "CheckTheHelpMenu" ]]
-[connection signal="popup_hide" from="CheckHelpMenu" to="." method="OnSpecificCloseClicked" binds= [ "CheckTheHelpMenu" ]]
 [connection signal="pressed" from="CheckHelpMenu/ScrollContainer/VBoxContainer/Button" to="." method="CheckHelpMenuPressed"]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Created a draggable and resizable Control and changed Cell Process, CheatMenu, EditorCheatMenu and Tutorial Dialogs to this Control.

**Related Issues**

closes #2326

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
