### PR TITLE
Fix engulfment of colony members

### DIFF
--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -472,6 +472,8 @@ public partial class Microbe
             }
         }
 
+        Colony?.RemoveFromColony(this);
+
         // Just in case player is engulfed again after escaping
         playerEngulfedDeathTimer = 0;
     }
@@ -650,7 +652,9 @@ public partial class Microbe
         {
             OnUnbound?.Invoke(this);
 
-            RevertNodeParent();
+            if (PhagocytosisStep == PhagocytosisPhase.None)
+                RevertNodeParent();
+
             ai?.ResetAI();
 
             Mode = ModeEnum.Rigid;

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -1023,6 +1023,9 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
         if (Colony == null)
             return GetParent();
 
+        if (Colony.Master.HostileEngulfer.Value != null)
+            return Colony.Master.HostileEngulfer.Value.GetStageAsParent();
+
         return Colony.Master.GetParent();
     }
 

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -1026,6 +1026,7 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
         // Due to the parent of the colony leader is the hostile engulfer (and not the actual stage)
         // when it's being engulfed, we need to get the actual stage node by accessing it from
         // the hostile engulfer instead
+        // NOTE: This is only useful to the colony members when the master is engulfed.
         if (Colony.Master.HostileEngulfer.Value != null)
             return Colony.Master.HostileEngulfer.Value.GetStageAsParent();
 

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -1023,6 +1023,9 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
         if (Colony == null)
             return GetParent();
 
+        // Due to the parent of the colony leader is the hostile engulfer (and not the actual stage)
+        // when it's being engulfed, we need to get the actual stage node by accessing it from
+        // the hostile engulfer instead
         if (Colony.Master.HostileEngulfer.Value != null)
             return Colony.Master.HostileEngulfer.Value.GetStageAsParent();
 

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -1023,9 +1023,9 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
         if (Colony == null)
             return GetParent();
 
-        // If the colony leader is engulfed, the colony children, when the colony is disbanded need to access the stage
-        // through the engulfer. Because at that point the colony leader is already re-parented to the engulfer, so its
-        // parent is no longer the stage here.
+        // If the colony leader is engulfed, the colony children, when the colony is disbanded, need to access the
+        // stage through the engulfer. Because at that point the colony leader is already re-parented to the engulfer,
+        // so its parent is no longer the stage here.
         if (Colony.Master.HostileEngulfer.Value != null)
             return Colony.Master.HostileEngulfer.Value.GetStageAsParent();
 

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -1023,10 +1023,9 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
         if (Colony == null)
             return GetParent();
 
-        // Due to the parent of the colony leader is the hostile engulfer (and not the actual stage)
-        // when it's being engulfed, we need to get the actual stage node by accessing it from
-        // the hostile engulfer instead
-        // NOTE: This is only useful to the colony members when the master is engulfed.
+        // If the colony leader is engulfed, the colony children, when the colony is disbanded need to access the stage
+        // through the engulfer. Because at that point the colony leader is already re-parented to the engulfer, so its
+        // parent is no longer the stage here.
         if (Colony.Master.HostileEngulfer.Value != null)
             return Colony.Master.HostileEngulfer.Value.GetStageAsParent();
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Colony members are now properly considered detached/removed if they're engulfed.

**Related Issues**

Fixes #3528

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
