### PR TITLE
Save name

### DIFF
--- a/src/saving/NewSaveMenu.cs
+++ b/src/saving/NewSaveMenu.cs
@@ -56,6 +56,7 @@ public class NewSaveMenu : Control
 
     public void SetSaveName(string name, bool selectText = false)
     {
+        
         saveNameBox.Text = name;
 
         if (selectText)
@@ -64,7 +65,7 @@ public class NewSaveMenu : Control
 
     private static bool IsSaveNameValid(string name)
     {
-        return !string.IsNullOrWhiteSpace(name) && !name.Any(Constants.FILE_NAME_DISALLOWED_CHARACTERS.Contains);
+        return !string.IsNullOrWhiteSpace(name) && !name.Any(Constants.FILE_NAME_DISALLOWED_CHARACTERS.Contains) &&  name.Length <= 244;
     }
 
     private void ShowOverwriteConfirm(string name)


### PR DESCRIPTION
    private static bool IsSaveNameValid(string name)
in NewSaceMenu now returns false if the string is length 244 or greater

**Brief Description of What This PR Does**
may remove players ability to add a ridiculously long save name. 
This PR does some stuff...
checks against string length
**Related Issues**
#2969
<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
