### PR TITLE
Slightly widen the mod manager layout

### DIFF
--- a/src/modding/ModManager.tscn
+++ b/src/modding/ModManager.tscn
@@ -91,35 +91,36 @@ __meta__ = {
 }
 
 [node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer"]
-margin_left = 263.0
-margin_top = 20.0
-margin_right = 1017.0
-margin_bottom = 653.0
+margin_left = 215.0
+margin_top = 34.0
+margin_right = 1065.0
+margin_bottom = 639.0
+rect_min_size = Vector2( 850, 0 )
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="UpperPart" type="HBoxContainer" parent="CenterContainer/VBoxContainer"]
-margin_right = 754.0
+margin_right = 850.0
 margin_bottom = 265.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 alignment = 1
 
 [node name="Left" type="VBoxContainer" parent="CenterContainer/VBoxContainer/UpperPart"]
-margin_right = 300.0
+margin_right = 348.0
 margin_bottom = 265.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/UpperPart/Left"]
-margin_right = 300.0
+margin_right = 348.0
 margin_bottom = 25.0
 text = "AVAILABLE_MODS"
 align = 1
 
 [node name="AvailableMods" type="ItemList" parent="CenterContainer/VBoxContainer/UpperPart/Left"]
 margin_top = 29.0
-margin_right = 300.0
+margin_right = 348.0
 margin_bottom = 229.0
 rect_min_size = Vector2( 300, 200 )
 size_flags_horizontal = 3
@@ -128,28 +129,28 @@ fixed_icon_size = Vector2( 32, 32 )
 
 [node name="HBoxContainer" type="HBoxContainer" parent="CenterContainer/VBoxContainer/UpperPart/Left"]
 margin_top = 233.0
-margin_right = 300.0
+margin_right = 348.0
 margin_bottom = 265.0
 size_flags_horizontal = 3
 
 [node name="Refresh" type="Button" parent="CenterContainer/VBoxContainer/UpperPart/Left/HBoxContainer"]
-margin_right = 148.0
+margin_right = 172.0
 margin_bottom = 32.0
 size_flags_horizontal = 3
 custom_fonts/font = ExtResource( 11 )
 text = "REFRESH"
 
 [node name="Browse" type="Button" parent="CenterContainer/VBoxContainer/UpperPart/Left/HBoxContainer"]
-margin_left = 152.0
-margin_right = 300.0
+margin_left = 176.0
+margin_right = 348.0
 margin_bottom = 32.0
 size_flags_horizontal = 3
 custom_fonts/font = ExtResource( 11 )
 text = "OPEN_FOLDER"
 
 [node name="Center" type="VBoxContainer" parent="CenterContainer/VBoxContainer/UpperPart"]
-margin_left = 304.0
-margin_right = 450.0
+margin_left = 352.0
+margin_right = 498.0
 margin_bottom = 265.0
 size_flags_vertical = 3
 alignment = 1
@@ -179,21 +180,21 @@ disabled = true
 text = "LEFT_ARROW"
 
 [node name="Right" type="VBoxContainer" parent="CenterContainer/VBoxContainer/UpperPart"]
-margin_left = 454.0
-margin_right = 754.0
+margin_left = 502.0
+margin_right = 850.0
 margin_bottom = 265.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/UpperPart/Right"]
-margin_right = 300.0
+margin_right = 348.0
 margin_bottom = 25.0
 text = "ENABLED_MODS"
 align = 1
 
 [node name="ActiveMods" type="ItemList" parent="CenterContainer/VBoxContainer/UpperPart/Right"]
 margin_top = 29.0
-margin_right = 300.0
+margin_right = 348.0
 margin_bottom = 229.0
 rect_min_size = Vector2( 300, 200 )
 size_flags_horizontal = 3
@@ -202,7 +203,7 @@ fixed_icon_size = Vector2( 32, 32 )
 
 [node name="DisableAll" type="Button" parent="CenterContainer/VBoxContainer/UpperPart/Right"]
 margin_top = 233.0
-margin_right = 300.0
+margin_right = 348.0
 margin_bottom = 265.0
 custom_fonts/font = ExtResource( 11 )
 disabled = true
@@ -210,20 +211,20 @@ text = "DISABLE_ALL"
 
 [node name="Spacer" type="Control" parent="CenterContainer/VBoxContainer"]
 margin_top = 269.0
