### PR TITLE
Wait for transition before loading

### DIFF
--- a/src/saving/InProgressLoad.cs
+++ b/src/saving/InProgressLoad.cs
@@ -88,10 +88,14 @@ public class InProgressLoad
                 break;
             case State.ReadingData:
             {
+                // Wait for transition to finish.
+                // Workaround for #1406
+                if (TransitionManager.Instance.HasQueuedTransitions)
+                    break;
+
                 // Start suppressing loaded node deletion
                 TemporaryLoadedNodeDeleter.Instance.AddDeletionHold(Constants.DELETION_HOLD_LOAD);
 
-                // TODO: do this in a background thread if possible
                 try
                 {
                     // Invalid is given as the target state here, because it's unknown yet.

--- a/src/saving/InProgressLoad.cs
+++ b/src/saving/InProgressLoad.cs
@@ -79,23 +79,21 @@ public class InProgressLoad
                     MainGameState.Invalid,
                     TranslationServer.Translate("READING_SAVE_DATA"));
 
-                TransitionManager.Instance.AddSequence(ScreenFade.FadeType.FadeIn, 0.5f, null, false, false);
+                TransitionManager.Instance.AddSequence(ScreenFade.FadeType.FadeIn, 0.5f, Step, false, false);
 
                 // Let all suppressed deletions happen
                 TemporaryLoadedNodeDeleter.Instance.ReleaseAllHolds();
                 JSONDebug.FlushJSONTracesOut();
 
-                break;
+                // Continue after transition finishes
+                return;
             case State.ReadingData:
             {
-                // Wait for transition to finish.
-                // Workaround for #1406
-                if (TransitionManager.Instance.HasQueuedTransitions)
-                    break;
-
                 // Start suppressing loaded node deletion
                 TemporaryLoadedNodeDeleter.Instance.AddDeletionHold(Constants.DELETION_HOLD_LOAD);
 
+                // TODO: do this in a background thread once possible
+                // https://github.com/Revolutionary-Games/Thrive/issues/1406
                 try
                 {
                     // Invalid is given as the target state here, because it's unknown yet.


### PR DESCRIPTION
**Brief Description of What This PR Does**

Waits for transition to finish before loading (Suggested by hhyyrylainen).
It's currently not possible to implement multi-threaded loading without major slowdown due to Godot 3 limitations (see https://github.com/godotengine/godot/issues/36793).

**Related Issues**

closes #3566

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
