### PR TITLE
Make patch map panning not use tweening

### DIFF
--- a/src/gui_common/DraggableScrollContainer.cs
+++ b/src/gui_common/DraggableScrollContainer.cs
@@ -40,7 +40,7 @@ public class DraggableScrollContainer : ScrollContainer
     private Int2 lastScrollValues;
 
     [Export]
-    public float DragSensitivity { get; set; } = 3.5f;
+    public float DragSensitivity { get; set; } = 1.0f;
 
     [Export]
     public float MaxZoom { get; set; } = 2.5f;
@@ -138,7 +138,7 @@ public class DraggableScrollContainer : ScrollContainer
             // vice versa.
             var scaleInverse = 1 / contentScale;
 
-            Pan(new Vector2(
+            ImmediatePan(new Vector2(
                 ScrollHorizontal - (int)(motion.Relative.x * scaleInverse) * DragSensitivity,
                 ScrollVertical - (int)(motion.Relative.y * scaleInverse) * DragSensitivity));
         }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Using tween for dragging make the panning speed feels a bit off. I think not using tweening makes it feel better and more controllable.

Extra point if this somehow fix issue #3484 

does in fact fixes #3484 

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
