### PR TITLE
Make it so that when you click on a compounds color the color matches the compound

### DIFF
--- a/Thrive.sln.DotSettings
+++ b/Thrive.sln.DotSettings
@@ -507,6 +507,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=chemoplast/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=chemoreception/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Chemoreceptor/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=chemoreceptors/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cofix/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cofixes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=collider/@EntryIndexedValue">True</s:Boolean>

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -22,13 +22,15 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     private List<Compound>? shownChoices;
     private OrganelleTemplate? storedOrganelle;
-
+    //setting list for saved colors
+    private List<Color> shownSavedColour;
     public override void _Ready()
     {
         compounds = GetNode<OptionButton>(CompoundsPath);
         maximumDistance = GetNode<Slider>(MaximumDistancePath);
         minimumAmount = GetNode<Slider>(MinimumAmountPath);
         colour = GetNode<TweakedColourPicker>(ColourPath);
+
 
         compounds.Clear();
 
@@ -43,10 +45,12 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
     {
         storedOrganelle = organelle;
         shownChoices = SimulationParameters.Instance.GetCloudCompounds();
-
+        
+        
         foreach (var choice in shownChoices)
         {
             compounds.AddItem(choice.Name);
+                
         }
 
         // Select glucose by default
@@ -88,5 +92,12 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
         // TODO: make an undoable action
         storedOrganelle.SetCustomUpgradeObject(new ChemoreceptorUpgrades(shownChoices[compounds.Selected],
             (float)maximumDistance.Value, (float)minimumAmount.Value, colour.Color));
+    }
+    public void CompoundChanged(int index)
+    {
+        if (shownChoices[index] != null)
+
+            colour.Color = shownChoices[index].Colour; // when the color changes then it changes it to match the color
+        }
     }
 }

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -92,22 +92,25 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     public void CompoundChanged(int index)
     {
-        if (shownChoices?[index] != null)
+        if (shownChoices == null)
         {
-            // If the color is in the shownChoices list don't change the color
-            bool isColorInCompundList = false;
-            foreach (Compound compound in shownChoices)
-            {
-                if (colour.Color == compound.Colour || colour.Color == Colors.White)
-                {
-                    isColorInCompundList = true;
-                }
-            }
+            GD.PrintErr("Shown choices are not set up correctly");
+            return;
+        }
 
-            if (isColorInCompundList)
+        // If the color is in the shownChoices list don't change the color
+        bool isColorInCompundList = false;
+        foreach (Compound compound in shownChoices)
+        {
+            if (colour.Color == compound.Colour || colour.Color == Colors.White)
             {
-                colour.Color = shownChoices[index].Colour;
+                isColorInCompundList = true;
             }
+        }
+
+        if (isColorInCompundList)
+        {
+            colour.Color = shownChoices[index].Colour;
         }
     }
 }

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -21,7 +21,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
     private Slider minimumAmount = null!;
     private TweakedColourPicker colour = null!;
 
-    private List<Compound>? shownChoices = null!;
+    private List<Compound>? shownChoices;
     private OrganelleTemplate? storedOrganelle;
 
     public override void _Ready()
@@ -70,7 +70,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
             compounds.Selected = defaultCompoundIndex;
             maximumDistance.Value = Constants.CHEMORECEPTOR_RANGE_DEFAULT;
             minimumAmount.Value = Constants.CHEMORECEPTOR_AMOUNT_DEFAULT;
-            colour.Color = shownChoices[defaultCompoundIndex].Colour;
+            colour.Color = SimulationParameters.Instance.GetCompound("Glucose").Colour;
         }
     }
 
