### PR TITLE
Fix various MP costs shown incorrectly in editors

### DIFF
--- a/src/early_multicellular_stage/editor/CellPopupMenu.cs
+++ b/src/early_multicellular_stage/editor/CellPopupMenu.cs
@@ -71,7 +71,6 @@ public class CellPopupMenu : HexPopupMenu
             throw new ArgumentException($"{nameof(GetActionPrice)} not set");
 
         var mpLabel = deleteButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
-        mpCost = (int)(mpCost * editorCostFactor);
 
         mpLabel.Text = new LocalizedString("MP_COST", -mpCost).ToString();
 
@@ -88,7 +87,6 @@ public class CellPopupMenu : HexPopupMenu
                 0))) ?? throw new ArgumentException($"{nameof(GetActionPrice)} not set");
 
         var mpLabel = moveButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
-        mpCost = (int)(mpCost * editorCostFactor);
 
         mpLabel.Text = new LocalizedString("MP_COST", -mpCost).ToString();
 

--- a/src/late_multicellular_stage/editor/MetaballBodyEditorComponent.cs
+++ b/src/late_multicellular_stage/editor/MetaballBodyEditorComponent.cs
@@ -795,7 +795,7 @@ public partial class MetaballBodyEditorComponent :
                 control.Connect(nameof(MicrobePartSelection.OnPartSelected), this, nameof(OnCellToPlaceSelected));
             }
 
-            control.MPCost = cellType.MPCost;
+            control.MPCost = Constants.METABALL_ADD_COST;
 
             // TODO: tooltips for these
         }

--- a/src/late_multicellular_stage/editor/MetaballPopupMenu.cs
+++ b/src/late_multicellular_stage/editor/MetaballPopupMenu.cs
@@ -71,7 +71,6 @@ public class MetaballPopupMenu : HexPopupMenu
             throw new ArgumentException($"{nameof(GetActionPrice)} not set");
 
         var mpLabel = deleteButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
-        mpCost = (int)(mpCost * editorCostFactor);
 
         mpLabel.Text = new LocalizedString("MP_COST", -mpCost).ToString();
 
@@ -89,7 +88,6 @@ public class MetaballPopupMenu : HexPopupMenu
                 o.Parent, null))) ?? throw new ArgumentException($"{nameof(GetActionPrice)} not set");
 
         var mpLabel = moveButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
-        mpCost = (int)(mpCost * editorCostFactor);
 
         mpLabel.Text = new LocalizedString("MP_COST", -mpCost).ToString();
 

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -392,14 +392,14 @@ public partial class CellEditorComponent
         foreach (var entry in placeablePartSelectionElements)
         {
             entry.Value.PartName = entry.Key.Name;
-            entry.Value.MPCost = entry.Key.MPCost;
+            entry.Value.MPCost = (int)(entry.Key.MPCost * CostMultiplier);
             entry.Value.PartIcon = entry.Key.LoadedIcon;
         }
 
         foreach (var entry in membraneSelectionElements)
         {
             entry.Value.PartName = entry.Key.Name;
-            entry.Value.MPCost = entry.Key.EditorCost;
+            entry.Value.MPCost = (int)(entry.Key.EditorCost * CostMultiplier);
             entry.Value.PartIcon = entry.Key.LoadedIcon;
         }
     }

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -218,56 +218,43 @@ public partial class CellEditorComponent
     }
 
     /// <summary>
-    ///   Updates the MP costs for organelle, membrane, and rigidity button lists and tooltips
+    ///   Updates the MP costs for organelle, membrane, and rigidity button lists and tooltips. Taking into account
+    ///   MP cost factor.
     /// </summary>
