### PR TITLE
Make loading screen tip text not expand all the way to the right

### DIFF
--- a/src/engine/LoadingScreen.tscn
+++ b/src/engine/LoadingScreen.tscn
@@ -32,9 +32,6 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource( 4 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 ArtworkPath = NodePath("CoolArt")
 ArtDescriptionPath = NodePath("CenterContainer/ArtDescription")
 LoadingMessagePath = NodePath("MarginContainer/HBoxContainer/VBoxContainer/LoadingMessage")
@@ -132,11 +129,12 @@ __meta__ = {
 
 [node name="TipLabel" type="RichTextLabel" parent="MarginContainer/HBoxContainer"]
 margin_top = 42.0
-margin_right = 1088.0
+margin_right = 650.0
 margin_bottom = 64.0
+rect_min_size = Vector2( 650, 0 )
 rect_clip_content = false
 mouse_filter = 2
-size_flags_horizontal = 3
+size_flags_horizontal = 2
 size_flags_vertical = 8
 custom_colors/default_color = Color( 1, 1, 1, 1 )
 custom_colors/font_color_shadow = Color( 0, 0, 0, 0 )


### PR DESCRIPTION
**Brief Description of What This PR Does**

Taken from part of #3509 as that won't be merged in this release. This limits the loading screen tip horizontal expansion to a set size to prevent this random line breaks from happening:

![tip](https://user-images.githubusercontent.com/54026083/179173597-994c378b-d83b-4700-aca6-e9423f1d0110.gif)

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
