### PR TITLE
Update exit entity label logic

### DIFF
--- a/src/engine/DebugOverlays.EntityLabel.cs
+++ b/src/engine/DebugOverlays.EntityLabel.cs
@@ -23,11 +23,14 @@ public partial class DebugOverlays
         }
     }
 
-    private void UpdateLabelColour(IEntity iEntity, Spatial entity, Label label)
+    private void UpdateLabelColour(IEntity iEntity, Label label)
     {
+        var entity = iEntity.EntityNode;
+
         if (!iEntity.AliveMarker.Alive)
         {
-            label.Set("custom_colors/font_color", new Color(1.0f, 0.3f, 0.3f));
+            label.AddColorOverride("font_color", new Color(1.0f, 0.3f, 0.3f));
+            return;
         }
 
         switch (entity)
@@ -38,25 +41,25 @@ public partial class DebugOverlays
                 {
                     case Microbe.MicrobeState.Binding:
                     {
-                        label.Set("custom_colors/font_color", new Color(0.2f, 0.5f, 0.0f));
+                        label.AddColorOverride("font_color", new Color(0.2f, 0.5f, 0.0f));
                         break;
                     }
 
                     case Microbe.MicrobeState.Engulf:
                     {
-                        label.Set("custom_colors/font_color", new Color(0.2f, 0.5f, 1.0f));
+                        label.AddColorOverride("font_color", new Color(0.2f, 0.5f, 1.0f));
                         break;
                     }
 
                     case Microbe.MicrobeState.Unbinding:
                     {
-                        label.Set("custom_colors/font_color", new Color(1.0f, 0.5f, 0.2f));
+                        label.AddColorOverride("font_color", new Color(1.0f, 0.5f, 0.2f));
                         break;
                     }
 
                     default:
                     {
-                        label.Set("custom_colors/font_color", new Color(1.0f, 1.0f, 1.0f));
+                        label.AddColorOverride("font_color", new Color(1.0f, 1.0f, 1.0f));
                         break;
                     }
                 }
@@ -82,7 +85,7 @@ public partial class DebugOverlays
 
             label.RectPosition = activeCamera.UnprojectPosition(entity.Transform.origin);
 
-            UpdateLabelColour(iEntity, entity, label);
+            UpdateLabelColour(iEntity, label);
 
             if (!label.Text.Empty())
                 continue;

--- a/src/engine/DebugOverlays.EntityLabel.cs
+++ b/src/engine/DebugOverlays.EntityLabel.cs
@@ -23,6 +23,49 @@ public partial class DebugOverlays
         }
     }
 
+    private void UpdateLabelColour(IEntity iEntity, Spatial entity, Label label)
+    {
+        if (!iEntity.AliveMarker.Alive)
+        {
+            label.Set("custom_colors/font_color", new Color(1.0f, 0.3f, 0.3f));
+        }
+
+        switch (entity)
+        {
+            case Microbe microbe:
+            {
+                switch (microbe.State)
+                {
+                    case Microbe.MicrobeState.Binding:
+                    {
+                        label.Set("custom_colors/font_color", new Color(0.2f, 0.5f, 0.0f));
+                        break;
+                    }
+
+                    case Microbe.MicrobeState.Engulf:
+                    {
+                        label.Set("custom_colors/font_color", new Color(0.2f, 0.5f, 1.0f));
+                        break;
+                    }
+
+                    case Microbe.MicrobeState.Unbinding:
+                    {
+                        label.Set("custom_colors/font_color", new Color(1.0f, 0.5f, 0.2f));
+                        break;
+                    }
+
+                    default:
+                    {
+                        label.Set("custom_colors/font_color", new Color(1.0f, 1.0f, 1.0f));
+                        break;
+                    }
+                }
+
+                break;
+            }
+        }
+    }
+
     private void UpdateEntityLabels()
     {
         if (activeCamera is not { Current: true })
@@ -33,10 +76,13 @@ public partial class DebugOverlays
 
         foreach (var pair in entityLabels)
         {
-            var entity = pair.Key.EntityNode;
+            var iEntity = pair.Key;
+            var entity = iEntity.EntityNode;
             var label = pair.Value;
 
             label.RectPosition = activeCamera.UnprojectPosition(entity.Transform.origin);
+
+            UpdateLabelColour(iEntity, entity, label);
 
             if (!label.Text.Empty())
                 continue;
@@ -70,12 +116,6 @@ public partial class DebugOverlays
         }
     }
 
