### PR TITLE
Created a new safe string format and switched all formatting to use it

### DIFF
--- a/doc/style_guide.md
+++ b/doc/style_guide.md
@@ -270,6 +270,18 @@ Code style rules
 - Avoid globals. Especially in object trees where you can easily
   enough pass the reference along.
 
+- Do not use `string.Format` with a translated format string, as
+  translation mistakes can crash the game in that case. Instead either
+  use `LocalizedString`, `LocalizedStringBuilder`, or
+  `StringUtils.FormatSafe`. Those ways will automatically catch
+  exceptions from broken translations and return the format string
+  un-formatted. `StringUtils` will likely want to be invoked as an
+  extension method on the string (`"example".FormatSafe(...)`). If the
+  format string is not user suplied normal `string.Format` is allowed,
+  but should be passed `CultureInfo.CurrentCulture` as the first
+  parameter as we want text shown to the user in the user's selected
+  locale.
+
 - Prefer `List` and other concrete containers over `IList` and similar
   interfaces. `IList` should be used only in very special cases that
   require it. In many cases `IEnumerable` is the preferred type to use

--- a/doc/style_guide.md
+++ b/doc/style_guide.md
@@ -272,7 +272,8 @@ Code style rules
 
 - Prefer `List` and other concrete containers over `IList` and similar
   interfaces. `IList` should be used only in very special cases that
-  require it.
+  require it. In many cases `IEnumerable` is the preferred type to use
+  to not place constraints on other code unnecessarily.
 
 - Methods should not use `=> style` bodies, properties when they are
   short should use that style bodies.
@@ -357,6 +358,9 @@ Godot usage
 - For spacing elements use either a spacer (that has a visual
   appearance) or for invisible space use an empty Control with rect
   `minsize` set to the amount of blank you want.
+
+- Don't use text in the GUI with leading or trailing spaces to add
+  padding, see previous bullet instead.
 
 - Node names should not contain spaces, instead use PascalCase naming.
 
@@ -466,10 +470,7 @@ Godot usage
 
 - When using `GD.PrintErr` don't use string concatenation, use the
   multi argument form instead, for example: `GD.PrintErr("My value is:
-  ", variable);`
-
-- Don't use text in the GUI with leading or trailing spaces to add
-  padding, see previous bullet instead.
+  ", variable);` Or use string interpolation.
 
 - You should follow general GUI standards in designing UI. Use widgets
   that are meant for whatever kind of interaction you are designing.

--- a/doc/style_guide.md
+++ b/doc/style_guide.md
@@ -277,7 +277,7 @@ Code style rules
   exceptions from broken translations and return the format string
   un-formatted. `StringUtils` will likely want to be invoked as an
   extension method on the string (`"example".FormatSafe(...)`). If the
-  format string is not user suplied normal `string.Format` is allowed,
+  format string is not user supplied, normal `string.Format` is allowed,
   but should be passed `CultureInfo.CurrentCulture` as the first
   parameter as we want text shown to the user in the user's selected
   locale.

--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -134,9 +133,7 @@ public class AutoEvoRun
                 var percentage = CompletionFraction * 100;
 
                 // {0:F1}% done. {1:n0}/{2:n0} steps.
-                return string.Format(CultureInfo.CurrentCulture,
-                    TranslationServer.Translate("AUTO-EVO_STEPS_DONE"),
-                    percentage, CompleteSteps, total);
+                return TranslationServer.Translate("AUTO-EVO_STEPS_DONE").FormatSafe(percentage, CompleteSteps, total);
             }
 
             return TranslationServer.Translate("STARTING");

--- a/src/engine/DebugOverlays.PerformanceMetrics.cs
+++ b/src/engine/DebugOverlays.PerformanceMetrics.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using Godot;
 using Nito.Collections;
@@ -88,8 +87,8 @@ public partial class DebugOverlays
                     Performance.GetMonitor(Performance.Monitor.ObjectNodeCount),
                     OS.GetName() == Constants.OS_WINDOWS_NAME ?
                         TranslationServer.Translate("UNKNOWN_ON_WINDOWS") :
-                        string.Format(CultureInfo.CurrentCulture, mibFormat, usedMemory),
-                    string.Format(CultureInfo.CurrentCulture, mibFormat, usedVideoMemory),
+                        mibFormat.FormatSafe(usedMemory),
+                    mibFormat.FormatSafe(usedVideoMemory),
                     Performance.GetMonitor(Performance.Monitor.RenderObjectsInFrame),
                     Performance.GetMonitor(Performance.Monitor.RenderDrawCallsInFrame),
                     Performance.GetMonitor(Performance.Monitor.Render2dDrawCallsInFrame),

--- a/src/engine/LocalizedStringBuilder.cs
+++ b/src/engine/LocalizedStringBuilder.cs
@@ -72,7 +72,7 @@ public class LocalizedStringBuilder : IFormattable
 
     public LocalizedStringBuilder Append(string value, params object[] args)
     {
-        return Append((object)string.Format(CultureInfo.CurrentCulture, value, args));
+        return Append((object)value.FormatSafe(args));
     }
 
     public LocalizedStringBuilder Append(char value)

--- a/src/engine/input/key_mapping/InputGroupList.cs
+++ b/src/engine/input/key_mapping/InputGroupList.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using Godot;
 
@@ -125,9 +124,8 @@ public class InputGroupList : VBoxContainer
         latestDialogConflict = conflict;
         latestDialogNewEvent = newEvent;
 
-        conflictDialog.DialogText = string.Format(CultureInfo.CurrentCulture,
-            TranslationServer.Translate("KEY_BINDING_CHANGE_CONFLICT"),
-            inputActionItem.DisplayName, inputActionItem.DisplayName);
+        conflictDialog.DialogText = TranslationServer.Translate("KEY_BINDING_CHANGE_CONFLICT")
+            .FormatSafe(inputActionItem.DisplayName, inputActionItem.DisplayName);
 
         conflictDialog.PopupCenteredShrink();
     }

