### PR TITLE
Made toxins fire relative to cell's actual orientation

### DIFF
--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -206,7 +206,7 @@ public partial class Microbe
         var props = new AgentProperties(Species, agentType);
 
         // Find the direction the microbe is facing (actual rotation, not LookAtPoint)
-        var direction = new Vector3((float)-Math.Sin(Rotation.y), 0, (float)-Math.Cos(Rotation.y)).Normalized();
+        var direction = GlobalTransform.basis.Quat().Xform(Vector3.Forward);
 
         var position = Translation + (direction * ejectionDistance);
 

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -205,8 +205,8 @@ public partial class Microbe
 
         var props = new AgentProperties(Species, agentType);
 
-        // Find the direction the microbe is facing
-        var direction = (LookAtPoint - Translation).Normalized();
+        // Find the direction the microbe is facing (actual rotation, not LookAtPoint)
+        var direction = new Vector3((float) -Math.Sin(Rotation.y), 0, (float) -Math.Cos(Rotation.y)).Normalized();
 
         var position = Translation + (direction * ejectionDistance);
 

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -206,7 +206,7 @@ public partial class Microbe
         var props = new AgentProperties(Species, agentType);
 
         // Find the direction the microbe is facing (actual rotation, not LookAtPoint)
-        var direction = new Vector3((float) -Math.Sin(Rotation.y), 0, (float) -Math.Cos(Rotation.y)).Normalized();
+        var direction = new Vector3((float)-Math.Sin(Rotation.y), 0, (float)-Math.Cos(Rotation.y)).Normalized();
 
         var position = Translation + (direction * ejectionDistance);
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Cells now fire toxins relative to their rotation, not their intended rotation (LookAtPoint). Needed now that variable rotation speeds are in the game.

**Related Issues**

Fixes #3372 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
