### PR TITLE
Slightly reduce the time it takes for freebuild's screen fade enter transition to finish

### DIFF
--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -291,20 +291,6 @@ public class MainMenu : NodeWithInput
         SceneManager.Instance.SwitchToScene(MainGameState.MicrobeStage);
     }
 
-    private void OnFreebuildFadeInEnded()
-    {
-        OnEnteringGame();
-
-        // Instantiate a new editor scene
-        var editor = (MicrobeEditor)SceneManager.Instance.LoadScene(MainGameState.MicrobeEditor).Instance();
-
-        // Start freebuild game
-        editor.CurrentGame = GameProperties.StartNewMicrobeGame(true);
-
-        // Switch to the editor scene
-        SceneManager.Instance.SwitchToScene(editor);
-    }
-
     private void NewGamePressed()
     {
         GUICommon.Instance.PlayButtonPressSound();
@@ -349,8 +335,16 @@ public class MainMenu : NodeWithInput
         // Disable the button to prevent it being executed again.
         freebuildButton.Disabled = true;
 
-        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.15f, false);
-        TransitionManager.Instance.StartTransitions(this, nameof(OnFreebuildFadeInEnded));
+        OnEnteringGame();
+
+        // Instantiate a new editor scene
+        var editor = (MicrobeEditor)SceneManager.Instance.LoadScene(MainGameState.MicrobeEditor).Instance();
+
+        // Start freebuild game
+        editor.CurrentGame = GameProperties.StartNewMicrobeGame(true);
+
+        // Switch to the editor scene
+        SceneManager.Instance.SwitchToScene(editor);
     }
 
     // TODO: this is now used by another sub menu as well so renaming this to be more generic would be good

--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -291,6 +291,20 @@ public class MainMenu : NodeWithInput
         SceneManager.Instance.SwitchToScene(MainGameState.MicrobeStage);
     }
 
+    private void OnFreebuildFadeInEnded()
+    {
+        OnEnteringGame();
+
+        // Instantiate a new editor scene
+        var editor = (MicrobeEditor)SceneManager.Instance.LoadScene(MainGameState.MicrobeEditor).Instance();
+
+        // Start freebuild game
+        editor.CurrentGame = GameProperties.StartNewMicrobeGame(true);
+
+        // Switch to the editor scene
+        SceneManager.Instance.SwitchToScene(editor);
+    }
+
     private void NewGamePressed()
     {
         GUICommon.Instance.PlayButtonPressSound();
@@ -335,16 +349,8 @@ public class MainMenu : NodeWithInput
         // Disable the button to prevent it being executed again.
         freebuildButton.Disabled = true;
 
-        OnEnteringGame();
-
-        // Instantiate a new editor scene
-        var editor = (MicrobeEditor)SceneManager.Instance.LoadScene(MainGameState.MicrobeEditor).Instance();
-
-        // Start freebuild game
-        editor.CurrentGame = GameProperties.StartNewMicrobeGame(true);
-
-        // Switch to the editor scene
-        SceneManager.Instance.SwitchToScene(editor);
+        TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.1f, false);
+        TransitionManager.Instance.StartTransitions(this, nameof(OnFreebuildFadeInEnded));
     }
 
     // TODO: this is now used by another sub menu as well so renaming this to be more generic would be good


### PR DESCRIPTION
**Brief Description of What This PR Does**

It adds an unnecessary delay.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
