### PR TITLE
Spawn density fixes

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -24,7 +24,15 @@ public static class Constants
     /// </summary>
     public const float SPAWN_SECTOR_SIZE = 120.0f;
 
-    public const int CLOUD_SPAWN_SCALE_FACTOR = 10000;
+    /// <summary>
+    ///   Scale factor for density of compound cloud spawns
+    /// </summary>
+    public const int CLOUD_SPAWN_DENSITY_SCALE_FACTOR = 10000;
+
+    /// <summary>
+    ///   Scale factor for amount of compound in each spawned cloud
+    /// </summary>
+    public const float CLOUD_SPAWN_AMOUNT_SCALE_FACTOR = 0.25f;
 
     /// <summary>
     ///   The (default) size of the hexagons, used in calculations. Don't change this.

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -32,7 +32,7 @@ public static class Constants
     /// <summary>
     ///   Scale factor for amount of compound in each spawned cloud
     /// </summary>
-    public const float CLOUD_SPAWN_AMOUNT_SCALE_FACTOR = 0.25f;
+    public const float CLOUD_SPAWN_AMOUNT_SCALE_FACTOR = 0.75f;
 
     /// <summary>
     ///   The (default) size of the hexagons, used in calculations. Don't change this.

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -799,12 +799,12 @@ public static class Constants
     /// <summary>
     ///   Minimum amount for the quite a bit category in the hover info.
     /// </summary>
-    public const float COMPOUND_DENSITY_CATEGORY_QUITE_A_BIT = 400f;
+    public const float COMPOUND_DENSITY_CATEGORY_QUITE_A_BIT = 800f;
 
     /// <summary>
     ///   Minimum amount for the an abundance category in the hover info.
     /// </summary>
-    public const float COMPOUND_DENSITY_CATEGORY_AN_ABUNDANCE = 600f;
+    public const float COMPOUND_DENSITY_CATEGORY_AN_ABUNDANCE = 3000f;
 
     public const float PHOTO_STUDIO_CAMERA_FOV = 70;
     public const float PHOTO_STUDIO_CAMERA_HALF_ANGLE = PHOTO_STUDIO_CAMERA_FOV / 2.0f;

--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -326,8 +326,8 @@
             "averageTemperature": 98,
             "compounds": {
                 "ammonia": {
-                    "amount": 26000,
-                    "density": 0.0004,
+                    "amount": 300000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "glucose": {
@@ -336,8 +336,8 @@
                     "dissolved": 0
                 },
                 "phosphates": {
-                    "amount": 26000,
-                    "density": 0.0004,
+                    "amount": 300000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "hydrogensulfide": {
@@ -670,7 +670,7 @@
                             "convexShapePath": "res://assets/models/organelles/Rusticyanin.shape"
                         }
                     ],
-                    "density": 0.0002,
+                    "density": 0.0001,
                     "dissolves": true,
                     "radius": 1,
                     "chunkScale": 1,
@@ -1359,7 +1359,7 @@
                             "scenePath": "res://src/microbe_stage/ToxinCloud.tscn"
                         }
                     ],
-                    "density": 0.001,
+                    "density": 0.0001,
                     "dissolves": false,
                     "radius": 2,
                     "chunkScale": 1,
@@ -1390,7 +1390,7 @@
                             "convexShapePath": "res://assets/models/Iron4.shape"
                         }
                     ],
-                    "density": 0.0003,
+                    "density": 0.00003,
                     "dissolves": true,
                     "radius": 1,
                     "chunkScale": 1,
@@ -1413,7 +1413,7 @@
                             "convexShapePath": "res://assets/models/Iron5.shape"
                         }
                     ],
-                    "density": 0.0001,
+                    "density": 0.00001,
                     "dissolves": true,
                     "radius": 10,
                     "chunkScale": 1,
@@ -1504,7 +1504,7 @@
                             "scenePath": "res://src/microbe_stage/ToxinCloud.tscn"
                         }
                     ],
-                    "density": 0.0005,
+                    "density": 0.00005,
                     "dissolves": false,
                     "radius": 2,
                     "chunkScale": 1,
@@ -1535,7 +1535,7 @@
                             "convexShapePath": "res://assets/models/Iron4.shape"
                         }
                     ],
-                    "density": 0.0002,
+                    "density": 0.00002,
                     "dissolves": true,
                     "radius": 1,
                     "chunkScale": 1,
