### PR TITLE
Auto-Evo Exploring Tool tweaks

### DIFF
--- a/src/auto-evo/AutoEvoExploringTool.cs
+++ b/src/auto-evo/AutoEvoExploringTool.cs
@@ -589,7 +589,8 @@ public class AutoEvoExploringTool : NodeWithInput
         autoEvoRun.ApplyAllResultsAndEffects(true);
 
         // Add run results, this must be called after results are applied to generate unique species ID
-        evolutionaryTree.UpdateEvolutionaryTreeWithRunResults(results, ++currentGeneration);
+        evolutionaryTree.UpdateEvolutionaryTreeWithRunResults(results, ++currentGeneration,
+            gameProperties.GameWorld.TotalPassedTime);
         speciesHistoryList.Add(
             gameProperties.GameWorld.Species.ToDictionary(pair => pair.Key, pair => (Species)pair.Value.Clone()));
 

--- a/src/auto-evo/AutoEvoExploringTool.tscn
+++ b/src/auto-evo/AutoEvoExploringTool.tscn
@@ -395,23 +395,23 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="GUI/VBoxContainer/ConfigEditor/PanelContainer/MarginContainer/HBoxContainer/CenterContainer"]
-margin_left = 114.0
+margin_left = 109.0
 margin_top = 101.0
-margin_right = 432.0
+margin_right = 437.0
 margin_bottom = 446.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_constants/separation = 10
 
 [node name="Label2" type="Label" parent="GUI/VBoxContainer/ConfigEditor/PanelContainer/MarginContainer/HBoxContainer/CenterContainer/VBoxContainer"]
-margin_right = 318.0
+margin_right = 328.0
 margin_bottom = 25.0
 custom_fonts/font = ExtResource( 6 )
 text = "CURRENT_GENERATION_COLON"
 
 [node name="CurrentGenerationLabel" type="Label" parent="GUI/VBoxContainer/ConfigEditor/PanelContainer/MarginContainer/HBoxContainer/CenterContainer/VBoxContainer"]
 margin_top = 35.0
-margin_right = 318.0
+margin_right = 328.0
 margin_bottom = 55.0
 custom_fonts/font = ExtResource( 7 )
 text = "0"
