### PR TITLE
Fixed tutorial dialogs missing the popup animation and position fixing

### DIFF
--- a/src/gui_common/CustomDialog.cs
+++ b/src/gui_common/CustomDialog.cs
@@ -190,10 +190,6 @@ public class CustomDialog : Popup, ICustomPopup
         scaleBorderSize = GetConstant("custom_scaleBorder_size", "WindowDialog");
         customMargin = decorate ? GetConstant("custom_margin", "Dialogs") : 0;
 
-        SetupCloseButton();
-        UpdateChildRects();
-        ApplyRectSettings();
-
         base._EnterTree();
     }
 
@@ -208,6 +204,14 @@ public class CustomDialog : Popup, ICustomPopup
     {
         switch (what)
         {
+            case NotificationReady:
+            {
+                SetupCloseButton();
+                UpdateChildRects();
+                ApplyRectSettings();
+                break;
+            }
+
             case NotificationResized:
             {
                 UpdateChildRects();
@@ -220,6 +224,7 @@ public class CustomDialog : Popup, ICustomPopup
                 if (Visible)
                 {
                     ApplyRectSettings();
+                    OnShown();
                 }
                 else
                 {
@@ -383,6 +388,10 @@ public class CustomDialog : Popup, ICustomPopup
     {
         // TODO: add proper close animation
         Hide();
+    }
+
+    protected virtual void OnShown()
+    {
     }
 
     /// <summary>

--- a/src/gui_common/dialogs/TutorialDialog.cs
+++ b/src/gui_common/dialogs/TutorialDialog.cs
@@ -42,7 +42,7 @@ public class TutorialDialog : CustomDialog
         AddChild(tween);
     }
 
-    public override void CustomShow()
+    protected override void OnShown()
     {
         // Don't animate if currently running inside the editor
         if (Engine.EditorHint)

--- a/src/gui_common/thrive_theme.tres
+++ b/src/gui_common/thrive_theme.tres
@@ -697,6 +697,7 @@ ProgressBar/styles/fg = null
 RichTextLabel/colors/default_color = Color( 1, 1, 1, 1 )
 RichTextLabel/colors/font_color_selected = Color( 0, 0, 0, 1 )
 RichTextLabel/colors/font_color_shadow = Color( 0, 0, 0, 0 )
+RichTextLabel/colors/selection_color = Color( 0, 0, 0, 1 )
 RichTextLabel/constants/line_separation = 1
 RichTextLabel/constants/shadow_as_outline = 0
 RichTextLabel/constants/shadow_offset_x = 1

--- a/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
+++ b/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
@@ -199,13 +199,14 @@ anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
 anchor_bottom = 0.5
-margin_left = -260.0
+margin_left = -279.0
 margin_top = -179.0
-margin_right = 0.0
+margin_right = -19.0
 margin_bottom = 61.0
 Description = "TUTORIAL_MICROBE_STAGE_REPRODUCE_TEXT"
 
 [node name="EditorButtonHighlight" parent="." instance=ExtResource( 11 )]
+visible = false
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_right = 490.0


### PR DESCRIPTION
**Brief Description of What This PR Does**

Was completely oblivious before with the tutorial dialogs missing the popup animation, didn't realize until now. This fixes that along with a bug with incorrect tutorial popups positioning when shown, this is due to CustomDialog's `BoundToScreenArea` positioning adjustment getting called too early in `_EnterTree` before anything could settle down so the result is incorrect.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
