### PR TITLE
Fixed pause locks being incorrectly cleared on save load failure

### DIFF
--- a/src/saving/InProgressLoad.cs
+++ b/src/saving/InProgressLoad.cs
@@ -206,9 +206,13 @@ public class InProgressLoad
 
                 SaveHelper.MarkLastSaveToCurrentTime();
 
-                // Make certain that if some game element paused and we unloaded it without it realizing that, we
-                // don't get stuck in paused mode
-                PauseManager.Instance.ForceClear();
+                if (success)
+                {
+                    // Make certain that if some game element paused and we unloaded it without it realizing that, we
+                    // don't get stuck in paused mode. But only on success because the failure dialog will want to
+                    // clear its own pause lock and print an error if it can't.
+                    PauseManager.Instance.ForceClear();
+                }
 
                 return;
             }


### PR DESCRIPTION
**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #3478

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
