### PR TITLE
Use local population for microbe spawns

### DIFF
--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -181,6 +181,7 @@ public class PatchManager : IChildPropertiesLoadCallback
         foreach (var entry in patch.SpeciesInPatch.OrderByDescending(entry => entry.Value))
         {
             var species = entry.Key;
+            var population = entry.Value;
 
             if (species.Population <= 0)
             {
@@ -194,7 +195,7 @@ public class PatchManager : IChildPropertiesLoadCallback
                 continue;
             }
 
-            var density = Mathf.Max(Mathf.Log(species.Population / 50.0f) * 0.01f, 0.0f);
+            var density = Mathf.Max(Mathf.Log(population / 25.0f) * 0.01f, 0.0f);
 
             var name = species.ID.ToString(CultureInfo.InvariantCulture);
 

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -183,7 +183,7 @@ public class PatchManager : IChildPropertiesLoadCallback
             var species = entry.Key;
             var population = entry.Value;
 
-            if (species.Population <= 0)
+            if (population <= 0)
             {
                 GD.Print(entry.Key.FormattedName, " population <= 0. Skipping Cell Spawn in patch.");
                 continue;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Use local rather than global population to determine microbe species spawn densities.

A bug that somehow slipped under everyone's noses for several years. This explains why the player species always seemed to have such a high spawn rate. This change will also mean the player species (other than the player cell and its daughter) won't spawn if the player moves to a patch they haven't yet colonised.

@buckly90 This may need a balancing pass. I picked 25 as the divisor, but there's not a lot of reasoning behind it. It needs to be less than 50 (otherwise the player species won't spawn for the next generation as well) and I went a fair bit lower to cancel out the reduction in spawn rate caused by using local rather than global populations.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
