### PR TITLE
Fixed all remaining cases with save/load not unpausing the game

### DIFF
--- a/src/engine/PauseManager.cs
+++ b/src/engine/PauseManager.cs
@@ -65,7 +65,7 @@ public class PauseManager : Node
         if (activeLocks.Count < 1)
             return;
 
-        GD.Print("Force clearing remaining pause locks");
+        GD.PrintErr("Force clearing remaining pause locks: ", string.Join(", ", activeLocks));
         activeLocks.Clear();
         ApplyPauseState();
     }

--- a/src/general/PauseMenu.cs
+++ b/src/general/PauseMenu.cs
@@ -41,6 +41,8 @@ public class PauseMenu : CustomDialog
     private CustomConfirmationDialog unsavedProgressWarning = null!;
     private AnimationPlayer animationPlayer = null!;
 
+    private bool paused;
+
     /// <summary>
     ///   The assigned pending exit type, will be used to specify what kind of
     ///   game exit will be performed on exit confirmation.
@@ -159,6 +161,26 @@ public class PauseMenu : CustomDialog
         }
     }
 
+    private bool Paused
+    {
+        set
+        {
+            if (paused == value)
+                return;
+
+            if (paused)
+            {
+                PauseManager.Instance.Resume(nameof(PauseMenu));
+            }
+            else
+            {
+                PauseManager.Instance.AddPause(nameof(PauseMenu));
+            }
+
+            paused = value;
+        }
+    }
+
     public override void _EnterTree()
     {
         // This needs to be done early here to make sure the help screen loads the right text
@@ -174,6 +196,7 @@ public class PauseMenu : CustomDialog
         base._ExitTree();
 
         InputManager.UnregisterReceiver(this);
+        Paused = false;
     }
 
     public override void _Ready()
@@ -236,7 +259,7 @@ public class PauseMenu : CustomDialog
             return;
 
         animationPlayer.Play("Open");
-        PauseManager.Instance.AddPause(nameof(PauseMenu));
+        Paused = true;
     }
 
     public void Close()
@@ -245,7 +268,7 @@ public class PauseMenu : CustomDialog
             return;
 
         animationPlayer.Play("Close");
-        PauseManager.Instance.Resume(nameof(PauseMenu));
+        Paused = false;
     }
 
     public void OpenToHelp()
@@ -347,8 +370,7 @@ public class PauseMenu : CustomDialog
 
     private void ReturnToMenu()
     {
-        // Unpause the game
-        PauseManager.Instance.Resume(nameof(PauseMenu));
+        Paused = false;
 
         TransitionManager.Instance.AddScreenFade(ScreenFade.FadeType.FadeOut, 0.1f, false);
         TransitionManager.Instance.StartTransitions(this, nameof(OnSwitchToMenu));
@@ -414,6 +436,7 @@ public class PauseMenu : CustomDialog
         Hide();
         EmitSignal(nameof(OnResumed));
         EmitSignal(nameof(MakeSave), name);
+        Paused = false;
     }
 
     /// <summary>
@@ -427,5 +450,11 @@ public class PauseMenu : CustomDialog
     private void OnLoadSaveConfirmed(SaveListItem item)
     {
         item.LoadThisSave();
+    }
+
+    private void OnSaveLoaded(string saveName)
+    {
+        _ = saveName;
+        Paused = false;
     }
 }

--- a/src/general/PauseMenu.tscn
+++ b/src/general/PauseMenu.tscn
@@ -291,6 +291,7 @@ anims/RESET = SubResource( 3 )
 [connection signal="pressed" from="CenterContainer/PrimaryMenu/ReturnToMenu" to="." method="ReturnToMenuPressed"]
 [connection signal="pressed" from="CenterContainer/PrimaryMenu/Exit" to="." method="ExitPressed"]
 [connection signal="OnConfirmed" from="CenterContainer/LoadMenu/SaveList" to="." method="OnLoadSaveConfirmed"]
+[connection signal="OnSaveLoaded" from="CenterContainer/LoadMenu/SaveList" to="." method="OnSaveLoaded"]
 [connection signal="pressed" from="CenterContainer/LoadMenu/Back" to="." method="CloseLoadPressed"]
 [connection signal="OnClosed" from="CenterContainer/NewSaveMenu" to="." method="CloseSavePressed"]
 [connection signal="OnSaveNameChosen" from="CenterContainer/NewSaveMenu" to="." method="ForwardSaveAction"]

--- a/src/saving/InProgressLoad.cs
+++ b/src/saving/InProgressLoad.cs
@@ -201,6 +201,10 @@ public class InProgressLoad
 
                 SaveHelper.MarkLastSaveToCurrentTime();
 
+                // Make certain that if some game element paused and we unloaded it without it realizing that, we
+                // don't get stuck in paused mode
+                PauseManager.Instance.ForceClear();
+
                 return;
             }
 

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -90,6 +90,9 @@ public class SaveList : ScrollContainer
     [Signal]
     public delegate void OnConfirmed(SaveListItem item);
 
+    [Signal]
+    public delegate void OnSaveLoaded(string saveName);
+
     public override void _Ready()
     {
         loadingItem = GetNode<Control>(LoadingItemPath);
@@ -160,6 +163,7 @@ public class SaveList : ScrollContainer
                 item.Connect(nameof(SaveListItem.OnKnownIncompatibleLoaded), this, nameof(OnKnownIncompatibleLoaded));
                 item.Connect(nameof(SaveListItem.OnDifferentVersionPrototypeLoaded), this,
                     nameof(OnDifferentVersionPrototypeLoaded));
+                item.Connect(nameof(SaveListItem.OnProblemFreeSaveLoaded), this, nameof(OnSaveLoadedWithoutProblems));
 
                 item.SaveName = save;
                 savesList.AddChild(item);
@@ -385,6 +389,12 @@ public class SaveList : ScrollContainer
         }
 
         SaveHelper.LoadSave(saveToBeLoaded);
+        EmitSignal(nameof(OnSaveLoaded), saveToBeLoaded);
         saveToBeLoaded = null;
+    }
+
+    private void OnSaveLoadedWithoutProblems(string saveName)
+    {
+        EmitSignal(nameof(OnSaveLoaded), saveName);
     }
 }

--- a/src/saving/SaveListItem.cs
+++ b/src/saving/SaveListItem.cs
@@ -102,6 +102,13 @@ public class SaveListItem : PanelContainer
     [Signal]
     public delegate void OnDifferentVersionPrototypeLoaded();
 
+    /// <summary>
+    ///   Triggered when this is loaded without a problem. This is triggered when the load is already in progress
+    ///   so this is more of an informative callback for components that need to know when a save load was done.
+    /// </summary>
+    [Signal]
+    public delegate void OnProblemFreeSaveLoaded(string saveName);
+
     public string SaveName
     {
         get => saveName;
@@ -296,6 +303,7 @@ public class SaveListItem : PanelContainer
     private void LoadSave()
     {
         SaveHelper.LoadSave(SaveName);
+        EmitSignal(nameof(OnProblemFreeSaveLoaded), saveName);
     }
 
     private void LoadSaveData()


### PR DESCRIPTION
I started trying to make the saves tell when they are loaded but eventually I remembered that quick load exists so I had to anyway remove the pause when the pause menu exits the scene tree

also added a force override for loading a save to make sure the loaded game is not stuck paused

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
