### PR TITLE
Reenable clip content for the inputs settings tab's scroll container

### DIFF
--- a/src/general/OptionsMenu.tscn
+++ b/src/general/OptionsMenu.tscn
@@ -1092,7 +1092,6 @@ custom_constants/separation = 0
 [node name="ScrollContainer" type="ScrollContainer" parent="CenterContainer/VBoxContainer/PanelContainer/Inputs/VBoxContainer/VBoxContainer"]
 margin_right = 657.0
 margin_bottom = 519.0
-rect_clip_content = false
 size_flags_horizontal = 3
 size_flags_vertical = 3
 __meta__ = {


### PR DESCRIPTION
**Brief Description of What This PR Does**

This probably got accidentally disabled at some point which makes the content of the inputs setting look overflowing out of its container panel.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
