### PR TITLE
Makes the nucleus reduce damage by half

### DIFF
--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -321,7 +321,7 @@ public partial class Microbe
         }
         else if (source == "atpDamage")
         {
-            set TakingAtpDamage = true
+            set TakingAtpDamage = true;
             PlaySoundEffect("res://assets/sounds/soundeffects/microbe-atp-damage.ogg");
         }
         else if (source == "ice")
@@ -334,7 +334,7 @@ public partial class Microbe
         
         if (!CellTypeProperties.IsBacteria)
         {
-            if TakingAtpDamage = false
+            (if TakingAtpDamage = false)
             amount /= 2;
         }
 

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -334,7 +334,7 @@ public partial class Microbe
         
         if (!CellTypeProperties.IsBacteria)
         {
-            (if TakingAtpDamage = false)
+            if TakingAtpDamage = false;
             amount /= 2;
         }
 

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -334,7 +334,7 @@ public partial class Microbe
         
         if (!CellTypeProperties.IsBacteria)
         {
-            if TakingAtpDamage = false;
+           if TakingAtpDamage = false
             amount /= 2;
         }
 

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -321,6 +321,7 @@ public partial class Microbe
         }
         else if (source == "atpDamage")
         {
+            set TakingAtpDamage = true
             PlaySoundEffect("res://assets/sounds/soundeffects/microbe-atp-damage.ogg");
         }
         else if (source == "ice")
@@ -329,6 +330,12 @@ public partial class Microbe
 
             // Divide damage by physical resistance
             amount /= CellTypeProperties.MembraneType.PhysicalResistance;
+        }
+        
+        if (!CellTypeProperties.IsBacteria)
+        {
+            if TakingAtpDamage = false
+            amount /= 2;
         }
 
         Hitpoints -= amount;


### PR DESCRIPTION
**Brief Description of What This PR Does**

This makes eukaryotes take half damage, except when they are starving. Pursuant to https://forum.revolutionarygamesstudio.com/t/gameplay-discussion-benefits-of-being-a-larger-cell/881/6

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
