### PR TITLE
fix auto-evo variable mistake

### DIFF
--- a/src/auto-evo/simulation/food_source/CompoundFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/CompoundFoodSource.cs
@@ -26,7 +26,7 @@ public class CompoundFoodSource : FoodSource
 
         var compoundUseScore = EnergyGenerationScore(microbeSpecies, compound);
 
-        var energyCost = simulationCache.GetEnergyBalanceForSpecies(microbeSpecies, patch).FinalBalanceStationary;
+        var energyCost = simulationCache.GetEnergyBalanceForSpecies(microbeSpecies, patch).TotalConsumptionStationary;
 
         return compoundUseScore / energyCost;
     }

--- a/src/auto-evo/simulation/food_source/EnvironmentalFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/EnvironmentalFoodSource.cs
@@ -23,7 +23,7 @@ public class EnvironmentalFoodSource : FoodSource
 
         var energyCreationScore = EnergyGenerationScore(microbeSpecies, compound);
 
-        var energyCost = simulationCache.GetEnergyBalanceForSpecies(microbeSpecies, patch).FinalBalanceStationary;
+        var energyCost = simulationCache.GetEnergyBalanceForSpecies(microbeSpecies, patch).TotalConsumptionStationary;
 
         return energyCreationScore / energyCost;
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Reviewing another PR made me realize that auto evo divides fitness scores by the net ATP, when it is supposed to divide by ATP cost. This might lower populations a little, which I don't think would be a problem, but might also be the reason that better ATP generators are punished. It might also help with the "spikes make everything better" issue.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
