### PR TITLE
Prevent multiple new game and exit game executions

### DIFF
--- a/src/general/NewGameSettings.cs
+++ b/src/general/NewGameSettings.cs
@@ -406,9 +406,6 @@ public class NewGameSettings : ControlWithInput
     {
         GUICommon.Instance.PlayButtonPressSound();
 
-        // Disable the button to prevent it being executed again.
-        confirmButton.Disabled = true;
-
         settings.Difficulty = SimulationParameters.Instance.GetDifficultyPresetByIndex(difficultyPresetButton.Selected);
         settings.Origin = (WorldGenerationSettings.LifeOrigin)lifeOriginButton.Selected;
         settings.LAWK = lawkButton.Pressed;
@@ -454,6 +451,9 @@ public class NewGameSettings : ControlWithInput
             microbeStage.CurrentGame = GameProperties.StartNewMicrobeGame(settings);
             SceneManager.Instance.SwitchToScene(microbeStage);
         });
+
+        // Disable the button to prevent it being executed again.
+        confirmButton.Disabled = true;
     }
 
     private void OnDifficultyPresetSelected(int index)

--- a/src/general/PauseMenu.cs
+++ b/src/general/PauseMenu.cs
@@ -49,6 +49,8 @@ public class PauseMenu : CustomDialog
     /// </summary>
     private ExitType exitType;
 
+    private bool exiting;
+
     [Signal]
     public delegate void OnResumed();
 
@@ -260,6 +262,7 @@ public class PauseMenu : CustomDialog
 
         animationPlayer.Play("Open");
         Paused = true;
+        exiting = false;
     }
 
     public void Close()
@@ -357,6 +360,11 @@ public class PauseMenu : CustomDialog
 
     private void ConfirmExit()
     {
+        if (exiting)
+            return;
+
+        exiting = true;
+
         switch (exitType)
         {
             case ExitType.ReturnToMenu:


### PR DESCRIPTION
**Brief Description of What This PR Does**

New game settings confirm button has a bug where it's not disabled once you press it, this is due to it being enabled again afterwards by a method call, reordering things fixed it. Also applied similar fix to the pause menu where exiting the game can be executed multiple times, this added a check to prevent that.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
