### PR TITLE
Split patch population numbers into simulation and gameplay numbers

### DIFF
--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -279,7 +279,7 @@ public class AutoEvoRun
         foreach (var entry in ExternalEffects)
         {
             var key = (entry.Species, entry.EventType, entry.Patch);
-            var speciesPopulation = entry.Species.Population;
+            var speciesPopulation = entry.Patch.GetSpeciesGameplayPopulation(entry.Species);
 
             combinedExternalEffects.TryGetValue(key, out var existingEffectAmount);
 
@@ -432,7 +432,8 @@ public class AutoEvoRun
                         continue;
 
                     // Adjust to the specified fraction of the full population change
-                    var previousPopulation = entry.Value.GetSpeciesPopulation(previousPopulationFrom ?? playerSpecies);
+                    var previousPopulation =
+                        entry.Value.GetSpeciesSimulationPopulation(previousPopulationFrom ?? playerSpecies);
 
                     var change = resultPopulation.Value - previousPopulation;
 

--- a/src/auto-evo/simulation/PopulationSimulation.cs
+++ b/src/auto-evo/simulation/PopulationSimulation.cs
@@ -85,7 +85,7 @@
 
                 foreach (var patch in patches)
                 {
-                    long currentPopulation = patch.GetSpeciesPopulation(currentSpecies);
+                    long currentPopulation = patch.GetSpeciesSimulationPopulation(currentSpecies);
 
                     // If this is an extra species, this first takes the
                     // population from excluded species that match its index, if that
@@ -100,7 +100,8 @@
                             {
                                 if (parameters.ExcludedSpecies.Count > i)
                                 {
-                                    currentPopulation = patch.GetSpeciesPopulation(parameters.ExcludedSpecies[i]);
+                                    currentPopulation =
+                                        patch.GetSpeciesSimulationPopulation(parameters.ExcludedSpecies[i]);
                                     useGlobal = false;
                                 }
 

--- a/src/auto-evo/simulation/SimulationConfiguration.cs
+++ b/src/auto-evo/simulation/SimulationConfiguration.cs
@@ -76,7 +76,7 @@
 
             foreach (var patchEntry in OriginalMap.Patches)
             {
-                if (patchEntry.Value.GetSpeciesPopulation(species) > 0)
+                if (patchEntry.Value.GetSpeciesSimulationPopulation(species) > 0)
                 {
                     PatchesToRun.Add(patchEntry.Value);
                 }

--- a/src/auto-evo/steps/FindBestMigration.cs
+++ b/src/auto-evo/steps/FindBestMigration.cs
@@ -107,7 +107,7 @@
                 {
                     Patch patch = entry[0].Value;
 
-                    var population = patch.GetSpeciesPopulation(species);
+                    var population = patch.GetSpeciesSimulationPopulation(species);
                     if (population < Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION)
                         continue;
 

--- a/src/general/EditorBase.cs
+++ b/src/general/EditorBase.cs
@@ -804,8 +804,6 @@ public abstract class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoa
         foreach (var species in extinct)
         {
             CurrentGame.GameWorld.RemoveSpecies(species);
-
-            GD.Print("Species ", species.FormattedName, " has gone extinct from the world.");
         }
 
         // Clear the run to make the cell stage start a new run when we go back there

--- a/src/general/GameWorld.cs
+++ b/src/general/GameWorld.cs
@@ -232,7 +232,6 @@ public class GameWorld : ISaveLoadable
 
         species.OnBecomePartOfWorld(++speciesIdCounter);
         worldSpecies[species.ID] = species;
-        GD.Print("New species has become part of the world: ", species.FormattedIdentifier);
     }
 
     /// <summary>

--- a/src/general/Species.cs
+++ b/src/general/Species.cs
@@ -51,8 +51,7 @@ public abstract class Species : ICloneable
     /// </summary>
     /// <remarks>
     ///   <para>
-    ///     Changing this has no effect as this is set after auto-evo
-    ///     from the per patch populations.
+    ///     Changing this has no effect as this is set after auto-evo from the per patch populations.
     ///   </para>
     /// </remarks>
     public long Population { get; set; } = 1;
@@ -64,9 +63,8 @@ public abstract class Species : ICloneable
     /// </summary>
     /// <remarks>
     ///   <para>
-    ///     In the previous version a string name was used to identify
-    ///     species, but it was just the word species followed by a
-    ///     sequential number, so now this is an actual number.
+    ///     In the previous version a string name was used to identify species, but it was just the word species
+    ///     followed by a sequential number, so now this is an actual number.
     ///   </para>
     /// </remarks>
     [JsonProperty]
@@ -143,17 +141,14 @@ public abstract class Species : ICloneable
     {
         ThrowPopulationChangeErrorIfNotPlayer();
 
-        var oldPopulation = patch.GetSpeciesPopulation(this);
+        var oldPopulation = patch.GetSpeciesGameplayPopulation(this);
         var population = (long)(oldPopulation * coefficient);
         population += constant;
 
         if (population < 0)
             population = 0;
 
-        var populationChange = population - oldPopulation;
-
-        patch.UpdateSpeciesPopulation(this, population);
-        Population += populationChange;
+        patch.UpdateSpeciesGameplayPopulation(this, population);
     }
 
     /// <summary>

--- a/src/general/StageBase.cs
+++ b/src/general/StageBase.cs
@@ -401,11 +401,11 @@ public abstract class StageBase<TPlayer> : NodeWithInput, IStage, IGodotEarlyNod
             if (GameWorld.Map.CurrentPatch == null)
                 throw new InvalidOperationException("No current patch set");
 
-            if (playerSpecies.Population <= 0)
+            if (IsGameOver())
             {
                 GameOver();
             }
-            else if (GameWorld.Map.CurrentPatch.GetSpeciesPopulation(playerSpecies) <= 0)
+            else if (GameWorld.Map.CurrentPatch.GetSpeciesGameplayPopulation(playerSpecies) <= 0)
             {
                 // Has run out of population in current patch but not globally
                 PlayerExtinctInPatch();
@@ -421,7 +421,8 @@ public abstract class StageBase<TPlayer> : NodeWithInput, IStage, IGodotEarlyNod
 
     protected bool IsGameOver()
     {
-        return GameWorld.PlayerSpecies.Population <= 0 && !CurrentGame!.FreeBuild;
+        return GameWorld.Map.GetSpeciesGlobalGameplayPopulation(CurrentGame!.GameWorld.PlayerSpecies) <= 0 &&
+            !CurrentGame.FreeBuild;
     }
 
     /// <summary>

--- a/src/general/StageHUDBase.cs
+++ b/src/general/StageHUDBase.cs
@@ -840,7 +840,7 @@ public abstract class StageHUDBase<TStage> : Control, IStageHUD
     protected void UpdatePopulation()
     {
         var playerSpecies = stage!.GameWorld.PlayerSpecies;
-        var population = stage.GameWorld.Map.CurrentPatch!.GetSpeciesPopulation(playerSpecies);
+        var population = stage.GameWorld.Map.CurrentPatch!.GetSpeciesGameplayPopulation(playerSpecies);
 
         if (population <= 0 && stage.HasPlayer)
             population = 1;

--- a/src/microbe_stage/Patch.cs
+++ b/src/microbe_stage/Patch.cs
@@ -18,6 +18,13 @@ public class Patch
     [JsonProperty]
     private readonly PatchSnapshot currentSnapshot;
 
+    /// <summary>
+    ///   The gameplay adjusted populations (only if set for a species, otherwise missing).
+    ///   <see cref="GetSpeciesGameplayPopulation"/>
+    /// </summary>
+    [JsonProperty]
+    private readonly Dictionary<Species, long> gameplayPopulations = new();
+
     [JsonProperty]
     private Deque<PatchSnapshot> history = new();
 
@@ -186,11 +193,10 @@ public class Patch
     }
 
     /// <summary>
-    ///   Adds a new species to this patch
+    ///   Adds a new species to this patch. May only be called after auto-evo has ran.
     /// </summary>
     /// <returns>True when added. False if the species was already in this patch</returns>
-    public bool AddSpecies(Species species, long population =
-        Constants.INITIAL_SPECIES_POPULATION)
+    public bool AddSpecies(Species species, long population)
     {
         if (currentSnapshot.SpeciesInPatch.ContainsKey(species))
             return false;
@@ -200,7 +206,7 @@ public class Patch
     }
 
     /// <summary>
-    ///   Removes a species from this patch
+    ///   Removes a species from this patch. May only be called after auto-evo has ran.
     /// </summary>
     /// <returns>True when a species was removed</returns>
     public bool RemoveSpecies(Species species)
@@ -209,10 +215,10 @@ public class Patch
     }
 
     /// <summary>
-    ///   Updates a species population in this patch
+    ///   Updates a species population in this patch. Should only be called by auto-evo applying the results.
     /// </summary>
     /// <returns>True on success</returns>
-    public bool UpdateSpeciesPopulation(Species species, long newPopulation)
+    public bool UpdateSpeciesSimulationPopulation(Species species, long newPopulation)
     {
         if (!currentSnapshot.SpeciesInPatch.ContainsKey(species))
             return false;
@@ -221,12 +227,75 @@ public class Patch
         return true;
     }
 
-    public long GetSpeciesPopulation(Species species)
+    /// <summary>
+    ///   Returns the auto-evo simulation confirmed population numbers
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     The simulation population is different from the gameplay population in that it may not be modified by
+    ///     anything else except auto-evo results applying. Auto-evo also relies on this population number not changing
+    ///     at all while it is running. Gameplay population is an additional layer on top of the last simulation
+    ///     population to record immediate external effects. The gameplay populations are not authoritative and will be
+    ///     overridden the next time simulation populations are updated
+    ///   </para>
+    /// </remarks>
+    /// <param name="species">The species to get the population for</param>
+    /// <returns>The population amount</returns>
+    public long GetSpeciesSimulationPopulation(Species species)
     {
         if (!currentSnapshot.SpeciesInPatch.TryGetValue(species, out var population))
             return 0;
 
         return population;
+    }
+
+    /// <summary>
+    ///   Gets the population that's potentially adjusted during the current swimming around cycle (before auto-evo
+    ///   results are applied)
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     See the remarks on <see cref="GetSpeciesSimulationPopulation"/> for more info
+    ///   </para>
+    /// </remarks>
+    /// <param name="species">The species to get the population for</param>
+    /// <returns>The gameplay population, or if not set the simulation population</returns>
+    public long GetSpeciesGameplayPopulation(Species species)
+    {
+        if (gameplayPopulations.TryGetValue(species, out var population))
+            return population;
+
+        return GetSpeciesSimulationPopulation(species);
+    }
+
+    /// <summary>
+    ///   Updates a species gameplay population in this patch. This maybe called even when auto-evo is running. Once
+    ///   this is called <see cref="GetSpeciesGameplayPopulation"/> starts returning the set value instead of the
+    ///   simulation population.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     Note that gameplay results disappear when auto-evo results are applied, so the same change needs to also
+    ///     be saved as an external effect.
+    ///   </para>
+    /// </remarks>
+    /// <returns>True on success</returns>
+    public bool UpdateSpeciesGameplayPopulation(Species species, long newPopulation)
+    {
+        if (!currentSnapshot.SpeciesInPatch.ContainsKey(species))
+            return false;
+
+        gameplayPopulations[species] = newPopulation;
+        return true;
+    }
+
+    /// <summary>
+    ///   Should only be called by auto-evo results after applying themselves to clear out the gameplay populations.
+    ///   <see cref="PatchMap.DiscardGameplayPopulations"/>
+    /// </summary>
+    public void DiscardGameplayPopulations()
+    {
+        gameplayPopulations.Clear();
     }
 
     public float GetCompoundAmount(string compoundName)

--- a/src/microbe_stage/PatchMap.cs
+++ b/src/microbe_stage/PatchMap.cs
@@ -303,9 +303,6 @@ public class PatchMap : ISaveLoadable
             {
                 patch.Value.RemoveSpecies(speciesEntry.Key);
 
-                GD.Print("Species ", speciesEntry.Key.FormattedName, " has gone extinct in ",
-                    patch.Value.Name);
-
                 if (!nonExtinctSpecies.Contains(speciesEntry.Key))
                 {
                     result.Add(speciesEntry.Key);

--- a/src/microbe_stage/PatchMap.cs
+++ b/src/microbe_stage/PatchMap.cs
@@ -267,16 +267,17 @@ public class PatchMap : ISaveLoadable
     /// <summary>
     ///   Gets the species population in all patches.
     /// </summary>
-    public long GetSpeciesGlobalPopulation(Species species)
+    public long GetSpeciesGlobalSimulationPopulation(Species species)
     {
-        long sum = 0;
+        return Patches.Values.Sum(p => p.GetSpeciesSimulationPopulation(species));
+    }
 
-        foreach (var entry in Patches.Values)
-        {
-            sum += entry.GetSpeciesPopulation(species);
-        }
-
-        return sum;
+    /// <summary>
+    ///   Gets the species gameplay population (<see cref="Patch.GetSpeciesGameplayPopulation"/>) in all patches.
+    /// </summary>
+    public long GetSpeciesGlobalGameplayPopulation(Species species)
+    {
+        return Patches.Values.Sum(p => p.GetSpeciesGameplayPopulation(species));
     }
 
     /// <summary>
@@ -337,6 +338,18 @@ public class PatchMap : ISaveLoadable
         }
 
         return found.ToList();
+    }
+
+    /// <summary>
+    ///   Called after auto-evo has applied results. Clears the previous gameplay populations so that next time
+    ///   gameplay populations are used they start off with the new simulation computed values.
+    /// </summary>
+    public void DiscardGameplayPopulations()
+    {
+        foreach (var entry in Patches)
+        {
+            entry.Value.DiscardGameplayPopulations();
+        }
     }
 
     /// <summary>

--- a/src/microbe_stage/PatchMapGenerator.cs
+++ b/src/microbe_stage/PatchMapGenerator.cs
@@ -847,7 +847,7 @@ public static class PatchMapGenerator
                 break;
         }
 
-        map.CurrentPatch.AddSpecies(defaultSpecies);
+        map.CurrentPatch.AddSpecies(defaultSpecies, Constants.INITIAL_SPECIES_POPULATION);
     }
 
     private static LocalizedString GetPatchLocalizedName(string regionName, string biomeType)

--- a/src/microbe_stage/gui/PatchDetailsPanel.cs
+++ b/src/microbe_stage/gui/PatchDetailsPanel.cs
@@ -268,7 +268,8 @@ public class PatchDetailsPanel : PanelContainer
         foreach (var species in SelectedPatch.SpeciesInPatch.Keys)
         {
             speciesList.AppendLine(string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate(
-                "SPECIES_WITH_POPULATION"), species.FormattedNameBbCode, SelectedPatch.GetSpeciesPopulation(species)));
+                    "SPECIES_WITH_POPULATION"), species.FormattedNameBbCode,
+                SelectedPatch.GetSpeciesSimulationPopulation(species)));
         }
 
         label.ExtendedBbcode = speciesList.ToString();

--- a/src/microbe_stage/gui/PatchExtinctionBox.cs
+++ b/src/microbe_stage/gui/PatchExtinctionBox.cs
@@ -25,7 +25,8 @@ public class PatchExtinctionBox : Control
                 throw new InvalidOperationException($"{nameof(PlayerSpecies)} must be set first");
 
             mapDrawer.Map = value ?? throw new ArgumentException("New map can't be null");
-            mapDrawer.SetPatchEnabledStatuses(value.Patches.Values, p => p.GetSpeciesPopulation(PlayerSpecies) > 0);
+            mapDrawer.SetPatchEnabledStatuses(value.Patches.Values,
+                p => p.GetSpeciesGameplayPopulation(PlayerSpecies) > 0);
             mapDrawer.MarkDirty();
         }
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**
this protects auto-evo runs from being messed up. This also makes death penalties calculate against the current population and not the simulation previous population

This PR does some stuff...

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
fixes #3460

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