-    private void UpdateMPCostFactors()
+    private void UpdateMPCost()
     {
         // Set the cost factor for each organelle button
         foreach (var entry in placeablePartSelectionElements)
         {
-            entry.Value.MPCost = (int)Math.Min(entry.Value.MPCost * CostMultiplier, 100);
+            var cost = (int)Math.Min(entry.Key.MPCost * CostMultiplier, 100);
+
+            entry.Value.MPCost = cost;
+
+            // Set the cost factor for each organelle tooltip
+            var tooltip = GetSelectionTooltip(entry.Key.InternalName, "organelleSelection");
+            if (tooltip != null)
+                tooltip.MutationPointCost = cost;
         }
 
         // Set the cost factor for each membrane button
         foreach (var entry in membraneSelectionElements)
         {
-            entry.Value.MPCost = (int)Math.Min(entry.Value.MPCost * CostMultiplier, 100);
-        }
+            var cost = (int)Math.Min(entry.Key.EditorCost * CostMultiplier, 100);
 
-        // Set the cost factor for each organelle tooltip
-        var organelleNames = SimulationParameters.Instance.GetAllOrganelles().Select(o => o.InternalName);
-        foreach (string name in organelleNames)
-        {
-            if (name == protoplasm.InternalName)
-                continue;
+            entry.Value.MPCost = cost;
 
-            var tooltip = GetSelectionTooltip(name, "organelleSelection");
+            // Set the cost factor for each membrane tooltip
+            var tooltip = GetSelectionTooltip(entry.Key.InternalName, "membraneSelection");
             if (tooltip != null)
-            {
-                tooltip.EditorCostFactor = editorCostFactor;
-                tooltip.MutationPointCost = (int)Math.Min(tooltip.MutationPointCost * CostMultiplier, 100);
-            }
-        }
-
-        // Set the cost factor for each membrane tooltip
-        var membraneNames = SimulationParameters.Instance.GetAllMembranes().Select(m => m.InternalName);
-        foreach (var name in membraneNames)
-        {
-            var tooltip = GetSelectionTooltip(name, "membraneSelection");
-            if (tooltip != null)
-            {
-                tooltip.EditorCostFactor = editorCostFactor;
-                tooltip.MutationPointCost = (int)Math.Min(tooltip.MutationPointCost * CostMultiplier, 100);
-            }
+                tooltip.MutationPointCost = cost;
         }
 
         // Set the cost factor for the rigidity tooltip
         var rigidityTooltip = GetSelectionTooltip("rigiditySlider", "editor");
         if (rigidityTooltip != null)
         {
-            rigidityTooltip.EditorCostFactor = editorCostFactor;
-            rigidityTooltip.MutationPointCost =
-                (int)Math.Min(rigidityTooltip.MutationPointCost * CostMultiplier, 100);
+            rigidityTooltip.MutationPointCost = (int)Math.Min(
+                Constants.MEMBRANE_RIGIDITY_COST_PER_STEP * CostMultiplier, 100);
         }
     }
 
@@ -405,14 +392,14 @@ public partial class CellEditorComponent
         foreach (var entry in placeablePartSelectionElements)
         {
             entry.Value.PartName = entry.Key.Name;
-            entry.Value.MPCost = (int)(entry.Key.MPCost * editorCostFactor);
+            entry.Value.MPCost = entry.Key.MPCost;
             entry.Value.PartIcon = entry.Key.LoadedIcon;
         }
 
         foreach (var entry in membraneSelectionElements)
         {
             entry.Value.PartName = entry.Key.Name;
-            entry.Value.MPCost = (int)(entry.Key.EditorCost * editorCostFactor);
+            entry.Value.MPCost = entry.Key.EditorCost;
             entry.Value.PartIcon = entry.Key.LoadedIcon;
         }
     }

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -199,11 +199,6 @@ public partial class CellEditorComponent :
     private OrganelleDefinition nucleus = null!;
     private OrganelleDefinition bindingAgent = null!;
 
-    /// <summary>
-    ///   Controls MP discounts (for multicellular)
-    /// </summary>
-    private float editorCostFactor = 1.0f;
-
     private EnergyBalanceInfo? energyBalanceInfo;
 
     private string? bestPatchName;
