### PR TITLE
Cloud brightness multiplier fix

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -296,6 +296,9 @@ public class MicrobeStage : NodeWithInput, IReturnableGameState, IGodotEarlyNode
     // Also begins a new game if one hasn't been started yet for easier debugging
     public void SetupStage()
     {
+        // Initialise the cloud system first so we can apply patch-specific brightness in OnGameStarted
+        Clouds.Init(FluidSystem);
+
         if (!IsLoadedFromSave)
         {
             spawner.Init();
@@ -317,8 +320,6 @@ public class MicrobeStage : NodeWithInput, IReturnableGameState, IGodotEarlyNode
         tutorialGUI.EventReceiver = TutorialState;
 
         HUD.SendEditorButtonToTutorial(TutorialState);
-
-        Clouds.Init(FluidSystem);
 
         // If this is a new game, place some phosphates as a learning tool
         if (!IsLoadedFromSave)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes the cloud brightness multiplier affect cloud brightness, since it stopped working at some point.

I'm considering also upping the brightness for the surface patches as part of this PR, but I'll wait for input from testing first to see whether people think this alone is enough.

**Related Issues**

Closes https://github.com/Revolutionary-Games/Thrive/issues/3468

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
