### PR TITLE
Made nucleus give a 50% damage reduction

### DIFF
--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -290,6 +290,9 @@ public partial class Microbe
             return;
         }
 
+        // Damage reduction is only wanted for non-starving damage
+        bool canApplyDamageReduction = true;
+
         if (source is "toxin" or "oxytoxy")
         {
             // TODO: Replace this take damage sound with a more appropriate one.
@@ -322,6 +325,7 @@ public partial class Microbe
         else if (source == "atpDamage")
         {
             PlaySoundEffect("res://assets/sounds/soundeffects/microbe-atp-damage.ogg");
+            canApplyDamageReduction = false;
         }
         else if (source == "ice")
         {
@@ -329,6 +333,11 @@ public partial class Microbe
 
             // Divide damage by physical resistance
             amount /= CellTypeProperties.MembraneType.PhysicalResistance;
+        }
+
+        if (!CellTypeProperties.IsBacteria && canApplyDamageReduction)
+        {
+            amount /= 2;
         }
 
         Hitpoints -= amount;


### PR DESCRIPTION
except to ATP damage

**Related Issues**
remade: https://github.com/Revolutionary-Games/Thrive/pull/3317 except this time it doesn't give bonus against starvation

If this is merged (which I'll do in a day or two if no one complains) I'll open some follow up issues for explaining this somewhere.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
