### PR TITLE
Compound venting on engulf

### DIFF
--- a/src/microbe_stage/ColonyCompoundBag.cs
+++ b/src/microbe_stage/ColonyCompoundBag.cs
@@ -88,18 +88,20 @@ public class ColonyCompoundBag : ICompoundStorage
 
     public float AddCompound(Compound compound, float amount)
     {
-        var originalAmount = amount;
+        var totalAmountAdded = 0.0f;
 
         foreach (var bagToAddTo in GetCompoundBags())
         {
             var amountAdded = bagToAddTo.AddCompound(compound, amount);
+
+            totalAmountAdded += amountAdded;
             amount -= amountAdded;
 
             if (amount <= MathUtils.EPSILON)
                 break;
         }
 
-        return originalAmount - amount;
+        return totalAmountAdded;
     }
 
     public void ClearCompounds()

--- a/src/microbe_stage/CompoundBag.cs
+++ b/src/microbe_stage/CompoundBag.cs
@@ -78,7 +78,7 @@ public class CompoundBag : ICompoundStorage
 
         Compounds[compound] = newAmount;
 
-        return newAmount - amount;
+        return newAmount - existingAmount;
     }
 
     public IEnumerator<KeyValuePair<Compound, float>> GetEnumerator()

--- a/src/microbe_stage/FloatingChunk.cs
+++ b/src/microbe_stage/FloatingChunk.cs
@@ -271,8 +271,6 @@ public class FloatingChunk : RigidBody, ISpawned, ISaveLoadedTracked
                     // Can engulf
                     if (ContainedCompounds != null)
                     {
-                        // TODO: could spill the amount that was wasted here as a cloud
-
                         foreach (var entry in ContainedCompounds)
                         {
                             var added = microbe.Compounds.AddCompound(entry.Key, entry.Value /

--- a/src/microbe_stage/FloatingChunk.cs
+++ b/src/microbe_stage/FloatingChunk.cs
@@ -275,8 +275,10 @@ public class FloatingChunk : RigidBody, ISpawned, ISaveLoadedTracked
 
                         foreach (var entry in ContainedCompounds)
                         {
-                            microbe.Compounds.AddCompound(entry.Key, entry.Value /
-                                Constants.CHUNK_ENGULF_COMPOUND_DIVISOR);
+                            var added = microbe.Compounds.AddCompound(entry.Key, entry.Value /
+                                Constants.CHUNK_ENGULF_COMPOUND_DIVISOR) * Constants.CHUNK_ENGULF_COMPOUND_DIVISOR;
+
+                            VentCompound(Translation, entry.Key, entry.Value - added);
                         }
                     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR makes cells vent excess compounds when engulfing a chunk.

It also fixes a bug in `AddCompound` method from `CompoundBag`, where the return value was the previous amount in the bag rather than what was added. This return was mistakenly used for colonies compounds sharing; no other call did make actual use of the return value.

*Nota: Observing the effect is much easier when disabling chunk venting.*

Also, since I changed returns of functions used by colony, it would be good to confirm everything still works.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
