### PR TITLE
Increased Jukebox's fade time

### DIFF
--- a/src/general/Jukebox.cs
+++ b/src/general/Jukebox.cs
@@ -8,7 +8,7 @@ using Godot;
 /// </summary>
 public class Jukebox : Node
 {
-    private const float FADE_TIME = 0.75f;
+    private const float FADE_TIME = 1.0f;
     private const float FADE_LOW_VOLUME = 0.0f;
     private const float NORMAL_VOLUME = 1.0f;
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Increased Jukebox's FADE_TIME const to 1.0 for more slightly smoother and less jarring transition. Let me know if this is not desired.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