@@ -1558,7 +1558,7 @@
                             "convexShapePath": "res://assets/models/Iceshard1.shape"
                         }
                     ],
-                    "density": 0.002,
+                    "density": 0.0001,
                     "dissolves": false,
                     "radius": 1,
                     "chunkScale": 1,
@@ -1577,7 +1577,7 @@
                             "convexShapePath": "res://assets/models/Iron5.shape"
                         }
                     ],
-                    "density": 0.0002,
+                    "density": 0.00002,
                     "dissolves": true,
                     "radius": 10,
                     "chunkScale": 1,

--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -102,18 +102,18 @@
             "averageTemperature": 8,
             "compounds": {
                 "ammonia": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "glucose": {
-                    "amount": 250000,
-                    "density": 0.00002,
+                    "amount": 125000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "phosphates": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "hydrogensulfide": {
@@ -326,23 +326,23 @@
             "averageTemperature": 98,
             "compounds": {
                 "ammonia": {
-                    "amount": 300000,
-                    "density": 0.00004,
+                    "amount": 150000,
+                    "density": 0.00008,
                     "dissolved": 0
                 },
                 "glucose": {
-                    "amount": 250000,
-                    "density": 0.00002,
+                    "amount": 125000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "phosphates": {
-                    "amount": 300000,
-                    "density": 0.00004,
+                    "amount": 150000,
+                    "density": 0.00008,
                     "dissolved": 0
                 },
                 "hydrogensulfide": {
-                    "amount": 300000,
-                    "density": 0.00004,
+                    "amount": 150000,
+                    "density": 0.00008,
                     "dissolved": 0
                 },
                 "oxygen": {
@@ -471,18 +471,18 @@
             "averageTemperature": 23,
             "compounds": {
                 "ammonia": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "glucose": {
-                    "amount": 250000,
-                    "density": 0.00002,
+                    "amount": 125000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "phosphates": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "hydrogensulfide": {
@@ -695,18 +695,18 @@
             "averageTemperature": 4,
             "compounds": {
                 "ammonia": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "glucose": {
-                    "amount": 250000,
-                    "density": 0.00002,
+                    "amount": 125000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "phosphates": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "hydrogensulfide": {
@@ -919,18 +919,18 @@
             "averageTemperature": 2,
             "compounds": {
                 "ammonia": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "glucose": {
-                    "amount": 250000,
-                    "density": 0.00002,
+                    "amount": 125000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "phosphates": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "hydrogensulfide": {
@@ -1143,18 +1143,18 @@
             "averageTemperature": 2,
             "compounds": {
                 "ammonia": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "glucose": {
-                    "amount": 250000,
-                    "density": 0.00002,
+                    "amount": 125000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "phosphates": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "hydrogensulfide": {
@@ -1288,18 +1288,18 @@
             "averageTemperature": 17,
             "compounds": {
                 "ammonia": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "glucose": {
-                    "amount": 250000,
-                    "density": 0.00002,
+                    "amount": 125000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "phosphates": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "hydrogensulfide": {
@@ -1432,23 +1432,23 @@
             "averageTemperature": 23,
             "compounds": {
                 "ammonia": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "glucose": {
-                    "amount": 250000,
-                    "density": 0.00002,
+                    "amount": 125000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "phosphates": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "hydrogensulfide": {
-                    "amount": 225000,
-                    "density": 0.00002,
+                    "amount": 112500,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "oxygen": {
@@ -1596,18 +1596,18 @@
             "averageTemperature": -1,
             "compounds": {
                 "ammonia": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "glucose": {
-                    "amount": 250000,
-                    "density": 0.00002,
+                    "amount": 125000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "phosphates": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "hydrogensulfide": {
@@ -1741,18 +1741,18 @@
             "averageTemperature": 17,
             "compounds": {
                 "ammonia": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "glucose": {
-                    "amount": 250000,
-                    "density": 0.00002,
+                    "amount": 125000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "phosphates": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "hydrogensulfide": {
@@ -1965,18 +1965,18 @@
             "averageTemperature": 4,
             "compounds": {
                 "ammonia": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "glucose": {
-                    "amount": 250000,
-                    "density": 0.00002,
+                    "amount": 125000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "phosphates": {
-                    "amount": 200000,
-                    "density": 0.00002,
+                    "amount": 100000,
+                    "density": 0.00004,
                     "dissolved": 0
                 },
                 "hydrogensulfide": {

--- a/src/microbe_stage/BiomeConditions.cs
+++ b/src/microbe_stage/BiomeConditions.cs
@@ -28,15 +28,19 @@ public class BiomeConditions : ICloneable, ISaveLoadable
         foreach (var compound in Compounds)
         {
             if (compound.Value.Density * Constants.CLOUD_SPAWN_DENSITY_SCALE_FACTOR is < 0 or > 1)
+            {
                 throw new InvalidRegistryDataException(name, GetType().Name,
                     $"Density {compound.Value.Density} invalid for {compound.Key.InternalName}");
+            }
         }
 
         foreach (var chunk in Chunks)
         {
             if (chunk.Value.Density * Constants.CLOUD_SPAWN_DENSITY_SCALE_FACTOR is < 0 or > 1)
+            {
                 throw new InvalidRegistryDataException(name, GetType().Name,
                     $"Density {chunk.Value.Density} invalid for {chunk.Key}");
+            }
         }
     }
 

--- a/src/microbe_stage/BiomeConditions.cs
+++ b/src/microbe_stage/BiomeConditions.cs
@@ -24,6 +24,20 @@ public class BiomeConditions : ICloneable, ISaveLoadable
             throw new InvalidRegistryDataException(name, GetType().Name,
                 "Chunks missing");
         }
+
+        foreach (var compound in Compounds)
+        {
+            if (compound.Value.Density * Constants.CLOUD_SPAWN_DENSITY_SCALE_FACTOR is < 0 or > 1)
+                throw new InvalidRegistryDataException(name, GetType().Name,
+                    $"Density {compound.Value.Density} invalid for {compound.Key.InternalName}");
+        }
+
+        foreach (var chunk in Chunks)
+        {
+            if (chunk.Value.Density * Constants.CLOUD_SPAWN_DENSITY_SCALE_FACTOR is < 0 or > 1)
+                throw new InvalidRegistryDataException(name, GetType().Name,
+                    $"Density {chunk.Value.Density} invalid for {chunk.Key}");
+        }
     }
 
     public void Resolve(SimulationParameters parameters)

--- a/src/microbe_stage/BiomeConditions.cs
+++ b/src/microbe_stage/BiomeConditions.cs
@@ -30,7 +30,8 @@ public class BiomeConditions : ICloneable, ISaveLoadable
             if (compound.Value.Density * Constants.CLOUD_SPAWN_DENSITY_SCALE_FACTOR is < 0 or > 1)
             {
                 throw new InvalidRegistryDataException(name, GetType().Name,
-                    $"Density {compound.Value.Density} invalid for {compound.Key.InternalName}");
+                    $"Density {compound.Value.Density} invalid for {compound.Key} " +
+                    $"(scale factor is {Constants.CLOUD_SPAWN_DENSITY_SCALE_FACTOR})");
             }
         }
 
@@ -39,7 +40,8 @@ public class BiomeConditions : ICloneable, ISaveLoadable
             if (chunk.Value.Density * Constants.CLOUD_SPAWN_DENSITY_SCALE_FACTOR is < 0 or > 1)
             {
                 throw new InvalidRegistryDataException(name, GetType().Name,
-                    $"Density {chunk.Value.Density} invalid for {chunk.Key}");
+                    $"Density {chunk.Value.Density} invalid for {chunk.Key} " +
+                    $"(scale factor is {Constants.CLOUD_SPAWN_DENSITY_SCALE_FACTOR})");
             }
         }
     }

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -147,7 +147,7 @@ public class PatchManager : IChildPropertiesLoadCallback
                 {
                     var spawner = new CreatedSpawner(entry.Key.InternalName,
                         Spawners.MakeCompoundSpawner(entry.Key, compoundCloudSystem,
-                        entry.Value.Amount * Constants.CLOUD_SPAWN_AMOUNT_SCALE_FACTOR));
+                            entry.Value.Amount * Constants.CLOUD_SPAWN_AMOUNT_SCALE_FACTOR));
 
                     spawnSystem.AddSpawnType(spawner.Spawner,
                         entry.Value.Density * Constants.CLOUD_SPAWN_DENSITY_SCALE_FACTOR,

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -121,12 +121,14 @@ public class PatchManager : IChildPropertiesLoadCallback
 
         foreach (var entry in biome.Chunks)
         {
-            HandleSpawnHelper(chunkSpawners, entry.Value.Name, entry.Value.Density * Constants.CLOUD_SPAWN_SCALE_FACTOR,
+            HandleSpawnHelper(chunkSpawners, entry.Value.Name,
+                entry.Value.Density * Constants.CLOUD_SPAWN_DENSITY_SCALE_FACTOR,
                 () =>
                 {
                     var spawner = new CreatedSpawner(entry.Value.Name, Spawners.MakeChunkSpawner(entry.Value));
 
-                    spawnSystem.AddSpawnType(spawner.Spawner, entry.Value.Density * Constants.CLOUD_SPAWN_SCALE_FACTOR,
+                    spawnSystem.AddSpawnType(spawner.Spawner,
+                        entry.Value.Density * Constants.CLOUD_SPAWN_DENSITY_SCALE_FACTOR,
                         Constants.MICROBE_SPAWN_RADIUS);
                     return spawner;
                 });
@@ -140,13 +142,15 @@ public class PatchManager : IChildPropertiesLoadCallback
         foreach (var entry in biome.Compounds)
         {
             HandleSpawnHelper(cloudSpawners, entry.Key.InternalName,
-                entry.Value.Density * Constants.CLOUD_SPAWN_SCALE_FACTOR,
+                entry.Value.Density * Constants.CLOUD_SPAWN_DENSITY_SCALE_FACTOR,
                 () =>
                 {
                     var spawner = new CreatedSpawner(entry.Key.InternalName,
-                        Spawners.MakeCompoundSpawner(entry.Key, compoundCloudSystem, entry.Value.Amount));
+                        Spawners.MakeCompoundSpawner(entry.Key, compoundCloudSystem,
+                        entry.Value.Amount * Constants.CLOUD_SPAWN_AMOUNT_SCALE_FACTOR));
 
-                    spawnSystem.AddSpawnType(spawner.Spawner, entry.Value.Density * Constants.CLOUD_SPAWN_SCALE_FACTOR,
+                    spawnSystem.AddSpawnType(spawner.Spawner,
+                        entry.Value.Density * Constants.CLOUD_SPAWN_DENSITY_SCALE_FACTOR,
                         Constants.CLOUD_SPAWN_RADIUS);
                     return spawner;
                 });

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -169,7 +169,7 @@ public static class SpawnHelpers
         int resolution = Settings.Instance.CloudResolution;
 
         // Randomise amount of compound in the cloud a bit
-        amount *= random.Next(0.25f, 1);
+        amount *= random.Next(0.5f, 1);
 
         // This spreads out the cloud spawn a bit
         clouds.AddCloud(compound, amount, location + new Vector3(0 + resolution, 0, 0));

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -164,9 +164,12 @@ public static class SpawnHelpers
     }
 
     public static void SpawnCloud(CompoundCloudSystem clouds, Vector3 location,
-        Compound compound, float amount)
+        Compound compound, float amount, Random random)
     {
         int resolution = Settings.Instance.CloudResolution;
+
+        // Randomise amount of compound in the cloud a bit
+        amount *= random.Next(0.25f, 1);
 
         // This spreads out the cloud spawn a bit
         clouds.AddCloud(compound, amount, location + new Vector3(0 + resolution, 0, 0));
@@ -269,6 +272,7 @@ public class CompoundCloudSpawner : Spawner
     private readonly Compound compound;
     private readonly CompoundCloudSystem clouds;
     private readonly float amount;
+    private readonly Random random = new();
 
     public CompoundCloudSpawner(Compound compound, CompoundCloudSystem clouds, float amount)
     {
@@ -279,7 +283,7 @@ public class CompoundCloudSpawner : Spawner
 
     public override IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location)
     {
-        SpawnHelpers.SpawnCloud(clouds, location, compound, amount);
+        SpawnHelpers.SpawnCloud(clouds, location, compound, amount, random);
 
         // We don't spawn entities
         return null;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adjusts cloud spawning for balance and sensibility.

* Added validation to biome conditions to check we never create a spawner with density greater than 1.
* Cut cloud amount in half and doubled cloud density in every biome (relative to where these values were prior to the spawn system rework in the case of the vents).
* Added cloud amount constant to tweak amount of compounds in each cloud.
* Added some randomness in the amount of compounds in each cloud.

I've playtested this a fair bit and I think it's roughly balanced for normal difficulty. My intention was to create more clouds but have less compound amount in each cloud, as I feel this creates a more interesting way of playing than getting all the compounds you need from one cloud.

**Related Issues**

N/A

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
