### PR TITLE
Stop auto-evo run if stage is exited (other than going to the editor)

### DIFF
--- a/src/general/StageBase.cs
+++ b/src/general/StageBase.cs
@@ -104,7 +104,8 @@ public abstract class StageBase<TPlayer> : NodeWithInput, IStage, IGodotEarlyNod
     }
 
     /// <summary>
-    ///   True when transitioning to the editor
+    ///   True when transitioning to the editor. Note this should only be unset *after* switching scenes to the editor
+    ///   otherwise some tree exit operations won't run correctly.
     /// </summary>
     [JsonIgnore]
     public bool MovingToEditor { get; set; }
@@ -168,6 +169,18 @@ public abstract class StageBase<TPlayer> : NodeWithInput, IStage, IGodotEarlyNod
     }
 
     protected abstract IStageHUD BaseHUD { get; }
+
+    public override void _ExitTree()
+    {
+        base._ExitTree();
+
+        // Cancel auto-evo if it is running to not leave background runs from other games running if the player
+        // just loaded a save
+        if (!MovingToEditor)
+        {
+            GameWorld.ResetAutoEvoRun();
+        }
+    }
 
     public virtual void ResolveNodeReferences()
     {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Prevents the game from getting locked up due to auto-evo runs from other saves if only a low number of background executor threads are used.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://community.revolutionarygamesstudio.com/t/error-when-trying-to-load-save/5139/16?u=hhyyrylainen

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
