### PR TITLE
Fixed auto-evo being permanently stuck with no player population and too harsh patch extinction penalty

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -439,7 +439,7 @@ public static class Constants
     public const int PLAYER_REPRODUCTION_POPULATION_GAIN_CONSTANT = 50;
     public const float PLAYER_REPRODUCTION_POPULATION_GAIN_COEFFICIENT = 1.2f;
     public const int PLAYER_PATCH_EXTINCTION_POPULATION_LOSS_CONSTANT = -35;
-    public const float PLAYER_PATCH_EXTINCTION_POPULATION_LOSS_COEFFICIENT = 1 / 2.0f;
+    public const float PLAYER_PATCH_EXTINCTION_POPULATION_LOSS_COEFFICIENT = 1 / 1.2f;
 
     /// <summary>
     ///   How often a microbe can get the engulf escape population bonus

--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -415,6 +415,12 @@ public class AutoEvoRun
         steps.Enqueue(new LambdaStep(
             result =>
             {
+                if (!result.SpeciesHasResults(playerSpecies))
+                {
+                    GD.Print("Player species has no auto-evo results, creating blank results to avoid problems");
+                    result.AddPlayerSpeciesBlankResult(playerSpecies, map.Patches.Values);
+                }
+
                 foreach (var entry in map.Patches)
                 {
                     var resultPopulation = result.GetPopulationInPatchIfExists(playerSpecies, entry.Value);

--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -228,7 +228,8 @@ public class AutoEvoRun
                 {
                     // It's possible for external effects to be added for extinct species (either completely extinct
                     // or extinct in the current patch)
-                    if (!results.SpeciesHasResults(entry.Species))
+                    // We ignore this for player to give the player's reproduction bonus the ability to rescue them
+                    if (!results.SpeciesHasResults(entry.Species) && !entry.Species.PlayerSpecies)
                     {
                         GD.Print("Extinct species ", entry.Species.FormattedIdentifier,
                             " had an external effect, ignoring the effect");

--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -191,6 +191,45 @@
             }
         }
 
+        /// <summary>
+        ///   Creates a blank results for the player species
+        /// </summary>
+        /// <param name="playerSpecies">The player species</param>
+        /// <param name="patchesToFillResultsFor">
+        ///   Patches to add results for if the species is missing from results. All patches in the used map need
+        ///   to be included here, otherwise population counting will throw an exception later.
+        /// </param>
+        /// <exception cref="ArgumentException">If species is not valid</exception>
+        /// <remarks>
+        ///   <para>
+        ///     When the player has 0 global population, but has not lost the game due to making it to the editor,
+        ///     the player species wouldn't have any results, but as that breaks a lot of stuff we need to create blank
+        ///     results for the player in that case. <see cref="AutoEvoRun.AddPlayerSpeciesPopulationChangeClampStep"/>
+        ///     handles calling this.
+        ///   </para>
+        /// </remarks>
+        public void AddPlayerSpeciesBlankResult(Species playerSpecies, IEnumerable<Patch> patchesToFillResultsFor)
+        {
+            if (!playerSpecies.PlayerSpecies)
+                throw new ArgumentException("Species must be player species");
+
+            lock (results)
+            {
+                if (results.ContainsKey(playerSpecies))
+                    return;
+
+                var result = new SpeciesResult(playerSpecies);
+
+                // All patches need to have a population result for population counting to work
+                foreach (var patch in patchesToFillResultsFor)
+                {
+                    result.NewPopulationInPatches[patch] = 0;
+                }
+
+                results[playerSpecies] = result;
+            }
+        }
+
         public void ApplyResults(GameWorld world, bool skipMutations)
         {
             foreach (var entry in results)

--- a/src/general/GameWorld.cs
+++ b/src/general/GameWorld.cs
@@ -294,11 +294,16 @@ public class GameWorld : ISaveLoadable
     public void AlterSpeciesPopulation(Species species, int constant, string description, Patch patch,
         bool immediate = false, float coefficient = 1)
     {
-        if (constant == 0 || coefficient == 0)
+        // It sort of makes sense to allow 0 coefficient to force population to 0, that's why this check is here
+        // now if this effect would do nothing, then it is skipped
+        if (constant == 0 && Math.Abs(coefficient - 1) < MathUtils.EPSILON)
             return;
 
         if (species == null)
             throw new ArgumentException("species is null");
+
+        if (coefficient < 0)
+            throw new ArgumentException("coefficient may not be negative");
 
         if (string.IsNullOrEmpty(description))
             throw new ArgumentException("May not be empty or null", nameof(description));
@@ -309,7 +314,9 @@ public class GameWorld : ISaveLoadable
             if (!species.PlayerSpecies)
                 throw new ArgumentException("immediate effect is only for player dying");
 
-            GD.Print("Applying immediate population effect (should only be used for the player dying)");
+            GD.Print(
+                $"Applying immediate population effect to {species.FormattedIdentifier}, constant: " +
+                $"{constant}, coefficient: {coefficient}, reason: {description}");
 
             species.ApplyImmediatePopulationChange(constant, coefficient, patch);
         }

--- a/src/general/StageBase.cs
+++ b/src/general/StageBase.cs
@@ -499,7 +499,7 @@ public abstract class StageBase<TPlayer> : NodeWithInput, IStage, IGodotEarlyNod
         GameWorld.AlterSpeciesPopulationInCurrentPatch(
             GameWorld.PlayerSpecies, Constants.PLAYER_PATCH_EXTINCTION_POPULATION_LOSS_CONSTANT,
             TranslationServer.Translate("EXTINCT_IN_PATCH"),
-            true, Constants.PLAYER_PATCH_EXTINCTION_POPULATION_LOSS_CONSTANT
+            true, Constants.PLAYER_PATCH_EXTINCTION_POPULATION_LOSS_COEFFICIENT
             / GameWorld.WorldSettings.PlayerDeathPopulationPenalty);
 
         // Do not grant the player population even if the global population is 0,


### PR DESCRIPTION
**Brief Description of What This PR Does**

adds logic to allow the editor to load even with the player completely extinct in auto-evo's eyes. Fixed wrong constant used for patch extinction coefficient which caused it to always set the population to 0.

closes #3526

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
