### PR TITLE
Flip the `moving` boolean in MetaballBodyEditorComponent's current action cost calculation

### DIFF
--- a/src/late_multicellular_stage/editor/MetaballBodyEditorComponent.cs
+++ b/src/late_multicellular_stage/editor/MetaballBodyEditorComponent.cs
@@ -383,12 +383,12 @@ public partial class MetaballBodyEditorComponent :
 
         if (MovingPlacedMetaball == null)
         {
-            moveOccupancies = GetMultiActionWithOccupancies(positions, cellTemplates, true);
+            moveOccupancies = GetMultiActionWithOccupancies(positions, cellTemplates, false);
         }
         else
         {
             moveOccupancies = GetMultiActionWithOccupancies(positions.Take(1).ToList(),
-                new List<MulticellularMetaball> { MovingPlacedMetaball }, false);
+                new List<MulticellularMetaball> { MovingPlacedMetaball }, true);
         }
 
         return Editor.WhatWouldActionsCost(moveOccupancies.Data);


### PR DESCRIPTION
**Brief Description of What This PR Does**

I noticed the late multicell editor component still has it incorrectly flipped. This reapplies the similar fix done to the preceding editor components a while ago #3437. No noticeable difference before and after this change for some reason but still, a logic error should be fixed.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
