### PR TITLE
Simplify IsPermute

### DIFF
--- a/src/general/Mutations.cs
+++ b/src/general/Mutations.cs
@@ -150,9 +150,9 @@ public class Mutations
         var part2 = newName.ToString(index - 2, 2);
         var part3 = newName.ToString(index, 2);
 
-        return (PronounceablePermutation.Contains(part1) ||
+        return PronounceablePermutation.Contains(part1) ||
             PronounceablePermutation.Contains(part2) ||
-            PronounceablePermutation.Contains(part3));
+            PronounceablePermutation.Contains(part3);
     }
 
     private void MutateBehaviour(Species parent, Species mutated)

--- a/src/general/Mutations.cs
+++ b/src/general/Mutations.cs
@@ -149,14 +149,10 @@ public class Mutations
         var part1 = newName.ToString(index - 1, 2);
         var part2 = newName.ToString(index - 2, 2);
         var part3 = newName.ToString(index, 2);
-        if (PronounceablePermutation.Contains(part1) ||
-            PronounceablePermutation.Contains(part2) ||
-            PronounceablePermutation.Contains(part3))
-        {
-            return true;
-        }
 
-        return false;
+        return (PronounceablePermutation.Contains(part1) ||
+            PronounceablePermutation.Contains(part2) ||
+            PronounceablePermutation.Contains(part3));
     }
 
     private void MutateBehaviour(Species parent, Species mutated)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Simplifies the `Mutations.IsPermute` function. This is done by replacing the if-else return boolean expression by just returning the boolean.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