--- a/src/general/Asset.cs
+++ b/src/general/Asset.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.IO;
+﻿using System.IO;
 using System.Text;
 using Godot;
 using Newtonsoft.Json;
@@ -48,12 +47,11 @@ public class Asset
 
         if (!string.IsNullOrEmpty(Title) && !string.IsNullOrEmpty(Artist))
         {
-            result.Append(string.Format(
-                CultureInfo.CurrentCulture, TranslationServer.Translate("ARTWORK_TITLE"), Title, Artist));
+            result.Append(TranslationServer.Translate("ARTWORK_TITLE").FormatSafe(Title, Artist));
         }
         else if (string.IsNullOrEmpty(Title) && !string.IsNullOrEmpty(Artist))
         {
-            result.Append(string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("ART_BY"), Artist));
+            result.Append(TranslationServer.Translate("ART_BY").FormatSafe(Artist));
         }
         else if (!string.IsNullOrEmpty(Title) && string.IsNullOrEmpty(Artist))
         {

--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using Godot;
 using Array = Godot.Collections.Array;
 
@@ -237,8 +236,8 @@ public class MainMenu : NodeWithInput
         else
         {
             storeLoggedInDisplay.Visible = true;
-            storeLoggedInDisplay.Text = string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("STORE_LOGGED_IN_AS"), SteamHandler.Instance.DisplayName);
+            storeLoggedInDisplay.Text = TranslationServer.Translate("STORE_LOGGED_IN_AS")
+                .FormatSafe(SteamHandler.Instance.DisplayName);
         }
     }
 

--- a/src/general/NewGameSettings.cs
+++ b/src/general/NewGameSettings.cs
@@ -564,9 +564,7 @@ public class NewGameSettings : ControlWithInput
     private void OnGlucoseDecayRateValueChanged(double percentage)
     {
         percentage = Math.Round(percentage, 2);
-        var percentageFormat = TranslationServer.Translate("PERCENTAGE_VALUE");
-        glucoseDecayRateReadout.Text = string.Format(CultureInfo.CurrentCulture, percentageFormat,
-            percentage);
+        glucoseDecayRateReadout.Text = TranslationServer.Translate("PERCENTAGE_VALUE").FormatSafe(percentage);
         settings.GlucoseDecay = (float)percentage * 0.01f;
 
         UpdateSelectedDifficultyPresetControl();

--- a/src/general/OptionsMenu.cs
+++ b/src/general/OptionsMenu.cs
@@ -632,8 +632,8 @@ public class OptionsMenu : ControlWithInput
             return;
 
         var screenResolution = OS.WindowSize * OS.GetScreenScale();
-        resolution.Text = string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("AUTO_RESOLUTION"),
-            screenResolution.x, screenResolution.y);
+        resolution.Text = TranslationServer.Translate("AUTO_RESOLUTION")
+            .FormatSafe(screenResolution.x, screenResolution.y);
     }
 
     /// <summary>
@@ -1028,7 +1028,7 @@ public class OptionsMenu : ControlWithInput
             textFormat = TranslationServer.Translate("LANGUAGE_TRANSLATION_PROGRESS");
         }
 
-        languageProgressLabel.Text = string.Format(CultureInfo.CurrentCulture, textFormat, Mathf.Floor(progress));
+        languageProgressLabel.Text = textFormat.FormatSafe(Mathf.Floor(progress));
     }
 
     // GUI Control Callbacks

--- a/src/general/StageHUDBase.cs
+++ b/src/general/StageHUDBase.cs
@@ -686,23 +686,18 @@ public abstract class StageHUDBase<TStage> : Control, IStageHUD
 
         oxygenBar.MaxValue = 100;
         oxygenBar.Value = oxygenPercentage;
-        oxygenBar.GetNode<Label>("Value").Text =
-            string.Format(CultureInfo.CurrentCulture, percentageFormat, oxygenPercentage);
+        oxygenBar.GetNode<Label>("Value").Text = percentageFormat.FormatSafe(oxygenPercentage);
 
         co2Bar.MaxValue = 100;
         co2Bar.Value = co2Percentage;
-        co2Bar.GetNode<Label>("Value").Text =
-            string.Format(CultureInfo.CurrentCulture, percentageFormat, co2Percentage);
+        co2Bar.GetNode<Label>("Value").Text = percentageFormat.FormatSafe(co2Percentage);
 
         nitrogenBar.MaxValue = 100;
         nitrogenBar.Value = nitrogenPercentage;
-        nitrogenBar.GetNode<Label>("Value").Text =
-            string.Format(CultureInfo.CurrentCulture, percentageFormat, nitrogenPercentage);
+        nitrogenBar.GetNode<Label>("Value").Text = percentageFormat.FormatSafe(nitrogenPercentage);
 
-        sunlightLabel.GetNode<Label>("Value").Text =
-            string.Format(CultureInfo.CurrentCulture, percentageFormat, sunlightPercentage);
-        temperatureBar.GetNode<Label>("Value").Text =
-            string.Format(CultureInfo.CurrentCulture, unitFormat, averageTemperature, temperature.Unit);
+        sunlightLabel.GetNode<Label>("Value").Text = percentageFormat.FormatSafe(sunlightPercentage);
+        temperatureBar.GetNode<Label>("Value").Text = unitFormat.FormatSafe(averageTemperature, temperature.Unit);
 
         // TODO: pressure?
     }
