### PR TITLE
Ai stop motion with no atp

### DIFF
--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -174,7 +174,9 @@ public class MicrobeAI
 
         if (atpTreshold > 0.0f)
         {
-            if(microbe.Compounds.GetCompoundAmount(atp) < microbe.Compounds.Capacity * atpTreshold)
+            if (microbe.Compounds.GetCompoundAmount(atp) < microbe.Compounds.Capacity * atpTreshold
+                && microbe.Compounds.Where(compound => IsVitalCompound(compound.Key) && compound.Value > 0.0f)
+                .Count() > 0)
             {
                 SetMoveSpeed(0.0f);
                 return;

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -169,7 +169,8 @@ public class MicrobeAI
         // If this microbe is out of ATP, pick an amount of time to rest
         if (microbe.Compounds.GetCompoundAmount(atp) < 1.0f)
         {
-            atpThreshold = SpeciesFocus / Constants.MAX_SPECIES_FOCUS;
+            // Keep the maximum at 95% full, as there is flickering when near full
+            atpThreshold = 0.95f * SpeciesFocus / Constants.MAX_SPECIES_FOCUS;
         }
 
         if (atpThreshold > 0.0f)

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -176,7 +176,7 @@ public class MicrobeAI
         {
             if (microbe.Compounds.GetCompoundAmount(atp) < microbe.Compounds.Capacity * atpTreshold
                 && microbe.Compounds.Where(compound => IsVitalCompound(compound.Key) && compound.Value > 0.0f)
-                .Count() > 0)
+                    .Count() > 0)
             {
                 SetMoveSpeed(0.0f);
                 return;

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -48,7 +48,7 @@ public class MicrobeAI
     ///   before resuming motion.
     /// </summary>
     [JsonProperty]
-    private float atpTreshold = 0.0f;
+    private float atpTreshold;
 
     /// <summary>
     ///   Stores the value of microbe.totalAbsorbedCompound at tick t-1 before it is cleared and updated at tick t.
@@ -181,10 +181,8 @@ public class MicrobeAI
                 SetMoveSpeed(0.0f);
                 return;
             }
-            else
-            {
-                atpTreshold = 0.0f;
-            }
+
+            atpTreshold = 0.0f;
         }
 
         // Follow received commands if we have them

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -169,7 +169,7 @@ public class MicrobeAI
         // If this microbe is out of ATP, pick an amount of time to rest
         if (microbe.Compounds.GetCompoundAmount(atp) < 1.0f)
         {
-            atpTreshold = 0.5f;
+            atpTreshold = SpeciesFocus / Constants.MAX_SPECIES_FOCUS;
         }
 
         if (atpTreshold > 0.0f)

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -48,7 +48,7 @@ public class MicrobeAI
     ///   before resuming motion.
     /// </summary>
     [JsonProperty]
-    private float atpTreshold;
+    private float atpThreshold;
 
     /// <summary>
     ///   Stores the value of microbe.totalAbsorbedCompound at tick t-1 before it is cleared and updated at tick t.
@@ -169,12 +169,12 @@ public class MicrobeAI
         // If this microbe is out of ATP, pick an amount of time to rest
         if (microbe.Compounds.GetCompoundAmount(atp) < 1.0f)
         {
-            atpTreshold = SpeciesFocus / Constants.MAX_SPECIES_FOCUS;
+            atpThreshold = SpeciesFocus / Constants.MAX_SPECIES_FOCUS;
         }
 
-        if (atpTreshold > 0.0f)
+        if (atpThreshold > 0.0f)
         {
-            if (microbe.Compounds.GetCompoundAmount(atp) < microbe.Compounds.Capacity * atpTreshold
+            if (microbe.Compounds.GetCompoundAmount(atp) < microbe.Compounds.Capacity * atpThreshold
                 && microbe.Compounds.Where(compound => IsVitalCompound(compound.Key) && compound.Value > 0.0f)
                     .Count() > 0)
             {
@@ -182,7 +182,7 @@ public class MicrobeAI
                 return;
             }
 
-            atpTreshold = 0.0f;
+            atpThreshold = 0.0f;
         }
 
         // Follow received commands if we have them


### PR DESCRIPTION
**Brief Description of What This PR Does**

Updates AI cells to cease motion upon running out of ATP, then wait until ATP is high enough again to start moving and actually get somewhere before running out. A second check prevents microbes from doing this if there are no remaining vital compounds. There is currently no calculation for double-metabolism species such as partial rust eaters, who may still waste some time pointlessly sitting around while dieing. 

**Related Issues**
 None, it looks like.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
