### PR TITLE
Validate cell type name in multicellular editor

### DIFF
--- a/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -1041,7 +1041,7 @@ public partial class CellBodyPlanEditorComponent :
 
     private void OnNewCellTypeNameChanged(string newText)
     {
-        if (!IsNewCellTypeNameValid(newText))
+        if (!Editor.IsNewCellTypeNameValid(newText))
         {
             GUICommon.MarkInputAsInvalid(duplicateCellTypeName);
         }
@@ -1049,14 +1049,6 @@ public partial class CellBodyPlanEditorComponent :
         {
             GUICommon.MarkInputAsValid(duplicateCellTypeName);
         }
-    }
-
-    private bool IsNewCellTypeNameValid(string text)
-    {
-        // Name is invalid if it is empty or a duplicate
-        // TODO: should this ensure the name doesn't have trailing whitespace?
-        return !string.IsNullOrWhiteSpace(text) && !Editor.EditedSpecies.CellTypes.Any(c =>
-            c.TypeName.Equals(text, StringComparison.InvariantCultureIgnoreCase));
     }
 
     private void OnNewCellTextAccepted(string text)
@@ -1072,7 +1064,7 @@ public partial class CellBodyPlanEditorComponent :
     {
         var newTypeName = duplicateCellTypeName.Text;
 
-        if (!IsNewCellTypeNameValid(newTypeName))
+        if (!Editor.IsNewCellTypeNameValid(newTypeName))
         {
             GD.Print("Bad name for new cell type");
             Editor.OnInvalidAction();

--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
@@ -156,7 +156,6 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
     public bool IsNewCellTypeNameValid(string newName)
     {
         return !string.IsNullOrWhiteSpace(newName) && !EditedSpecies.CellTypes.Any(c =>
-            c != selectedCellTypeToEdit &&
             c.TypeName.Equals(newName, StringComparison.InvariantCultureIgnoreCase));
     }
 

--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
@@ -153,6 +153,13 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
         return false;
     }
 
+    public bool IsNewCellTypeNameValid(string newName)
+    {
+        return !string.IsNullOrWhiteSpace(newName) && !EditedSpecies.CellTypes.Any(c =>
+            c != selectedCellTypeToEdit &&
+            c.TypeName.Equals(newName, StringComparison.InvariantCultureIgnoreCase));
+    }
+
     protected override void ResolveDerivedTypeNodeReferences()
     {
         reportTab = GetNode<MicrobeEditorReportComponent>(ReportTabPath);
@@ -212,6 +219,7 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
         patchMapTab.OnNextTab = () => SetEditorTab(EditorTab.CellEditor);
         bodyPlanEditorTab.OnFinish = ForwardEditorComponentFinishRequest;
         cellEditorTab.OnNextTab = () => SetEditorTab(EditorTab.CellEditor);
+        cellEditorTab.ValidateNewCellTypeName = IsNewCellTypeNameValid;
 
         foreach (var editorComponent in GetAllEditorComponents())
         {
@@ -489,10 +497,6 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
             cellEditorTab.OnEditorSpeciesSetup(EditedBaseSpecies);
         }
 
-        // We need to handle the renaming here as the cell editor doesn't really know what other cell types exist
-        // so it can't check if the name is unique or not
-        // TODO: would be nice to re-architecture this so that the cell editor could show if the new name is valid
-        // or not
         var oldName = data.FinishedCellType.TypeName;
 
         cellEditorTab.OnFinishEditing();

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -429,6 +429,19 @@ public partial class CellEditorComponent :
 
     private float CostMultiplier => IsMulticellularEditor ? Constants.MULTICELLULAR_EDITOR_COST_FACTOR : 1.0f;
 
+    /// <summary>
+    ///   true if the name has been changed since applying new state, false otherwise
+    /// </summary>
+    public bool HasNewName()
+    {
+        if (Editor.EditedCellProperties == null)
+        {
+            return false;
+        }
+
+        return Editor.EditedCellProperties.FormattedName != newName;
+    }
+
     public override void _Ready()
     {
         base._Ready();

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1887,7 +1887,8 @@ public partial class CellEditorComponent :
     {
         newName = newText;
 
-        if (IsMulticellularEditor)
+        // Validate name against other cells and if the name has changed
+        if (IsMulticellularEditor && HasNewName())
         {
             if (ValidateNewCellTypeName != null)
             {

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -423,6 +423,8 @@ public partial class CellEditorComponent :
     [JsonIgnore]
     public bool NodeReferencesResolved { get; private set; }
 
+    public Func<string, bool>? ValidateNewCellTypeName { get; set; }
+
     protected override bool ForceHideHover => MicrobePreviewMode;
 
     private float CostMultiplier => IsMulticellularEditor ? Constants.MULTICELLULAR_EDITOR_COST_FACTOR : 1.0f;
@@ -1874,8 +1876,14 @@ public partial class CellEditorComponent :
 
         if (IsMulticellularEditor)
         {
-            // TODO: somehow update the architecture so that we can know here if the name conflicts with another type
-            componentBottomLeftButtons.ReportValidityOfName(!string.IsNullOrWhiteSpace(newText));
+            if (ValidateNewCellTypeName != null)
+            {
+                componentBottomLeftButtons.ReportValidityOfName(ValidateNewCellTypeName(newText));
+            }
+            else
+            {
+                componentBottomLeftButtons.ReportValidityOfName(!string.IsNullOrWhiteSpace(newText));
+            }
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

* Factor out logic for name validation from CellBodyPlanEditorComponent into EarlyMulticellularEditor
* Pass validation function to CellEditorComponent to use when name changes

**Related Issues**

Closes #3168 
**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
