### PR TITLE
Fixed auto-evo external effects not applying to the patch they should

### DIFF
--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -215,16 +215,12 @@ public class AutoEvoRun
     {
         if (ExternalEffects.Count > 0)
         {
-            // Effects are applied in the current patch
-            var currentPatch = Parameters.World.Map.CurrentPatch ??
-                throw new InvalidOperationException("Cannot apply external effects without current map patch");
-
             foreach (var entry in ExternalEffects)
             {
                 try
                 {
                     // It's possible for external effects to be added for extinct species (either completely extinct
-                    // or extinct in the current patch)
+                    // or extinct in the patch it applies to)
                     // We ignore this for player to give the player's reproduction bonus the ability to rescue them
                     if (!results.SpeciesHasResults(entry.Species) && !entry.Species.PlayerSpecies)
                     {
@@ -233,10 +229,10 @@ public class AutoEvoRun
                         continue;
                     }
 
-                    long currentPop = results.GetPopulationInPatchIfExists(entry.Species, currentPatch) ?? 0;
+                    long currentPop = results.GetPopulationInPatchIfExists(entry.Species, entry.Patch) ?? 0;
 
                     results.AddPopulationResultForSpecies(
-                        entry.Species, currentPatch, (int)(currentPop * entry.Coefficient) + entry.Constant);
+                        entry.Species, entry.Patch, (int)(currentPop * entry.Coefficient) + entry.Constant);
                 }
                 catch (Exception e)
                 {

--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -232,7 +232,7 @@ public class AutoEvoRun
                     long currentPop = results.GetPopulationInPatchIfExists(entry.Species, entry.Patch) ?? 0;
 
                     results.AddPopulationResultForSpecies(
-                        entry.Species, entry.Patch, (int)(currentPop * entry.Coefficient) + entry.Constant);
+                        entry.Species, entry.Patch, (long)(currentPop * entry.Coefficient) + entry.Constant);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
**Brief Description of What This PR Does**

I noticed reading the code that all external effects were applied in the *current* patch and not the patch the external effect specified it applied to

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
might do something to  #3128

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
