### PR TITLE
Add `SmoothStop` method to Jukebox

### DIFF
--- a/src/general/Jukebox.cs
+++ b/src/general/Jukebox.cs
@@ -126,6 +126,22 @@ public class Jukebox : Node
         operations.Clear();
     }
 
+    /// <summary>
+    ///   Smoothly stops the currently playing music with fade out (doesn't preserve positions for when
+    ///   Resume is called)
+    /// </summary>
+    public void SmoothStop()
+    {
+        operations.Clear();
+        AddFadeOut();
+        operations.Enqueue(new Operation(_ =>
+        {
+            Pause();
+            StopStreams();
+            return true;
+        }));
+    }
+
     public override void _Process(float delta)
     {
         // https://github.com/Revolutionary-Games/Thrive/issues/1976

--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -317,11 +317,11 @@ public class MainMenu : NodeWithInput
 
         // Stop music for the video (stop is used instead of pause to stop the menu music playing a bit after the video
         // before the stage music starts)
-        Jukebox.Instance.Stop();
+        Jukebox.Instance.SmoothStop();
 
         if (Settings.Instance.PlayMicrobeIntroVideo && LaunchOptions.VideosEnabled)
         {
-            TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.5f);
+            TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 1.5f);
             TransitionManager.Instance.AddCutscene("res://assets/videos/microbe_intro2.ogv", 0.65f);
         }
         else


### PR DESCRIPTION
**Brief Description of What This PR Does**

This is so when pressing new game in main menu the music doesn't just
stops abruptly instead it fades out smoothly.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