@@ -421,14 +421,14 @@ __meta__ = {
 
 [node name="Label" type="Label" parent="GUI/VBoxContainer/ConfigEditor/PanelContainer/MarginContainer/HBoxContainer/CenterContainer/VBoxContainer"]
 margin_top = 65.0
-margin_right = 318.0
+margin_right = 328.0
 margin_bottom = 90.0
 custom_fonts/font = ExtResource( 6 )
 text = "STATUS_COLON"
 
 [node name="RunStatusLabel" type="Label" parent="GUI/VBoxContainer/ConfigEditor/PanelContainer/MarginContainer/HBoxContainer/CenterContainer/VBoxContainer"]
 margin_top = 100.0
-margin_right = 318.0
+margin_right = 328.0
 margin_bottom = 120.0
 custom_fonts/font = ExtResource( 7 )
 text = "READY"
@@ -438,7 +438,7 @@ __meta__ = {
 
 [node name="HBoxContainer" type="HBoxContainer" parent="GUI/VBoxContainer/ConfigEditor/PanelContainer/MarginContainer/HBoxContainer/CenterContainer/VBoxContainer"]
 margin_top = 130.0
-margin_right = 318.0
+margin_right = 328.0
 margin_bottom = 165.0
 
 [node name="FinishXGenerationsSpin" type="SpinBox" parent="GUI/VBoxContainer/ConfigEditor/PanelContainer/MarginContainer/HBoxContainer/CenterContainer/VBoxContainer/HBoxContainer"]
@@ -446,39 +446,39 @@ margin_right = 72.0
 margin_bottom = 35.0
 size_flags_horizontal = 3
 min_value = 2.0
-value = 2.0
+value = 10.0
 align = 1
 
 [node name="FinishXGenerations" type="Button" parent="GUI/VBoxContainer/ConfigEditor/PanelContainer/MarginContainer/HBoxContainer/CenterContainer/VBoxContainer/HBoxContainer"]
 margin_left = 76.0
-margin_right = 318.0
+margin_right = 328.0
 margin_bottom = 35.0
-text = "FINISH_2_GENERATIONS"
+text = "FINISH_10_GENERATIONS"
 __meta__ = {
 "_editor_description_": "PLACEHOLDER"
 }
 
 [node name="RunGeneration" type="Button" parent="GUI/VBoxContainer/ConfigEditor/PanelContainer/MarginContainer/HBoxContainer/CenterContainer/VBoxContainer"]
 margin_top = 175.0
-margin_right = 318.0
+margin_right = 328.0
 margin_bottom = 210.0
 text = "FINISH_ONE_GENERATION"
 
 [node name="RunStep" type="Button" parent="GUI/VBoxContainer/ConfigEditor/PanelContainer/MarginContainer/HBoxContainer/CenterContainer/VBoxContainer"]
 margin_top = 220.0
-margin_right = 318.0
+margin_right = 328.0
 margin_bottom = 255.0
 text = "RUN_ONE_STEP"
 
 [node name="Abort" type="Button" parent="GUI/VBoxContainer/ConfigEditor/PanelContainer/MarginContainer/HBoxContainer/CenterContainer/VBoxContainer"]
 margin_top = 265.0
-margin_right = 318.0
+margin_right = 328.0
 margin_bottom = 300.0
 text = "ABORT"
 
 [node name="PlayWithThis" type="Button" parent="GUI/VBoxContainer/ConfigEditor/PanelContainer/MarginContainer/HBoxContainer/CenterContainer/VBoxContainer"]
 margin_top = 310.0
-margin_right = 318.0
+margin_right = 328.0
 margin_bottom = 345.0
 text = "PLAY_WITH_CURRENT_SETTING"
 

--- a/src/auto-evo/AutoEvoExploringTool.tscn
+++ b/src/auto-evo/AutoEvoExploringTool.tscn
@@ -446,7 +446,6 @@ margin_right = 72.0
 margin_bottom = 35.0
 size_flags_horizontal = 3
 min_value = 2.0
-max_value = 10.0
 value = 2.0
 align = 1
 

--- a/src/auto-evo/AutoEvoExploringTool.tscn
+++ b/src/auto-evo/AutoEvoExploringTool.tscn
@@ -677,7 +677,8 @@ margin_bottom = 486.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 MaxZoom = 1.0
-MinZoom = 0.4
+MinZoom = 0.2
+ZoomStep = 0.1
 ShowScrollbars = false
 ContentPath = NodePath("EvolutionaryTree")
 

--- a/src/auto-evo/AutoEvoExploringTool.tscn
+++ b/src/auto-evo/AutoEvoExploringTool.tscn
@@ -453,7 +453,7 @@ align = 1
 margin_left = 76.0
 margin_right = 328.0
 margin_bottom = 35.0
-text = "FINISH_10_GENERATIONS"
+text = "Finish 10 Generations"
 __meta__ = {
 "_editor_description_": "PLACEHOLDER"
 }

--- a/src/auto-evo/EvolutionaryTree.cs
+++ b/src/auto-evo/EvolutionaryTree.cs
@@ -23,7 +23,7 @@ public class EvolutionaryTree : Control
     private readonly System.Collections.Generic.Dictionary<uint, (uint ParentSpeciesID, int SplitGeneration)>
         speciesOrigin = new();
 
-    private readonly System.Collections.Generic.Dictionary<int, double> generationTime = new();
+    private readonly System.Collections.Generic.Dictionary<int, double> generationTimes = new();
 
     private readonly ButtonGroup nodesGroup = new();
 
@@ -58,7 +58,7 @@ public class EvolutionaryTree : Control
 
         speciesOrigin.Add(luca.ID, (uint.MaxValue, 0));
         speciesNames.Add(luca.ID, luca.FormattedName);
-        generationTime.Add(0, 0);
+        generationTimes.Add(0, 0);
     }
 
     public override void _Draw()
@@ -76,7 +76,7 @@ public class EvolutionaryTree : Control
                     TIMELINE_LINE_Y + TIMELINE_MARK_SIZE),
                 Colors.Cyan, TIMELINE_LINE_THICKNESS);
 
-            var localizedText = string.Format(CultureInfo.CurrentCulture, "{0:#,##0,,}", generationTime[i]) + " "
+            var localizedText = string.Format(CultureInfo.CurrentCulture, "{0:#,##0,,}", generationTimes[i]) + " "
                 + TranslationServer.Translate("MEGA_YEARS");
             var size = latoSmallItalic.GetStringSize(localizedText);
             DrawString(latoSmallRegular, new Vector2(
@@ -164,7 +164,7 @@ public class EvolutionaryTree : Control
         }
 
         latestGeneration = generation;
-        generationTime[generation] = time;
+        generationTimes[generation] = time;
 
         BuildTree();
         AdjustSize();

--- a/src/auto-evo/EvolutionaryTree.cs
+++ b/src/auto-evo/EvolutionaryTree.cs
@@ -25,6 +25,8 @@ public class EvolutionaryTree : Control
     private readonly System.Collections.Generic.Dictionary<uint, (uint ParentSpeciesID, int SplitGeneration)>
         speciesOrigin = new();
 
+    private readonly System.Collections.Generic.Dictionary<int, double> generationTime = new();
+
     private readonly ButtonGroup nodesGroup = new();
 
     private Font latoSmallItalic = null!;
@@ -58,6 +60,7 @@ public class EvolutionaryTree : Control
 
         speciesOrigin.Add(luca.ID, (uint.MaxValue, 0));
         speciesNames.Add(luca.ID, luca.FormattedName);
+        generationTime.Add(0, 0);
     }
 
     public override void _Draw()
