### PR TITLE
Refactored pausing to use named pause locks to solve pause stuck after saving

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -96,6 +96,7 @@
     <Compile Include="src\engine\Invoke.cs" />
     <Compile Include="src\engine\LoadingScreen.cs" />
     <Compile Include="src\engine\NodeHelpers.cs" />
+    <Compile Include="src\engine\PauseManager.cs" />
     <Compile Include="src\engine\PerformanceMetrics.cs" />
     <Compile Include="src\engine\PhotoStudio.cs" />
     <Compile Include="src\engine\PostStartupActions.cs" />

--- a/Thrive.sln.DotSettings
+++ b/Thrive.sln.DotSettings
@@ -609,6 +609,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tweening/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unapplied/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unpaused/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unpausing/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unported/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=venter/@EntryIndexedValue">True</s:Boolean>

--- a/project.godot
+++ b/project.godot
@@ -48,6 +48,7 @@ TemporaryLoadedNodeDeleter="*res://src/saving/TemporaryLoadedNodeDeleter.cs"
 FileDropHandler="*res://src/engine/FileDropHandler.cs"
 ProceduralDataCache="*res://src/engine/ProceduralDataCache.cs"
 PhotoStudio="*res://src/engine/PhotoStudio.tscn"
+PauseManager="*res://src/engine/PauseManager.cs"
 PostStartupActions="*res://src/engine/PostStartupActions.cs"
 
 [debug]

--- a/src/engine/PauseManager.cs
+++ b/src/engine/PauseManager.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+using Godot;
+
+/// <summary>
+///   Handles pausing and resuming the game based on named pause locks
+/// </summary>
+public class PauseManager : Node
+{
+    private static PauseManager? instance;
+
+    private readonly HashSet<string> activeLocks = new();
+
+    private bool isPaused;
+
+    private PauseManager()
+    {
+        instance = this;
+    }
+
+    public static PauseManager Instance => instance ?? throw new InstanceNotLoadedYetException();
+
+    public bool Paused
+    {
+        get => isPaused;
+        private set
+        {
+            if (isPaused != value)
+            {
+                GetTree().Paused = value;
+                isPaused = value;
+            }
+        }
+    }
+
+    public void AddPause(string pauseLockName)
+    {
+        if (activeLocks.Add(pauseLockName))
+        {
+            ApplyPauseState();
+        }
+        else
+        {
+            GD.PrintErr("Duplicate pause lock was added: ", pauseLockName);
+        }
+    }
+
+    public void Resume(string pauseLockName)
+    {
+        if (activeLocks.Remove(pauseLockName))
+        {
+            ApplyPauseState();
+        }
+        else
+        {
+            GD.PrintErr("Pause lock that was not created was removed: ", pauseLockName);
+        }
+    }
+
+    /// <summary>
+    ///   Force clears all locks. Should *only* be called in the main menu, where this is just an extra safety measure
+    ///   against requiring the player to restart the game entirely if they get a pause state stuck issue
+    /// </summary>
+    public void ForceClear()
+    {
+        if (activeLocks.Count < 1)
+            return;
+
+        GD.Print("Force clearing remaining pause locks");
+        activeLocks.Clear();
+        ApplyPauseState();
+    }
+
+    private void ApplyPauseState()
+    {
+        Paused = activeLocks.Count > 0;
+    }
+}

--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -76,7 +76,7 @@ public class MainMenu : NodeWithInput
     public override void _Ready()
     {
         // Unpause the game as the MainMenu should never be paused.
-        GetTree().Paused = false;
+        PauseManager.Instance.ForceClear();
 
         RunMenuSetup();
 

--- a/src/general/PauseMenu.cs
+++ b/src/general/PauseMenu.cs
@@ -236,7 +236,7 @@ public class PauseMenu : CustomDialog
             return;
 
         animationPlayer.Play("Open");
-        GetTree().Paused = true;
+        PauseManager.Instance.AddPause(nameof(PauseMenu));
     }
 
     public void Close()
