### PR TITLE
Added a system for skipping invokes on disposed Godot objects

### DIFF
--- a/src/gui_common/CustomRichTextLabel.cs
+++ b/src/gui_common/CustomRichTextLabel.cs
@@ -54,7 +54,7 @@ public class CustomRichTextLabel : RichTextLabel
             extendedBbcode = value;
 
             // Need to delay this so we can get the correct input controls from settings.
-            Invoke.Instance.Queue(ParseCustomTags);
+            Invoke.Instance.QueueForObject(ParseCustomTags, this);
         }
     }
 
@@ -84,7 +84,7 @@ public class CustomRichTextLabel : RichTextLabel
         // See https://github.com/Revolutionary-Games/Thrive/issues/2236
         // Queue to run on the next frame due to null RID error with some bbcode image display if otherwise
 #pragma warning disable CA2245 // Necessary for workaround
-        Invoke.Instance.Queue(() => BbcodeText = BbcodeText);
+        Invoke.Instance.QueueForObject(() => BbcodeText = BbcodeText, this);
 #pragma warning restore CA2245
     }
 


### PR DESCRIPTION
and switched the rich text label over to using it

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #2477

I didn't move over the custom checkbox or timeline which could theoretically suffer from the same problem but it seems that in normal use they are never disposed before the invoke gets a chance to run, so I left those as they were for now.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
