### PR TITLE
Fixed remaining cases where mutation code could get auto-evo stuck

### DIFF
--- a/src/general/HexLayout.cs
+++ b/src/general/HexLayout.cs
@@ -220,7 +220,7 @@ public abstract class HexLayout<T> : ICollection<T>
         var hexesWithNeighbours = new List<Hex> { initHex };
 
         // These are all of the existing hexes, that if there are no islands will all be visited
-        var shouldBeVisited = existingHexes.Select(p => p.Position).ToList();
+        var shouldBeVisited = ComputeHexCache();
 
         CheckmarkNeighbors(hexesWithNeighbours);
 

--- a/src/general/Mutations.cs
+++ b/src/general/Mutations.cs
@@ -282,14 +282,10 @@ public class Mutations
                     break;
             }
 
-            minSubHex.Q = (int)(minSubHex.Q * (minDistance - 1.0) / minDistance);
-            minSubHex.R = (int)(minSubHex.R * (minDistance - 1.0) / minDistance);
+            if (minSubHex.Q != minSubHex.R)
+                minSubHex.Q = (int)(minSubHex.Q * (minDistance - 1.0) / minDistance);
 
-            if (minSubHex.Q == 0 && minSubHex.R == 0)
-            {
-                // Exactly symmetrical islands. Avoid infinite loop by using this value
-                minSubHex = new Hex(1, 0);
-            }
+            minSubHex.R = (int)(minSubHex.R * (minDistance - 1.0) / minDistance);
 
             // Move all island organelles by minSubHex
             foreach (var organelle in mutatedOrganelles.Where(

--- a/src/general/Mutations.cs
+++ b/src/general/Mutations.cs
@@ -282,6 +282,8 @@ public class Mutations
                     break;
             }
 
+            // Calculate the path to move island organelles.
+            // If statement is there because otherwise the path could be (0, 0).
             if (minSubHex.Q != minSubHex.R)
                 minSubHex.Q = (int)(minSubHex.Q * (minDistance - 1.0) / minDistance);
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

I found two problems that caused the issue. First, the code didn't always recognize island hexes correctly meaning that they could be next to main hexes. Second, the code could calculate the movement path incorrectly if `minSubHex.Q == minSubHex.R`. This PR fixes both of them. I tested this quite a bit and think that auto-evo should now never get stuck.

**Related Issues**

Fixes #3373

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
