### PR TITLE
Added a couple of auto-evo run species null checks

### DIFF
--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -311,6 +311,10 @@ public class AutoEvoRun
             var speciesInPatchCopy = entry.Value.SpeciesInPatch.ToList();
             foreach (var speciesEntry in speciesInPatchCopy)
             {
+                // Trying to find where a null comes from https://github.com/Revolutionary-Games/Thrive/issues/3004
+                if (speciesEntry.Key == null)
+                    throw new Exception("Species key in a patch is null");
+
                 if (alreadyHandledSpecies.Contains(speciesEntry.Key))
                     continue;
 

--- a/src/auto-evo/simulation/PopulationSimulation.cs
+++ b/src/auto-evo/simulation/PopulationSimulation.cs
@@ -116,6 +116,13 @@
                 }
             }
 
+            foreach (var entry in species)
+            {
+                // Trying to find where a null comes from https://github.com/Revolutionary-Games/Thrive/issues/3004
+                if (entry == null)
+                    throw new Exception("Species in a simulation run is null");
+            }
+
             return species;
         }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**
I couldn't figure out what is causing https://github.com/Revolutionary-Games/Thrive/issues/3004 nor can I get it to happen on my computer so I added a few null checks for species in auto-evo this should at least partly allow us to rule out that the species object is null (or if we hit the new exception throws, then we know that a null species comes from somewhere).

I've tested this quite many auto-evo runs and none of the times the new exception throws were hit so this shouldn't affect the normal, non-error uses.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
