### PR TITLE
Fix patch extinction animation not showing

### DIFF
--- a/src/general/StageHUDBase.cs
+++ b/src/general/StageHUDBase.cs
@@ -648,8 +648,6 @@ public abstract class StageHUDBase<TStage> : Control, IStageHUD
 
     public void ShowPatchExtinctionBox()
     {
-        winExtinctBoxHolder.Show();
-
         if (patchExtinctionBox == null)
         {
             patchExtinctionBox = PatchExtinctionBoxScene.Instance<PatchExtinctionBox>();
@@ -658,10 +656,15 @@ public abstract class StageHUDBase<TStage> : Control, IStageHUD
             patchExtinctionBox.OnMovedToNewPatch = MoveToNewPatchAfterExtinctInCurrent;
         }
 
-        patchExtinctionBox.PlayerSpecies = stage!.GameWorld.PlayerSpecies;
-        patchExtinctionBox.Map = stage.GameWorld.Map;
+        if (!winExtinctBoxHolder.Visible)
+        {
+            winExtinctBoxHolder.Show();
 
-        patchExtinctionBox.Show();
+            patchExtinctionBox.PlayerSpecies = stage!.GameWorld.PlayerSpecies;
+            patchExtinctionBox.Map = stage.GameWorld.Map;
+
+            patchExtinctionBox.Show();
+        }
     }
 
     public void HidePatchExtinctionBox()

--- a/src/microbe_stage/editor/PatchMapDrawer.cs
+++ b/src/microbe_stage/editor/PatchMapDrawer.cs
@@ -49,7 +49,13 @@ public class PatchMapDrawer : Control
         get => map;
         set
         {
-            map = value ?? throw new ArgumentNullException(nameof(value), "setting to null not allowed");
+            if (value == null)
+                throw new ArgumentNullException(nameof(value), "setting to null not allowed");
+
+            if (map == value)
+                return;
+
+            map = value;
             dirty = true;
 
             playerPatch ??= map.CurrentPatch;
@@ -91,6 +97,8 @@ public class PatchMapDrawer : Control
 
     public override void _Ready()
     {
+        base._Ready();
+
         nodeScene = GD.Load<PackedScene>("res://src/microbe_stage/editor/PatchMapNode.tscn");
 
         if (DrawDefaultMapIfEmpty && Map == null)
@@ -102,6 +110,8 @@ public class PatchMapDrawer : Control
 
     public override void _Process(float delta)
     {
+        base._Process(delta);
+
         CheckForDirtyNodes();
 
         if (dirty)
@@ -120,6 +130,8 @@ public class PatchMapDrawer : Control
     /// </summary>
     public override void _Draw()
     {
+        base._Draw();
+
         if (Map == null)
             return;
 

--- a/src/microbe_stage/editor/PatchMapDrawer.cs
+++ b/src/microbe_stage/editor/PatchMapDrawer.cs
@@ -156,6 +156,11 @@ public class PatchMapDrawer : Control
         EmitSignal(nameof(OnCurrentPatchCentered), PlayerPatch!.ScreenCoordinates);
     }
 
+    public void MarkDirty()
+    {
+        dirty = true;
+    }
+
     /// <summary>
     ///   Stores patch node status values that will be applied when creating the patch nodes
     /// </summary>

--- a/src/microbe_stage/editor/PatchMapNode.cs
+++ b/src/microbe_stage/editor/PatchMapNode.cs
@@ -158,6 +158,8 @@ public class PatchMapNode : MarginContainer
 
     public override void _Ready()
     {
+        base._Ready();
+
         if (patch == null)
             GD.PrintErr($"{nameof(PatchMapNode)} should have {nameof(Patch)} set");
 
@@ -174,6 +176,8 @@ public class PatchMapNode : MarginContainer
 
     public override void _Process(float delta)
     {
+        base._Process(delta);
+
         currentBlinkTime += delta;
         if (currentBlinkTime > HalfBlinkInterval)
         {

--- a/src/microbe_stage/gui/PatchExtinctionBox.cs
+++ b/src/microbe_stage/gui/PatchExtinctionBox.cs
@@ -26,6 +26,7 @@ public class PatchExtinctionBox : Control
 
             mapDrawer.Map = value ?? throw new ArgumentException("New map can't be null");
             mapDrawer.SetPatchEnabledStatuses(value.Patches.Values, p => p.GetSpeciesPopulation(PlayerSpecies) > 0);
+            mapDrawer.MarkDirty();
         }
     }
 


### PR DESCRIPTION
Fixes #3543 

Turns out map is rebuilt every time so there isn't a chance for them to animate.

Personally I dislike the approach to attempt to update map every frame, but adding early return causes a crash. If you think this approach is acceptable, go on and merge this.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
