### PR TITLE
Rigidity slider no longer jumps to mouse

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -202,7 +202,7 @@ public partial class CellEditorComponent
 
     private void UpdateRigiditySliderState(int mutationPoints)
     {
-        Godot.Texture grabberDisableIcon = rigiditySlider.GetIcon("grabber_disabled");
+        Texture grabberDisableIcon = rigiditySlider.GetIcon("grabber_disabled");
 
         int costPerStep = (int)Math.Min(Constants.MEMBRANE_RIGIDITY_COST_PER_STEP * CostMultiplier, 100);
         if (mutationPoints >= costPerStep && MovingPlacedHex == null)

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -202,14 +202,18 @@ public partial class CellEditorComponent
 
     private void UpdateRigiditySliderState(int mutationPoints)
     {
+        Godot.Texture grabberDisableIcon = rigiditySlider.GetIcon("grabber_disabled");
+
         int costPerStep = (int)Math.Min(Constants.MEMBRANE_RIGIDITY_COST_PER_STEP * CostMultiplier, 100);
         if (mutationPoints >= costPerStep && MovingPlacedHex == null)
         {
-            rigiditySlider.Editable = true;
+            rigiditySlider.AddIconOverride("grabber", null);
+            rigiditySlider.AddIconOverride("grabber_highlight", null);
         }
         else
         {
-            rigiditySlider.Editable = false;
+            rigiditySlider.AddIconOverride("grabber", grabberDisableIcon);
+            rigiditySlider.AddIconOverride("grabber_highlight", grabberDisableIcon);
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

The PR changes the rigidity slider so that once it becomes locked at an edge, resetting it through a undo will no longer cause it to snap to the position of the mouse when the mouse is hovered.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

closes #1533

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
