### PR TITLE
Fix new bug in external effect final value calculation for extinct species

### DIFF
--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -270,6 +270,13 @@ public class AutoEvoRun
         {
             var key = (effect.Species, effect.Patch);
 
+            // If the species is extinct, don't try to calculate the coefficient values as that will cause an error
+            if (!results.SpeciesHasResults(effect.Species))
+            {
+                effect.Coefficient = 1;
+                continue;
+            }
+
             if (!adjustedPopulations.TryGetValue(key, out var population))
             {
                 population = results.GetPopulationInPatchIfExists(effect.Species, effect.Patch) ?? 0;


### PR DESCRIPTION
**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
fixes a new exception reported by a player of the last devbuild:
```
System.Collections.Generic.KeyNotFoundException: The given key 'Ceripsis oriloyes (60)' was not present in the dictionary.
  at System.Collections.Concurrent.ConcurrentDictionary`2[TKey,TValue].ThrowKeyNotFoundException (System.Object key) [0x00010] in <1400ea11d6fd49d4939be686a9549fb4>:0 
  at System.Collections.Concurrent.ConcurrentDictionary`2[TKey,TValue].get_Item (TKey key) [0x0000b] in <1400ea11d6fd49d4939be686a9549fb4>:0 
  at AutoEvo.RunResults.GetPopulationInPatchIfExists (Species species, Patch patch) [0x00000] in <72a49607358c409581bf244910e9b956>:0 
  at AutoEvoRun.CalculateFinalExternalEffectSizes () [0x0005e] in <72a49607358c409581bf244910e9b956>:0 
  at EditorBase`2[TAction,TStage].OnEditorReady () [0x00043] in <72a49607358c409581bf244910e9b956>:0 
  at MicrobeEditor.OnEditorReady () [0x00048] in <72a49607358c409581bf244910e9b956>:0 
  at EditorBase`2[TAction,TStage].InitEditor (System.Boolean fresh) [0x000a4] in <72a49607358c409581bf244910e9b956>:0 
  at MicrobeEditor.InitEditor (System.Boolean fresh) [0x0001b] in <72a49607358c409581bf244910e9b956>:0 
  at EditorBase`2[TAction,TStage].OnEnterEditor () [0x00081] in <72a49607358c409581bf244910e9b956>:0 
  at MicrobeEditor.OnEnterEditor () [0x00000] in <72a49607358c409581bf244910e9b956>:0 
  at EditorBase`2[TAction,TStage]._Ready () [0x00013] in <72a49607358c409581bf244910e9b956>:0 
  at MicrobeEditor._Ready () [0x00000] in <72a49607358c409581bf244910e9b956>:0 
  at (wrapper managed-to-native) Godot.NativeCalls.godot_icall_2_441(intptr,intptr,intptr,bool)
  at Godot.Node.AddChild (Godot.Node node, System.Boolean legibleUniqueName) [0x00011] in <df946455c2cf40b099246a638508efd4>:0 
  at SceneManager.SwitchToScene (Godot.Node newSceneRoot, System.Boolean keepOldRoot) [0x00027] in <72a49607358c409581bf244910e9b956>:0 
  at MicrobeStage.MoveToEditor () [0x000ca] in <72a49607358c409581bf244910e9b956>:0 
  at TransitionManager+Sequence.StartNext () [0x00094] in <72a49607358c409581bf244910e9b956>:0 
  at TransitionManager+Sequence.Process () [0x00087] in <72a49607358c409581bf244910e9b956>:0 
  at TransitionManager._Process (System.Single delta) [0x00019] in <72a49607358c409581bf244910e9b956>:0 
```

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