@@ -1117,8 +1112,8 @@ public abstract class StageHUDBase<TStage> : Control, IStageHUD
             if (hoveredSpeciesCount.Value > 1)
             {
                 AddHoveredCellLabel(
-                    string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("SPECIES_N_TIMES"),
-                        hoveredSpeciesCount.Key.FormattedName, hoveredSpeciesCount.Value));
+                    TranslationServer.Translate("SPECIES_N_TIMES").FormatSafe(hoveredSpeciesCount.Key.FormattedName,
+                        hoveredSpeciesCount.Value));
             }
             else
             {

--- a/src/general/StringUtils.cs
+++ b/src/general/StringUtils.cs
@@ -18,27 +18,24 @@ public static class StringUtils
         if (number is >= 1000000000 or <= -1000000000)
         {
             return withSuffix ?
-                string.Format(
-                    CultureInfo.CurrentCulture, TranslationServer.Translate("BILLION_ABBREVIATION"),
-                    number.ToString("0,,,.###", CultureInfo.CurrentCulture)) :
+                TranslationServer.Translate("BILLION_ABBREVIATION")
+                    .FormatSafe(number.ToString("0,,,.###", CultureInfo.CurrentCulture)) :
                 number.ToString("0,,,.###", CultureInfo.CurrentCulture);
         }
 
         if (number is >= 1000000 or <= -1000000)
         {
             return withSuffix ?
-                string.Format(
-                    CultureInfo.CurrentCulture, TranslationServer.Translate("MILLION_ABBREVIATION"),
-                    number.ToString("0,,.##", CultureInfo.CurrentCulture)) :
+                TranslationServer.Translate("MILLION_ABBREVIATION")
+                    .FormatSafe(number.ToString("0,,.##", CultureInfo.CurrentCulture)) :
                 number.ToString("0,,.##", CultureInfo.CurrentCulture);
         }
 
         if (number is >= 1000 or <= -1000)
         {
             return withSuffix ?
-                string.Format(
-                    CultureInfo.CurrentCulture, TranslationServer.Translate("KILO_ABBREVIATION"),
-                    number.ToString("0,.#", CultureInfo.CurrentCulture)) :
+                TranslationServer.Translate("KILO_ABBREVIATION")
+                    .FormatSafe(number.ToString("0,.#", CultureInfo.CurrentCulture)) :
                 number.ToString("0,.#", CultureInfo.CurrentCulture);
         }
 
@@ -52,6 +49,32 @@ public static class StringUtils
     public static string FormatNumber(this long number, bool withSuffix = true)
     {
         return ((double)number).FormatNumber();
+    }
+
+    /// <summary>
+    ///   Safely formats a string where the format is loaded form a translation
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///      This should always be used instead of <see cref="string.Format(string,object)"/>
+    ///   </para>
+    /// </remarks>
+    /// <param name="format">The format to use</param>
+    /// <param name="formatArguments">Arguments to pass to the formatting</param>
+    /// <returns>
+    ///   The formatted string or <see cref="format"/> if the placeholders were incorrect in the translation
+    /// </returns>
+    public static string FormatSafe(this string format, params object?[] formatArguments)
+    {
+        try
+        {
+            return string.Format(CultureInfo.CurrentCulture, format, formatArguments);
+        }
+        catch (FormatException e)
+        {
+            GD.PrintErr("Invalid translation format for current language in text: ", format, ", exception: ", e);
+            return format;
+        }
     }
 
     /// <summary>

--- a/src/gui_common/CompoundAmount.cs
+++ b/src/gui_common/CompoundAmount.cs
@@ -168,13 +168,11 @@ public class CompoundAmount : HBoxContainer
         string numberPart;
         if (!string.IsNullOrEmpty(compound!.Unit))
         {
-            numberPart = string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("VALUE_WITH_UNIT"),
-                Math.Round(amount), compound.Unit);
+            numberPart = TranslationServer.Translate("VALUE_WITH_UNIT").FormatSafe(Math.Round(amount), compound.Unit);
         }
         else if (UsePercentageDisplay)
         {
-            numberPart = string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("PERCENTAGE_VALUE"),
-                Math.Round(amount * 100, 1));
+            numberPart = TranslationServer.Translate("PERCENTAGE_VALUE").FormatSafe(Math.Round(amount * 100, 1));
         }
         else
         {

--- a/src/gui_common/TweakedColourPicker.cs
+++ b/src/gui_common/TweakedColourPicker.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using Godot;
 
@@ -577,9 +576,8 @@ public class TweakedColourPicker : ColorPicker
 
         private void UpdateTooltip()
         {
-            HintTooltip = string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("COLOUR_PICKER_PRESET_TOOLTIP"),
-                Color.IsRaw() ? "argb(" + Color + ")" : "#" + Color.ToHtml());
+            HintTooltip = TranslationServer.Translate("COLOUR_PICKER_PRESET_TOOLTIP")
+                .FormatSafe(Color.IsRaw() ? "argb(" + Color + ")" : "#" + Color.ToHtml());
         }
     }
 

--- a/src/gui_common/charts/line/LineChart.cs
+++ b/src/gui_common/charts/line/LineChart.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using Godot;
 using Array = Godot.Collections.Array;
@@ -416,13 +415,11 @@ public class LineChart : VBoxContainer
 
                 var xValueForm = string.IsNullOrEmpty(TooltipXAxisFormat) ?
                     $"{point.X.FormatNumber()} {XAxisName}" :
-                    string.Format(CultureInfo.CurrentCulture,
-                        TooltipXAxisFormat!, point.X);
+                    TooltipXAxisFormat!.FormatSafe(point.X);
 
                 var yValueForm = string.IsNullOrEmpty(TooltipYAxisFormat) ?
                     $"{point.Y.FormatNumber()} {YAxisName}" :
-                    string.Format(CultureInfo.CurrentCulture,
-                        TooltipYAxisFormat!, point.Y);
+                    TooltipYAxisFormat!.FormatSafe(point.Y);
 
                 toolTip.DisplayName = data.Key + point;
                 toolTip.Description = $"{data.Key}\n{xValueForm}\n{yValueForm}";
@@ -1111,15 +1108,15 @@ public class LineChart : VBoxContainer
             {
                 case DataSetVisibilityUpdateResult.MaxVisibleLimitReached:
                     icon.Pressed = false;
-                    ToolTipManager.Instance.ShowPopup(string.Format(
-                        CultureInfo.CurrentCulture, TranslationServer.Translate(
-                            "MAX_VISIBLE_DATASET_WARNING"), chart.MaxDisplayedDataSet), 1.0f);
+                    ToolTipManager.Instance.ShowPopup(
+                        TranslationServer.Translate("MAX_VISIBLE_DATASET_WARNING")
+                            .FormatSafe(chart.MaxDisplayedDataSet), 1.0f);
                     break;
                 case DataSetVisibilityUpdateResult.MinVisibleLimitReached:
                     icon.Pressed = true;
-                    ToolTipManager.Instance.ShowPopup(string.Format(
-                        CultureInfo.CurrentCulture, TranslationServer.Translate(
-                            "MIN_VISIBLE_DATASET_WARNING"), chart.MinDisplayedDataSet), 1.0f);
+                    ToolTipManager.Instance.ShowPopup(
+                        TranslationServer.Translate("MIN_VISIBLE_DATASET_WARNING")
+                            .FormatSafe(chart.MinDisplayedDataSet), 1.0f);
                     break;
             }
         }
