### PR TITLE
Fixed changing organelle rotation in place

### DIFF
--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -2113,10 +2113,11 @@ public class MicrobeEditor : NodeWithInput, ILoadableGameState, IGodotEarlyNodeR
             return false;
         }
 
-        // Don't register the action if the final location is the same as previous. This is so the player can't exploit
-        // the MovedThisSession flag allowing them to freely move an organelle that was placed in another session
-        // while on zero mutation points. Also it makes more sense to not count that organelle as moved either way.
-        if (oldLocation == newLocation)
+        // Don't register the action if the final location and rotation is the same as previous. This is so the player
+        // can't exploit the MovedThisSession flag allowing them to freely move an organelle that was placed in another
+        // session while on zero mutation points. Also it makes more sense to not count that organelle as moved either
+        // way.
+        if (oldLocation == newLocation && oldRotation == newRotation)
         {
             CancelCurrentAction();
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Added rotation equals check in MoveOrganelle's anti-exploit position equals check so that rotating an organelle in place actually rotates the organelle into that particular angle when you finishes the action.

Steps to reproduce the original issue
- Place pilus
- Start organelle move action
- Rotate it in place in a different angle
- Place it
- It reverts back to the previous angle

**Related Issues**

Fixes #2993 

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