@@ -75,7 +78,7 @@ public class EvolutionaryTree : Control
                     TIMELINE_LINE_Y + TIMELINE_MARK_SIZE),
                 Colors.Cyan, TIMELINE_LINE_THICKNESS, true);
 
-            var localizedText = string.Format(CultureInfo.CurrentCulture, "{0:#,##0}", i * 100) + " "
+            var localizedText = string.Format(CultureInfo.CurrentCulture, "{0:#,##0,,}", generationTime[i]) + " "
                 + TranslationServer.Translate("MEGA_YEARS");
             var size = latoSmallItalic.GetStringSize(localizedText);
             DrawString(latoSmallRegular, new Vector2(
@@ -113,7 +116,7 @@ public class EvolutionaryTree : Control
         }
     }
 
-    public void UpdateEvolutionaryTreeWithRunResults(RunResults results, int generation)
+    public void UpdateEvolutionaryTreeWithRunResults(RunResults results, int generation, double time)
     {
         foreach (var speciesResultPair in results.OrderBy(r => r.Value.Species.ID))
         {
@@ -147,6 +150,7 @@ public class EvolutionaryTree : Control
         }
 
         latestGeneration = generation;
+        generationTime[generation] = time;
 
         BuildTree();
         AdjustSize();

--- a/src/auto-evo/EvolutionaryTree.cs
+++ b/src/auto-evo/EvolutionaryTree.cs
@@ -67,14 +67,14 @@ public class EvolutionaryTree : Control
 
         // Draw timeline
         DrawLine(new Vector2(0, TIMELINE_LINE_Y), new Vector2(RectSize.x, TIMELINE_LINE_Y), Colors.Cyan,
-            TIMELINE_LINE_THICKNESS, true);
+            TIMELINE_LINE_THICKNESS);
 
         for (int i = 0; i <= latestGeneration; i++)
         {
             DrawLine(new Vector2(LEFT_MARGIN + i * GENERATION_SEPARATION + treeNodeSize.x / 2, TIMELINE_LINE_Y),
                 new Vector2(LEFT_MARGIN + i * GENERATION_SEPARATION + treeNodeSize.x / 2,
                     TIMELINE_LINE_Y + TIMELINE_MARK_SIZE),
-                Colors.Cyan, TIMELINE_LINE_THICKNESS, true);
+                Colors.Cyan, TIMELINE_LINE_THICKNESS);
 
             var localizedText = string.Format(CultureInfo.CurrentCulture, "{0:#,##0,,}", generationTime[i]) + " "
                 + TranslationServer.Translate("MEGA_YEARS");
@@ -230,14 +230,14 @@ public class EvolutionaryTree : Control
     {
         if (to.y - from.y < MathUtils.EPSILON)
         {
-            DrawLine(from, to, Colors.DarkCyan, 4.0f, true);
+            DrawLine(from, to, Colors.DarkCyan, 4.0f);
         }
         else
         {
             var mid = to - new Vector2(GENERATION_SEPARATION / 2.0f, 0);
-            DrawLine(from, new Vector2(mid.x, from.y), Colors.DarkCyan, 4.0f, true);
-            DrawLine(new Vector2(mid.x, from.y), new Vector2(mid.x, to.y), Colors.DarkCyan, 4.0f, true);
-            DrawLine(new Vector2(mid.x, to.y), to, Colors.DarkCyan, 4.0f, true);
+            DrawLine(from, new Vector2(mid.x, from.y), Colors.DarkCyan, 4.0f);
+            DrawLine(new Vector2(mid.x, from.y), new Vector2(mid.x, to.y), Colors.DarkCyan, 4.0f);
+            DrawLine(new Vector2(mid.x, to.y), to, Colors.DarkCyan, 4.0f);
         }
     }
 


### PR DESCRIPTION
Fixes #3628 - I think we can allow 100 runs at a time (default value), as long as one can abort it at any moment.

Fixes #3629 - Now each generation passes its time to the evolutionary tree.

Fixes #3624 - Disabled draw line antialiasing.

Another small performance gain - Tweaks to drawing algorithm.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