@@ -1203,14 +1200,14 @@ public class LineChart : VBoxContainer
             switch (result)
             {
                 case DataSetVisibilityUpdateResult.MaxVisibleLimitReached:
-                    ToolTipManager.Instance.ShowPopup(string.Format(
-                        CultureInfo.CurrentCulture, TranslationServer.Translate(
-                            "MAX_VISIBLE_DATASET_WARNING"), chart.MaxDisplayedDataSet), 1.0f);
+                    ToolTipManager.Instance.ShowPopup(
+                        TranslationServer.Translate("MAX_VISIBLE_DATASET_WARNING")
+                            .FormatSafe(chart.MaxDisplayedDataSet), 1.0f);
                     break;
                 case DataSetVisibilityUpdateResult.MinVisibleLimitReached:
-                    ToolTipManager.Instance.ShowPopup(string.Format(
-                        CultureInfo.CurrentCulture, TranslationServer.Translate(
-                            "MIN_VISIBLE_DATASET_WARNING"), chart.MinDisplayedDataSet), 1.0f);
+                    ToolTipManager.Instance.ShowPopup(
+                        TranslationServer.Translate("MIN_VISIBLE_DATASET_WARNING")
+                            .FormatSafe(chart.MinDisplayedDataSet), 1.0f);
                     break;
             }
         }

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -205,7 +205,7 @@ public class MicrobeHUD : StageHUDBase<MicrobeStage>
             // Show the digestion progress to the player
             hp = 1 - (stage.Player!.DigestedAmount / Constants.PARTIALLY_DIGESTED_THRESHOLD);
             maxHP = Constants.FULLY_DIGESTED_LIMIT;
-            hpText = string.Format(CultureInfo.CurrentCulture, percentageValue, Mathf.Round((1 - hp) * 100));
+            hpText = percentageValue.FormatSafe(Mathf.Round((1 - hp) * 100));
             playerWasDigested = true;
             FlashHealthBar(new Color(0.96f, 0.5f, 0.27f), delta);
         }
@@ -292,8 +292,8 @@ public class MicrobeHUD : StageHUDBase<MicrobeStage>
 
     protected override string GetMouseHoverCoordinateText()
     {
-        return string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("STUFF_AT"),
-            stage!.Camera.CursorWorldPos.x, stage.Camera.CursorWorldPos.z);
+        return TranslationServer.Translate("STUFF_AT")
+            .FormatSafe(stage!.Camera.CursorWorldPos.x, stage.Camera.CursorWorldPos.z);
     }
 
     protected override void UpdateAbilitiesHotBar()
@@ -381,8 +381,8 @@ public class MicrobeHUD : StageHUDBase<MicrobeStage>
         if (playerColonySize == null)
             return;
 
-        multicellularButton.Text = string.Format(TranslationServer.Translate("BECOME_MULTICELLULAR"), playerColonySize,
-            Constants.COLONY_SIZE_REQUIRED_FOR_MULTICELLULAR);
+        multicellularButton.Text = TranslationServer.Translate("BECOME_MULTICELLULAR")
+            .FormatSafe(playerColonySize, Constants.COLONY_SIZE_REQUIRED_FOR_MULTICELLULAR);
     }
 
     private void UpdateMacroscopicButton(Microbe player)
@@ -417,8 +417,8 @@ public class MicrobeHUD : StageHUDBase<MicrobeStage>
         if (playerColonySize == null)
             return;
 
-        macroscopicButton.Text = string.Format(TranslationServer.Translate("BECOME_MACROSCOPIC"), playerColonySize,
-            Constants.COLONY_SIZE_REQUIRED_FOR_MACROSCOPIC);
+        macroscopicButton.Text = TranslationServer.Translate("BECOME_MACROSCOPIC")
+            .FormatSafe(playerColonySize, Constants.COLONY_SIZE_REQUIRED_FOR_MACROSCOPIC);
     }
 
     private void OnBecomeMulticellularPressed()

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -303,8 +303,7 @@ public partial class CellEditorComponent
 
             subBar.RegisterToolTipForControl(tooltip);
 
-            tooltip.Description = string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("ENERGY_BALANCE_TOOLTIP_PRODUCTION"),
+            tooltip.Description = TranslationServer.Translate("ENERGY_BALANCE_TOOLTIP_PRODUCTION").FormatSafe(
                 SimulationParameters.Instance.GetOrganelleType(subBar.Name).Name,
                 energyBalance.Production[subBar.Name]);
         }
@@ -341,9 +340,8 @@ public partial class CellEditorComponent
                 }
             }
 
-            tooltip.Description = string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("ENERGY_BALANCE_TOOLTIP_CONSUMPTION"), displayName,
-                energyBalance.Consumption[subBar.Name]);
+            tooltip.Description = TranslationServer.Translate("ENERGY_BALANCE_TOOLTIP_CONSUMPTION").FormatSafe(
+                displayName, energyBalance.Consumption[subBar.Name]);
         }
     }
 

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -2037,12 +2037,12 @@ public partial class CellEditorComponent :
             autoEvoPredictionFailedLabel.Hide();
         }
 