-margin_right = 754.0
+margin_right = 850.0
 margin_bottom = 274.0
 rect_min_size = Vector2( 0, 5 )
 
 [node name="PanelContainer" type="PanelContainer" parent="CenterContainer/VBoxContainer"]
 margin_top = 278.0
-margin_right = 754.0
-margin_bottom = 513.0
+margin_right = 850.0
+margin_bottom = 485.0
 
 [node name="MarginContainer" type="MarginContainer" parent="CenterContainer/VBoxContainer/PanelContainer"]
 margin_left = 1.0
 margin_top = 1.0
-margin_right = 753.0
-margin_bottom = 234.0
+margin_right = 849.0
+margin_bottom = 206.0
 custom_constants/margin_right = 10
 custom_constants/margin_top = 10
 custom_constants/margin_left = 10
@@ -232,11 +233,11 @@ custom_constants/margin_bottom = 10
 [node name="CurrentlySelected" type="VBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer"]
 margin_left = 10.0
 margin_top = 10.0
-margin_right = 742.0
-margin_bottom = 223.0
+margin_right = 838.0
+margin_bottom = 195.0
 
 [node name="NameLine" type="HBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected"]
-margin_right = 732.0
+margin_right = 828.0
 margin_bottom = 32.0
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected/NameLine"]
@@ -271,7 +272,7 @@ __meta__ = {
 
 [node name="AuthorLine" type="HBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected"]
 margin_top = 36.0
-margin_right = 732.0
+margin_right = 828.0
 margin_bottom = 61.0
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected/AuthorLine"]
@@ -281,13 +282,13 @@ text = "MOD_AUTHOR"
 
 [node name="Control" type="Control" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected/AuthorLine"]
 margin_left = 138.0
-margin_right = 615.0
+margin_right = 711.0
 margin_bottom = 25.0
 size_flags_horizontal = 3
 
 [node name="Label2" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected/AuthorLine"]
-margin_left = 619.0
-margin_right = 732.0
+margin_left = 715.0
+margin_right = 828.0
 margin_bottom = 25.0
 text = "Some dude"
 __meta__ = {
@@ -296,7 +297,7 @@ __meta__ = {
 
 [node name="VersionLine" type="HBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected"]
 margin_top = 65.0
-margin_right = 732.0
+margin_right = 828.0
 margin_bottom = 92.0
 
 [node name="ModVersion" type="HBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected/VersionLine"]
@@ -329,13 +330,13 @@ __meta__ = {
 
 [node name="Control" type="Control" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected/VersionLine"]
 margin_left = 179.0
-margin_right = 230.0
+margin_right = 326.0
 margin_bottom = 27.0
 size_flags_horizontal = 3
 
 [node name="ThriveVersionLine" type="HBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected/VersionLine"]
-margin_left = 234.0
-margin_right = 732.0
+margin_left = 330.0
+margin_right = 828.0
 margin_bottom = 27.0
 alignment = 2
 
@@ -428,25 +429,25 @@ __meta__ = {
 
 [node name="DescriptionLine" type="HBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected"]
 margin_top = 96.0
-margin_right = 732.0
-margin_bottom = 177.0
+margin_right = 828.0
+margin_bottom = 149.0
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected/DescriptionLine"]
-margin_top = 28.0
+margin_top = 14.0
 margin_right = 182.0
-margin_bottom = 53.0
+margin_bottom = 39.0
 text = "MOD_DESCRIPTION"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected/DescriptionLine"]
 margin_left = 186.0
-margin_right = 732.0
-margin_bottom = 81.0
+margin_right = 828.0
+margin_bottom = 53.0
 size_flags_horizontal = 3
 alignment = 2
 
 [node name="Label2" type="Label" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected/DescriptionLine/HBoxContainer"]
-margin_right = 546.0
-margin_bottom = 81.0
+margin_right = 642.0
+margin_bottom = 53.0
 size_flags_horizontal = 3
 text = "Mod description goes here that can get a bit long sometimes so this needs a bit of space here to allow it to fit here"
 align = 2
@@ -457,9 +458,9 @@ __meta__ = {
 }
 
 [node name="ButtonsLine" type="HBoxContainer" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected"]
-margin_top = 181.0
-margin_right = 732.0
-margin_bottom = 213.0
+margin_top = 153.0
+margin_right = 828.0
+margin_bottom = 185.0
 
 [node name="MoreInfo" type="Button" parent="CenterContainer/VBoxContainer/PanelContainer/MarginContainer/CurrentlySelected/ButtonsLine"]
 margin_right = 109.0
@@ -478,15 +479,15 @@ disabled = true
 text = "OPEN_MOD_URL"
 
 [node name="Spacer2" type="Control" parent="CenterContainer/VBoxContainer"]
-margin_top = 517.0
-margin_right = 754.0
-margin_bottom = 522.0
+margin_top = 489.0
+margin_right = 850.0
+margin_bottom = 494.0
 rect_min_size = Vector2( 0, 5 )
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="CenterContainer/VBoxContainer"]
-margin_top = 526.0
-margin_right = 754.0
-margin_bottom = 558.0
+margin_top = 498.0
+margin_right = 850.0
+margin_bottom = 530.0
 size_flags_horizontal = 3
 alignment = 2
 __meta__ = {
@@ -494,54 +495,54 @@ __meta__ = {
 }
 
 [node name="Workshop" type="Button" parent="CenterContainer/VBoxContainer/HBoxContainer2"]
-margin_left = 421.0
-margin_right = 614.0
+margin_left = 517.0
+margin_right = 710.0
 margin_bottom = 32.0
 custom_fonts/font = ExtResource( 11 )
 text = "BROWSE_WORKSHOP"
 
 [node name="Upload" type="Button" parent="CenterContainer/VBoxContainer/HBoxContainer2"]
-margin_left = 618.0
-margin_right = 700.0
+margin_left = 714.0
+margin_right = 796.0
 margin_bottom = 32.0
 custom_fonts/font = ExtResource( 11 )
 text = "UPLOAD"
 
 [node name="New" type="Button" parent="CenterContainer/VBoxContainer/HBoxContainer2"]
-margin_left = 704.0
-margin_right = 754.0
+margin_left = 800.0
+margin_right = 850.0
 margin_bottom = 32.0
 custom_fonts/font = ExtResource( 11 )
 text = "NEW"
 
 [node name="Spacer3" type="Control" parent="CenterContainer/VBoxContainer"]
-margin_top = 562.0
-margin_right = 754.0
-margin_bottom = 567.0
+margin_top = 534.0
+margin_right = 850.0
+margin_bottom = 539.0
 rect_min_size = Vector2( 0, 5 )
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer"]
-margin_top = 571.0
-margin_right = 754.0
-margin_bottom = 588.0
+margin_top = 543.0
+margin_right = 850.0
+margin_bottom = 560.0
 custom_fonts/font = ExtResource( 5 )
 text = "MOD_LOAD_UNLOAD_CAVEATS"
 align = 1
 autowrap = true
 
 [node name="Spacer4" type="Control" parent="CenterContainer/VBoxContainer"]
-margin_top = 592.0
-margin_right = 754.0
-margin_bottom = 597.0
+margin_top = 564.0
+margin_right = 850.0
+margin_bottom = 569.0
 rect_min_size = Vector2( 0, 5 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="HBoxContainer" type="HBoxContainer" parent="CenterContainer/VBoxContainer"]
-margin_top = 601.0
-margin_right = 754.0
-margin_bottom = 633.0
+margin_top = 573.0
+margin_right = 850.0
+margin_bottom = 605.0
 alignment = 1
 
 [node name="LoadAll" type="Button" parent="CenterContainer/VBoxContainer/HBoxContainer"]
@@ -555,8 +556,8 @@ custom_fonts/font = ExtResource( 11 )
 text = "ENABLE_ALL_COMPATIBLE"
 
 [node name="Apply" type="Button" parent="CenterContainer/VBoxContainer/HBoxContainer"]
-margin_left = 297.0
-margin_right = 456.0
+margin_left = 345.0
+margin_right = 504.0
 margin_bottom = 32.0
 size_flags_horizontal = 0
 custom_fonts/font = ExtResource( 11 )


### PR DESCRIPTION
**Brief Description of What This PR Does**

Due to the autowrap enabling PR recently, the mod manager feels too cramped. I've now set the main container node's rect min size to 850 to widen it slightly closer to as it was originally.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
