### PR TITLE
Cancel auto-evo prediction run earlier

### DIFF
--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -1317,6 +1317,10 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
             return;
         }
 
+        // Note that in rare cases the auto-evo run doesn't manage to stop before we edit the cached species object
+        // which may cause occasional background task errors
+        gui.CancelPreviousAutoEvoPrediction();
+
         cachedAutoEvoPredictionSpecies ??= (MicrobeSpecies)editedSpecies.Clone();
 
         CopyEditedPropertiesToSpecies(cachedAutoEvoPredictionSpecies);

--- a/src/microbe_stage/editor/MicrobeEditorGUI.cs
+++ b/src/microbe_stage/editor/MicrobeEditorGUI.cs
@@ -858,11 +858,27 @@ public class MicrobeEditorGUI : Control, ISaveLoadedTracked
         compoundBalance.UpdateBalances(balances);
     }
 
+    /// <summary>
+    ///   Cancels the previous auto-evo prediction run if there is one
+    /// </summary>
+    public void CancelPreviousAutoEvoPrediction()
+    {
+        if (waitingForPrediction == null)
+            return;
+
+        GD.Print("Canceling previous auto-evo prediction run as it didn't manage to finish yet");
+        waitingForPrediction.AutoEvoRun.Abort();
+        waitingForPrediction = null;
+    }
+
     public void UpdateAutoEvoPrediction(EditorAutoEvoRun startedRun, MicrobeSpecies playerSpeciesOriginal,
         MicrobeSpecies playerSpeciesNew)
     {
-        // Cancel previous one if there is one
-        waitingForPrediction?.AutoEvoRun.Abort();
+        if (waitingForPrediction != null)
+        {
+            GD.PrintErr(
+                $"{nameof(CancelPreviousAutoEvoPrediction)} has not been called before starting a new prediction");
+        }
 
         totalPopulationIndicator.Show();
         totalPopulationIndicator.Texture = questionIcon;


### PR DESCRIPTION
**Brief Description of What This PR Does**

so that species data modification while auto-evo is still running is much less likely

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

related to https://github.com/Revolutionary-Games/Thrive/issues/3006 but doesn't really properly address that, but at least on my computer with a really many species in a single patch I can only very rarely even get the warning print (when spamming undo and redo in the editor as quick as I can click) I added here to trigger, so this might be good enough.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