+        var populationFormat = TranslationServer.Translate("POPULATION_IN_PATCH_SHORT");
+
         if (!string.IsNullOrEmpty(bestPatchName))
         {
-            bestPatchLabel.Text = string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("POPULATION_IN_PATCH_SHORT"),
-                TranslationServer.Translate(bestPatchName),
-                bestPatchPopulation);
+            bestPatchLabel.Text =
+                populationFormat.FormatSafe(TranslationServer.Translate(bestPatchName), bestPatchPopulation);
         }
         else
         {
@@ -2051,10 +2051,8 @@ public partial class CellEditorComponent :
 
         if (!string.IsNullOrEmpty(worstPatchName))
         {
-            worstPatchLabel.Text = string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("POPULATION_IN_PATCH_SHORT"),
-                TranslationServer.Translate(worstPatchName),
-                worstPatchPopulation);
+            worstPatchLabel.Text =
+                populationFormat.FormatSafe(TranslationServer.Translate(worstPatchName), worstPatchPopulation);
         }
         else
         {

--- a/src/microbe_stage/editor/CellStatsIndicator.cs
+++ b/src/microbe_stage/editor/CellStatsIndicator.cs
@@ -110,6 +110,6 @@ public class CellStatsIndicator : HBoxContainer
 
         valueLabel.Text = string.IsNullOrEmpty(Format) ?
             Value.ToString(CultureInfo.CurrentCulture) :
-            string.Format(CultureInfo.CurrentCulture, Format!, Value);
+            Format!.FormatSafe(Value);
     }
 }

--- a/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
+++ b/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
@@ -363,14 +363,11 @@ public class MicrobeEditorReportComponent : EditorComponentBase<IEditorReportDat
 
     public void UpdateGlucoseReduction(float value)
     {
-        var percentage = string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("PERCENTAGE_VALUE"),
-            Math.Round(value * 100));
+        var percentage = TranslationServer.Translate("PERCENTAGE_VALUE").FormatSafe(Math.Round(value * 100));
 
         // The amount of glucose has been reduced to {0} of the previous amount.
-        glucoseReductionLabel.Text =
-            string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("THE_AMOUNT_OF_GLUCOSE_HAS_BEEN_REDUCED"),
-                percentage);
+        glucoseReductionLabel.Text = TranslationServer.Translate("THE_AMOUNT_OF_GLUCOSE_HAS_BEEN_REDUCED")
+            .FormatSafe(percentage);
     }
 
     public void UpdateTimeIndicator(double value)
@@ -383,9 +380,8 @@ public class MicrobeEditorReportComponent : EditorComponentBase<IEditorReportDat
         if (tooltip == null)
             throw new InvalidOperationException("Could not find time indicator tooltip");
 
-        tooltip.Description = string.Format(
-            CultureInfo.CurrentCulture, TranslationServer.Translate("TIME_INDICATOR_TOOLTIP"),
-            Editor.CurrentGame.GameWorld.TotalPassedTime);
+        tooltip.Description = TranslationServer.Translate("TIME_INDICATOR_TOOLTIP")
+            .FormatSafe(Editor.CurrentGame.GameWorld.TotalPassedTime);
     }
 
     public override void OnInsufficientMP(bool playSound = true)

--- a/src/microbe_stage/editor/MicrobePartSelection.cs
+++ b/src/microbe_stage/editor/MicrobePartSelection.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using Godot;
+﻿using Godot;
 
 /// <summary>
 ///   A specialized button to display a microbe part for selection in the cell editor.
@@ -146,8 +145,7 @@ public class MicrobePartSelection : MarginContainer
         if (mpLabel == null || nameLabel == null)
             return;
 
-        mpLabel.Text = string.Format(
-            CultureInfo.CurrentCulture, TranslationServer.Translate("MP_COST"), MPCost);
+        mpLabel.Text = TranslationServer.Translate("MP_COST").FormatSafe(MPCost);
 
         nameLabel.Text = PartName;
 

--- a/src/microbe_stage/editor/PatchMapEditorComponent.cs
+++ b/src/microbe_stage/editor/PatchMapEditorComponent.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using Godot;
 using Newtonsoft.Json;
@@ -79,8 +78,8 @@ public abstract class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEd
             UpdatePlayerPatch(playerPatchOnEntry);
         }
 
-        seedLabel.Text = string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("SEED_LABEL"),
-            owningEditor.CurrentGame.GameWorld.WorldSettings.Seed);
+        seedLabel.Text = TranslationServer.Translate("SEED_LABEL")
+            .FormatSafe(owningEditor.CurrentGame.GameWorld.WorldSettings.Seed);
     }
 
     public void SetMap(PatchMap map)

--- a/src/microbe_stage/editor/tooltips/SelectionMenuToolTip.cs
+++ b/src/microbe_stage/editor/tooltips/SelectionMenuToolTip.cs
@@ -261,8 +261,8 @@ public class SelectionMenuToolTip : Control, ICustomToolTip
             else
             {
                 modifier.ModifierValue = (deltaValue >= 0 ? "+" : string.Empty)
-                    + string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("PERCENTAGE_VALUE"),
-                        (deltaValue * 100).ToString("F0", CultureInfo.CurrentCulture));
+                    + TranslationServer.Translate("PERCENTAGE_VALUE")
+                        .FormatSafe((deltaValue * 100).ToString("F0", CultureInfo.CurrentCulture));
             }
 
             if (modifier.Name == "osmoregulationCost")

--- a/src/microbe_stage/gui/PatchDetailsPanel.cs
+++ b/src/microbe_stage/gui/PatchDetailsPanel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.Text;
 using Godot;
 
@@ -225,9 +224,7 @@ public class PatchDetailsPanel : PanelContainer
         name.Text = SelectedPatch!.Name.ToString();
 
         // Biome: {0}
-        biome.Text = string.Format(CultureInfo.CurrentCulture,
-            TranslationServer.Translate("BIOME_LABEL"),
-            SelectedPatch.BiomeTemplate.Name);
+        biome.Text = TranslationServer.Translate("BIOME_LABEL").FormatSafe(SelectedPatch.BiomeTemplate.Name);
 
         // {0}-{1}m below sea level
         depth.Text = new LocalizedString("BELOW_SEA_LEVEL", SelectedPatch.Depth[0], SelectedPatch.Depth[1]).ToString();
