### PR TITLE
Fix bug using balance and not consumption for individual cost in ATP

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -486,7 +486,7 @@ public static class Constants
     public const float AUTO_EVO_CHUNK_LEAK_MULTIPLIER = 0.1f;
     public const float AUTO_EVO_PREDATION_ENERGY_MULTIPLIER = 0.4f;
     public const float AUTO_EVO_SUNLIGHT_ENERGY_AMOUNT = 100000;
-    public const float AUTO_EVO_COMPOUND_ENERGY_AMOUNT = 1200;
+    public const float AUTO_EVO_COMPOUND_ENERGY_AMOUNT = 2400;
     public const float AUTO_EVO_CHUNK_ENERGY_AMOUNT = 90000000;
     public const float AUTO_EVO_CHUNK_AMOUNT_NERF = 0.01f;
     public const int AUTO_EVO_MINIMUM_SPECIES_SIZE_BEFORE_SPLIT = 80;

--- a/src/auto-evo/simulation/PopulationSimulation.cs
+++ b/src/auto-evo/simulation/PopulationSimulation.cs
@@ -240,15 +240,16 @@
             foreach (var currentSpecies in species)
             {
                 var energyBalanceInfo = cache.GetEnergyBalanceForSpecies(currentSpecies, patch);
+                var individualCost = energyBalanceInfo.TotalConsumptionStationary;
 
                 // Modify populations based on energy
                 var newPopulation = (long)(energyBySpecies[currentSpecies]
-                    / energyBalanceInfo.FinalBalanceStationary);
+                    / individualCost);
 
                 if (trackEnergy)
                 {
                     populations.AddTrackedEnergyConsumptionForSpecies(currentSpecies, patch, newPopulation,
-                        energyBySpecies[currentSpecies], energyBalanceInfo.FinalBalanceStationary);
+                        energyBySpecies[currentSpecies], individualCost);
                 }
 
                 // TODO: this is a hack for now to make the player experience better, try to get the same rules working


### PR DESCRIPTION
**Brief Description of What This PR Does**

As per the title, fix a leftover bug in the ATP, where the individual cost is not related to consumption per se. This fix corrects this for consistency. As it allows for cells that produce excess atp, it could also marginally help costly organelles emerge since there will be excess to draw from them.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
