### PR TITLE
Fix colony spawn

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -84,7 +84,7 @@ public static class Constants
     ///   Extra radius added to the spawn radius of things to allow them to move in the "wrong" direction a bit
     ///   without causing them to despawn instantly
     /// </summary>
-    public const int DESPAWN_RADIUS_OFFSET = 7;
+    public const int DESPAWN_RADIUS_OFFSET = 50;
 
     public const float STARTING_SPAWN_DENSITY = 70000.0f;
     public const float MAX_SPAWN_DENSITY = 20000.0f;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -84,7 +84,7 @@ public static class Constants
     ///   Extra radius added to the spawn radius of things to allow them to move in the "wrong" direction a bit
     ///   without causing them to despawn instantly
     /// </summary>
-    public const int DESPAWN_RADIUS_OFFSET_SQUARED = 2500;
+    public const int DESPAWN_RADIUS_OFFSET = 7;
 
     public const float STARTING_SPAWN_DENSITY = 70000.0f;
     public const float MAX_SPAWN_DENSITY = 20000.0f;

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -90,9 +90,9 @@ public class SpawnSystem
     ///   Adds an externally spawned entity to be despawned
     /// </summary>
     public static void AddEntityToTrack(ISpawned entity,
-        float radius = Constants.MICROBE_SPAWN_RADIUS)
+        float radius = Constants.MICROBE_SPAWN_RADIUS + Constants.DESPAWN_RADIUS_OFFSET)
     {
-        entity.DespawnRadiusSquared = (int)(radius * radius) + Constants.DESPAWN_RADIUS_OFFSET_SQUARED;
+        entity.DespawnRadiusSquared = (int)(radius * radius);
         entity.EntityNode.AddToGroup(Constants.SPAWNED_GROUP);
     }
 
