### PR TITLE
Fade pause menu background on opening and closing

### DIFF
--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.tscn
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.tscn
@@ -82,7 +82,7 @@ HelpCategory = "MicrobeEditor"
 
 [connection signal="OnCellTypeToEditSelected" from="EarlyMulticellularEditorGUI/CellBodyPlanEditorComponent" to="." method="OnStartEditingCellType"]
 [connection signal="OnTabSelected" from="EarlyMulticellularEditorGUI/MicrobeEditorTabButtons" to="." method="SetEditorTab"]
-[connection signal="OnOpenHelp" from="EarlyMulticellularEditorGUI/EditorCommonBottomLeftButtons" to="PauseMenu" method="OpenFromEditorToHelp"]
-[connection signal="OnOpenMenu" from="EarlyMulticellularEditorGUI/EditorCommonBottomLeftButtons" to="PauseMenu" method="OpenFromEditor"]
+[connection signal="OnOpenHelp" from="EarlyMulticellularEditorGUI/EditorCommonBottomLeftButtons" to="PauseMenu" method="OpenToHelp"]
+[connection signal="OnOpenMenu" from="EarlyMulticellularEditorGUI/EditorCommonBottomLeftButtons" to="PauseMenu" method="Open"]
 
 [editable path="EditorWorld"]

--- a/src/general/PauseMenu.cs
+++ b/src/general/PauseMenu.cs
@@ -6,12 +6,6 @@ using Godot;
 /// </summary>
 public class PauseMenu : CustomDialog
 {
-    /// <summary>
-    ///   Causes various things to automatically happen to reduce the code duplication needed for the various editors
-    /// </summary>
-    [Export]
-    public bool IsEditorPauseMenu;
-
     [Export]
     public string HelpCategory = null!;
 
@@ -42,6 +36,7 @@ public class PauseMenu : CustomDialog
     private OptionsMenu optionsMenu = null!;
     private NewSaveMenu saveMenu = null!;
     private CustomConfirmationDialog unsavedProgressWarning = null!;
+    private AnimationPlayer animationPlayer = null!;
 
     /// <summary>
     ///   The assigned pending exit type, will be used to specify what kind of
@@ -185,6 +180,7 @@ public class PauseMenu : CustomDialog
         optionsMenu = GetNode<OptionsMenu>(OptionsMenuPath);
         saveMenu = GetNode<NewSaveMenu>(SaveMenuPath);
         unsavedProgressWarning = GetNode<CustomConfirmationDialog>(UnsavedProgressWarningPath);
+        animationPlayer = GetNode<AnimationPlayer>("AnimationPlayer");
     }
 
     [RunOnKeyDown("ui_cancel", Priority = Constants.PAUSE_MENU_CANCEL_PRIORITY)]
@@ -195,9 +191,7 @@ public class PauseMenu : CustomDialog
             ActiveMenu = ActiveMenuType.Primary;
 
             EmitSignal(nameof(OnClosed));
-
-            if (IsEditorPauseMenu)
-                CloseFromEditor();
+            Close();
 
             return true;
         }
@@ -206,9 +200,7 @@ public class PauseMenu : CustomDialog
             return false;
 
         EmitSignal(nameof(OnOpenWithKeyPress));
-
-        if (IsEditorPauseMenu)
-            OpenFromEditor();
+        Open();
 
         return true;
     }
@@ -220,9 +212,7 @@ public class PauseMenu : CustomDialog
             return false;
 
         EmitSignal(nameof(OnOpenWithKeyPress));
-
-        if (IsEditorPauseMenu)
-            OpenFromEditor();
+        Open();
 
         ShowHelpScreen();
         return true;
@@ -237,25 +227,27 @@ public class PauseMenu : CustomDialog
         helpScreen.RandomizeEasterEgg();
     }
 
-    public void OpenFromEditor()
+    public void Open()
     {
-        GUICommon.Instance.PlayButtonPressSound();
+        if (Visible)
+            return;
 
-        Show();
+        animationPlayer.Play("Open");
         GetTree().Paused = true;
     }
 
