### PR TITLE
Prevent player getting stuck when leaving multicellular editor.

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -671,7 +671,9 @@ public class MicrobeStage : NodeWithInput, IReturnableGameState, IGodotEarlyNode
         {
             daughter.BecomeFullyGrownMulticellularColony();
 
-            // TODO: add more extra offset between the player and the divided cell
+            // Back the daughter away so the player isn't stuck inside
+            while (daughter.Colony!.ColonyMembers.Any(member => member.GlobalTransform.origin.DistanceSquaredTo(Player.GlobalTransform.origin) < 50.0f))
+                daughter.Translation += new Vector3(0.0f, 0, -1.0f);
         }
 
         // Update the player's cell

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -673,7 +673,7 @@ public class MicrobeStage : NodeWithInput, IReturnableGameState, IGodotEarlyNode
 
             // Back the daughter away so the player isn't stuck inside
             while (daughter.Colony!.ColonyMembers.Any(member =>
-            member.GlobalTransform.origin.DistanceSquaredTo(Player.GlobalTransform.origin) < 50.0f))
+                    member.GlobalTransform.origin.DistanceSquaredTo(Player.GlobalTransform.origin) < 50.0f))
             {
                 daughter.Translation += new Vector3(0.0f, 0, -1.0f);
             }

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -673,7 +673,7 @@ public class MicrobeStage : NodeWithInput, IReturnableGameState, IGodotEarlyNode
 
             // Back the daughter away so the player isn't stuck inside
             while (daughter.Colony!.ColonyMembers.Any(member =>
-                    member.GlobalTransform.origin.DistanceSquaredTo(Player.GlobalTransform.origin) < 50.0f))
+                       member.GlobalTransform.origin.DistanceSquaredTo(Player.GlobalTransform.origin) < 50.0f))
             {
                 daughter.Translation += new Vector3(0.0f, 0, -1.0f);
             }

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -673,7 +673,7 @@ public class MicrobeStage : NodeWithInput, IReturnableGameState, IGodotEarlyNode
 
             // Back the daughter away so the player isn't stuck inside
             while (daughter.Colony!.ColonyMembers.Any(member =>
-                member.GlobalTransform.origin.DistanceSquaredTo(Player.GlobalTransform.origin) < 50.0f))
+            member.GlobalTransform.origin.DistanceSquaredTo(Player.GlobalTransform.origin) < 50.0f))
             {
                 daughter.Translation += new Vector3(0.0f, 0, -1.0f);
             }

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -672,8 +672,11 @@ public class MicrobeStage : NodeWithInput, IReturnableGameState, IGodotEarlyNode
             daughter.BecomeFullyGrownMulticellularColony();
 
             // Back the daughter away so the player isn't stuck inside
-            while (daughter.Colony!.ColonyMembers.Any(member => member.GlobalTransform.origin.DistanceSquaredTo(Player.GlobalTransform.origin) < 50.0f))
+            while (daughter.Colony!.ColonyMembers.Any(member =>
+                member.GlobalTransform.origin.DistanceSquaredTo(Player.GlobalTransform.origin) < 50.0f))
+            {
                 daughter.Translation += new Vector3(0.0f, 0, -1.0f);
+            }
         }
 
         // Update the player's cell


### PR DESCRIPTION
**Brief Description of What This PR Does**

Uses a very simple algorithm to pull the parent away from the player. The player may still be stuck between cells if the species uses very big cells.

**Related Issues**

(I think there's an issue for this, but I couldn't find it)

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
