### PR TITLE
Clear `attemptingToEngulf` from old entries in places where it should be warranted

### DIFF
--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -1092,6 +1092,10 @@ public partial class Microbe
                 State = MicrobeState.Normal;
             }
         }
+        else
+        {
+            attemptingToEngulf.Clear();
+        }
 
         // Play sound
         if (State == MicrobeState.Engulf)
@@ -1157,7 +1161,11 @@ public partial class Microbe
 
             var body = engulfable as RigidBody;
             if (body == null)
+            {
+                attemptingToEngulf.Remove(engulfable);
+                engulfedObjects.Remove(engulfedObject);
                 continue;
+            }
 
             body.Mode = ModeEnum.Static;
 
@@ -1399,6 +1407,8 @@ public partial class Microbe
 
             // TODO: should this also check for pilus before removing the collision?
             hitMicrobe.touchedEntities.Remove(engulfable);
+
+            hitMicrobe.attemptingToEngulf.Remove(engulfable);
         }
     }
 
@@ -1526,6 +1536,8 @@ public partial class Microbe
         {
             return;
         }
+
+        attemptingToEngulf.Remove(target);
 
         var body = target as RigidBody;
         if (body == null)


### PR DESCRIPTION
**Brief Description of What This PR Does**

I think clearing it from these places is enough, especially clearing all when engulfing mode is stopped, the old code does it in similar way. Need testing.

**Related Issues**

Fixes #3474 

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
