### PR TITLE
Fixed the editor report tab having bad performance due to rich text labels

### DIFF
--- a/src/gui_common/CustomRichTextLabel.cs
+++ b/src/gui_common/CustomRichTextLabel.cs
@@ -12,6 +12,8 @@ public class CustomRichTextLabel : RichTextLabel
 {
     private string? extendedBbcode;
 
+    private string? heightWorkaroundRanForString;
+
     /// <summary>
     ///   Custom BBCodes exclusive for Thrive. Acts more like an extension to the built-in tags.
     /// </summary>
@@ -84,7 +86,18 @@ public class CustomRichTextLabel : RichTextLabel
         // See https://github.com/Revolutionary-Games/Thrive/issues/2236
         // Queue to run on the next frame due to null RID error with some bbcode image display if otherwise
 #pragma warning disable CA2245 // Necessary for workaround
-        Invoke.Instance.QueueForObject(() => BbcodeText = BbcodeText, this);
+        Invoke.Instance.QueueForObject(() =>
+        {
+            var bbCode = BbcodeText;
+
+            // Only run this once to not absolutely tank performance with long rich text labels
+            if (heightWorkaroundRanForString == bbCode)
+                return;
+
+            heightWorkaroundRanForString = bbCode;
+
+            BbcodeText = bbCode;
+        }, this);
 #pragma warning restore CA2245
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

I noticed I got only 180 FPS in the editor tab and my CPU fans picked up, turns out the constant bbcode assigning caused each rich text label to call _Draw again on each frame which meant the entire text was reparsed each frame.

This hopefully doesn't break the height of any tooltips.

Related to: https://github.com/Revolutionary-Games/Thrive/issues/2236#issuecomment-1188986399

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