@@ -245,7 +245,7 @@ public class PauseMenu : CustomDialog
             return;
 
         animationPlayer.Play("Close");
-        GetTree().Paused = false;
+        PauseManager.Instance.Resume(nameof(PauseMenu));
     }
 
     public void OpenToHelp()
@@ -348,7 +348,7 @@ public class PauseMenu : CustomDialog
     private void ReturnToMenu()
     {
         // Unpause the game
-        GetTree().Paused = false;
+        PauseManager.Instance.Resume(nameof(PauseMenu));
 
         TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.1f, false);
         TransitionManager.Instance.StartTransitions(this, nameof(OnSwitchToMenu));

--- a/src/gui_common/dialogs/ErrorDialog.cs
+++ b/src/gui_common/dialogs/ErrorDialog.cs
@@ -61,6 +61,8 @@ public class ErrorDialog : CustomDialog
         }
     }
 
+    private string PauseLock => $"{nameof(ErrorDialog)}_{Name}";
+
     public override void _Ready()
     {
         extraDescriptionLabel = GetNode<Label>("VBoxContainer/ExtraErrorDescription");
@@ -87,6 +89,8 @@ public class ErrorDialog : CustomDialog
 
         onDismissReturnToMenu = returnToMenu;
         onCloseCallback = onClosed;
+
+        PauseManager.Instance.AddPause(PauseLock);
     }
 
     private void UpdateMessage()
@@ -105,7 +109,7 @@ public class ErrorDialog : CustomDialog
 
     private void OnErrorDialogDismissed()
     {
-        SceneManager.Instance.GetTree().Paused = false;
+        PauseManager.Instance.Resume(PauseLock);
 
         if (onDismissReturnToMenu)
         {

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -650,11 +650,7 @@ public class MicrobeHUD : Control
         // To prevent being clicked twice
         editorButton.Disabled = true;
 
-        // Make sure the game is unpaused
-        if (GetTree().Paused)
-        {
-            PauseButtonPressed();
-        }
+        EnsureGameIsUnpausedForEditor();
 
         TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.3f, false);
         TransitionManager.Instance.StartTransitions(stage, nameof(MicrobeStage.MoveToEditor));
@@ -1295,7 +1291,7 @@ public class MicrobeHUD : Control
             pauseButton.Pressed = false;
 
             // Pause the game
-            GetTree().Paused = true;
+            PauseManager.Instance.AddPause(nameof(MicrobeHUD));
         }
         else
         {
@@ -1304,7 +1300,7 @@ public class MicrobeHUD : Control
             resumeButton.Pressed = false;
 
             // Unpause the game
-            GetTree().Paused = false;
+            PauseManager.Instance.Resume(nameof(MicrobeHUD));
         }
     }
 
