### PR TITLE
Fixed hover hex not shown when moving placed organelle

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -715,15 +715,15 @@ public partial class CellEditorComponent :
         }
 
         // Show the organelle that is about to be placed
-        if (ActiveActionName != null && Editor.ShowHover && !MicrobePreviewMode)
+        if (Editor.ShowHover && !MicrobePreviewMode)
         {
             GetMouseHex(out int q, out int r);
 
-            OrganelleDefinition shownOrganelle;
+            OrganelleDefinition? shownOrganelle = null;
 
             var effectiveSymmetry = Symmetry;
 
-            if (MovingPlacedHex == null)
+            if (MovingPlacedHex == null && ActiveActionName != null)
             {
                 // Can place stuff at all?
                 isPlacementProbablyValid = IsValidPlacement(new OrganelleTemplate(
@@ -731,7 +731,7 @@ public partial class CellEditorComponent :
 
                 shownOrganelle = SimulationParameters.Instance.GetOrganelleType(ActiveActionName);
             }
-            else
+            else if (MovingPlacedHex != null)
             {
                 isPlacementProbablyValid = IsMoveTargetValid(new Hex(q, r), placementRotation, MovingPlacedHex);
                 shownOrganelle = MovingPlacedHex.Definition;
@@ -740,16 +740,19 @@ public partial class CellEditorComponent :
                     effectiveSymmetry = HexEditorSymmetry.None;
             }
 
-            HashSet<(Hex Hex, int Orientation)> hoveredHexes = new();
+            if (shownOrganelle != null)
+            {
+                HashSet<(Hex Hex, int Orientation)> hoveredHexes = new();
 
-            RunWithSymmetry(q, r,
-                (finalQ, finalR, rotation) =>
-                {
-                    RenderHighlightedOrganelle(finalQ, finalR, rotation, shownOrganelle);
-                    hoveredHexes.Add((new Hex(finalQ, finalR), rotation));
-                }, effectiveSymmetry);
+                RunWithSymmetry(q, r,
+                    (finalQ, finalR, rotation) =>
+                    {
+                        RenderHighlightedOrganelle(finalQ, finalR, rotation, shownOrganelle);
+                        hoveredHexes.Add((new Hex(finalQ, finalR), rotation));
+                    }, effectiveSymmetry);
 
-            MouseHoverPositions = hoveredHexes.ToList();
+                MouseHoverPositions = hoveredHexes.ToList();
+            }
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixed hover hex not shown when moving placed organelle **after placing a unique organelle**. The part of code that renders hover organelles is not ran if no organelle is selected, as a result the organelle that is being moved is also not rendered. This fixes that flawed logic on the code.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
