### PR TITLE
Boosted FPS by seperating compound cloud calculation in its own process loop

### DIFF
--- a/src/microbe_stage/CompoundCloudPlane.cs
+++ b/src/microbe_stage/CompoundCloudPlane.cs
@@ -299,7 +299,7 @@ public class CompoundCloudPlane : CSGMesh, ISaveLoadedTracked
     /// <summary>
     ///   Updates the cloud in parallel.
     /// </summary>
-    public void QueueUpdateCloud(float delta, List<Task> queue)
+    public IEnumerable<Task> QueueUpdateCloud(float delta)
     {
         // The diffusion rate seems to have a bigger effect
         delta *= 100.0f;
@@ -316,7 +316,7 @@ public class CompoundCloudPlane : CSGMesh, ISaveLoadedTracked
                     Size / Constants.CLOUD_SQUARES_PER_SIDE,
                     Size / Constants.CLOUD_SQUARES_PER_SIDE,
                     delta, pos));
-                queue.Add(task);
+                yield return task;
             }
         }
     }
@@ -324,7 +324,7 @@ public class CompoundCloudPlane : CSGMesh, ISaveLoadedTracked
     /// <summary>
     ///   Updates the cloud in parallel.
     /// </summary>
-    public void QueueUpdateTextureImage(List<Task> queue)
+    public IEnumerable<Task> QueueUpdateTextureImage()
     {
         image.Lock();
 
@@ -338,7 +338,7 @@ public class CompoundCloudPlane : CSGMesh, ISaveLoadedTracked
                     y0 * Size / Constants.CLOUD_SQUARES_PER_SIDE,
                     Size / Constants.CLOUD_SQUARES_PER_SIDE,
                     Size / Constants.CLOUD_SQUARES_PER_SIDE));
-                queue.Add(task);
+                yield return task;
             }
         }
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Boosted the FPS on my laptop in battery mode from 30FPS to about 70FPS. The only thing that lags on weak hardware are the compound clouds, not the whole game.

Needs testing on fast hardware to verify that this doesn't affect the compound cloud system on them.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