@@ -93,16 +93,15 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     public void CompoundChanged(int index)
     {
+        if (shownChoices?[index] != null && shownChoices?.Any() == true)
+        {
+            // If the color is in the shownChoices list  change the color
+            bool isColorInCompundList = shownChoices.Any(c => c.Colour == colour.Color);
 
-        if (shownChoices?[index] == null)
-        {
-            return;
-        }
-        // If the color is in the shownChoices list change the color
-        bool isColourInCompoundList = shownChoices.Any(c => c.Colour == colour.Color);
-        if (isColourInCompoundList)
-        {
-            colour.Color = shownChoices[index].Colour;
+            if (isColorInCompundList)
+            {
+                colour.Color = shownChoices[index].Colour;
+            }
         }
     }
 }

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -70,7 +70,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
             compounds.Selected = defaultCompoundIndex;
             maximumDistance.Value = Constants.CHEMORECEPTOR_RANGE_DEFAULT;
             minimumAmount.Value = Constants.CHEMORECEPTOR_AMOUNT_DEFAULT;
-            colour.Color = SimulationParameters.Instance.GetCompound("Glucose").Colour;
+            colour.Color = shownChoices[defaultCompoundIndex].Colour;
         }
     }
 

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -92,9 +92,25 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     public void CompoundChanged(int index)
     {
-        if (shownChoices != null)
+        if (shownChoices == null || shownChoices[index] == null)
         {
-            colour.Color = shownChoices[index].Colour; // when the color changes then it changes it to match the color
+            GD.PrintErr("Compound list was not generated correctly");
+            return;
+        }
+
+        // If the color is in the shownChoices list don't change the color
+        bool isColorInCompundList = false;
+        foreach (Compound compound in shownChoices)
+        {
+            if (colour.Color == compound.Colour || colour.Color == Colors.White)
+            {
+                isColorInCompundList = true;
+            }
+        }
+
+        if (isColorInCompundList == true)
+        {
+            colour.Color = shownChoices[index].Colour;
         }
     }
 }

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -92,7 +92,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     public void CompoundChanged(int index)
     {
-        if (shownChoices != null && shownChoices[index] != null)
+        if (shownChoices?[index] != null)
         {
         // If the color is in the shownChoices list don't change the color
             bool isColorInCompundList = false;

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -21,7 +21,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
     private Slider minimumAmount = null!;
     private TweakedColourPicker colour = null!;
 
-    private List<Compound>? shownChoices;
+    private List<Compound>? shownChoices = null!;
     private OrganelleTemplate? storedOrganelle;
 
     public override void _Ready()

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -92,7 +92,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     public void CompoundChanged(int index)
     {
-        if (shownChoices != null)
+        if (shownChoices?[index] != null)
         {
             // If the color is in the shownChoices list don't change the color
             bool isColorInCompundList = false;

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -91,6 +91,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
         storedOrganelle.SetCustomUpgradeObject(new ChemoreceptorUpgrades(shownChoices[compounds.Selected],
             (float)maximumDistance.Value, (float)minimumAmount.Value, colour.Color));
     }
+
     public void CompoundChanged(int index)
     {
         if (shownChoices[index] != null)

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -93,15 +93,11 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     public void CompoundChanged(int index)
     {
-        if (shownChoices?[index] != null && shownChoices?.Any() == true)
+        // If the currently selected colour is in the shownChoices list change the colour to the colour of the newly
+        // selected compound to make setting up chemoreceptors easier
+        if (shownChoices?.Any(c => c.Colour == colour.Color) == true)
         {
-            // If the color is in the shownChoices list  change the color
-            bool isColorInCompundList = shownChoices.Any(c => c.Colour == colour.Color);
-
-            if (isColorInCompundList)
-            {
-                colour.Color = shownChoices[index].Colour;
-            }
+            colour.Color = shownChoices[index].Colour;
         }
     }
 }

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -92,7 +92,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     public void CompoundChanged(int index)
     {
-        if (shownChoices?[index] != null)
+        if (shownChoices?[index] != null && shownChoices != null)
         {
             // If the color is in the shownChoices list don't change the color
             bool isColorInCompundList = false;

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -93,14 +93,16 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     public void CompoundChanged(int index)
     {
-        if (shownChoices != null)
+
+        if (shownChoices?[index] == null)
         {
-            // If the color is in the shownChoices list change the color
-            bool isColourInCompoundList = shownChoices.Any(c => c.Colour == colour.Color);
-            if (isColourInCompoundList)
-            {
-                colour.Color = shownChoices[index].Colour;
-            }
+            return;
+        }
+        // If the color is in the shownChoices list change the color
+        bool isColourInCompoundList = shownChoices.Any(c => c.Colour == colour.Color);
+        if (isColourInCompoundList)
+        {
+            colour.Color = shownChoices[index].Colour;
         }
     }
 }

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -94,7 +94,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
     {
         if (shownChoices?[index] != null)
         {
-        // If the color is in the shownChoices list don't change the color
+            // If the color is in the shownChoices list don't change the color
             bool isColorInCompundList = false;
             foreach (Compound compound in shownChoices)
             {

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -49,7 +49,6 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
         foreach (var choice in shownChoices)
         {
             compounds.AddItem(choice.Name);
-                
         }
 
         // Select glucose by default

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Godot;
 
 public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
@@ -69,7 +70,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
             compounds.Selected = defaultCompoundIndex;
             maximumDistance.Value = Constants.CHEMORECEPTOR_RANGE_DEFAULT;
             minimumAmount.Value = Constants.CHEMORECEPTOR_AMOUNT_DEFAULT;
-            colour.Color = Colors.White;
+            colour.Color = SimulationParameters.Instance.GetCompound("glucose").Colour;
         }
     }
 
@@ -94,16 +95,8 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
     {
         if (shownChoices?[index] != null && shownChoices != null)
         {
-            // If the color is in the shownChoices list don't change the color
-            bool isColorInCompundList = false;
-            foreach (Compound compound in shownChoices)
-            {
-                if (colour.Color == compound.Colour || colour.Color == Colors.White)
-                {
-                    isColorInCompundList = true;
-                }
-            }
-
+            // If the color is in the shownChoices list change the color
+            bool isColorInCompundList = shownChoices.Any(c => c.Colour == colour.Color);
             if (isColorInCompundList)
             {
                 colour.Color = shownChoices[index].Colour;

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -30,7 +30,6 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
         minimumAmount = GetNode<Slider>(MinimumAmountPath);
         colour = GetNode<TweakedColourPicker>(ColourPath);
 
-
         compounds.Clear();
 
         maximumDistance.MinValue = Constants.CHEMORECEPTOR_RANGE_MIN;
@@ -44,8 +43,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
     {
         storedOrganelle = organelle;
         shownChoices = SimulationParameters.Instance.GetCloudCompounds();
-        
-        
+
         foreach (var choice in shownChoices)
         {
             compounds.AddItem(choice.Name);
@@ -94,8 +92,8 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     public void CompoundChanged(int index)
     {
-        if (shownChoices[index] != null)
-        { 
+        if (shownChoices != null)
+        {
             colour.Color = shownChoices[index].Colour; // when the color changes then it changes it to match the color
         }
     }

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -95,7 +95,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
     public void CompoundChanged(int index)
     {
         if (shownChoices[index] != null)
-
+        { 
             colour.Color = shownChoices[index].Colour; // when the color changes then it changes it to match the color
         }
     }

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -93,7 +93,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     public void CompoundChanged(int index)
     {
-        if (shownChoices?[index] != null && shownChoices != null)
+        if (shownChoices != null)
         {
             // If the color is in the shownChoices list change the color
             bool isColourInCompoundList = shownChoices.Any(c => c.Colour == colour.Color);

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -94,7 +94,6 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
     {
         if (shownChoices == null)
         {
-            GD.PrintErr("Shown choices are not set up correctly");
             return;
         }
 

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -92,24 +92,22 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     public void CompoundChanged(int index)
     {
-        if (shownChoices == null)
+        if (shownChoices != null)
         {
-            return;
-        }
-
-        // If the color is in the shownChoices list don't change the color
-        bool isColorInCompundList = false;
-        foreach (Compound compound in shownChoices)
-        {
-            if (colour.Color == compound.Colour || colour.Color == Colors.White)
+            // If the color is in the shownChoices list don't change the color
+            bool isColorInCompundList = false;
+            foreach (Compound compound in shownChoices)
             {
-                isColorInCompundList = true;
+                if (colour.Color == compound.Colour || colour.Color == Colors.White)
+                {
+                    isColorInCompundList = true;
+                }
             }
-        }
 
-        if (isColorInCompundList)
-        {
-            colour.Color = shownChoices[index].Colour;
+            if (isColorInCompundList)
+            {
+                colour.Color = shownChoices[index].Colour;
+            }
         }
     }
 }

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -22,8 +22,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     private List<Compound>? shownChoices;
     private OrganelleTemplate? storedOrganelle;
-    //setting list for saved colors
-    private List<Color> shownSavedColour;
+
     public override void _Ready()
     {
         compounds = GetNode<OptionButton>(CompoundsPath);

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -92,25 +92,22 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
 
     public void CompoundChanged(int index)
     {
-        if (shownChoices == null || shownChoices[index] == null)
+        if (shownChoices != null && shownChoices[index] != null)
         {
-            GD.PrintErr("Compound list was not generated correctly");
-            return;
-        }
-
         // If the color is in the shownChoices list don't change the color
-        bool isColorInCompundList = false;
-        foreach (Compound compound in shownChoices)
-        {
-            if (colour.Color == compound.Colour || colour.Color == Colors.White)
+            bool isColorInCompundList = false;
+            foreach (Compound compound in shownChoices)
             {
-                isColorInCompundList = true;
+                if (colour.Color == compound.Colour || colour.Color == Colors.White)
+                {
+                    isColorInCompundList = true;
+                }
             }
-        }
 
-        if (isColorInCompundList == true)
-        {
-            colour.Color = shownChoices[index].Colour;
+            if (isColorInCompundList)
+            {
+                colour.Color = shownChoices[index].Colour;
+            }
         }
     }
 }

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -70,7 +70,7 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
             compounds.Selected = defaultCompoundIndex;
             maximumDistance.Value = Constants.CHEMORECEPTOR_RANGE_DEFAULT;
             minimumAmount.Value = Constants.CHEMORECEPTOR_AMOUNT_DEFAULT;
-            colour.Color = SimulationParameters.Instance.GetCompound("glucose").Colour;
+            colour.Color = shownChoices[defaultCompoundIndex].Colour;
         }
     }
 
@@ -96,8 +96,8 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
         if (shownChoices?[index] != null && shownChoices != null)
         {
             // If the color is in the shownChoices list change the color
-            bool isColorInCompundList = shownChoices.Any(c => c.Colour == colour.Color);
-            if (isColorInCompundList)
+            bool isColorInCompoundList = shownChoices.Any(c => c.Colour == colour.Color);
+            if (isColorInCompoundList)
             {
                 colour.Color = shownChoices[index].Colour;
             }

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.cs
@@ -96,8 +96,8 @@ public class ChemoreceptorUpgradeGUI : VBoxContainer, IOrganelleUpgrader
         if (shownChoices?[index] != null && shownChoices != null)
         {
             // If the color is in the shownChoices list change the color
-            bool isColorInCompoundList = shownChoices.Any(c => c.Colour == colour.Color);
-            if (isColorInCompoundList)
+            bool isColourInCompoundList = shownChoices.Any(c => c.Colour == colour.Color);
+            if (isColourInCompoundList)
             {
                 colour.Color = shownChoices[index].Colour;
             }

--- a/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.tscn
+++ b/src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.tscn
@@ -10,9 +10,6 @@ anchor_bottom = 1.0
 size_flags_horizontal = 3
 theme = ExtResource( 1 )
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 CompoundsPath = NodePath("Compound")
 MaximumDistancePath = NodePath("Distance")
 MinimumAmountPath = NodePath("Amount")
@@ -88,5 +85,7 @@ text = "LINE_COLOUR"
 margin_left = 0.0
 margin_top = 200.0
 margin_right = 1280.0
-margin_bottom = 794.0
+margin_bottom = 759.0
 edit_alpha = false
+
+[connection signal="item_selected" from="Compound" to="." method="CompoundChanged"]


### PR DESCRIPTION
**Brief Description of What This PR Does**

closes[ #3043](https://github.com/Revolutionary-Games/Thrive/issues/3043)

this makes it so that when you select a different component it automatically switch the color of the components

**Related Issues**

**Progress Checklist**

