### PR TITLE
Set the attempt to write save file popup's close button to be visible

### DIFF
--- a/src/saving/NewSaveMenu.tscn
+++ b/src/saving/NewSaveMenu.tscn
@@ -120,7 +120,6 @@ WindowTitle = "OVERWRITE_EXISTING_SAVE_PROMPT"
 rect_min_size = Vector2( 500, 0 )
 WindowTitle = "CANNOT_WRITE_SAVE"
 Movable = false
-ShowCloseButton = false
 HideCancelButton = true
 DialogText = "ATTEMPT_TO_WRITE_SAVE_FAILED"
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Should have close button enabled for normal popups.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
