### PR TITLE
Fix cell preview getting stuck in multicell editor

### DIFF
--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
@@ -311,6 +311,11 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
 
             case EditorTab.CellEditor:
             {
+                // If we have an edited cell type, then we can apply those changes when we go back to the main editor
+                // tab as that's the only exit point and the point where we actually need to use the edited cell
+                // type information
+                CheckAndApplyCellTypeEdit();
+
                 bodyPlanEditorTab.Show();
                 SetEditorObjectVisibility(true);
                 cellEditorTab.SetEditorWorldTabSpecificObjectVisibility(false);
@@ -320,11 +325,6 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
                 // This line (and also in CellTypeEditor) doesn't help:
                 bodyPlanEditorTab.UpdateArrow();
                 bodyPlanEditorTab.UpdateCamera();
-
-                // If we have an edited cell type, then we can apply those changes when we go back to the main editor
-                // tab as that's the only exit point and the point where we actually need to use the edited cell
-                // type information
-                CheckAndApplyCellTypeEdit();
 
                 break;
             }


### PR DESCRIPTION
**Brief Description of What This PR Does**

A simple fix by calling `CheckAndApplyCellTypeEdit` earlier before setting specific editor world tab object visibility.

**Related Issues**

Fixes #3368 

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
