### PR TITLE
Disabled the x button on the organelle upgrade popup

### DIFF
--- a/src/microbe_stage/editor/upgrades/OrganelleUpgradeGUI.tscn
+++ b/src/microbe_stage/editor/upgrades/OrganelleUpgradeGUI.tscn
@@ -20,6 +20,7 @@ ScrollContainerPath = NodePath("ModifyPopup/VBoxContainer2/ScrollContainer")
 [node name="ModifyPopup" parent="." instance=ExtResource( 1 )]
 WindowTitle = "MODIFY_ORGANELLE"
 Resizable = true
+ShowCloseButton = false
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="ModifyPopup"]
 margin_right = 40.0


### PR DESCRIPTION
**Brief Description of What This PR Does**
Disabled the normal popup window X button on the organelle modify menu as I noticed that sonofmowgef managed to use it instead of applying or canceling the organelle modification. So I think it'll be better to force the user to press the "OK" or "Cancel" button explicitly so they understand what they just did

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
