### PR TITLE
Fixed master build cache not being written with the right key

### DIFF
--- a/CIConfiguration.yml
+++ b/CIConfiguration.yml
@@ -7,7 +7,7 @@ jobs:
       loadFrom:
         - v3-{Branch}-build
         - v3-master-build
-      writeTo: v2-{Branch}-build
+      writeTo: v3-{Branch}-build
       shared:
         .git/lfs: v2-lfs
         .import: v4-import

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,10 @@ When updating Godot import settings (meaning changing the settings for
 an existing asset, if you just added a new one, you don't need to do
 this), or adding new C# dependencies, you should update the cache
 versions for CI. To do this you need to increment the relevant numbers
-by 1 in `CIConfiguration.yml`. If you are unsure which cache names to
-increment, please ask.
+by 1 in `CIConfiguration.yml`. When updating the caches you must also
+remember to update the `writeTo` cache. Otherwise caching will not
+work correctly. If you are unsure which cache names to increment,
+please ask.
 
 ## Getting help
 


### PR DESCRIPTION
this probably prevented LFS caching for new branches from working

I probably missed this when updating this or when someone else's PR updated this.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
