### PR TITLE
Fixed spawner cleaning not working and causing duplicate spawner registrations

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -41,6 +41,24 @@ public static class Constants
     public const float CLOUD_SPAWN_AMOUNT_SCALE_FACTOR = 0.75f;
 
     /// <summary>
+    ///   Scale factor for how dense microbes spawn (also affected by their populations).
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     Due to an earlier problem old, species spawners were never cleared so they accumulated a lot.
+    ///     This multiplier has now been increased quite a bit to try to make the lower number of species spawners
+    ///     result in the same level of microbe spawning.
+    ///   </para>
+    /// </remarks>
+    public const float MICROBE_SPAWN_DENSITY_SCALE_FACTOR = 0.022f;
+
+    /// <summary>
+    ///   Along with <see cref="MICROBE_SPAWN_DENSITY_SCALE_FACTOR"/> affects spawn density of microbes.
+    ///   The lower this multiplier is set the more evenly species with different populations are spawned.
+    /// </summary>
+    public const float MICROBE_SPAWN_DENSITY_POPULATION_MULTIPLIER = 1 / 25.0f;
+
+    /// <summary>
     ///   The (default) size of the hexagons, used in calculations. Don't change this.
     /// </summary>
     public const float DEFAULT_HEX_SIZE = 0.75f;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -45,7 +45,7 @@ public static class Constants
     /// </summary>
     /// <remarks>
     ///   <para>
-    ///     Due to an earlier problem old, species spawners were never cleared so they accumulated a lot.
+    ///     Due to an earlier problem, old species spawners were never cleared so they accumulated a lot.
     ///     This multiplier has now been increased quite a bit to try to make the lower number of species spawners
     ///     result in the same level of microbe spawning.
     ///   </para>

--- a/src/general/Species.cs
+++ b/src/general/Species.cs
@@ -257,7 +257,7 @@ public abstract class Species : ICloneable
 
     public override string ToString()
     {
-        return FormattedIdentifier;
+        return Obsolete ? "[OBSOLETE] " + FormattedIdentifier : FormattedIdentifier;
     }
 
     /// <summary>

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -368,6 +368,9 @@ public class MicrobeStage : StageBase<Microbe>
 
             if (microbe == Player)
                 playerHandled = true;
+
+            if (microbe.Species != multicellularSpecies)
+                throw new Exception("Failed to apply multicellular species");
         }
 
         if (!playerHandled)

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -378,6 +378,9 @@ public class MicrobeStage : StageBase<Microbe>
 
         GameWorld.NotifySpeciesChangedStages();
 
+        // Make sure no queued player species can spawn with the old species
+        spawner.ClearSpawnQueue();
+
         var scene = SceneManager.Instance.LoadScene(MainGameState.EarlyMulticellularEditor);
 
         var editor = (EarlyMulticellularEditor)scene.Instance();

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -185,7 +185,9 @@ public class PatchManager : IChildPropertiesLoadCallback
                 continue;
             }
 
-            var density = Mathf.Max(Mathf.Log(population / 25.0f) * 0.01f, 0.0f);
+            var density = Mathf.Max(
+                Mathf.Log(population / Constants.MICROBE_SPAWN_DENSITY_POPULATION_MULTIPLIER) *
+                Constants.MICROBE_SPAWN_DENSITY_SCALE_FACTOR, 0.0f);
 
             var name = species.ID.ToString(CultureInfo.InvariantCulture);
 

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -239,6 +239,11 @@ public class PatchManager : IChildPropertiesLoadCallback
 
         if (existing != null)
         {
+            if (existing.Marked)
+            {
+                GD.PrintErr($"Multiple spawn items want to use the same spawner {existing.Name} ({existing})");
+            }
+
             existing.Marked = true;
 
             if (existing.Spawner.Density != density)

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -109,10 +109,7 @@ public class SpawnSystem : ISpawnSystem
 
     public void DespawnAll()
     {
-        foreach (var queuedSpawn in queuedSpawns)
-            queuedSpawn.Dispose();
-
-        queuedSpawns.Clear();
+        ClearSpawnQueue();
         int despawned = 0;
 
         foreach (var spawned in worldRoot.GetChildrenToProcess<ISpawned>(Constants.SPAWNED_GROUP))
@@ -130,6 +127,18 @@ public class SpawnSystem : ISpawnSystem
             debugOverlay.ReportDespawns(despawned);
 
         ClearSpawnCoordinates();
+    }
+
+    /// <summary>
+    ///   Clears all of the queued spawns. For use when the queue might contain something that
+    ///   should not be allowed to spawn.
+    /// </summary>
+    public void ClearSpawnQueue()
+    {
+        foreach (var queuedSpawn in queuedSpawns)
+            queuedSpawn.Dispose();
+
+        queuedSpawns.Clear();
     }
 
     /// <summary>

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -298,6 +298,11 @@ public class MicrobeSpawner : Spawner
             }
         }
     }
+
+    public override string ToString()
+    {
+        return $"MicrobeSpawner for {Species}";
+    }
 }
 
 /// <summary>
@@ -324,6 +329,11 @@ public class CompoundCloudSpawner : Spawner
         // We don't spawn entities
         return null;
     }
+
+    public override string ToString()
+    {
+        return $"CloudSpawner for {compound}";
+    }
 }
 
 /// <summary>
@@ -349,5 +359,10 @@ public class ChunkSpawner : Spawner
         yield return chunk;
 
         ModLoader.ModInterface.TriggerOnChunkSpawned(chunk, true);
+    }
+
+    public override string ToString()
+    {
+        return $"ChunkSpawner for {chunkType.Name}";
     }
 }

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -269,7 +269,7 @@ public class MicrobeSpawner : Spawner
 
     public override IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location, ISpawnSystem spawnSystem)
     {
-        // TODO: figure out why these spawn. At least in some player provided logs this seemed to happen quite a bit
+        // This should no longer happen, but let's keep this print here to keep track of the situation
         if (Species.Obsolete)
             GD.PrintErr("Obsolete species microbe has spawned");
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

So turns out for a while now the patch manager had registered a bunch of duplicate species spawners on each editor cycle. This should fix that. One thing to note was that saving and loading also properly cleaned the spawners so in all my testing until now I had not noticed this problem.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #3544

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