@@ -238,38 +235,36 @@ public class PatchDetailsPanel : PanelContainer
 
         // Atmospheric gasses
         var temperature = SimulationParameters.Instance.GetCompound("temperature");
-        temperatureLabel.Text = string.Format(CultureInfo.CurrentCulture, unitFormat,
-            SelectedPatch.Biome.Compounds[temperature].Ambient, temperature.Unit);
-        pressure.Text = "20 bar";
-        light.Text = string.Format(CultureInfo.CurrentCulture, percentageFormat,
-            GetCompoundAmount(SelectedPatch, sunlightCompound.InternalName)) + " lx";
-        oxygen.Text = string.Format(CultureInfo.CurrentCulture, percentageFormat,
-            GetCompoundAmount(SelectedPatch, oxygenCompound.InternalName));
-        nitrogen.Text = string.Format(CultureInfo.CurrentCulture, percentageFormat,
-            GetCompoundAmount(SelectedPatch, nitrogenCompound.InternalName));
-        co2.Text = string.Format(CultureInfo.CurrentCulture, percentageFormat,
-            GetCompoundAmount(SelectedPatch, carbondioxideCompound.InternalName));
+        temperatureLabel.Text =
+            unitFormat.FormatSafe(SelectedPatch.Biome.Compounds[temperature].Ambient, temperature.Unit);
+        pressure.Text = unitFormat.FormatSafe(20, "bar");
+        light.Text =
+            unitFormat.FormatSafe(
+                percentageFormat.FormatSafe(GetCompoundAmount(SelectedPatch, sunlightCompound.InternalName)), "lx");
+        oxygen.Text = percentageFormat.FormatSafe(GetCompoundAmount(SelectedPatch, oxygenCompound.InternalName));
+        nitrogen.Text = percentageFormat.FormatSafe(GetCompoundAmount(SelectedPatch, nitrogenCompound.InternalName));
+        co2.Text = percentageFormat.FormatSafe(GetCompoundAmount(SelectedPatch, carbondioxideCompound.InternalName));
 
         // Compounds
-        hydrogenSulfide.Text = string.Format(CultureInfo.CurrentCulture, percentageFormat,
-            Math.Round(GetCompoundAmount(SelectedPatch, hydrogensulfideCompound.InternalName), 3));
-        ammonia.Text = string.Format(CultureInfo.CurrentCulture, percentageFormat,
-            Math.Round(GetCompoundAmount(SelectedPatch, ammoniaCompound.InternalName), 3));
-        glucose.Text = string.Format(CultureInfo.CurrentCulture, percentageFormat,
-            Math.Round(GetCompoundAmount(SelectedPatch, glucoseCompound.InternalName), 3));
-        phosphate.Text = string.Format(CultureInfo.CurrentCulture, percentageFormat,
-            Math.Round(GetCompoundAmount(SelectedPatch, phosphatesCompound.InternalName), 3));
-        iron.Text = string.Format(CultureInfo.CurrentCulture, percentageFormat,
-            GetCompoundAmount(SelectedPatch, ironCompound.InternalName));
+        hydrogenSulfide.Text =
+            percentageFormat.FormatSafe(
+                Math.Round(GetCompoundAmount(SelectedPatch, hydrogensulfideCompound.InternalName), 3));
+        ammonia.Text =
+            percentageFormat.FormatSafe(Math.Round(GetCompoundAmount(SelectedPatch, ammoniaCompound.InternalName), 3));
+        glucose.Text =
+            percentageFormat.FormatSafe(Math.Round(GetCompoundAmount(SelectedPatch, glucoseCompound.InternalName), 3));
+        phosphate.Text =
+            percentageFormat.FormatSafe(
+                Math.Round(GetCompoundAmount(SelectedPatch, phosphatesCompound.InternalName), 3));
+        iron.Text = percentageFormat.FormatSafe(GetCompoundAmount(SelectedPatch, ironCompound.InternalName));
 
         var label = speciesListBox.GetItem<CustomRichTextLabel>("SpeciesList");
         var speciesList = new StringBuilder(100);
 
         foreach (var species in SelectedPatch.SpeciesInPatch.Keys)
         {
-            speciesList.AppendLine(string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate(
-                    "SPECIES_WITH_POPULATION"), species.FormattedNameBbCode,
-                SelectedPatch.GetSpeciesSimulationPopulation(species)));
+            speciesList.AppendLine(TranslationServer.Translate("SPECIES_WITH_POPULATION").FormatSafe(
+                species.FormattedNameBbCode, SelectedPatch.GetSpeciesSimulationPopulation(species)));
         }
 
         label.ExtendedBbcode = speciesList.ToString();

--- a/src/modding/ModLoader.cs
+++ b/src/modding/ModLoader.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Godot;
@@ -223,8 +222,7 @@ public class ModLoader : Node
         if (info == null)
         {
             GD.PrintErr("Can't load mod due to failed info reading: ", name);
-            modErrors.Add(string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("CANT_LOAD_MOD_INFO"),
-                name));
+            modErrors.Add(TranslationServer.Translate("CANT_LOAD_MOD_INFO").FormatSafe(name));
             return;
         }
 
@@ -246,9 +244,7 @@ public class ModLoader : Node
             catch (Exception e)
             {
                 GD.PrintErr("Could not load mod assembly due to exception: ", e);
-                modErrors.Add(string.Format(CultureInfo.CurrentCulture,
-                    TranslationServer.Translate("MOD_ASSEMBLY_LOAD_EXCEPTION"),
-                    name, e));
+                modErrors.Add(TranslationServer.Translate("MOD_ASSEMBLY_LOAD_EXCEPTION").FormatSafe(name, e));
                 return;
             }
 
@@ -263,9 +259,7 @@ public class ModLoader : Node
         if (!loadedSomething)
         {
             GD.Print("A mod contained no loadable resources");
-            modErrors.Add(string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("MOD_HAS_NO_LOADABLE_RESOURCES"),
-                name));
+            modErrors.Add(TranslationServer.Translate("MOD_HAS_NO_LOADABLE_RESOURCES").FormatSafe(name));
         }
     }
 
