### PR TITLE
Remastered trash button texture and added missing pressed state texture

### DIFF
--- a/assets/textures/gui/bevel/TrashIcon.png
+++ b/assets/textures/gui/bevel/TrashIcon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a27a2dc6a99756467c1b83507b0b2803ad4bf68ec1b2de6147e15f89ecc1a41
-size 723
+oid sha256:31188a989b405ceb3c587b6b184f839ff6fc7d7428a111997a3976d9712fa438
+size 3232

--- a/assets/textures/gui/bevel/trashButton.png
+++ b/assets/textures/gui/bevel/trashButton.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7fd2cca02d2acfe2ab6333bd7de603fd2c21e7c21dbee581f0e6cbd97febcf5
-size 1474
+oid sha256:2ec85297aaafa46644f8505841a0ac898a641ead0d505b0be16f8c92f000cb3d
+size 9191

--- a/assets/textures/gui/bevel/trashButtonActive.png
+++ b/assets/textures/gui/bevel/trashButtonActive.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6318872b249875dae7983700c48a5b60a6385a2a979e38097e070fda1cf7ded9
+size 6246

--- a/assets/textures/gui/bevel/trashButtonActive.png.import
+++ b/assets/textures/gui/bevel/trashButtonActive.png.import
@@ -1,0 +1,35 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/trashButtonActive.png-b13a0674043e48bd997075ae58d2d6cf.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://assets/textures/gui/bevel/trashButtonActive.png"
+dest_files=[ "res://.import/trashButtonActive.png-b13a0674043e48bd997075ae58d2d6cf.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=true
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+process/normal_map_invert_y=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/assets/textures/gui/bevel/trashButtonHover.png
+++ b/assets/textures/gui/bevel/trashButtonHover.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca1122097fde0f1a14b4be2b1c6e78f2bc096a99f86163f645037e8b2623837c
-size 1475
+oid sha256:5c09b62fc13d0549b0c46d3981bb98c7f6dfb53518a28738b7bf6b05a25cff6f
+size 9033

--- a/src/saving/SaveListItem.tscn
+++ b/src/saving/SaveListItem.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://assets/textures/gui/bevel/TrashIcon.png" type="Texture" id=1]
 [ext_resource path="res://src/gui_common/thrive_theme.tres" type="Theme" id=2]
@@ -8,6 +8,7 @@
 [ext_resource path="res://assets/textures/gui/bevel/trashButton.png" type="Texture" id=6]
 [ext_resource path="res://src/gui_common/dialogs/CustomConfirmationDialog.tscn" type="PackedScene" id=7]
 [ext_resource path="res://src/gui_common/fonts/Lato-Bold-Regular.tres" type="DynamicFont" id=8]
+[ext_resource path="res://assets/textures/gui/bevel/trashButtonActive.png" type="Texture" id=9]
 [ext_resource path="res://src/gui_common/fonts/Lato-Regular-AlmostSmall.tres" type="DynamicFont" id=10]
 
 [sub_resource type="StyleBoxFlat" id=1]
@@ -259,8 +260,10 @@ margin_bottom = 43.0
 rect_min_size = Vector2( 43, 43 )
 size_flags_vertical = 0
 texture_normal = ExtResource( 6 )
+texture_pressed = ExtResource( 9 )
 texture_hover = ExtResource( 4 )
 texture_disabled = ExtResource( 1 )
+expand = true
 
 [node name="Load" type="Button" parent="MarginContainer/HBoxContainer/HBoxContainer"]
 margin_left = 47.0


### PR DESCRIPTION
**Brief Description of What This PR Does**

The trash button is missing a pressed texture, so I added one. While at that, I "remastered" the textures using Inkscape as close as I could.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
