### PR TITLE
Only react to left or right click on patch map nodes

### DIFF
--- a/src/microbe_stage/editor/PatchMapNode.cs
+++ b/src/microbe_stage/editor/PatchMapNode.cs
@@ -91,13 +91,13 @@ public class PatchMapNode : MarginContainer
 
     public override void _GuiInput(InputEvent @event)
     {
-        if (@event is InputEventMouseButton mouse)
-        {
-            if (mouse.Pressed)
+        if (@event is InputEventMouseButton
             {
-                OnSelect();
-                AcceptEvent();
-            }
+                Pressed: true, ButtonIndex: (int)ButtonList.Left or (int)ButtonList.Right,
+            })
+        {
+            OnSelect();
+            GetTree().SetInputAsHandled();
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

fixes scroll wheel activating the patch map nodes

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
