### PR TITLE
Fixed Sessile Species not Always Leaving Engulf

### DIFF
--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -246,6 +246,9 @@ public class MicrobeAI
             return;
         }
 
+        // There is no reason to be engulfing at this stage
+        microbe.State = Microbe.MicrobeState.Normal;
+
         // Otherwise just wander around and look for compounds
         if (SpeciesActivity > Constants.MAX_SPECIES_ACTIVITY / 10)
         {
@@ -501,9 +504,6 @@ public class MicrobeAI
 
     private void SeekCompounds(Random random, MicrobeAICommonData data)
     {
-        // If we are still engulfing for some reason, stop
-        microbe.State = Microbe.MicrobeState.Normal;
-
         // More active species just try to get distance to avoid over-clustering
         if (RollCheck(SpeciesActivity, Constants.MAX_SPECIES_ACTIVITY + (Constants.MAX_SPECIES_ACTIVITY / 2), random))
         {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Because the line to switch out of engulfing state occurs within SeekCompounds(), it is possible for sessile species to get stuck in engulf mode. This ensures that that behavior cannot happen. No need to get this in to 0.5.8, as it's pretty minor.

**Related Issues**

None

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
