### PR TITLE
Sync extinction track better with final death

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -653,7 +653,7 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
             TranslationServer.Translate("PLAYER_DIED"),
             true, Constants.PLAYER_DEATH_POPULATION_LOSS_COEFFICIENT);
 
-        if (GameWorld.PlayerSpecies.Population <= 0 && !CurrentGame!.FreeBuild)
+        if (IsGameOver())
         {
             Jukebox.Instance.PlayCategory("Extinction");
         }
@@ -703,7 +703,7 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
         HUD.HintText = string.Empty;
 
         // Respawn if not extinct (or freebuild)
-        if (GameWorld.PlayerSpecies.Population <= 0 && !CurrentGame!.FreeBuild)
+        if (IsGameOver())
         {
             gameOver = true;
         }
@@ -805,5 +805,10 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
         }
 
         return chemoreceptionLines[index];
+    }
+
+    private bool IsGameOver()
+    {
+        return GameWorld.PlayerSpecies.Population <= 0 && !CurrentGame!.FreeBuild;
     }
 }

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -406,7 +406,6 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
             // Show the game lost popup if not already visible
             HUD.ShowExtinctionBox();
 
-            Jukebox.Instance.PlayCategory("Extinction");
             return;
         }
 
@@ -648,6 +647,17 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
     {
         GD.Print("The player has died");
 
+        // Decrease the population by the constant for the player dying
+        GameWorld.AlterSpeciesPopulation(
+            GameWorld.PlayerSpecies, Constants.PLAYER_DEATH_POPULATION_LOSS_CONSTANT,
+            TranslationServer.Translate("PLAYER_DIED"),
+            true, Constants.PLAYER_DEATH_POPULATION_LOSS_COEFFICIENT);
+
+        if (GameWorld.PlayerSpecies.Population <= 0 && !CurrentGame!.FreeBuild)
+        {
+            Jukebox.Instance.PlayCategory("Extinction");
+        }
+
         HUD.HideReproductionDialog();
 
         TutorialState.SendEvent(TutorialEventType.MicrobePlayerDied, EventArgs.Empty, this);
@@ -690,18 +700,10 @@ public class MicrobeStage : NodeWithInput, ILoadableGameState, IGodotEarlyNodeRe
     /// </summary>
     private void HandlePlayerRespawn()
     {
-        var playerSpecies = GameWorld.PlayerSpecies;
-
-        // Decrease the population by the constant for the player dying
-        GameWorld.AlterSpeciesPopulation(
-            playerSpecies, Constants.PLAYER_DEATH_POPULATION_LOSS_CONSTANT,
-            TranslationServer.Translate("PLAYER_DIED"),
-            true, Constants.PLAYER_DEATH_POPULATION_LOSS_COEFFICIENT);
-
         HUD.HintText = string.Empty;
 
         // Respawn if not extinct (or freebuild)
-        if (playerSpecies.Population <= 0 && !CurrentGame!.FreeBuild)
+        if (GameWorld.PlayerSpecies.Population <= 0 && !CurrentGame!.FreeBuild)
         {
             gameOver = true;
         }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Because the extinction track builds up for a bit, this PR makes it so that it starts playing when the player dies, while the text shows up when the player would have been due to respawn. This happens to make the audio and visuals sync up really well.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
