### PR TITLE
Fix starting from MicrobeStage.tscn

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -94,8 +94,7 @@ public class MicrobeStage : StageBase<Microbe>
         // Start a new game if started directly from MicrobeStage.tscn
         if (CurrentGame == null)
         {
-            WorldGenerationSettings settings = new WorldGenerationSettings();
-            CurrentGame = GameProperties.StartNewMicrobeGame(settings);
+            CurrentGame = GameProperties.StartNewMicrobeGame(new WorldGenerationSettings());
         }
 
         ResolveNodeReferences();

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -92,10 +92,7 @@ public class MicrobeStage : StageBase<Microbe>
         base._Ready();
 
         // Start a new game if started directly from MicrobeStage.tscn
-        if (CurrentGame == null)
-        {
-            CurrentGame = GameProperties.StartNewMicrobeGame(new WorldGenerationSettings());
-        }
+        CurrentGame ??= GameProperties.StartNewMicrobeGame(new WorldGenerationSettings());
 
         ResolveNodeReferences();
 

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -91,6 +91,13 @@ public class MicrobeStage : StageBase<Microbe>
     {
         base._Ready();
 
+        // Start a new game if started directly from MicrobeStage.tscn
+        if (CurrentGame == null)
+        {
+            WorldGenerationSettings settings = new WorldGenerationSettings();
+            CurrentGame = GameProperties.StartNewMicrobeGame(settings);
+        }
+
         ResolveNodeReferences();
 
         glucose = SimulationParameters.Instance.GetCompound("glucose");


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes an exception when starting directly from MicrobeStage.tscn by creating a new game with default settings.

**Related Issues**

fixes #3506
<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
