### PR TITLE
Made auto-evo prediction tutorial close when details are opened

### DIFF
--- a/src/microbe_stage/editor/MicrobeEditorGUI.cs
+++ b/src/microbe_stage/editor/MicrobeEditorGUI.cs
@@ -2254,6 +2254,8 @@ public class MicrobeEditorGUI : Control, ISaveLoadedTracked
         UpdateAutoEvoPredictionDetailsText();
 
         autoEvoPredictionExplanationPopup.PopupCenteredShrink();
+
+        editor.TutorialState.SendEvent(TutorialEventType.MicrobeEditorAutoEvoPredictionOpened, EventArgs.Empty, this);
     }
 
     private void CloseAutoEvoPrediction()

--- a/src/tutorial/TutorialEventType.cs
+++ b/src/tutorial/TutorialEventType.cs
@@ -87,4 +87,9 @@ public enum TutorialEventType
     ///   The player unbound any cell
     /// </summary>
     MicrobePlayerUnbound,
+
+    /// <summary>
+    ///   Player opened the auto-evo prediction details
+    /// </summary>
+    MicrobeEditorAutoEvoPredictionOpened,
 }

--- a/src/tutorial/microbe_editor/AutoEvoPrediction.cs
+++ b/src/tutorial/microbe_editor/AutoEvoPrediction.cs
@@ -1,5 +1,6 @@
 ﻿namespace Tutorial
 {
+    using System;
     using Godot;
     using Newtonsoft.Json;
 
@@ -23,6 +24,28 @@
 
             gui.AutoEvoPredictionHighlight.TargetControl = ShownCurrently ? EditorAutoEvoPredictionPanel : null;
             gui.AutoEvoPredictionHighlight.Visible = ShownCurrently;
+        }
+
+        public override bool CheckEvent(TutorialState overallState, TutorialEventType eventType, EventArgs args,
+            object sender)
+        {
+            if (base.CheckEvent(overallState, eventType, args, sender))
+                return true;
+
+            switch (eventType)
+            {
+                case TutorialEventType.MicrobeEditorAutoEvoPredictionOpened:
+                {
+                    if (ShownCurrently)
+                    {
+                        Hide();
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
about the prediction

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

resolves issue with tutorial being on top of the prediction details panel

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author.
