### PR TITLE
Fixed microbe sfx volume only assigned once on audio player creation

### DIFF
--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -453,7 +453,6 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
                 return;
 
             player = new AudioStreamPlayer3D();
-            player.UnitDb = GD.Linear2Db(volume);
             player.MaxDistance = 100.0f;
             player.Bus = "SFX";
 
@@ -461,6 +460,7 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
             otherAudioPlayers.Add(player);
         }
 
+        player.UnitDb = GD.Linear2Db(volume);
         player.Stream = sound;
         player.Play();
     }
@@ -480,13 +480,13 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
                 return;
 
             player = new AudioStreamPlayer();
-            player.VolumeDb = GD.Linear2Db(volume);
             player.Bus = "SFX";
 
             AddChild(player);
             nonPositionalAudioPlayers.Add(player);
         }
 
+        player.VolumeDb = GD.Linear2Db(volume);
         player.Stream = sound;
         player.Play();
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Just realized this while working on earlier PR. The audio volume assignment is only done during new concurrent audio player creation, resulting in possible incorrect volume when the microbe tries to play an SFX with available audio players later on.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
