### PR TITLE
Fix saving/loading not possible after loading a stage save

### DIFF
--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -490,11 +490,14 @@ public class MicrobeHUD : Control
             throw new InvalidOperationException("Stage not setup for HUD");
 
         if (stage.IsLoadedFromSave && !returningFromEditor)
+        {
+            stage.OnFinishTransitioning();
             return;
+        }
 
-        // Fade out for that smooth satisfying transition
         stage.TransitionFinished = false;
 
+        // Fade out for that smooth satisfying transition
         TransitionManager.Instance.AddSequence(
             ScreenFade.FadeType.FadeIn, longerDuration ? 1.0f : 0.5f, stage.OnFinishTransitioning);
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Call `MicrobeStage.OnFinishTransitioning` if stage is loaded from save.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Related Issues**

Fixes #3400 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