@@ -1409,7 +1405,7 @@ public class MicrobeHUD : Control
 
     private void OnBecomeMulticellularPressed()
     {
-        if (!GetTree().Paused)
+        if (!PauseManager.Instance.Paused)
         {
             // The button press sound will play along with this
             PauseButtonPressed();
@@ -1425,7 +1421,7 @@ public class MicrobeHUD : Control
     private void OnBecomeMulticellularCancelled()
     {
         // The game should have been paused already but just in case
-        if (GetTree().Paused)
+        if (PauseManager.Instance.Paused)
         {
             // The button press sound will play along with this
             PauseButtonPressed();
@@ -1448,16 +1444,26 @@ public class MicrobeHUD : Control
         // To prevent being clicked twice
         multicellularButton.Disabled = true;
 
-        // Make sure the game is unpaused
-        if (GetTree().Paused)
-        {
-            PauseButtonPressed();
-        }
+        EnsureGameIsUnpausedForEditor();
 
         TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.3f, false);
         TransitionManager.Instance.StartTransitions(stage, nameof(MicrobeStage.MoveToMulticellular));
 
         stage.MovingToEditor = true;
+    }
+
+    /// <summary>
+    ///   Makes sure the game is unpaused (at least by us)
+    /// </summary>
+    private void EnsureGameIsUnpausedForEditor()
+    {
+        if (PauseManager.Instance.Paused)
+        {
+            PauseButtonPressed();
+
+            if (PauseManager.Instance.Paused)
+                GD.PrintErr("Unpausing the game after editor button press didn't work");
+        }
     }
 
     private void OnBecomeMacroscopicPressed()
@@ -1466,12 +1472,6 @@ public class MicrobeHUD : Control
 
         // TODO: late multicellular not done yet
         ToolTipManager.Instance.ShowPopup(TranslationServer.Translate("TO_BE_IMPLEMENTED"), 2.5f);
-    }
-
-    private void FixPauseStateOnPauseMenuClose()
-    {
-        if (paused)
-            GetTree().Paused = true;
     }
 
     private class HoveredCompoundControl : HBoxContainer

--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -2252,7 +2252,6 @@ custom_styles/separator = SubResource( 36 )
 anims/FadeInOut = SubResource( 37 )
 
 [node name="PauseMenu" parent="." instance=ExtResource( 11 )]
-visible = true
 
 [connection signal="pressed" from="MicrobeHUD/BottomLeft/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer/EnvironmentExpandButton" to="MicrobeHUD" method="OnEnvironmentPanelSizeButtonPressed" binds= [ "expand" ]]
 [connection signal="pressed" from="MicrobeHUD/BottomLeft/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer/EnvironmentCompressButton" to="MicrobeHUD" method="OnEnvironmentPanelSizeButtonPressed" binds= [ "compress" ]]

--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -2252,6 +2252,7 @@ custom_styles/separator = SubResource( 36 )
 anims/FadeInOut = SubResource( 37 )
 
 [node name="PauseMenu" parent="." instance=ExtResource( 11 )]
+visible = true
 
 [connection signal="pressed" from="MicrobeHUD/BottomLeft/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer/EnvironmentExpandButton" to="MicrobeHUD" method="OnEnvironmentPanelSizeButtonPressed" binds= [ "expand" ]]
 [connection signal="pressed" from="MicrobeHUD/BottomLeft/LeftPanels/EnvironmentPanel/VBoxContainer/Header/HBoxContainer/EnvironmentCompressButton" to="MicrobeHUD" method="OnEnvironmentPanelSizeButtonPressed" binds= [ "compress" ]]
@@ -2279,4 +2280,3 @@ anims/FadeInOut = SubResource( 37 )
 [connection signal="OnHelpMenuOpenRequested" from="TutorialGUI" to="MicrobeHUD" method="HelpButtonPressed"]
 [connection signal="OnItemSelected" from="RadialPopup" to="MicrobeHUD" method="OnRadialItemSelected"]
 [connection signal="MakeSave" from="PauseMenu" to="." method="SaveGame"]
-[connection signal="OnResumed" from="PauseMenu" to="MicrobeHUD" method="FixPauseStateOnPauseMenuClose"]

--- a/src/microbe_stage/gui/ExtinctionBox.cs
+++ b/src/microbe_stage/gui/ExtinctionBox.cs
@@ -62,8 +62,10 @@ public class ExtinctionBox : CustomDialog
     {
         GUICommon.Instance.PlayButtonPressSound();
 
-        // Unpause the game
-        GetTree().Paused = false;
+        // This now just prints an error if we are paused here, this used to unpause but when refactoring the pausing
+        // what should have paused the game before this wasn't found so this was probably just a safety check
+        if (PauseManager.Instance.Paused)
+            GD.PrintErr("Game is unexpectedly paused when closing the extinction screen");
 
         TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.1f, false);
         TransitionManager.Instance.StartTransitions(this, nameof(OnSwitchToMenu));

--- a/src/saving/InProgressLoad.cs
+++ b/src/saving/InProgressLoad.cs
@@ -62,7 +62,7 @@ public class InProgressLoad
 
         IsLoading = true;
         SceneManager.Instance.DetachCurrentScene();
-        SceneManager.Instance.GetTree().Paused = true;
+        PauseManager.Instance.AddPause(nameof(InProgressLoad));
 
         Invoke.Instance.Perform(Step);
     }
