### PR TITLE
Fixed cells spawned with cheats not despawning

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -729,9 +729,12 @@ public class MicrobeStage : NodeWithInput, IReturnableGameState, IGodotEarlyNode
 
         var randomSpecies = species.Random(random);
 
-        SpawnHelpers.SpawnMicrobe(randomSpecies, Player.Translation + Vector3.Forward * 20,
+        var copyEntity = SpawnHelpers.SpawnMicrobe(randomSpecies, Player.Translation + Vector3.Forward * 20,
             rootOfDynamicallySpawned, SpawnHelpers.LoadMicrobeScene(), true, Clouds,
             CurrentGame!);
+
+        // Make the cell despawn like normal
+        SpawnSystem.AddEntityToTrack(copyEntity);
     }
 
     [DeserializedCallbackAllowed]


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR fixes an issue that prevents enemy cells spawned by cheats from despawning. A simple way to test the functionality is to spawn enemy cells with the cheat and then migrate to another patch, which despawns the cells. Before this fix, that would not despawn the cells even though other entities are despawned.

**Related Issues**

Fixes issue 3 on this post:
https://community.revolutionarygamesstudio.com/t/issues-related-to-despawning/4638


**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
