### PR TITLE
Adjust custom tooltips direction if they overlap screen border

### DIFF
--- a/src/gui_common/tooltip/ToolTipManager.cs
+++ b/src/gui_common/tooltip/ToolTipManager.cs
@@ -105,6 +105,9 @@ public class ToolTipManager : CanvasLayer
         {
             displayTimer -= delta;
 
+            // To avoid tooltip "jumping" to the correct position once it's visible
+            UpdateCurrentTooltip(0);
+
             if (displayTimer < 0)
             {
                 lastMousePosition = GetViewport().GetMousePosition();
@@ -112,67 +115,8 @@ public class ToolTipManager : CanvasLayer
             }
         }
 
-        // Adjust position and size
         if (MainToolTip.ToolTipNode.Visible)
-        {
-            Vector2 position;
-            var offset = 0.0f;
-
-            switch (MainToolTip.Positioning)
-            {
-                case ToolTipPositioning.LastMousePosition:
-                    position = lastMousePosition;
-                    offset = Constants.TOOLTIP_OFFSET;
-                    break;
-                case ToolTipPositioning.FollowMousePosition:
-                    position = GetViewport().GetMousePosition();
-                    offset = Constants.TOOLTIP_OFFSET;
-                    break;
-                case ToolTipPositioning.ControlBottomRightCorner:
-                {
-                    var control = ToolTipHelper.GetControlAssociatedWithToolTip(MainToolTip);
-                    if (control != null)
-                    {
-                        position = new Vector2(
-                            control.RectGlobalPosition.x + control.RectSize.x,
-                            control.RectGlobalPosition.y + control.RectSize.y);
-                    }
-                    else
-                    {
-                        position = new Vector2(0, 0);
-                        GD.PrintErr("Failed to find control associated with main tooltip");
-                    }
-
-                    break;
-                }
-
-                default:
-                    throw new Exception("Invalid tooltip positioning type");
-            }
-
-            var screenSize = GetViewport().GetVisibleRect().Size;
-
-            // Clamp tooltip position so it doesn't go offscreen
-            // TODO: Take into consideration of viewport (window) resizing for the offsetting.
-            MainToolTip.ToolTipNode.RectPosition = new Vector2(
-                Mathf.Clamp(position.x + offset, 0, screenSize.x - MainToolTip.ToolTipNode.RectSize.x),
-                Mathf.Clamp(position.y + offset, 0, screenSize.y - MainToolTip.ToolTipNode.RectSize.y));
-
-            MainToolTip.ToolTipNode.RectSize = Vector2.Zero;
-
-            // Handle temporary tooltips/popup
-            if (currentIsTemporary && hideTimer >= 0)
-            {
-                hideTimer -= delta;
-
-                if (hideTimer < 0)
-                {
-                    currentIsTemporary = false;
-                    UpdateToolTipVisibility(MainToolTip, false);
-                    MainToolTip = null;
-                }
-            }
-        }
+            UpdateCurrentTooltip(delta);
     }
 
     public override void _Input(InputEvent @event)
@@ -341,6 +285,89 @@ public class ToolTipManager : CanvasLayer
         tooltips.Add(groupNode, new List<ICustomToolTip>());
 
         return groupNode;
+    }
+
+    /// <summary>
+    ///   Adjusts <see cref="MainToolTip"/>'s position and size.
+    /// </summary>
+    private void UpdateCurrentTooltip(float delta)
+    {
+        if (MainToolTip == null)
+            return;
+
+        Vector2 position;
+        var offset = new Vector2(Constants.TOOLTIP_OFFSET, Constants.TOOLTIP_OFFSET);
+
+        switch (MainToolTip.Positioning)
+        {
+            case ToolTipPositioning.LastMousePosition:
+                position = lastMousePosition;
+                break;
+            case ToolTipPositioning.FollowMousePosition:
+                position = GetViewport().GetMousePosition();
+                break;
+            case ToolTipPositioning.ControlBottomRightCorner:
+            {
+                var control = ToolTipHelper.GetControlAssociatedWithToolTip(MainToolTip);
+                if (control != null)
+                {
+                    position = new Vector2(
+                        control.RectGlobalPosition.x + control.RectSize.x, control.RectGlobalPosition.y);
+                    offset = new Vector2(0, control.RectSize.y);
+                }
+                else
+                {
+                    position = new Vector2(0, 0);
+                    GD.PrintErr("Failed to find control associated with main tooltip");
+                }
+
+                break;
+            }
+
+            default:
+                throw new Exception("Invalid tooltip positioning type");
+        }
+
+        var screenRect = GetViewport().GetVisibleRect();
+        var newPos = new Vector2(position.x + offset.x, position.y + offset.y);
+        var tooltipSize = MainToolTip.ToolTipNode.RectSize;
+
+        if (newPos.x + tooltipSize.x > screenRect.Size.x)
+        {
+            newPos.x -= tooltipSize.x + offset.x;
+
+            if (newPos.x < screenRect.Position.x)
+                newPos.x = position.x + offset.x;
+        }
+
+        if (newPos.y + tooltipSize.y > screenRect.Size.y)
+        {
+            newPos.y -= tooltipSize.y + offset.y;
+
+            if (newPos.y < screenRect.Position.y)
+                newPos.y = position.y + offset.y;
+        }
+
+        // Clamp tooltip position so it doesn't go offscreen
+        // TODO: Take into account viewport (window) resizing for the offsetting.
+        MainToolTip.ToolTipNode.RectPosition = new Vector2(
+            Mathf.Clamp(newPos.x, 0, screenRect.Size.x - tooltipSize.x),
+            Mathf.Clamp(newPos.y, 0, screenRect.Size.y - tooltipSize.y));
+
+        MainToolTip.ToolTipNode.RectSize = Vector2.Zero;
+
+        // Handle temporary tooltips/popup
+        if (currentIsTemporary && hideTimer >= 0)
+        {
+            hideTimer -= delta;
+
+            if (hideTimer < 0)
+            {
+                currentIsTemporary = false;
+                UpdateToolTipVisibility(MainToolTip, false);
+                MainToolTip = null;
+            }
+        }
     }
 
     private Control? GetGroup(string name, bool verbose = true)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Shows the custom tooltips in the opposite direction if they overlap screen border and _only_ if that doesn't  result in another border overlap in which case the tooltip manager just aborts the direction changing.

Extra: should fix tooltips seemingly "jumping" to the correct position once it is shown.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