@@ -444,7 +444,8 @@ public class SpawnSystem
     /// </summary>
     private void ProcessSpawnedEntity(ISpawned entity, Spawner spawnType)
     {
-        entity.DespawnRadiusSquared = spawnType.SpawnRadiusSquared + Constants.DESPAWN_RADIUS_OFFSET_SQUARED;
+        float radius = spawnType.SpawnRadius + Constants.DESPAWN_RADIUS_OFFSET;
+        entity.DespawnRadiusSquared = (int)(radius * radius);
 
         entity.EntityNode.AddToGroup(Constants.SPAWNED_GROUP);
     }

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -332,7 +332,7 @@ public class SpawnSystem
                         squaredDistance >= spawnType.MinSpawnRadiusSquared)
                     {
                         // Second condition passed. Spawn the entity.
-                        if (SpawnWithSpawner(spawnType, playerPosition + displacement, existing,
+                        if (SpawnWithSpawner(spawnType, playerPosition + displacement, playerPosition, existing,
                                 ref spawnsLeftThisFrame, ref spawned))
                         {
                             estimateEntityCountInSpawnRadius += spawned;
@@ -356,10 +356,10 @@ public class SpawnSystem
     ///   Does a single spawn with a spawner
     /// </summary>
     /// <returns>True if we have exceeded the spawn limit and no further spawns should be done this frame</returns>
-    private bool SpawnWithSpawner(Spawner spawnType, Vector3 location, int existing, ref int spawnsLeftThisFrame,
-        ref int spawned)
+    private bool SpawnWithSpawner(Spawner spawnType, Vector3 location, Vector3 playerPosition, int existing,
+        ref int spawnsLeftThisFrame, ref int spawned)
     {
-        var enumerable = spawnType.Spawn(worldRoot, location);
+        var enumerable = spawnType.Spawn(worldRoot, location, playerPosition);
 
         if (enumerable == null)
             return false;

--- a/src/microbe_stage/Spawner.cs
+++ b/src/microbe_stage/Spawner.cs
@@ -40,8 +40,9 @@ public abstract class Spawner
     /// </summary>
     /// <param name="worldNode">The parent node of spawned entities</param>
     /// <param name="location">Location the spawn system wants to spawn a thing at</param>
+    /// <param name="playerPosition">Player's position</param>
     /// <returns>An enumerator that on each next call spawns one thing</returns>
-    public abstract IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location);
+    public abstract IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location, Vector3 playerPosition);
 
     public void SetFrequencyFromDensity(float spawnDensity)
     {

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -103,8 +103,8 @@ public static class SpawnHelpers
     // TODO: this is likely a huge cause of lag. Would be nice to be able
     // to spawn these so that only one per tick is spawned.
     public static IEnumerable<Microbe> SpawnBacteriaColony(Species species, Vector3 location,
-        Node worldRoot, PackedScene microbeScene, CompoundCloudSystem cloudSystem,
-        GameProperties currentGame, Random random)
+        Vector3 playerPosition, Node worldRoot, PackedScene microbeScene,
+        CompoundCloudSystem cloudSystem, GameProperties currentGame, Random random)
     {
         var curSpawn = new Vector3(random.Next(1, 8), 0, random.Next(1, 8));
 
@@ -115,10 +115,16 @@ public static class SpawnHelpers
             for (int i = 0; i < random.Next(Constants.MIN_BACTERIAL_COLONY_SIZE,
                      Constants.MAX_BACTERIAL_COLONY_SIZE + 1); i++)
             {
-                // Dont spawn them on top of each other because it
-                // causes them to bounce around and lag
-                yield return SpawnMicrobe(species, location + curSpawn, worldRoot, microbeScene, true,
-                    cloudSystem, currentGame);
+                // Skip spawning this microbe if it would spawn outside of the despawn radius
+                float distanceSquared = (playerPosition - (location + curSpawn)).LengthSquared();
+                float despawnRadius = Constants.MICROBE_SPAWN_RADIUS + Constants.DESPAWN_RADIUS_OFFSET;
+                if (distanceSquared < despawnRadius * despawnRadius)
+                {
+                    // Dont spawn them on top of each other because it
+                    // causes them to bounce around and lag
+                    yield return SpawnMicrobe(species, location + curSpawn, worldRoot, microbeScene, true,
+                        cloudSystem, currentGame);
+                }
 
                 curSpawn = curSpawn + new Vector3(random.Next(-7, 8), 0, random.Next(-7, 8));
             }
@@ -133,10 +139,16 @@ public static class SpawnHelpers
             for (int i = 0; i < random.Next(Constants.MIN_BACTERIAL_LINE_SIZE,
                      Constants.MAX_BACTERIAL_LINE_SIZE + 1); i++)
             {
-                // Dont spawn them on top of each other because it
-                // Causes them to bounce around and lag
-                yield return SpawnMicrobe(species, location + curSpawn, worldRoot, microbeScene, true,
-                    cloudSystem, currentGame);
+                // Skip spawning this microbe if it would spawn outside of the despawn radius
+                float distanceSquared = (playerPosition - (location + curSpawn)).LengthSquared();
+                float despawnRadius = Constants.MICROBE_SPAWN_RADIUS + Constants.DESPAWN_RADIUS_OFFSET;
+                if (distanceSquared < despawnRadius * despawnRadius)
+                {
+                    // Dont spawn them on top of each other because it
+                    // Causes them to bounce around and lag
+                    yield return SpawnMicrobe(species, location + curSpawn, worldRoot, microbeScene, true,
+                        cloudSystem, currentGame);
+                }
 
                 curSpawn = curSpawn + new Vector3(line + random.Next(-2, 3), 0, line + random.Next(-2, 3));
             }
@@ -161,7 +173,7 @@ public static class SpawnHelpers
                     colony.Horizontal = true;
                     vertical = false;
 
-                    foreach (var microbe in MicrobeColonySpawnHelper(colony, location))
+                    foreach (var microbe in MicrobeColonySpawnHelper(colony, location, playerPosition))
                         yield return microbe;
                 }
                 else if (random.Next(0, 5) < 2 && !vertical)
@@ -169,7 +181,7 @@ public static class SpawnHelpers
                     colony.Horizontal = false;
                     vertical = true;
 
-                    foreach (var microbe in MicrobeColonySpawnHelper(colony, location))
+                    foreach (var microbe in MicrobeColonySpawnHelper(colony, location, playerPosition))
                         yield return microbe;
                 }
                 else if (random.Next(0, 5) < 2 && !colony.Horizontal)
@@ -177,7 +189,7 @@ public static class SpawnHelpers
                     colony.Horizontal = true;
                     vertical = false;
 
-                    foreach (var microbe in MicrobeColonySpawnHelper(colony, location))
+                    foreach (var microbe in MicrobeColonySpawnHelper(colony, location, playerPosition))
                         yield return microbe;
                 }
                 else if (random.Next(0, 5) < 2 && !vertical)
@@ -185,7 +197,7 @@ public static class SpawnHelpers
                     colony.Horizontal = false;
                     vertical = true;
 
-                    foreach (var microbe in MicrobeColonySpawnHelper(colony, location))
+                    foreach (var microbe in MicrobeColonySpawnHelper(colony, location, playerPosition))
                         yield return microbe;
                 }
                 else
@@ -194,7 +206,7 @@ public static class SpawnHelpers
                     colony.Horizontal = false;
                     vertical = false;
 