-    public void CloseFromEditor()
+    public void Close()
     {
-        Hide();
+        if (!Visible)
+            return;
+
+        animationPlayer.Play("Close");
         GetTree().Paused = false;
     }
 
-    public void OpenFromEditorToHelp()
+    public void OpenToHelp()
     {
-        GUICommon.Instance.PlayButtonPressSound();
-
-        OpenFromEditor();
+        Open();
         ShowHelpScreen();
     }
 
@@ -293,9 +285,7 @@ public class PauseMenu : CustomDialog
     {
         GUICommon.Instance.PlayButtonPressSound();
         EmitSignal(nameof(OnClosed));
-
-        if (IsEditorPauseMenu)
-            CloseFromEditor();
+        Close();
     }
 
     private void ReturnToMenuPressed()

--- a/src/general/PauseMenu.cs
+++ b/src/general/PauseMenu.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Godot;
 
 /// <summary>
 ///   Handles logic in the pause menu
 /// </summary>
+[SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification =
+    "We don't manually dispose Godot derived types")]
 public class PauseMenu : CustomDialog
 {
     [Export]

--- a/src/general/PauseMenu.tscn
+++ b/src/general/PauseMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://src/general/PauseMenu.cs" type="Script" id=1]
 [ext_resource path="res://src/gui_common/thrive_theme.tres" type="Theme" id=2]
@@ -8,8 +8,128 @@
 [ext_resource path="res://src/general/OptionsMenu.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/gui_common/dialogs/CustomConfirmationDialog.tscn" type="PackedScene" id=7]
 
+[sub_resource type="Animation" id=1]
+resource_name = "Close"
+length = 0.3
+tracks/0/type = "value"
+tracks/0/path = NodePath(".:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 0.3 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ true, false ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("Overlay:self_modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0, 0.3 ),
+"transitions": PoolRealArray( 0.5, 1 ),
+"update": 0,
+"values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0.145098 ) ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("CenterContainer:visible")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+
+[sub_resource type="Animation" id=2]
+resource_name = "Open"
+length = 0.3
+tracks/0/type = "value"
+tracks/0/path = NodePath(".:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ true ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("Overlay:self_modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0, 0.3 ),
+"transitions": PoolRealArray( 0.5, 1 ),
+"update": 0,
+"values": [ Color( 1, 1, 1, 0.145098 ), Color( 1, 1, 1, 1 ) ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("CenterContainer:visible")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ true ]
+}
+
+[sub_resource type="Animation" id=3]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/path = NodePath(".:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ true ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("Overlay:self_modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Color( 1, 1, 1, 1 ) ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("CenterContainer:visible")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ true ]
+}
+
 [node name="PauseMenu" type="Popup"]
 pause_mode = 2
+visible = true
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
@@ -32,9 +152,6 @@ UnsavedProgressWarningPath = NodePath("UnsavedProgressWarning")
 anchor_right = 1.0
 anchor_bottom = 1.0
 color = Color( 0, 0, 0, 0.588235 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="CenterContainer" type="CenterContainer" parent="."]
 anchor_right = 1.0
@@ -161,6 +278,11 @@ visible = false
 margin_right = 391.0
 rect_min_size = Vector2( 391, 0 )
 WindowTitle = "CONFIRM_EXIT"
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+anims/Close = SubResource( 1 )
+anims/Open = SubResource( 2 )
+anims/RESET = SubResource( 3 )
 
 [connection signal="pressed" from="CenterContainer/PrimaryMenu/Resume" to="." method="ClosePressed"]
 [connection signal="pressed" from="CenterContainer/PrimaryMenu/SaveGame" to="." method="OpenSavePressed"]

