### PR TITLE
Fix theme for file dialog

### DIFF
--- a/src/gui_common/thrive_theme.tres
+++ b/src/gui_common/thrive_theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=65 format=2]
+[gd_resource type="Theme" load_steps=66 format=2]
 
 [ext_resource path="res://src/gui_common/fonts/Jura-Regular-AlmostSmaller.tres" type="DynamicFont" id=1]
 [ext_resource path="res://assets/textures/gui/bevel/grab.png" type="Texture" id=2]
@@ -352,6 +352,15 @@ corner_radius_top_left = 5
 corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id=45]
+bg_color = Color( 0.0666667, 0.168627, 0.211765, 1 )
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color( 0.0784314, 0.960784, 0.803922, 1 )
+border_blend = true
 
 [sub_resource type="StyleBoxFlat" id=35]
 bg_color = Color( 0.0666667, 1, 0.835294, 1 )
@@ -798,7 +807,7 @@ TooltipPanel/styles/panel = SubResource( 34 )
 Tree/colors/cursor_color = Color( 0, 0, 0, 1 )
 Tree/colors/custom_button_font_highlight = Color( 0, 0, 0, 1 )
 Tree/colors/drop_position_color = Color( 0, 0, 0, 1 )
-Tree/colors/font_color = Color( 0, 0, 0, 1 )
+Tree/colors/font_color = Color( 1, 1, 1, 1 )
 Tree/colors/font_color_selected = Color( 0, 0, 0, 1 )
 Tree/colors/guide_color = Color( 0, 0, 0, 1 )
 Tree/colors/relationship_line_color = Color( 0, 0, 0, 1 )
@@ -820,7 +829,7 @@ Tree/icons/checked = null
 Tree/icons/select_arrow = null
 Tree/icons/unchecked = null
 Tree/icons/updown = null
-Tree/styles/bg = null
+Tree/styles/bg = SubResource( 45 )
 Tree/styles/bg_focus = null
 Tree/styles/button_pressed = null
 Tree/styles/cursor = null


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes the GUI theme for the file dialog. The tree GUI node needed a background, I used the color of button nodes for it. Here's how it looks with a file dialog node and in the theme editor.

![FileDialog](https://user-images.githubusercontent.com/6080368/152620823-30f629e7-6b95-4bb7-9fb9-fa43868671fc.PNG)
![FileDialogText](https://user-images.githubusercontent.com/6080368/152620824-cd7e0c50-05e6-4516-b28f-0a9006ba4d15.PNG)

**Related Issues**

Closes #2812

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


