### PR TITLE
Fix broken resulting MP calculation in cell editor

### DIFF
--- a/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -473,13 +473,13 @@ public partial class CellBodyPlanEditorComponent :
 
         if (MovingPlacedHex == null)
         {
-            moveOccupancies = GetMultiActionWithOccupancies(positions, cellTemplates, true);
+            moveOccupancies = GetMultiActionWithOccupancies(positions, cellTemplates, false);
         }
         else
         {
             moveOccupancies = GetMultiActionWithOccupancies(positions.Take(1).ToList(),
                 new List<HexWithData<CellTemplate>>
-                    { MovingPlacedHex }, false);
+                    { MovingPlacedHex }, true);
         }
 
         return Editor.WhatWouldActionsCost(moveOccupancies.Data);

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -752,8 +752,6 @@ public partial class CellEditorComponent :
                         RenderHighlightedOrganelle(finalQ, finalR, rotation, shownOrganelle);
                         hoveredHexes.Add((new Hex(finalQ, finalR), rotation));
                     }, effectiveSymmetry);
-
-                MouseHoverPositions = hoveredHexes.ToList();
             }
         }
     }

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -744,14 +744,9 @@ public partial class CellEditorComponent :
 
             if (shownOrganelle != null)
             {
-                HashSet<(Hex Hex, int Orientation)> hoveredHexes = new();
-
                 RunWithSymmetry(q, r,
-                    (finalQ, finalR, rotation) =>
-                    {
-                        RenderHighlightedOrganelle(finalQ, finalR, rotation, shownOrganelle);
-                        hoveredHexes.Add((new Hex(finalQ, finalR), rotation));
-                    }, effectiveSymmetry);
+                    (finalQ, finalR, rotation) => RenderHighlightedOrganelle(finalQ, finalR, rotation, shownOrganelle),
+                    effectiveSymmetry);
             }
         }
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

~Removed `MouseHoverPositions` overwrite in `CellEditorComponent._Process`, don't know why it's there? `CellBodyPlanEditorComponent` doesn't do that and yet its resulting MP is working, I figured that removing this one line should do the same and fix the problem and it does. I haven't yet found any issues from this change.~

https://github.com/Revolutionary-Games/Thrive/pull/3437#issuecomment-1159689346

**Related Issues**

Fixes #3397 

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