@@ -276,8 +270,7 @@ public class ModLoader : Node
         if (info == null)
         {
             GD.PrintErr("Can't unload mod due to failed info reading: ", name);
-            modErrors.Add(string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("CANT_LOAD_MOD_INFO"),
-                name));
+            modErrors.Add(TranslationServer.Translate("CANT_LOAD_MOD_INFO").FormatSafe(name));
             return;
         }
 
@@ -290,17 +283,14 @@ public class ModLoader : Node
                 if (!mod.Unload())
                 {
                     GD.PrintErr("Mod's (", name, ") assembly unload method call failed");
-                    modErrors.Add(string.Format(CultureInfo.CurrentCulture,
-                        TranslationServer.Translate("MOD_ASSEMBLY_UNLOAD_CALL_FAILED"),
-                        name));
+                    modErrors.Add(TranslationServer.Translate("MOD_ASSEMBLY_UNLOAD_CALL_FAILED").FormatSafe(name));
                 }
             }
             catch (Exception e)
             {
                 GD.PrintErr("Mod's (", name, ") assembly unload method call failed with an exception: ", e);
-                modErrors.Add(string.Format(CultureInfo.CurrentCulture,
-                    TranslationServer.Translate("MOD_ASSEMBLY_UNLOAD_CALL_FAILED_EXCEPTION"),
-                    name, e));
+                modErrors.Add(TranslationServer.Translate("MOD_ASSEMBLY_UNLOAD_CALL_FAILED_EXCEPTION")
+                    .FormatSafe(name, e));
             }
 
             loadedModAssemblies.Remove(name);
@@ -380,9 +370,7 @@ public class ModLoader : Node
         if (type == null)
         {
             GD.Print("No class with name \"", className, "\" found, can't finish loading mod assembly");
-            modErrors.Add(string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("MOD_ASSEMBLY_CLASS_NOT_FOUND"),
-                name, className));
+            modErrors.Add(TranslationServer.Translate("MOD_ASSEMBLY_CLASS_NOT_FOUND").FormatSafe(name, className));
             return false;
         }
 
@@ -393,9 +381,7 @@ public class ModLoader : Node
             if (!mod.Initialize(modInterface!, info.Info))
             {
                 GD.PrintErr("Mod's (", name, ") initialize method call failed");
-                modErrors.Add(string.Format(CultureInfo.CurrentCulture,
-                    TranslationServer.Translate("MOD_ASSEMBLY_INIT_CALL_FAILED"),
-                    name));
+                modErrors.Add(TranslationServer.Translate("MOD_ASSEMBLY_INIT_CALL_FAILED").FormatSafe(name));
             }
 
             loadedModAssemblies.Add(name, mod);
@@ -409,9 +395,7 @@ public class ModLoader : Node
         catch (Exception e)
         {
             GD.PrintErr("Mod's (", name, ") initialization failed with an exception: ", e);
-            modErrors.Add(string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("MOD_ASSEMBLY_LOAD_CALL_FAILED_EXCEPTION"),
-                name, e));
+            modErrors.Add(TranslationServer.Translate("MOD_ASSEMBLY_LOAD_CALL_FAILED_EXCEPTION").FormatSafe(name, e));
         }
 
         return true;
@@ -434,9 +418,7 @@ public class ModLoader : Node
         catch (Exception e)
         {
             GD.PrintErr("Mod's (", name, ") harmony loading failed with an exception: ", e);
-            modErrors.Add(string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("MOD_HARMONY_LOAD_FAILED_EXCEPTION"),
-                name, e));
+            modErrors.Add(TranslationServer.Translate("MOD_HARMONY_LOAD_FAILED_EXCEPTION").FormatSafe(name, e));
         }
     }
 
@@ -457,9 +439,7 @@ public class ModLoader : Node
         catch (Exception e)
         {
             GD.PrintErr("Mod's (", name, ") harmony unload failed with an exception: ", e);
-            modErrors.Add(string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("MOD_HARMONY_UNLOAD_FAILED_EXCEPTION"),
-                name, e));
+            modErrors.Add(TranslationServer.Translate("MOD_HARMONY_UNLOAD_FAILED_EXCEPTION").FormatSafe(name, e));
         }
     }
 
@@ -470,8 +450,7 @@ public class ModLoader : Node
         if (!ProjectSettings.LoadResourcePack(path))
         {
             GD.PrintErr(".pck loading failed");
-            modErrors.Add(string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("PCK_LOAD_FAILED"),
-                Path.GetFileName(path)));
+            modErrors.Add(TranslationServer.Translate("PCK_LOAD_FAILED").FormatSafe(Path.GetFileName(path)));
         }
     }
 

--- a/src/modding/ModUploader.cs
+++ b/src/modding/ModUploader.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using Godot;
 using Path = System.IO.Path;
@@ -271,8 +270,8 @@ public class ModUploader : Control
             changeNotes.Text = "Initial version";
         }
 
-        toBeUploadedContentLocation.Text = string.Format(CultureInfo.CurrentCulture,
-            TranslationServer.Translate("CONTENT_UPLOADED_FROM"), ProjectSettings.GlobalizePath(selectedMod.Folder));
+        toBeUploadedContentLocation.Text = TranslationServer.Translate("CONTENT_UPLOADED_FROM")
+            .FormatSafe(ProjectSettings.GlobalizePath(selectedMod.Folder));
 
         UpdatePreviewRect();
     }
@@ -338,8 +337,7 @@ public class ModUploader : Control
             {
                 if (!SteamHandler.Tags.Contains(tag))
                 {
-                    SetError(string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("INVALID_TAG"),
-                        tag));
+                    SetError(TranslationServer.Translate("INVALID_TAG").FormatSafe(tag));
                     return false;
                 }
             }
@@ -641,9 +639,7 @@ public class ModUploader : Control
         catch (Exception e)
         {
             GD.PrintErr("Saving workshop data failed: ", e);
-            SetError(string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("SAVING_DATA_FAILED_DUE_TO"),
-                e.Message));
+            SetError(TranslationServer.Translate("SAVING_DATA_FAILED_DUE_TO").FormatSafe(e.Message));
             return false;
         }
 
