### PR TITLE
Make population indicator for the microbe HUD show local population instead of global

### DIFF
--- a/src/general/StageHUDBase.cs
+++ b/src/general/StageHUDBase.cs
@@ -837,7 +837,7 @@ public abstract class StageHUDBase<TStage> : Control, IStageHUD
     protected void UpdatePopulation()
     {
         var playerSpecies = stage!.GameWorld.PlayerSpecies;
-        populationLabel.Text = stage!.GameWorld.Map.CurrentPatch!.GetSpeciesPopulation(playerSpecies).FormatNumber();
+        populationLabel.Text = stage.GameWorld.Map.CurrentPatch!.GetSpeciesPopulation(playerSpecies).FormatNumber();
     }
 
     /// <summary>

--- a/src/general/StageHUDBase.cs
+++ b/src/general/StageHUDBase.cs
@@ -836,7 +836,8 @@ public abstract class StageHUDBase<TStage> : Control, IStageHUD
 
     protected void UpdatePopulation()
     {
-        populationLabel.Text = stage!.GameWorld.PlayerSpecies.Population.FormatNumber();
+        var playerSpecies = stage!.GameWorld.PlayerSpecies;
+        populationLabel.Text = stage!.GameWorld.Map.CurrentPatch!.GetSpeciesPopulation(playerSpecies).FormatNumber();
     }
 
     /// <summary>


### PR DESCRIPTION
**Brief Description of What This PR Does**

With patchwide population system merged, there now needs to be some way for the player to know how much population the player has (read: how many lives left) in a certain patch before they get kicked out. The population indicator can fulfil this role both as a local and global extinction indicator. 

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
