### PR TITLE
Fix cloud spawns being constrained by entity limit

### DIFF
--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -345,11 +345,8 @@ public class SpawnSystem : ISpawnSystem
         int spawns = 0;
         foreach (var spawnType in spawnTypes)
         {
-            if (spawnType is MicrobeSpawner)
+            if (!SpawnsBlocked(spawnType) && spawnType is MicrobeSpawner)
             {
-                if (SpawnsBlocked(spawnType))
-                    continue;
-
                 spawns += SpawnWithSpawner(spawnType,
                     playerLocation + new Vector3(Mathf.Cos(angle) * Constants.SPAWN_SECTOR_SIZE * 2, 0,
                         Mathf.Sin(angle) * Constants.SPAWN_SECTOR_SIZE * 2), ref spawnsLeftThisFrame);
@@ -367,8 +364,7 @@ public class SpawnSystem : ISpawnSystem
     /// </summary>
     private bool SpawnsBlocked(Spawner spawnType)
     {
-        return spawnType is not CompoundCloudSpawner &&
-            estimateEntityCount >= Settings.Instance.MaxSpawnedEntities.Value;
+        return spawnType.SpawnsEntities && estimateEntityCount >= Settings.Instance.MaxSpawnedEntities.Value;
     }
 
     /// <summary>

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -363,7 +363,7 @@ public class SpawnSystem : ISpawnSystem
     }
 
     /// <summary>
-    ///   Checks that spawning this type is currently allowed
+    ///   Checks whether we're currently blocked from spawning this type
     /// </summary>
     private bool SpawnsBlocked(Spawner spawnType)
     {

--- a/src/microbe_stage/Spawner.cs
+++ b/src/microbe_stage/Spawner.cs
@@ -7,6 +7,11 @@ using Godot;
 public abstract class Spawner
 {
     /// <summary>
+    ///   Whether this spawner spawns items contributing to the entity limit
+    /// </summary>
+    public abstract bool SpawnsEntities { get; }
+
+    /// <summary>
     ///   The distance at which spawning happens
     /// </summary>
     public int SpawnRadius { get; set; }

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -265,6 +265,8 @@ public class MicrobeSpawner : Spawner
         random = new Random();
     }
 
+    public override bool SpawnsEntities => true;
+
     public Species Species { get; }
 
     public override IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location, ISpawnSystem spawnSystem)
@@ -322,6 +324,8 @@ public class CompoundCloudSpawner : Spawner
         this.amount = amount;
     }
 
+    public override bool SpawnsEntities => false;
+
     public override IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location, ISpawnSystem spawnSystem)
     {
         SpawnHelpers.SpawnCloud(clouds, location, compound, amount, random);
@@ -350,6 +354,8 @@ public class ChunkSpawner : Spawner
         this.chunkType = chunkType;
         chunkScene = SpawnHelpers.LoadChunkScene();
     }
+
+    public override bool SpawnsEntities => true;
 
     public override IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location, ISpawnSystem spawnSystem)
     {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes cloud spawns being erroneously prevented if we're over the entity limit. Also renames a method to prevent a similar bug creeping in again.

**Related Issues**

Fixes https://github.com/Revolutionary-Games/Thrive/issues/3663

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
