### PR TITLE
Align cell body plan editor elements position with the rest of the editor components

### DIFF
--- a/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.tscn
+++ b/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.tscn
@@ -195,18 +195,15 @@ CellPopupMenuPath = NodePath("CellPopupMenu")
 
 [node name="LeftPanel" type="MarginContainer" parent="."]
 anchor_bottom = 1.0
-margin_top = 41.0
+margin_top = 40.0
 margin_right = 350.0
-margin_bottom = -49.0
+margin_bottom = -50.0
 rect_min_size = Vector2( 350, 0 )
 size_flags_horizontal = 4
 size_flags_vertical = 0
 custom_constants/margin_top = 5
 custom_constants/margin_left = 10
 custom_constants/margin_bottom = 5
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="MainPanel" type="PanelContainer" parent="LeftPanel"]
 margin_left = 10.0
@@ -488,6 +485,7 @@ margin_top = 40.0
 FinishOrNextButtonPath = NodePath("")
 
 [node name="EditorComponentBottomLeftButtons" parent="." instance=ExtResource( 13 )]
+margin_right = 641.0
 ShowNewButton = false
 
 [node name="BottomRight" type="MarginContainer" parent="."]
@@ -499,9 +497,6 @@ margin_right = -10.0
 margin_bottom = -10.0
 grow_horizontal = 0
 grow_vertical = 0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="HBoxContainer" type="HBoxContainer" parent="BottomRight"]
 margin_right = 150.0

--- a/src/microbe_stage/editor/CellEditorComponent.tscn
+++ b/src/microbe_stage/editor/CellEditorComponent.tscn
@@ -623,10 +623,10 @@ size_flags_horizontal = 3
 custom_styles/separator = SubResource( 16 )
 
 [node name="TweakedColourPicker" parent="LeftPanel/MainPanel/VBoxContainer/MarginContainer/EditingPanel/Membrane/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer2" instance=ExtResource( 43 )]
-margin_left = 200.0
-margin_top = 225.0
-margin_right = 516.0
-margin_bottom = 815.0
+margin_left = 204.0
+margin_top = 229.0
+margin_right = 520.0
+margin_bottom = 819.0
 RawButtonEnabled = false
 
 [node name="Behaviour" parent="LeftPanel/MainPanel/VBoxContainer/MarginContainer/EditingPanel" instance=ExtResource( 14 )]
@@ -1199,19 +1199,20 @@ mouse_filter = 1
 custom_styles/separator = SubResource( 6 )
 
 [node name="EditorComponentBottomLeftButtons" parent="." instance=ExtResource( 3 )]
+margin_top = -53.0
+margin_right = 641.0
 
 [node name="BottomRight" type="MarginContainer" parent="."]
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
+margin_left = -160.0
+margin_top = -49.0
 margin_right = -10.0
-margin_bottom = -10.0
+margin_bottom = -9.0
 grow_horizontal = 0
 grow_vertical = 0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="HBoxContainer" type="HBoxContainer" parent="BottomRight"]
 margin_right = 150.0


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes this (OCD inducing) nonaligment:

https://user-images.githubusercontent.com/54026083/176371216-701f208f-54e1-409f-9226-f58875ac9789.mp4

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
