### PR TITLE
Initialize chart axes names with empty string

### DIFF
--- a/src/gui_common/charts/line/LineChart.cs
+++ b/src/gui_common/charts/line/LineChart.cs
@@ -134,8 +134,8 @@ public class LineChart : VBoxContainer
     /// </summary>
     private LineChart? parentChart;
 
-    private string xAxisName = "x";
-    private string yAxisName = "y";
+    private string xAxisName = string.Empty;
+    private string yAxisName = string.Empty;
 
     /// <summary>
     ///   If true this means that this chart is part of another parent chart.


### PR DESCRIPTION
**Brief Description of What This PR Does**

Apparently `xAxisName` and `yAxisName` is initialized with non-empty string which makes "x" and "y" shows up in-game as the default name. This PR replaces both strings with empty value.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
