### PR TITLE
Add proper glucose factor

### DIFF
--- a/src/general/NewGameSettings.cs
+++ b/src/general/NewGameSettings.cs
@@ -301,7 +301,7 @@ public class NewGameSettings : ControlWithInput
         OnAIMutationRateValueChanged(preset.AIMutationMultiplier);
         OnCompoundDensityValueChanged(preset.CompoundDensity);
         OnPlayerDeathPopulationPenaltyValueChanged(preset.PlayerDeathPopulationPenalty);
-        OnGlucoseDecayRateValueChanged(preset.GlucoseDecay);
+        OnGlucoseDecayRateValueChanged(preset.GlucoseDecay * 100);
         OnOsmoregulationMultiplierValueChanged(preset.OsmoregulationMultiplier);
         OnFreeGlucoseCloudToggled(preset.FreeGlucoseCloud);
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Discovered only after trying the devbuild that a last-minute change to the new game settings messed up how it displays glucose percentage. -_-

This fixes that, initialising the displayed value to 80% instead of 0.8%. The value used in gameplay isn't affected.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
