### PR TITLE
Remove visible tutorial keys

### DIFF
--- a/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
+++ b/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
@@ -125,6 +125,7 @@ margin_bottom = 61.0
 Description = "MICROBE_STAGE_CONTROL_TEXT"
 
 [node name="KeyPrompts" type="Control" parent="MicrobeMovementTutorial"]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes a regression where tutorial keys would appear when starting a new game without tutorials. Seems to have appeared with https://github.com/Revolutionary-Games/Thrive/commit/b89fd590f36bed29188d909d3844c03ced919804#diff-cf1e0bd9c1c485ca2387f30cf7addb334f29d93047cb656e69a408bdce1d2667.

**Related Issues**

N/A

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
