### PR TITLE
Fix multicellular editing after loading a save, and fixed already placed cells not updating

### DIFF
--- a/src/early_multicellular_stage/CellTemplate.cs
+++ b/src/early_multicellular_stage/CellTemplate.cs
@@ -2,6 +2,7 @@
 using Godot;
 using Newtonsoft.Json;
 
+[JsonObject(IsReference = true)]
 public class CellTemplate : IPositionedCell, ICloneable, IActionHex
 {
     private int orientation;

--- a/src/early_multicellular_stage/CellType.cs
+++ b/src/early_multicellular_stage/CellType.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 /// <summary>
 ///   Type of a cell in a multicellular species. There can be multiple instances of a cell type placed at once
 /// </summary>
+[JsonObject(IsReference = true)]
 public class CellType : ICellProperties, IPhotographable, ICloneable
 {
     [JsonConstructor]

--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
@@ -310,6 +310,10 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
 
             case EditorTab.CellEditor:
             {
+                // This must be set visible before CheckAndApplyCellTypeEdit otherwise it won't update already placed
+                // visuals
+                bodyPlanEditorTab.Show();
+
                 // If we have an edited cell type, then we can apply those changes when we go back to the main editor
                 // tab as that's the only exit point and the point where we actually need to use the edited cell
                 // type information
@@ -317,7 +321,6 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
                 // See: https://github.com/Revolutionary-Games/Thrive/pull/3457
                 CheckAndApplyCellTypeEdit();
 
-                bodyPlanEditorTab.Show();
                 SetEditorObjectVisibility(true);
                 cellEditorTab.SetEditorWorldTabSpecificObjectVisibility(false);
                 bodyPlanEditorTab.SetEditorWorldTabSpecificObjectVisibility(true);

--- a/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
+++ b/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
@@ -343,6 +343,8 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
                 // See: https://github.com/Revolutionary-Games/Thrive/pull/3457
                 CheckAndApplyCellTypeEdit();
 
+                // This doesn't need to be before CheckAndApplyCellTypeEdit like in early multicellular editor as
+                // this doesn't skip anything even if the tab is not visible yet
                 bodyPlanEditorTab.Show();
                 SetEditorObjectVisibility(true);
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

there was a problem where the cell template instances where different in different places (because they weren't saved as references) that caused some editing problems. Fixed already placed cell visuals no longer reacting to cell type edits.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
