### PR TITLE
Improved the English text for the auto-evo exploring tool

### DIFF
--- a/locale/en.po
+++ b/locale/en.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2022-08-02 13:55+0300\n"
-"PO-Revision-Date: 2022-07-31 20:14+0300\n"
+"PO-Revision-Date: 2022-08-03 16:32+0300\n"
 "Last-Translator: Georgi Georgiev (RacerBG) <g.georgiev.shumen@gmail.com>\n"
 "Language-Team: English <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/en/>\n"
 "Language: en\n"
@@ -999,7 +999,7 @@ msgstr ""
 "[b]Colour[/b]\n"
 "  #{4}\n"
 "[b]Behaviour[/b]\n"
-"  {5}\n"
+"  {5}"
 
 #: ../src/auto-evo/AutoEvoExploringTool.cs:716
 msgid "MICROBE_SPECIES_DETAIL_TEXT"
@@ -1032,35 +1032,35 @@ msgstr "Viewer"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:162
 msgid "ALLOW_SPECIES_TO_NOT_MUTATE"
-msgstr "Allow species to not mutate"
+msgstr "Allow species to not mutate (if no good mutation is found)"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:169
 msgid "ALLOW_SPECIES_TO_NOT_MIGRATE"
-msgstr "Allow species to not migrate"
+msgstr "Allow species to not migrate (if no good migration is found)"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:182
 msgid "BIODIVERSITY_ATTEMPT_FILL_CHANCE"
-msgstr "Biodiversity attempt fill chance"
+msgstr "Chance in each patch with few species (low biodiversity) to create a new species"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:202
 msgid "BIODIVERSITY_FROM_NEIGHBOUR_PATCH_CHANCE"
-msgstr "Biodiversity from neighbour patch chance"
+msgstr "Chance to create a new species to increase biodiversity form a nearby patch"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:216
 msgid "BIODIVERSITY_NEARBY_PATCH_IS_FREE_POPULATION"
-msgstr "Biodiversity nearby patch is free population"
+msgstr "Biodiversity increasing species from nearby patch is given free population"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:223
 msgid "BIODIVERSITY_SPLIT_IS_MUTATED"
-msgstr "Biodiversity split is mutated"
+msgstr "Biodiversity increasing species is mutated on creation"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:236
 msgid "LOW_BIODIVERSITY_LIMIT"
-msgstr "Low biodiversity limit"
+msgstr "Consider patches with up to this many species having low biodiversity"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:254
 msgid "MAXIMUM_SPECIES_IN_PATCH"
-msgstr "Maximum species in patch"
+msgstr "Maximum species in a patch before forced extinctions"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:272
 msgid "MOVE_ATTEMPTS_PER_SPECIES"
@@ -1068,39 +1068,39 @@ msgstr "Move attempts per species"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:290
 msgid "MUTATIONS_PER_SPECIES"
-msgstr "Mutations per species"
+msgstr "Mutation attempts per species"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:308
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
-msgstr "New biodiversity increasing species population"
+msgstr "Initial population for biodiversity increasing species"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:322
 msgid "PROTECT_MIGRATIONS_FROM_SPECIES_CAP"
-msgstr "Protect migrations from species cap"
+msgstr "Protect just migrated populations from species cap"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:329
 msgid "PROTECT_NEW_CELLS_FROM_SPECIES_CAP"
-msgstr "Protect new cells from species cap"
+msgstr "Protect just created species from species cap"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:336
 msgid "REFUND_MIGRATIONS_IN_EXTINCTIONS"
-msgstr "Refund migrations in extinctions"
+msgstr "Refund migrations in case of extinction in the target patch"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:343
 msgid "STRICT_NICHE_COMPETITION"
-msgstr "Strict niche competition"
+msgstr "Strict niche competition (fitness differences are exaggerated)"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:356
 msgid "SPECIES_SPLIT_BY_MUTATION_THRESHOLD_POPULATION_AMOUNT"
-msgstr "Species split by mutation threshold population amount"
+msgstr "Minimum population for species to split by multiple good found mutations"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:376
 msgid "SPECIES_SPLIT_BY_MUTATION_THRESHOLD_POPULATION_FRACTION"
-msgstr "Species split by mutation threshold population fraction"
+msgstr "Minimum population fraction of a species to allow split by mutations"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:388
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
-msgstr "Use biodiversity force split"
+msgstr "Biodiversity increasing species creation steals population from existing species"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:410
 msgid "CURRENT_GENERATION_COLON"


### PR DESCRIPTION
also fixed one string with a trailing newline Poedit complained about each time

![2022-08-03_16 34 39 5619](https://user-images.githubusercontent.com/3796411/182621725-602901ed-510f-4bf1-8852-3fdbf99ff2bd.png)


**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
translators, pretty fairly, complained that the English text was not clear at all in the auto-evo exploring tool, so I tried to improve that without getting too wordy


**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
