### PR TITLE
Tweaked binding agent size and nucleus submesh render priorities

### DIFF
--- a/assets/models/organelles/BindingAgent.tscn
+++ b/assets/models/organelles/BindingAgent.tscn
@@ -34,7 +34,7 @@ shader_param/texture = ExtResource( 2 )
 shader_param/dissolveTexture = ExtResource( 4 )
 
 [node name="BindingAgent" type="MeshInstance"]
-transform = Transform( 100, 0, 0, 0, -1.62921e-05, 100, 0, -100, -1.62921e-05, 0, 0, 0 )
+transform = Transform( 85, 0, 0, 0, -3.71547e-06, 85, 0, -85, -3.71547e-06, 0, 0, 0 )
 material_override = SubResource( 1 )
 mesh = ExtResource( 5 )
 material/0 = null

--- a/assets/models/organelles/Nucleus.tscn
+++ b/assets/models/organelles/Nucleus.tscn
@@ -24,6 +24,7 @@ shader_param/dissolveTexture = ExtResource( 9 )
 
 [sub_resource type="ShaderMaterial" id=2]
 resource_local_to_scene = true
+render_priority = -1
 shader = ExtResource( 2 )
 shader_param/dissolveValue = 0.0
 shader_param/fresnelValue = 1.0
@@ -36,6 +37,7 @@ shader_param/dissolveTexture = ExtResource( 9 )
 
 [sub_resource type="ShaderMaterial" id=3]
 resource_local_to_scene = true
+render_priority = -1
 shader = ExtResource( 2 )
 shader_param/dissolveValue = 0.0
 shader_param/fresnelValue = 1.0


### PR DESCRIPTION
**Brief Description of What This PR Does**

I think this is an overdue change... Binding agent now fits in one hex, the Golgi and ER models in the nucleus now have -1 render priority so that they don't appear on top of the nucleus.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