@@ -657,8 +653,7 @@ public class ModUploader : Control
             ClearError();
         }
 
-        errorDisplay.Text = string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("FORM_ERROR_MESSAGE"),
-            message);
+        errorDisplay.Text = TranslationServer.Translate("FORM_ERROR_MESSAGE").FormatSafe(message);
     }
 
     private void ClearError()

--- a/src/modding/NewModGUI.cs
+++ b/src/modding/NewModGUI.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.IO;
 using Godot;
 using Newtonsoft.Json;
@@ -278,8 +277,7 @@ public class NewModGUI : Control
         }
         catch (JsonSerializationException e)
         {
-            SetError(string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("MISSING_OR_INVALID_REQUIRED_FIELD"), e.Message));
+            SetError(TranslationServer.Translate("MISSING_OR_INVALID_REQUIRED_FIELD").FormatSafe(e.Message));
             return null;
         }
 
@@ -289,8 +287,7 @@ public class NewModGUI : Control
         }
         catch (Exception e)
         {
-            SetError(string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("ADDITIONAL_VALIDATION_FAILED"), e.Message));
+            SetError(TranslationServer.Translate("ADDITIONAL_VALIDATION_FAILED").FormatSafe(e.Message));
             return null;
         }
 
@@ -304,8 +301,7 @@ public class NewModGUI : Control
             ClearError();
         }
 
-        errorDisplay.Text = string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("FORM_ERROR_MESSAGE"),
-            message);
+        errorDisplay.Text = TranslationServer.Translate("FORM_ERROR_MESSAGE").FormatSafe(message);
     }
 
     private void ClearError()

--- a/src/saving/InProgressLoad.cs
+++ b/src/saving/InProgressLoad.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Globalization;
 using Godot;
 using Saving;
 
@@ -236,8 +235,7 @@ public class InProgressLoad
         }
         catch (Exception e2)
         {
-            return string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("SAVE_LOAD_ALREADY_LOADED_FREE_FAILURE"), e2);
+            return TranslationServer.Translate("SAVE_LOAD_ALREADY_LOADED_FREE_FAILURE").FormatSafe(e2);
         }
 
         return string.Empty;

--- a/src/saving/NewSaveMenu.cs
+++ b/src/saving/NewSaveMenu.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using Godot;
@@ -77,9 +76,7 @@ public class NewSaveMenu : Control
     private void ShowOverwriteConfirm(string name)
     {
         // The chosen filename ({0}) already exists. Overwrite?
-        overwriteConfirm.DialogText = string.Format(CultureInfo.CurrentCulture,
-            TranslationServer.Translate("CHOSEN_FILENAME_ALREADY_EXISTS"),
-            name);
+        overwriteConfirm.DialogText = TranslationServer.Translate("CHOSEN_FILENAME_ALREADY_EXISTS").FormatSafe(name);
         overwriteConfirm.PopupCenteredShrink();
     }
 

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Threading.Tasks;
 using Godot;
 using Array = Godot.Collections.Array;
@@ -215,9 +214,7 @@ public class SaveList : ScrollContainer
         saveToBeDeleted = saveName;
 
         // Deleting this save cannot be undone, are you sure you want to permanently delete {0}?
-        deleteConfirmDialog.DialogText = string.Format(CultureInfo.CurrentCulture,
-            TranslationServer.Translate("SAVE_DELETE_WARNING"),
-            saveName);
+        deleteConfirmDialog.DialogText = TranslationServer.Translate("SAVE_DELETE_WARNING").FormatSafe(saveName);
         deleteConfirmDialog.PopupCenteredShrink();
     }
 

--- a/src/saving/SaveManagerGUI.cs
+++ b/src/saving/SaveManagerGUI.cs
@@ -128,8 +128,8 @@ public class SaveManagerGUI : Control
         getBackupCountTask = null;
 
         totalSaveCount.Text = info.Count.ToString(CultureInfo.CurrentCulture);
-        totalSaveSize.Text = string.Format(CultureInfo.CurrentCulture, TranslationServer.Translate("MIB_VALUE"),
-            Math.Round((float)info.DiskSpace / Constants.MEBIBYTE, 2));
+        totalSaveSize.Text = TranslationServer.Translate("MIB_VALUE")
+            .FormatSafe(Math.Round((float)info.DiskSpace / Constants.MEBIBYTE, 2));
 
         UpdateSelectedCount();
         UpdateButtonsStatus();
@@ -220,9 +220,7 @@ public class SaveManagerGUI : Control
         GUICommon.Instance.PlayButtonPressSound();
 
         deleteSelectedConfirmDialog.DialogText =
-            string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("DELETE_SELECTED_SAVE_WARNING"),
-                Selected.Count);
+            TranslationServer.Translate("DELETE_SELECTED_SAVE_WARNING").FormatSafe(Selected.Count);
         deleteSelectedConfirmDialog.PopupCenteredShrink();
     }
 
@@ -232,10 +230,8 @@ public class SaveManagerGUI : Control
         int quickSavesToDeleteCount = Math.Max(currentQuickSaveCount - 1, 0);
         int oldBackupsToDeleteCount = Math.Max(currentBackupCount, 0);
 
-        deleteOldConfirmDialog.DialogText =
-            string.Format(CultureInfo.CurrentCulture,
-                TranslationServer.Translate("DELETE_ALL_OLD_SAVE_WARNING_2"),
-                autoSavesToDeleteCount, quickSavesToDeleteCount, oldBackupsToDeleteCount);
+        deleteOldConfirmDialog.DialogText = TranslationServer.Translate("DELETE_ALL_OLD_SAVE_WARNING_2").FormatSafe(
+            autoSavesToDeleteCount, quickSavesToDeleteCount, oldBackupsToDeleteCount);
         deleteOldConfirmDialog.PopupCenteredShrink();
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

now if a translation has broken string placeholders, it won't crash the game, just that one text will be shown as is without formatting, which is much better than allowing a crash

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #3227

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
