### PR TITLE
Fixed crashing on invalid localization bbcode text

### DIFF
--- a/src/engine/LocalizedString.cs
+++ b/src/engine/LocalizedString.cs
@@ -48,8 +48,17 @@ public class LocalizedString : IFormattable, IEquatable<LocalizedString>
             return format ?? TranslationServer.Translate(translationKey);
         }
 
-        return string.Format(formatProvider ?? CultureInfo.CurrentCulture,
-            format ?? TranslationServer.Translate(translationKey), formatStringArgs);
+        try
+        {
+            return string.Format(formatProvider ?? CultureInfo.CurrentCulture,
+                format ?? TranslationServer.Translate(translationKey), formatStringArgs);
+        }
+        catch (FormatException e)
+        {
+            GD.PrintErr("Invalid translation format in string ", translationKey, " for current language, exception: ",
+                e);
+            return TranslationServer.Translate(translationKey);
+        }
     }
 
     public override bool Equals(object? obj)

--- a/src/gui_common/CustomRichTextLabel.cs
+++ b/src/gui_common/CustomRichTextLabel.cs
@@ -89,17 +89,13 @@ public class CustomRichTextLabel : RichTextLabel
     }
 
     /// <summary>
-    ///   Parses ExtendedBbcode for any custom Thrive tags and applying the final result
-    ///   into this RichTextLabel's bbcode text.
+    ///   The actual method parsing our extended bbcode, <see cref="ParseCustomTags"/>. This is a separate method
+    ///   to be able to easily catch any exceptions this causes.
     /// </summary>
-    private void ParseCustomTags()
+    /// <param name="extendedBbcode">The extended bbcode string</param>
+    /// <returns>Parsed bbcode string in standard format</returns>
+    private static string ParseCustomTagsString(string extendedBbcode)
     {
-        if (extendedBbcode == null)
-        {
-            BbcodeText = null;
-            return;
-        }
-
         var result = new StringBuilder(extendedBbcode.Length);
         var currentTagBlock = new StringBuilder(50);
 
@@ -197,12 +193,20 @@ public class CustomRichTextLabel : RichTextLabel
                 // Is a closing tag
                 if (bbcodeNamespace.StartsWith("/", StringComparison.InvariantCulture))
                 {
+                    if (tagStack.Count < 1)
+                    {
+                        // We have a closing tag with no opening tag seen
+                        result.Append($"[{tagBlock}]");
+                        isIteratingTag = false;
+                        continue;
+                    }
+
                     var chunks = tagStack.Peek();
 
                     var bbcode = chunks[0];
 
                     // Closing tag doesn't match opening tag or vice versa, aborting parsing
-                    if (tagStack.Count == 0 || bbcode != splitTagBlock[0])
+                    if (bbcode != splitTagBlock[0])
                     {
                         result.Append($"[{tagBlock}]");
                         isIteratingTag = false;
@@ -248,8 +252,8 @@ public class CustomRichTextLabel : RichTextLabel
             }
         }
 
-        // Apply the final string into this RichTextLabel's bbcode text
-        BbcodeText = result.ToString();
+        // Return the final string which will be used as this RichTextLabel's bbcode text
+        return result.ToString();
     }
 
     /// <summary>
@@ -258,7 +262,7 @@ public class CustomRichTextLabel : RichTextLabel
     /// <param name="input">The string enclosed by the custom tags</param>
     /// <param name="bbcode">Custom Thrive bbcode-styled tags</param>
     /// <param name="attributes">Attributes specifying additional functionalities to the bbcode.</param>
-    private string BuildTemplateForTag(string input, ThriveBbCode bbcode, List<string> attributes)
+    private static string BuildTemplateForTag(string input, ThriveBbCode bbcode, List<string> attributes)
     {
         // Defaults to input so if something fails output returns unchanged
         var output = input;
@@ -382,6 +386,32 @@ public class CustomRichTextLabel : RichTextLabel
         }
 
         return output;
+    }
+
+    /// <summary>
+    ///   Parses ExtendedBbcode for any custom Thrive tags and applying the final result
+    ///   into this RichTextLabel's bbcode text.
+    /// </summary>
+    private void ParseCustomTags()
+    {
+        if (extendedBbcode == null)
+        {
+            BbcodeText = null;
+            return;
+        }
+
+        try
+        {
+            // Parse our custom tags into standard tags and display that text
+            BbcodeText = ParseCustomTagsString(extendedBbcode);
+        }
+        catch (Exception e)
+        {
+            GD.PrintErr("Failed to parse bbcode string due to exception: ", e);
+
+            // Just display the raw markup for now
+            BbcodeText = extendedBbcode;
+        }
     }
 
     private void OnInputsRemapped(object sender, EventArgs args)

--- a/src/microbe_stage/editor/PatchMapEditorComponent.cs
+++ b/src/microbe_stage/editor/PatchMapEditorComponent.cs
@@ -384,9 +384,7 @@ public abstract class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEd
             patch.BiomeTemplate.Name);
 
         // {0}-{1}m below sea level
-        patchDepth.Text = string.Format(CultureInfo.CurrentCulture,
-            TranslationServer.Translate("BELOW_SEA_LEVEL"),
-            patch.Depth[0], patch.Depth[1]);
+        patchDepth.Text = new LocalizedString("BELOW_SEA_LEVEL", patch.Depth[0], patch.Depth[1]).ToString();
         patchPlayerHere.Visible = Editor.CurrentPatch == patch;
 
         var percentageFormat = TranslationServer.Translate("PERCENTAGE_VALUE");


### PR DESCRIPTION
also now the rich text labels will catch any exceptions that happen to be safe against this happening again

This PR does some stuff...

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
no issue was opened for this crash, I immediately made this fix

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