@@ -499,10 +494,6 @@ public partial class CellEditorComponent :
 
         if (IsMulticellularEditor)
         {
-            editorCostFactor = Constants.MULTICELLULAR_EDITOR_COST_FACTOR;
-            organelleMenu.EditorCostFactor = editorCostFactor;
-            UpdateMicrobePartSelections();
-
             componentBottomLeftButtons.HandleRandomSpeciesName = false;
             componentBottomLeftButtons.UseSpeciesNameValidation = false;
 
@@ -520,7 +511,7 @@ public partial class CellEditorComponent :
 
         // After the if multicellular check so the tooltip cost factors are correct
         // on changing editor types, as tooltip manager is persistent while the game is running
-        UpdateMPCostFactors();
+        UpdateMPCost();
 
         UpdateOrganelleUnlockTooltips();
 
@@ -860,8 +851,7 @@ public partial class CellEditorComponent :
         if (intRigidity == rigidity)
             return;
 
-        int costPerStep = (int)Math.Min(Constants.MEMBRANE_RIGIDITY_COST_PER_STEP *
-            editorCostFactor * CostMultiplier, 100);
+        int costPerStep = (int)Math.Min(Constants.MEMBRANE_RIGIDITY_COST_PER_STEP * CostMultiplier, 100);
         int cost = Math.Abs(rigidity - intRigidity) * costPerStep;
 
         if (cost > Editor.MutationPoints)
@@ -975,7 +965,7 @@ public partial class CellEditorComponent :
         var organelleDefinition = SimulationParameters.Instance.GetOrganelleType(ActiveActionName!);
 
         // Calculated in this order to be consistent with placing unique organelles
-        var cost = (int)Math.Min(organelleDefinition.MPCost * editorCostFactor * CostMultiplier, 100);
+        var cost = (int)Math.Min(organelleDefinition.MPCost * CostMultiplier, 100);
 
         if (MouseHoverPositions == null)
             return cost * Symmetry.PositionCount();
@@ -1843,7 +1833,7 @@ public partial class CellEditorComponent :
             control.PartIcon = organelle.LoadedIcon ?? throw new Exception("Organelle with no icon");
             control.PartName = organelle.UntranslatedName;
             control.SelectionGroup = organelleButtonGroup;
-            control.MPCost = (int)(organelle.MPCost * editorCostFactor);
+            control.MPCost = organelle.MPCost;
             control.Name = organelle.InternalName;
 
             // Special case with registering the tooltip here for item with no associated organelle
@@ -1868,7 +1858,7 @@ public partial class CellEditorComponent :
             control.PartIcon = membraneType.LoadedIcon;
             control.PartName = membraneType.UntranslatedName;
             control.SelectionGroup = membraneButtonGroup;
-            control.MPCost = (int)(membraneType.EditorCost * editorCostFactor);
+            control.MPCost = membraneType.EditorCost;
             control.Name = membraneType.InternalName;
 
             control.RegisterToolTipForControl(membraneType.InternalName, "membraneSelection");

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -440,7 +440,6 @@ public partial class CellEditorComponent :
             GD.Load<PackedScene>("res://src/microbe_stage/editor/MicrobePartSelection.tscn");
 
         SetupMicrobePartSelections();
-        UpdateMicrobePartSelections();
 
         ApplySelectionMenuTab();
         RegisterTooltips();
@@ -508,6 +507,8 @@ public partial class CellEditorComponent :
             behaviourTabButton.Visible = false;
             behaviourEditor.Visible = false;
         }
+
+        UpdateMicrobePartSelections();
 
         // After the if multicellular check so the tooltip cost factors are correct
         // on changing editor types, as tooltip manager is persistent while the game is running
@@ -1808,6 +1809,10 @@ public partial class CellEditorComponent :
     /// <summary>
     ///   Creates part and membrane selection buttons
     /// </summary>
