### PR TITLE
Cloud visibility adjustments

### DIFF
--- a/shaders/CompoundCloudPlane.shader
+++ b/shaders/CompoundCloudPlane.shader
@@ -25,7 +25,7 @@ const float CLOUD_MAX_INTENSITY_SHOWN = 1000.f;
 
 // This needs to be less than 0.5 otherwise large cloud areas (due to the noise texture 
 // not being very high resolution) are invisible
-const float NOISE_ZERO_OFFSET = 0.45f;
+const float NOISE_ZERO_OFFSET = 0.35f;
 
 // Needs to match the value in CompoundCloudPlane.cs
 // TODO: implement this or increase the perlin noise texture size to give the clouds more detail

--- a/src/microbe_stage/CompoundCloudPlane.tscn
+++ b/src/microbe_stage/CompoundCloudPlane.tscn
@@ -16,9 +16,6 @@ shader_param/colour1 = Plane( 0.2, 0.3, 0, 1 )
 shader_param/colour2 = Plane( 1, 0, 1, 1 )
 shader_param/colour3 = Plane( 1, 0, 0, 1 )
 shader_param/colour4 = Plane( 0, 1, 1, 1 )
-shader_param/UVOffset = Vector2( 0, 0 )
-shader_param/BrightnessMultiplier = 1.0
-shader_param/CloudAlpha = 0.7
 shader_param/densities = ExtResource( 4 )
 shader_param/noise = ExtResource( 2 )
 

--- a/src/microbe_stage/CompoundCloudPlane.tscn
+++ b/src/microbe_stage/CompoundCloudPlane.tscn
@@ -16,6 +16,9 @@ shader_param/colour1 = Plane( 0.2, 0.3, 0, 1 )
 shader_param/colour2 = Plane( 1, 0, 1, 1 )
 shader_param/colour3 = Plane( 1, 0, 0, 1 )
 shader_param/colour4 = Plane( 0, 1, 1, 1 )
+shader_param/UVOffset = Vector2( 0, 0 )
+shader_param/BrightnessMultiplier = 1.0
+shader_param/CloudAlpha = 0.7
 shader_param/densities = ExtResource( 4 )
 shader_param/noise = ExtResource( 2 )
 

--- a/src/microbe_stage/MicrobeCamera.tscn
+++ b/src/microbe_stage/MicrobeCamera.tscn
@@ -12,7 +12,7 @@ size = Vector2( 800, 400 )
 
 [sub_resource type="ShaderMaterial" id=2]
 resource_local_to_scene = true
-render_priority = -2
+render_priority = -100
 shader = ExtResource( 5 )
 shader_param/repeats = Vector2( 2, 1 )
 shader_param/layer0 = ExtResource( 6 )


### PR DESCRIPTION
**Brief Description of What This PR Does**

Two cloud visibility adjustments:

* Fixed bug introduced by Godot 3.5 where clouds could be rendered below the background.
* Upped the minimum opacity of clouds to prevent invisible cloud sections.

**Related Issues**

Doesn't obviously close any issue, but might mitigate https://github.com/Revolutionary-Games/Thrive/issues/3619 and https://github.com/Revolutionary-Games/Thrive/issues/3234.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