-                    foreach (var microbe in MicrobeColonySpawnHelper(colony, location))
+                    foreach (var microbe in MicrobeColonySpawnHelper(colony, location, playerPosition))
                         yield return microbe;
                 }
             }
@@ -290,7 +302,8 @@ public static class SpawnHelpers
         return GD.Load<PackedScene>("res://src/microbe_stage/AgentProjectile.tscn");
     }
 
-    private static IEnumerable<Microbe> MicrobeColonySpawnHelper(ColonySpawnInfo colony, Vector3 location)
+    private static IEnumerable<Microbe> MicrobeColonySpawnHelper(ColonySpawnInfo colony, Vector3 location,
+        Vector3 playerPosition)
     {
         for (int c = 0; c < colony.Random.Next(Constants.MIN_BACTERIAL_LINE_SIZE,
                  Constants.MAX_BACTERIAL_LINE_SIZE + 1); c++)
@@ -310,8 +323,14 @@ public static class SpawnHelpers
                 colony.CurSpawn.x += colony.Random.Next(-2, 3);
             }
 
-            yield return SpawnMicrobe(colony.Species, location + colony.CurSpawn, colony.WorldRoot,
-                colony.MicrobeScene, true, colony.CloudSystem, colony.CurrentGame);
+            // Skip spawning this microbe if it would spawn outside of the despawn radius
+            float distanceSquared = (playerPosition - (location + colony.CurSpawn)).LengthSquared();
+            float despawnRadius = Constants.MICROBE_SPAWN_RADIUS + Constants.DESPAWN_RADIUS_OFFSET;
+            if (distanceSquared < despawnRadius * despawnRadius)
+            {
+                yield return SpawnMicrobe(colony.Species, location + colony.CurSpawn, colony.WorldRoot,
+                    colony.MicrobeScene, true, colony.CloudSystem, colony.CurrentGame);
+            }
         }
     }
 
@@ -363,7 +382,7 @@ public class MicrobeSpawner : Spawner
         random = new Random();
     }
 
-    public override IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location)
+    public override IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location, Vector3 playerPosition)
     {
         // The true here is that this is AI controlled
         var first = SpawnHelpers.SpawnMicrobe(species, location, worldNode, microbeScene, true, cloudSystem,
@@ -381,8 +400,8 @@ public class MicrobeSpawner : Spawner
         // Just in case the is bacteria flag is not correct in a multicellular cell type, here's an extra safety check
         if (first.CellTypeProperties.IsBacteria && !first.IsMulticellular)
         {
-            foreach (var colonyMember in SpawnHelpers.SpawnBacteriaColony(species, location, worldNode, microbeScene,
-                         cloudSystem, currentGame, random))
+            foreach (var colonyMember in SpawnHelpers.SpawnBacteriaColony(species, location, playerPosition, worldNode,
+                         microbeScene, cloudSystem, currentGame, random))
             {
                 yield return colonyMember;
 
@@ -408,7 +427,7 @@ public class CompoundCloudSpawner : Spawner
         this.amount = amount;
     }
 
-    public override IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location)
+    public override IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location, Vector3 playerPosition)
     {
         SpawnHelpers.SpawnCloud(clouds, location, compound, amount);
 
@@ -434,7 +453,7 @@ public class ChunkSpawner : Spawner
         chunkScene = SpawnHelpers.LoadChunkScene();
     }
 
-    public override IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location)
+    public override IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location, Vector3 playerPosition)
     {
         var chunk = SpawnHelpers.SpawnChunk(chunkType, location, worldNode, chunkScene,
             cloudSystem, random);


### PR DESCRIPTION
**Brief Description of What This PR Does**

This pull request aims to fix bacterial colony members spawning outside of the despawn radius.  It does three things:
1. Refactor the despawn radius calculation slightly so that it's easier to work with.
2. Increase the despawn radius so that its 170 + 50. This makes it much rarer for colonies to get "cut off".
3. Add a check to bacterial colony spawning that skips spawning cells if they'd spawn outside of the despawn radius. This required giving its spawn method access to the player's position.

After these changes, spawning and despawning looks like this:
![Spawn and despawn radius](https://user-images.githubusercontent.com/58150375/165249813-1788df08-3201-4532-8cf7-330bfb6e6d3c.png)

Observations I made testing these changes:

- It works.
- The amount of existing entities is increased a bit, by about 5 to 10. This makes sense since fewer colonies get cut off and there's more room for cells.
- The density of entities during gameplay seems to be about the same. Which is what I expected, since if I understand correctly, existing entities don't affect spawning unless you've hit the entity limit or if you're sitting still.
- Increased despawn radius has a nice side effect of giving floating chunks a slightly better sense of object permanence.

**Related Issues**
fixes #3245
<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
