### PR TITLE
Fixed a crash when quitting the game while a game pausing popup is open

### DIFF
--- a/src/engine/PauseManager.cs
+++ b/src/engine/PauseManager.cs
@@ -26,8 +26,19 @@ public class PauseManager : Node
         {
             if (isPaused != value)
             {
-                GetTree().Paused = value;
                 isPaused = value;
+
+                var tree = GetTree();
+
+                // If the game was closed while paused from a dialog, we get the unpause signal after the node tree
+                // is no longer usable
+                if (tree == null)
+                {
+                    GD.PrintErr("PauseManager can't apply paused state as node tree doesn't exist");
+                    return;
+                }
+
+                tree.Paused = value;
             }
         }
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes a crash I noticed when trying to close the game with a save load error dialog open.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