--- a/src/general/PauseMenu.tscn
+++ b/src/general/PauseMenu.tscn
@@ -129,7 +129,6 @@ tracks/2/keys = {
 
 [node name="PauseMenu" type="Popup"]
 pause_mode = 2
-visible = true
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -1222,22 +1222,7 @@ public class MicrobeHUD : Control
     private void OpenMicrobeStageMenuPressed()
     {
         GUICommon.Instance.PlayButtonPressSound();
-
-        OpenMenu();
-    }
-
-    private void OpenMenu()
-    {
-        menu.Show();
-        GetTree().Paused = true;
-    }
-
-    private void CloseMenu()
-    {
-        menu.Hide();
-
-        if (!paused)
-            GetTree().Paused = false;
+        menu.Open();
     }
 
     private void PauseButtonPressed()
@@ -1284,9 +1269,7 @@ public class MicrobeHUD : Control
     private void HelpButtonPressed()
     {
         GUICommon.Instance.PlayButtonPressSound();
-
-        OpenMenu();
-        menu.ShowHelpScreen();
+        menu.OpenToHelp();
     }
 
     private void OnEditorButtonMouseEnter()

--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -2278,5 +2278,3 @@ anims/FadeInOut = SubResource( 37 )
 [connection signal="OnHelpMenuOpenRequested" from="TutorialGUI" to="MicrobeHUD" method="HelpButtonPressed"]
 [connection signal="OnItemSelected" from="RadialPopup" to="MicrobeHUD" method="OnRadialItemSelected"]
 [connection signal="MakeSave" from="PauseMenu" to="." method="SaveGame"]
-[connection signal="OnClosed" from="PauseMenu" to="MicrobeHUD" method="CloseMenu"]
-[connection signal="OnOpenWithKeyPress" from="PauseMenu" to="MicrobeHUD" method="OpenMenu"]

--- a/src/microbe_stage/editor/EditorCommonBottomLeftButtons.cs
+++ b/src/microbe_stage/editor/EditorCommonBottomLeftButtons.cs
@@ -30,11 +30,13 @@ public class EditorCommonBottomLeftButtons : MarginContainer
 
     private void OnMenuButtonPressed()
     {
+        GUICommon.Instance.PlayButtonPressSound();
         EmitSignal(nameof(OnOpenMenu));
     }
 
     private void OnHelpButtonPressed()
     {
+        GUICommon.Instance.PlayButtonPressSound();
         EmitSignal(nameof(OnOpenHelp));
     }
 }

--- a/src/microbe_stage/editor/MicrobeEditor.tscn
+++ b/src/microbe_stage/editor/MicrobeEditor.tscn
@@ -72,12 +72,11 @@ CellEditorClosingWordsPath = NodePath("../TutorialGUI/CellEditorClosingWords")
 
 [node name="PauseMenu" parent="." instance=ExtResource( 52 )]
 theme = ExtResource( 53 )
-IsEditorPauseMenu = true
 HelpCategory = "MicrobeEditor"
 
 [connection signal="OnTabSelected" from="MicrobeEditorGUI/MicrobeEditorTabButtons" to="." method="SetEditorTab"]
-[connection signal="OnOpenHelp" from="MicrobeEditorGUI/EditorCommonBottomLeftButtons" to="PauseMenu" method="OpenFromEditorToHelp"]
-[connection signal="OnOpenMenu" from="MicrobeEditorGUI/EditorCommonBottomLeftButtons" to="PauseMenu" method="OpenFromEditor"]
+[connection signal="OnOpenHelp" from="MicrobeEditorGUI/EditorCommonBottomLeftButtons" to="PauseMenu" method="OpenToHelp"]
+[connection signal="OnOpenMenu" from="MicrobeEditorGUI/EditorCommonBottomLeftButtons" to="PauseMenu" method="Open"]
 [connection signal="MakeSave" from="PauseMenu" to="." method="SaveGame"]
 
 [editable path="EditorWorld"]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Pause menu background now fades in and out. Cleaned up the pause menu's open and close logic to reduce confusion.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
