### PR TITLE
Fixed 3d part of HybridAudioPlayer not behaving spatially

### DIFF
--- a/src/general/HybridAudioPlayer.cs
+++ b/src/general/HybridAudioPlayer.cs
@@ -9,7 +9,7 @@
 ///     Useful in cases where the playing of an audio stream must be able to fulfill both of these conditions.
 ///   </para>
 /// </remarks>
-public class HybridAudioPlayer : Node
+public class HybridAudioPlayer : Spatial
 {
     private AudioStreamPlayer3D player3D;
     private AudioStreamPlayer playerNonPositional;

--- a/src/microbe_stage/Microbe.tscn
+++ b/src/microbe_stage/Microbe.tscn
@@ -46,9 +46,10 @@ MaterialToEdit = SubResource( 1 )
 
 [node name="OrganelleParent" type="Spatial" parent="."]
 
-[node name="EngulfAudio" type="Node" parent="."]
+[node name="EngulfAudio" type="Spatial" parent="."]
 script = ExtResource( 8 )
 Stream = ExtResource( 6 )
+Volume = 0.0
 Bus = "SFX"
 
 [node name="BindingAudio" type="AudioStreamPlayer3D" parent="."]
@@ -57,7 +58,7 @@ unit_size = 50.0
 max_distance = 100.0
 bus = "SFX"
 
-[node name="MovementAudio" type="Node" parent="."]
+[node name="MovementAudio" type="Spatial" parent="."]
 script = ExtResource( 8 )
 Stream = ExtResource( 7 )
 Volume = 0.0


### PR DESCRIPTION
**Brief Description of What This PR Does**

Changed the root node of HybridAudioPlayer to Spatial to fix 3d space related issue.

**Related Issues**

This is an oversight on my part, the root node of HybridAudioPlayer was Node and this of course doesn't work nicely as a child of Spatial-derived microbes, that is it doesn't behave spatially thus the AudioStreamPlayer3D is stuck at some static position (being the direct child of the Node).

Shouldn't affect the non-positional AudioStreamPlayer in any way.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
