### PR TITLE
Removed mitigation for #3006 to make editor entry not get stuck

### DIFF
--- a/src/general/StageHUDBase.cs
+++ b/src/general/StageHUDBase.cs
@@ -618,15 +618,6 @@ public abstract class StageHUDBase<TStage> : Control, IStageHUD
         TransitionManager.Instance.AddSequence(ScreenFade.FadeType.FadeOut, 0.3f, stage.MoveToEditor, false);
 
         stage.MovingToEditor = true;
-
-        // TODO: mitigation for https://github.com/Revolutionary-Games/Thrive/issues/3006 remove once solved
-        // Start auto-evo if not started already to make sure it doesn't start after we are in the editor
-        // scene, this is a potential mitigation for the issue linked above
-        if (!Settings.Instance.RunAutoEvoDuringGamePlay)
-        {
-            GD.Print("Starting auto-evo while fading into the editor as mitigation for issue #3006");
-            stage.GameWorld.IsAutoEvoFinished(true);
-        }
     }
 
     public void ShowPatchName(string localizedPatchName)


### PR DESCRIPTION
when using just one background thread

**Brief Description of What This PR Does**

Seems like the chunk limiting code gets stuck if auto-evo is started too soon when entering the editor with just one thread

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
might make #3006 worse unless my later other auto-evo fixes have made that original problem disappear.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
