### PR TITLE
Made the tutorial GUI control highlight background much darker

### DIFF
--- a/src/gui_common/ControlHighlight.tscn
+++ b/src/gui_common/ControlHighlight.tscn
@@ -22,23 +22,23 @@ BottomPlanePath = NodePath("BottomPlanking")
 [node name="LeftBlanking" type="ColorRect" parent="."]
 margin_right = 40.0
 margin_bottom = 40.0
-color = Color( 0.14902, 0.137255, 0.137255, 0.705882 )
+color = Color( 0.14902, 0.137255, 0.137255, 0.882353 )
 
 [node name="RightBlanking" type="ColorRect" parent="."]
 margin_right = 40.0
 margin_bottom = 40.0
 rect_pivot_offset = Vector2( 1520, -62 )
-color = Color( 0.14902, 0.137255, 0.137255, 0.705882 )
+color = Color( 0.14902, 0.137255, 0.137255, 0.882353 )
 
 [node name="TopBlanking" type="ColorRect" parent="."]
 margin_right = 40.0
 margin_bottom = 40.0
-color = Color( 0.14902, 0.137255, 0.137255, 0.705882 )
+color = Color( 0.14902, 0.137255, 0.137255, 0.882353 )
 
 [node name="BottomPlanking" type="ColorRect" parent="."]
 margin_right = 40.0
 margin_bottom = 40.0
-color = Color( 0.14902, 0.137255, 0.137255, 0.705882 )
+color = Color( 0.14902, 0.137255, 0.137255, 0.882353 )
 __meta__ = {
 "_edit_use_anchors_": false
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

to make it more obvious with higher contrast where the highlighted GUI control is

Now looks like this:

![2022-02-20_18 39 26 3731](https://user-images.githubusercontent.com/3796411/154853709-0f4bc1f0-ebaf-475e-bc0c-40da4b967d2c.png)

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #2977

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
