### PR TITLE
Fixed errors about external effects from extinct species

### DIFF
--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -225,7 +225,16 @@ public class AutoEvoRun
             {
                 try
                 {
-                    long currentPop = results.GetPopulationInPatch(entry.Species, currentPatch);
+                    // It's possible for external effects to be added for extinct species (either completely extinct
+                    // or extinct in the current patch)
+                    if (!results.SpeciesHasResults(entry.Species))
+                    {
+                        GD.Print("Extinct species ", entry.Species.FormattedIdentifier,
+                            " had an external effect, ignoring the effect");
+                        continue;
+                    }
+
+                    long currentPop = results.GetPopulationInPatchIfExists(entry.Species, currentPatch) ?? 0;
 
                     results.AddPopulationResultForSpecies(
                         entry.Species, currentPatch, (int)(currentPop * entry.Coefficient) + entry.Constant);

--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -179,6 +179,19 @@
             dataReceiver.IndividualCost = individualCost;
         }
 
+        /// <summary>
+        ///   Checks if species has results. Species doesn't have results if it was extinct or was not part of the run
+        /// </summary>
+        /// <param name="species">The species to check</param>
+        /// <returns>True if the species has results</returns>
+        public bool SpeciesHasResults(Species species)
+        {
+            lock (results)
+            {
+                return results.ContainsKey(species);
+            }
+        }
+
         public void ApplyResults(GameWorld world, bool skipMutations)
         {
             foreach (var entry in results)

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -561,6 +561,14 @@ public class MicrobeHUD : Control
     {
         GD.Print("Move to editor pressed");
 
+        // TODO: find out when this can happen (this happened when a really laggy save was loaded and the editor button
+        // was pressed before the stage fade in fully completed)
+        if (stage.Player == null)
+        {
+            GD.PrintErr("Trying to press editor button while having no player object");
+            return;
+        }
+
         // To prevent being clicked twice
         editorButton.Disabled = true;
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

As members of a species can still exist when it is already extinct

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #3005

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
