### PR TITLE
Remove `DetachAndFree`

### DIFF
--- a/src/engine/NodeHelpers.cs
+++ b/src/engine/NodeHelpers.cs
@@ -16,25 +16,6 @@ public static class NodeHelpers
     }
 
     /// <summary>
-    ///   Safely frees a Node. Detaches from parent if attached to not leave disposed objects in scene tree.
-    ///   This should always be preferred over Free, except when multiple children should be deleted.
-    ///   For that see <see cref="NodeHelpers.FreeChildren"/>
-    /// </summary>
-    /// <remarks>
-    ///   <para>
-    ///     TODO: should this be removed now that there is (and Free isn't actually bugged):
-    ///     https://github.com/Revolutionary-Games/Thrive/pull/2028
-    ///   </para>
-    /// </remarks>
-    public static void DetachAndFree(this Node node)
-    {
-        var parent = node.GetParent();
-        parent?.RemoveChild(node);
-
-        node.Free();
-    }
-
-    /// <summary>
     ///   Safely queues a Node free. Detaches from parent if attached to not leave disposed objects in scene tree.
     ///   This should always be preferred over QueueFree, except when multiple children should be deleted.
     ///   For that see <see cref="NodeHelpers.QueueFreeChildren"/>
@@ -76,7 +57,6 @@ public static class NodeHelpers
     /// <param name="node">Node to delete children of</param>
     /// <param name="detach">
     ///   If true the children are also removed from the parent. Shouldn't actually have an effect.
-    ///   <see cref="DetachAndFree"/>
     /// </param>
     public static void FreeChildren(this Node node, bool detach = false)
     {

--- a/src/engine/input/key_mapping/InputGroupList.cs
+++ b/src/engine/input/key_mapping/InputGroupList.cs
@@ -165,7 +165,7 @@ public class InputGroupList : VBoxContainer
         if (activeInputGroupList != null)
         {
             foreach (var inputGroupItem in activeInputGroupList)
-                inputGroupItem.DetachAndFree();
+                inputGroupItem.Free();
         }
 
         activeInputGroupList = BuildGUI(SimulationParameters.Instance.InputGroups, data);

--- a/src/gui_common/CompoundAmount.cs
+++ b/src/gui_common/CompoundAmount.cs
@@ -210,7 +210,7 @@ public class CompoundAmount : HBoxContainer
 
     private void UpdateIcon()
     {
-        icon?.DetachAndFree();
+        icon?.Free();
 
         icon = GUICommon.Instance.CreateCompoundIcon(compound!.InternalName);
         AddChild(icon);

--- a/src/gui_common/SegmentedBar.cs
+++ b/src/gui_common/SegmentedBar.cs
@@ -83,7 +83,7 @@ public class SegmentedBar : HBoxContainer
 
         foreach (var unusedBar in unusedBars)
         {
-            unusedBar.DetachAndFree();
+            unusedBar.Free();
             SubBars.Remove(unusedBar);
         }
     }

--- a/src/microbe_stage/editor/PatchMapDrawer.cs
+++ b/src/microbe_stage/editor/PatchMapDrawer.cs
@@ -134,7 +134,7 @@ public class PatchMapDrawer : Control
     {
         foreach (var node in nodes)
         {
-            node.DetachAndFree();
+            node.Free();
         }
 
         nodes.Clear();


### PR DESCRIPTION
**Brief Description of What This PR Does**

No problems from my test. Places that used `DetachAndFree` still works fine (mostly microbe editor related stuff). Loading save also works.

**Related Issues**

Fixes #2030

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
