### PR TITLE
Persistent selected/visibility value for line graph's datasets

### DIFF
--- a/src/gui_common/charts/line/LineChart.cs
+++ b/src/gui_common/charts/line/LineChart.cs
@@ -392,7 +392,7 @@ public class LineChart : VBoxContainer
                 if (stored.TryGetValue(data.Key, out bool value))
                     visible = value;
 
-                GD.Print(UpdateDataSetVisibility(data.Key, visible));
+                UpdateDataSetVisibility(data.Key, visible);
 
                 if (visible)
                     visibleDataSetCount++;

--- a/src/gui_common/charts/line/LineChart.cs
+++ b/src/gui_common/charts/line/LineChart.cs
@@ -96,6 +96,8 @@ public class LineChart : VBoxContainer
     /// </remarks>
     public string? TooltipYAxisFormat;
 
+    private static readonly Dictionary<string, Dictionary<string, bool>> StoredDatasetsVisibilityStatus = new();
+
     /// <summary>
     ///   Datasets to be plotted on the chart. Key is the dataset's name
     /// </summary>
@@ -369,6 +371,11 @@ public class LineChart : VBoxContainer
 
         UpdateMinimumAndMaximumValues();
 
+        if (!StoredDatasetsVisibilityStatus.ContainsKey(ChartName))
+            StoredDatasetsVisibilityStatus.Add(ChartName, new Dictionary<string, bool>());
+
+        var stored = StoredDatasetsVisibilityStatus[ChartName];
+
         foreach (var data in dataSets)
         {
             childChart?.dataSets.Add(data.Key, (LineChartData)data.Value.Clone());
@@ -377,14 +384,18 @@ public class LineChart : VBoxContainer
             if (string.IsNullOrEmpty(data.Key))
                 throw new Exception("Dataset dictionary key is null");
 
-            // Hide the rest, if number of shown dataset exceeds initialVisibleDataSets
-            if (visibleDataSetCount >= initialVisibleDataSets && data.Key != defaultDataSet)
+            if (data.Key != defaultDataSet)
             {
-                UpdateDataSetVisibility(data.Key, false);
-            }
-            else if (visibleDataSetCount < initialVisibleDataSets && data.Key != defaultDataSet)
-            {
-                visibleDataSetCount++;
+                var visible = visibleDataSetCount < initialVisibleDataSets;
+
+                // Override visible value if stored value exists
+                if (stored.TryGetValue(data.Key, out bool value))
+                    visible = value;
+
+                GD.Print(UpdateDataSetVisibility(data.Key, visible));
+
+                if (visible)
+                    visibleDataSetCount++;
             }
 
             // Initialize line
@@ -565,6 +576,11 @@ public class LineChart : VBoxContainer
 
         // Update the legend
         DataSetsLegend?.OnDataSetVisibilityChange(visible, name);
+
+        if (StoredDatasetsVisibilityStatus.TryGetValue(ChartName, out Dictionary<string, bool> value))
+        {
+            value[name] = visible;
+        }
 
         return DataSetVisibilityUpdateResult.Success;
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

The datasets selected to be shown/hidden for a line graph can now be stored and loaded throughout the entirety of the game. This is done using a static variable in LineGraph to track the saved values.

**Related Issues**

Closes #3272 

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