-    private void UpdateLabelOnMicrobeDeath(Microbe microbe)
-    {
-        if (entityLabels.TryGetValue(microbe, out var label))
-            label.Set("custom_colors/font_color", new Color(1.0f, 0.3f, 0.3f));
-    }
-
     private void OnNodeAdded(Node node)
     {
         if (node is not IEntity entity)
@@ -87,12 +127,6 @@ public partial class DebugOverlays
 
         switch (entity)
         {
-            case Microbe microbe:
-            {
-                microbe.OnDeath += UpdateLabelOnMicrobeDeath;
-                break;
-            }
-
             case FloatingChunk:
             case AgentProjectile:
             {
@@ -122,11 +156,6 @@ public partial class DebugOverlays
         {
             label.DetachAndQueueFree();
             entityLabels.Remove(entity);
-
-            if (entity is Microbe microbe)
-            {
-                microbe.OnDeath -= UpdateLabelOnMicrobeDeath;
-            }
         }
     }
 

--- a/src/engine/DebugOverlays.EntityLabel.cs
+++ b/src/engine/DebugOverlays.EntityLabel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Godot;
 
 /// <summary>
@@ -150,10 +151,8 @@ public partial class DebugOverlays
 
     private void CleanEntityLabels()
     {
-        foreach (var label in entityLabels.Values)
-            label.DetachAndQueueFree();
-
-        entityLabels.Clear();
+        foreach (var entityLabelsKey in entityLabels.Keys.ToList())
+            OnNodeRemoved(entityLabelsKey.EntityNode);
 
         activeCamera = null;
 

--- a/src/engine/DebugOverlays.EntityLabel.cs
+++ b/src/engine/DebugOverlays.EntityLabel.cs
@@ -23,17 +23,17 @@ public partial class DebugOverlays
         }
     }
 
-    private void UpdateLabelColour(IEntity iEntity, Label label)
+    private void UpdateLabelColour(IEntity entity, Label label)
     {
-        var entity = iEntity.EntityNode;
+        var node = entity.EntityNode;
 
-        if (!iEntity.AliveMarker.Alive)
+        if (!entity.AliveMarker.Alive)
         {
             label.AddColorOverride("font_color", new Color(1.0f, 0.3f, 0.3f));
             return;
         }
 
-        switch (entity)
+        switch (node)
         {
             case Microbe microbe:
             {
@@ -79,19 +79,19 @@ public partial class DebugOverlays
 
         foreach (var pair in entityLabels)
         {
-            var iEntity = pair.Key;
-            var entity = iEntity.EntityNode;
+            var entity = pair.Key;
+            var node = entity.EntityNode;
             var label = pair.Value;
 
-            label.RectPosition = activeCamera.UnprojectPosition(entity.Transform.origin);
+            label.RectPosition = activeCamera.UnprojectPosition(node.Transform.origin);
 
-            UpdateLabelColour(iEntity, label);
+            UpdateLabelColour(entity, label);
 
             if (!label.Text.Empty())
                 continue;
 
             // Update names
-            switch (entity)
+            switch (node)
             {
                 case Microbe microbe:
                 {
@@ -112,7 +112,7 @@ public partial class DebugOverlays
 
                 default:
                 {
-                    label.Text = $"[{entity.Name}]";
+                    label.Text = $"[{node.Name}]";
                     break;
                 }
             }


### PR DESCRIPTION
Found a bug when testing engulfment revamp.

**NOTICE: Because the CallbackConverter.cs fails to handle static class callback, save will fail when you turn entity label on.**

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