@@ -183,13 +183,12 @@ public class InProgressLoad
 
                 JSONDebug.FlushJSONTracesOut();
 
+                PauseManager.Instance.Resume(nameof(InProgressLoad));
+
                 if (success)
                 {
                     LoadingScreen.Instance.Hide();
                     SaveStatusOverlay.Instance.ShowMessage(message);
-
-                    // TODO: does this cause problems if the game was paused when saving?
-                    loadedState!.GameStateRoot.GetTree().Paused = false;
                 }
                 else
                 {

--- a/src/steam/SteamHandler.cs
+++ b/src/steam/SteamHandler.cs
@@ -186,15 +186,15 @@ public class SteamHandler : Node, ISteamSignalReceiver
     /// <param name="active">True if overlay active</param>
     public void OverlayStatusChanged(bool active)
     {
-        if (active && !GetTree().Paused)
+        if (active && !wePaused)
         {
+            PauseManager.Instance.AddPause(nameof(SteamHandler));
             wePaused = true;
-            GetTree().Paused = true;
         }
-        else if (!active && GetTree().Paused && wePaused)
+        else if (!active && wePaused)
         {
+            PauseManager.Instance.Resume(nameof(SteamHandler));
             wePaused = false;
-            GetTree().Paused = false;
         }
 
         steamClient?.OverlayStatusChanged(active);

--- a/src/tutorial/TutorialState.cs
+++ b/src/tutorial/TutorialState.cs
@@ -12,16 +12,10 @@ using Tutorial;
 public class TutorialState : ITutorialInput
 {
     /// <summary>
-    ///   Pause state to return the game to when a tutorial popup that paused the game is closed
+    ///   True when the tutorial has paused the game
     /// </summary>
     [JsonProperty]
     private bool hasPaused;
-
-    /// <summary>
-    ///   Pause state to return the game to when a tutorial popup that paused the game is closed
-    /// </summary>
-    [JsonProperty]
-    private bool returnToPauseState;
 
     private bool needsToApplyEvenIfDisabled;
 
@@ -197,7 +191,7 @@ public class TutorialState : ITutorialInput
         HandlePausing(gui);
 
         // Pause if the game is paused, but we didn't want to pause things
-        if (gui.GUINode.GetTree().Paused && !WantsGamePaused)
+        if (PauseManager.Instance.Paused && !WantsGamePaused)
         {
             // Apply GUI states anyway to not have a chance of locking a tutorial on screen
             ApplyGUIState(gui);
@@ -314,18 +308,7 @@ public class TutorialState : ITutorialInput
                     return;
 
                 // Pause
-                returnToPauseState = gui.GUINode.GetTree().Paused;
-
-                if (InProgressSave.IsSaving)
-                {
-                    // I'd hope this never happens but at least in developing individual scenes and things this can
-                    // happen, so we don't at least want to softlock here
-                    GD.Print("Overriding tutorial return pause state as save is in progress, " +
-                        "this shouldn't happen in normal gameplay");
-                    returnToPauseState = false;
-                }
-
-                gui.GUINode.GetTree().Paused = true;
+                PauseManager.Instance.AddPause(nameof(TutorialState));
                 hasPaused = true;
             }
         }
@@ -333,7 +316,8 @@ public class TutorialState : ITutorialInput
 
     private void UnPause(ITutorialGUI gui)
     {
-        gui.GUINode.GetTree().Paused = returnToPauseState;
+        if (hasPaused)
+            PauseManager.Instance.Resume(nameof(TutorialState));
         hasPaused = false;
     }
 


### PR DESCRIPTION
 instead of juggling the single paused state flag which started to become unwieldy and error prone

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Should fix pausing getting stuck on with the changes in: https://github.com/Revolutionary-Games/Thrive/commit/a6a39d071f10a2dbc1a520c342da3b15fbef359f

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
