### PR TITLE
Removed full screen mode

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -58,7 +58,6 @@ settings/fps/force_fps=400
 
 window/size/width=1280
 window/size/height=720
-window/size/fullscreen=true
 window/dpi/allow_hidpi=true
 mouse_cursor/custom_image="res://assets/textures/gui/cursors/default.png"
 mouse_cursor/tooltip_position_offset=Vector2( 15, 15 )


### PR DESCRIPTION
**Brief Description of What This PR Does**

Removed full screen mode in the project file.

The reason I do this is that on Windows, if you open this option, the initializing period is full-screened which is annoying; and the window is sized to nearly full screen (instead of 1280x720, default project window size)

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
