### PR TITLE
Make Nucleus Reduce Incoming Damage by Half

### DIFF
--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -331,6 +331,11 @@ public partial class Microbe
             amount /= CellTypeProperties.MembraneType.PhysicalResistance;
         }
 
+        if (!CellTypeProperties.IsBacteria)
+        {
+            amount /= 2;
+        }
+
         Hitpoints -= amount;
 
         ModLoader.ModInterface.TriggerOnDamageReceived(this, amount, IsPlayerMicrobe);


### PR DESCRIPTION
**Brief Description of What This PR Does**

Pursuant to https://forum.revolutionarygamesstudio.com/t/gameplay-discussion-benefits-of-being-a-larger-cell/881/6, this makes eukaryotes take half damage from all sources.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