+    /// <remarks>
+    ///   This doesn't multiply the shown MP Cost by the cost factor as this is called much earlier before editor is
+    ///   initialized proper, for that use <see cref="UpdateMicrobePartSelections"/> or <see cref="UpdateMPCost"/>.
+    /// </remarks>
     private void SetupMicrobePartSelections()
     {
         var simulationParameters = SimulationParameters.Instance;

--- a/src/microbe_stage/editor/HexPopupMenu.cs
+++ b/src/microbe_stage/editor/HexPopupMenu.cs
@@ -24,8 +24,6 @@ public abstract class HexPopupMenu : PopupPanel
     protected Button? moveButton;
     protected Button? modifyButton;
 
-    protected float editorCostFactor = 1.0f;
-
     private bool showPopup;
     private bool enableDelete = true;
     private bool enableMove = true;
@@ -41,12 +39,6 @@ public abstract class HexPopupMenu : PopupPanel
 
     [Signal]
     public delegate void ModifyPressed();
-
-    public float EditorCostFactor
-    {
-        get => editorCostFactor;
-        set => editorCostFactor = value;
-    }
 
     public Func<IEnumerable<EditorCombinableActionData>, int>? GetActionPrice { get; set; }
 

--- a/src/microbe_stage/editor/OrganellePopupMenu.cs
+++ b/src/microbe_stage/editor/OrganellePopupMenu.cs
@@ -77,7 +77,6 @@ public class OrganellePopupMenu : HexPopupMenu
             throw new ArgumentException($"{nameof(GetActionPrice)} not set");
 
         var mpLabel = deleteButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
-        mpCost = (int)(mpCost * editorCostFactor);
 
         mpLabel.Text = new LocalizedString("MP_COST", -mpCost).ToString();
 
@@ -98,7 +97,6 @@ public class OrganellePopupMenu : HexPopupMenu
             })) ?? throw new ArgumentException($"{nameof(GetActionPrice)} not set");
 
         var mpLabel = moveButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
-        mpCost = (int)(mpCost * editorCostFactor);
 
         mpLabel.Text = new LocalizedString("MP_COST", -mpCost).ToString();
 

--- a/src/microbe_stage/editor/tooltips/SelectionMenuToolTip.cs
+++ b/src/microbe_stage/editor/tooltips/SelectionMenuToolTip.cs
@@ -52,7 +52,6 @@ public class SelectionMenuToolTip : Control, ICustomToolTip
     private string processesDescription = string.Empty;
     private int mpCost;
     private bool requiresNucleus;
-    private float editorCostFactor = 1.0f;
 
     [Export]
     public string DisplayName
@@ -124,17 +123,6 @@ public class SelectionMenuToolTip : Control, ICustomToolTip
         {
             requiresNucleus = value;
             UpdateRequiresNucleus();
-        }
-    }
-
-    [Export]
-    public float EditorCostFactor
-    {
-        get => editorCostFactor;
-        set
-        {
-            editorCostFactor = value;
-            UpdateMpCost();
         }
     }
 
@@ -325,7 +313,7 @@ public class SelectionMenuToolTip : Control, ICustomToolTip
         if (mpLabel == null)
             return;
 
-        mpLabel.Text = ((int)(mpCost * editorCostFactor)).ToString(CultureInfo.CurrentCulture);
+        mpLabel.Text = mpCost.ToString(CultureInfo.CurrentCulture);
     }
 
     private void UpdateRequiresNucleus()


### PR DESCRIPTION
**Brief Description of What This PR Does**

The code used to display MP cost multiplied by the cost factor to the editor elements was completely broken and funnily enough the cost shown on the parts tooltip decreased every editor cycle.

This refactored the logic quite a bit. Removes obsolete `editorCostMpFactor` fields and properties in favor of the new `CostMultiplier` property, changed shown MP costs to not multiply itself by the cost factor so that it won't decrease every editor cycle, also fixed incorrect MP cost shown for placing metaball in late multicell editor as 15 MP (should be 7 MP).

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
