### PR TITLE
Cilia Balance

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -72,9 +72,9 @@ public static class Constants
 
     public const float CELL_BASE_ROTATION = 0.2f;
     public const float CELL_MAX_ROTATION = 0.40f;
-    public const float CELL_MIN_ROTATION = 0.0001f;
-    public const float CELL_MOMENT_OF_INERTIA_DISTANCE_MULTIPLIER = 0.8f;
-    public const float CILIA_ROTATION_FACTOR = 0.035f;
+    public const float CELL_MIN_ROTATION = 0.01f;
+    public const float CELL_MOMENT_OF_INERTIA_DISTANCE_MULTIPLIER = 0.2f;
+    public const float CILIA_ROTATION_FACTOR = 0.020f;
     public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 0.7f;
 
     public const float CELL_COLONY_MAX_ROTATION_MULTIPLIER = 2.5f;
@@ -82,9 +82,9 @@ public static class Constants
     public const float CELL_COLONY_MAX_ROTATION_HELP = 2.5f;
     public const float CELL_COLONY_MEMBER_ROTATION_FACTOR_MULTIPLIER = 45.0f;
 
-    public const float CILIA_ENERGY_COST = 3.0f;
+    public const float CILIA_ENERGY_COST = 2.0f;
     public const float CILIA_ROTATION_NEEDED_FOR_ATP_COST = 0.03f;
-    public const float CILIA_ROTATION_ENERGY_BASE_MULTIPLIER = 6.0f;
+    public const float CILIA_ROTATION_ENERGY_BASE_MULTIPLIER = 4.0f;
 
     public const float CILIA_DEFAULT_ANIMATION_SPEED = 0.3f;
     public const float CILIA_MIN_ANIMATION_SPEED = 0.15f;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -72,9 +72,9 @@ public static class Constants
 
     public const float CELL_BASE_ROTATION = 0.2f;
     public const float CELL_MAX_ROTATION = 0.40f;
-    public const float CELL_MIN_ROTATION = 0.01f;
-    public const float CELL_MOMENT_OF_INERTIA_DISTANCE_MULTIPLIER = 0.2f;
-    public const float CILIA_ROTATION_FACTOR = 0.020f;
+    public const float CELL_MIN_ROTATION = 0.005f;
+    public const float CELL_MOMENT_OF_INERTIA_DISTANCE_MULTIPLIER = 0.5f;
+    public const float CILIA_ROTATION_FACTOR = 0.008f;
     public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 0.7f;
 
     public const float CELL_COLONY_MAX_ROTATION_MULTIPLIER = 2.5f;


### PR DESCRIPTION
**Brief Description of What This PR Does**
Adjusts loss of turning speed from larger cells, as well as the impact of cilia in the wake of implementation.

As always, I would like some input from others about if it feels right to them or not.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
