### PR TITLE
Fixed save writability check not working when saves folder doesn't exist

### DIFF
--- a/Thrive.sln.DotSettings
+++ b/Thrive.sln.DotSettings
@@ -614,4 +614,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=venter/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=vseparation/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Wigglyness/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Wigglyness/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=writability/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/saving/NewSaveMenu.cs
+++ b/src/saving/NewSaveMenu.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using Godot;
 using Path = System.IO.Path;
@@ -110,6 +111,19 @@ public class NewSaveMenu : Control
         // Verify name is writable
         var name = GetSaveName();
         var path = Path.Combine(Constants.SAVE_FOLDER, name);
+
+        // Make sure the save folder exists, otherwise the write test will always fail
+        try
+        {
+            FileHelpers.MakeSureDirectoryExists(Constants.SAVE_FOLDER);
+        }
+        catch (IOException e)
+        {
+            GD.PrintErr("Could not make sure save folder exists for save writability check: ", e);
+            attemptWriteFailAccept.PopupCenteredShrink();
+            return;
+        }
+
         if (!FileHelpers.Exists(path) && FileHelpers.TryWriteFile(path) != Error.Ok)
         {
             attemptWriteFailAccept.PopupCenteredShrink();


### PR DESCRIPTION
this was caused by the fact that the folder was not made sure it exists before a file was attempted to be written in it

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
bug reported on reddit: https://www.reddit.com/r/thrive/comments/vauiry/cannot_save_game_cannot_access_the_save_folder/

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
