### PR TITLE
Increased the min horizontal size of the metabolosomes organelle tooltip title

### DIFF
--- a/src/gui_common/tooltip/ToolTipManager.tscn
+++ b/src/gui_common/tooltip/ToolTipManager.tscn
@@ -365,7 +365,8 @@ margin_bottom = 189.0
 
 [node name="metabolosome" parent="GroupHolder/organelleSelection" instance=ExtResource( 5 )]
 visible = false
-margin_bottom = 173.0
+margin_right = 500.0
+margin_bottom = 2.0
 DisplayName = "METABOLOSOMES"
 ProcessesDescription = "METABOLOSOMES_PROCESSES_DESCRIPTION"
 Description = "METABOLOSOMES_DESCRIPTION"
@@ -376,6 +377,11 @@ margin_bottom = 216.0
 
 [node name="VBoxContainer" parent="GroupHolder/organelleSelection/metabolosome/MarginContainer" index="0"]
 margin_bottom = 208.0
+
+[node name="Title" parent="GroupHolder/organelleSelection/metabolosome/MarginContainer/VBoxContainer/Header" index="1"]
+margin_right = 299.0
+margin_bottom = 31.0
+rect_min_size = Vector2( 210, 0 )
 
 [node name="ModifierList" parent="GroupHolder/organelleSelection/metabolosome/MarginContainer/VBoxContainer" index="3"]
 margin_bottom = 134.0

--- a/src/gui_common/tooltip/ToolTipManager.tscn
+++ b/src/gui_common/tooltip/ToolTipManager.tscn
@@ -577,6 +577,11 @@ margin_bottom = 220.0
 [node name="VBoxContainer" parent="GroupHolder/organelleSelection/chemoSynthesizingProteins/MarginContainer" index="0"]
 margin_bottom = 208.0
 
+[node name="Title" parent="GroupHolder/organelleSelection/chemoSynthesizingProteins/MarginContainer/VBoxContainer/Header" index="1"]
+margin_right = 349.0
+margin_bottom = 31.0
+rect_min_size = Vector2( 260, 0 )
+
 [node name="ModifierList" parent="GroupHolder/organelleSelection/chemoSynthesizingProteins/MarginContainer/VBoxContainer" index="3"]
 margin_bottom = 138.0
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Increased the label's min horizontal size to 210.

**Related Issues**

The recent thrive font version upgrade may have broken some labels wrapping due to the slight size difference, which in this case would be the metabolosomes tooltip title.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
