### PR TITLE
Environment in fitness score

### DIFF
--- a/src/auto-evo/simulation/food_source/ChunkFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/ChunkFoodSource.cs
@@ -57,7 +57,7 @@
 
             // We ponder the score for each compound by its amount, leading to pondering in proportion of total
             // quantity, with a constant factor that will be eliminated when making ratios of scores for this niche.
-            var score = energyCompounds.Sum(c => EnergyGenerationScore(microbeSpecies, c.Key) * c.Value);
+            var score = energyCompounds.Sum(c => EnergyGenerationScore(microbeSpecies, c.Key, patch) * c.Value);
 
             score *= chunkEaterSpeed * species.Behaviour.Activity;
 

--- a/src/auto-evo/simulation/food_source/CompoundFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/CompoundFoodSource.cs
@@ -26,7 +26,7 @@
         {
             var microbeSpecies = (MicrobeSpecies)species;
 
-            var compoundUseScore = EnergyGenerationScore(microbeSpecies, compound);
+            var compoundUseScore = EnergyGenerationScore(microbeSpecies, compound, patch);
 
             var energyCost = simulationCache
                 .GetEnergyBalanceForSpecies(microbeSpecies, patch)

--- a/src/auto-evo/simulation/food_source/EnvironmentalFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/EnvironmentalFoodSource.cs
@@ -22,7 +22,7 @@
         {
             var microbeSpecies = (MicrobeSpecies)species;
 
-            var energyCreationScore = EnergyGenerationScore(microbeSpecies, compound);
+            var energyCreationScore = EnergyGenerationScore(microbeSpecies, compound, patch);
 
             var energyCost = simulationCache
                 .GetEnergyBalanceForSpecies(microbeSpecies, patch)

--- a/src/auto-evo/simulation/food_source/FoodSource.cs
+++ b/src/auto-evo/simulation/food_source/FoodSource.cs
@@ -28,7 +28,7 @@
         /// <returns>A formattable that has the description in it</returns>
         public abstract IFormattable GetDescription();
 
-        protected float EnergyGenerationScore(MicrobeSpecies species, Compound compound)
+        protected float EnergyGenerationScore(MicrobeSpecies species, Compound compound, Patch patch)
         {
             var energyCreationScore = 0.0f;
             foreach (var organelle in species.Organelles)
@@ -37,16 +37,19 @@
                 {
                     if (process.Process.Inputs.ContainsKey(compound))
                     {
+                        var processEfficiency = ProcessSystem.CalculateProcessMaximumSpeed(
+                            process, patch.Biome).Efficiency;
+
                         if (process.Process.Outputs.ContainsKey(glucose))
                         {
-                            energyCreationScore += process.Process.Outputs[glucose]
-                                / process.Process.Inputs[compound] * Constants.AUTO_EVO_GLUCOSE_USE_SCORE_MULTIPLIER;
+                            energyCreationScore += process.Process.Outputs[glucose] / process.Process.Inputs[compound]
+                                * processEfficiency * Constants.AUTO_EVO_GLUCOSE_USE_SCORE_MULTIPLIER;
                         }
 
                         if (process.Process.Outputs.ContainsKey(atp))
                         {
-                            energyCreationScore += process.Process.Outputs[atp]
-                                / process.Process.Inputs[compound] * Constants.AUTO_EVO_ATP_USE_SCORE_MULTIPLIER;
+                            energyCreationScore += process.Process.Outputs[atp] / process.Process.Inputs[compound]
+                                * processEfficiency * Constants.AUTO_EVO_ATP_USE_SCORE_MULTIPLIER;
                         }
                     }
                 }

--- a/src/microbe_stage/ProcessSpeedInformation.cs
+++ b/src/microbe_stage/ProcessSpeedInformation.cs
@@ -40,5 +40,16 @@ public class ProcessSpeedInformation : IProcessDisplayInfo
 
     public float CurrentSpeed { get; set; }
 
+    /// <summary>
+    ///   Efficiency is a measure of how well the environment is favourable to the process.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     It is computed as the product of the available amounts of environmental compounds 
+    ///     at instanciation and stored here.
+    ///   </para>
+    /// </remarks>
+    public float Efficiency { get; set; }
+
     public IReadOnlyList<Compound> LimitingCompounds => WritableLimitingCompounds;
 }

--- a/src/microbe_stage/ProcessSystem.cs
+++ b/src/microbe_stage/ProcessSystem.cs
@@ -259,7 +259,7 @@ public class ProcessSystem
     ///   Calculates the maximum speed a process can run at in a biome
     ///   based on the environmental compounds.
     /// </summary>
-    private static ProcessSpeedInformation CalculateProcessMaximumSpeed(TweakedProcess process,
+    public static ProcessSpeedInformation CalculateProcessMaximumSpeed(TweakedProcess process,
         BiomeConditions biome)
     {
         var result = new ProcessSpeedInformation(process.Process);
@@ -267,25 +267,25 @@ public class ProcessSystem
         float speedFactor = 1.0f;
 
         // Environmental inputs need to be processed first
-        foreach (var entry in process.Process.Inputs)
+        foreach (var input in process.Process.Inputs)
         {
-            if (!entry.Key.IsEnvironmental)
+            if (!input.Key.IsEnvironmental)
                 continue;
 
             // Environmental compound that can limit the rate
 
-            var availableInEnvironment = GetDissolvedInBiome(entry.Key, biome);
+            var availableInEnvironment = GetDissolvedInBiome(input.Key, biome);
 
-            var availableRate = availableInEnvironment / entry.Value;
+            var availableRate = availableInEnvironment / input.Value;
 
-            result.AvailableAmounts[entry.Key] = availableInEnvironment;
+            result.AvailableAmounts[input.Key] = availableInEnvironment;
 
             // More than needed environment value boosts the effectiveness
-            result.AvailableRates[entry.Key] = availableRate;
+            result.AvailableRates[input.Key] = availableRate;
 
             speedFactor *= availableRate;
 
-            result.WritableInputs[entry.Key] = entry.Value;
+            result.WritableInputs[input.Key] = input.Value;
         }
 
         speedFactor *= process.Rate;

--- a/src/microbe_stage/ProcessSystem.cs
+++ b/src/microbe_stage/ProcessSystem.cs
@@ -265,6 +265,7 @@ public class ProcessSystem
         var result = new ProcessSpeedInformation(process.Process);
 
         float speedFactor = 1.0f;
+        float efficiency = 1.0f;
 
         // Environmental inputs need to be processed first
         foreach (var input in process.Process.Inputs)
@@ -280,6 +281,8 @@ public class ProcessSystem
 
             result.AvailableAmounts[input.Key] = availableInEnvironment;
 
+            efficiency *= availableInEnvironment;
+
             // More than needed environment value boosts the effectiveness
             result.AvailableRates[input.Key] = availableRate;
 
@@ -287,6 +290,8 @@ public class ProcessSystem
 
             result.WritableInputs[input.Key] = input.Value;
         }
+
+        result.Efficiency = efficiency;
 
         speedFactor *= process.Rate;
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR mitigates energy score generation by integrating process efficiency, derived from compound concentrations in the patch.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

Closes #3132 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
