### PR TITLE
Created customized registry types concept for auto-evo settings saving

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -24,11 +24,14 @@
     <Compile Include="simulation_parameters\CompoundLoader.cs" />
     <Compile Include="simulation_parameters\EnzymeLoader.cs" />
     <Compile Include="simulation_parameters\GameCredits.cs" />
+    <Compile Include="simulation_parameters\IRegistryAssignable.cs" />
     <Compile Include="simulation_parameters\TranslationsInfo.cs" />
     <Compile Include="src\auto-evo\AutoEvoExploringTool.cs" />
     <Compile Include="src\auto-evo\EditorAutoEvoRun.cs" />
     <Compile Include="src\auto-evo\EvolutionaryTree.cs" />
     <Compile Include="src\auto-evo\EvolutionaryTreeNode.cs" />
+    <Compile Include="src\auto-evo\IAutoEvoConfiguration.cs" />
+    <Compile Include="src\auto-evo\PredefinedAutoEvoConfiguration.cs" />
     <Compile Include="src\auto-evo\simulation\food_source\ChunkFoodSource.cs" />
     <Compile Include="src\auto-evo\simulation\food_source\CompoundFoodSource.cs" />
     <Compile Include="src\auto-evo\simulation\food_source\FoodSource.cs" />
@@ -120,6 +123,8 @@
     <Compile Include="src\general\Asset.cs" />
     <Compile Include="src\general\AssetCategory.cs" />
     <Compile Include="src\general\AssetType.cs" />
+    <Compile Include="src\general\CustomDifficulty.cs" />
+    <Compile Include="src\general\IDifficulty.cs" />
     <Compile Include="src\gui_common\art_gallery\TextureThumbnailResource.cs" />
     <Compile Include="src\gui_common\PhotographablePreview.cs" />
     <Compile Include="src\microbe_stage\CellHexesPhotoBuilder.cs" />

--- a/simulation_parameters/IRegistryAssignable.cs
+++ b/simulation_parameters/IRegistryAssignable.cs
@@ -1,0 +1,7 @@
+﻿/// <summary>
+///   Marks classes and interfaces that can be assigned from registry types, used in the saving system along with
+///   <see cref="CustomizedRegistryTypeAttribute"/> and <see cref="SupportsCustomizedRegistryTypeAttribute"/>.
+/// </summary>
+public interface IRegistryAssignable
+{
+}

--- a/simulation_parameters/IRegistryType.cs
+++ b/simulation_parameters/IRegistryType.cs
@@ -1,4 +1,4 @@
-﻿public interface IRegistryType
+﻿public interface IRegistryType : IRegistryAssignable
 {
     /// <summary>
     ///   The name referred to this registry object in json

--- a/simulation_parameters/SimulationParameters.cs
+++ b/simulation_parameters/SimulationParameters.cs
@@ -11,6 +11,8 @@ using File = Godot.File;
 /// </summary>
 public class SimulationParameters : Node
 {
+    public const string AUTO_EVO_CONFIGURATION_NAME = "AutoEvoConfiguration";
+
     private static SimulationParameters? instance;
 
     private Dictionary<string, MembraneType> membranes = null!;
@@ -22,7 +24,7 @@ public class SimulationParameters : Node
     private Dictionary<string, Enzyme> enzymes = null!;
     private Dictionary<string, MusicCategory> musicCategories = null!;
     private Dictionary<string, HelpTexts> helpTexts = null!;
-    private AutoEvoConfiguration autoEvoConfiguration = null!;
+    private PredefinedAutoEvoConfiguration autoEvoConfiguration = null!;
     private List<NamedInputGroup> inputGroups = null!;
     private Dictionary<string, Gallery> gallery = null!;
     private TranslationsInfo translationsInfo = null!;
@@ -42,7 +44,7 @@ public class SimulationParameters : Node
 
     public IEnumerable<NamedInputGroup> InputGroups => inputGroups;
 
-    public AutoEvoConfiguration AutoEvoConfiguration => autoEvoConfiguration;
+    public IAutoEvoConfiguration AutoEvoConfiguration => autoEvoConfiguration;
 
     public NameGenerator NameGenerator { get; private set; } = null!;
     public PatchMapNameGenerator PatchMapNameGenerator { get; private set; } = null!;
@@ -87,7 +89,8 @@ public class SimulationParameters : Node
         inputGroups = LoadListRegistry<NamedInputGroup>("res://simulation_parameters/common/input_options.json");
 
         autoEvoConfiguration =
-            LoadDirectObject<AutoEvoConfiguration>("res://simulation_parameters/common/auto-evo_parameters.json");
+            LoadDirectObject<PredefinedAutoEvoConfiguration>(
+                "res://simulation_parameters/common/auto-evo_parameters.json");
 
         gallery = LoadRegistry<Gallery>("res://simulation_parameters/common/gallery.json");
 
@@ -447,6 +450,7 @@ public class SimulationParameters : Node
         NameGenerator.Check(string.Empty);
         PatchMapNameGenerator.Check(string.Empty);
         autoEvoConfiguration.Check(string.Empty);
+        autoEvoConfiguration.InternalName = AUTO_EVO_CONFIGURATION_NAME;
         translationsInfo.Check(string.Empty);
         gameCredits.Check(string.Empty);
     }

--- a/src/auto-evo/AutoEvoConfiguration.cs
+++ b/src/auto-evo/AutoEvoConfiguration.cs
@@ -1,150 +1,42 @@
-﻿using System;
-using Newtonsoft.Json;
-
-/// <summary>
-///   Settings for auto-evo
+﻿/// <summary>
+///   Settings for auto-evo that have been (potentially) tweaked
 /// </summary>
-/// <remarks>
-///   <para>
-///     Like all registry types, this should not be modified during runtime at all. The reason the properties
-///     are modifiable is to allow auto-evo exploring tool to modify its own copy of the settings.
-///   </para>
-/// </remarks>
-public class AutoEvoConfiguration : IRegistryType, ICloneable
+[CustomizedRegistryType]
+public class AutoEvoConfiguration : IAutoEvoConfiguration
 {
-    [JsonProperty]
     public int MutationsPerSpecies { get; set; }
 
-    [JsonProperty]
     public bool AllowSpeciesToNotMutate { get; set; }
 
-    [JsonProperty]
     public int MoveAttemptsPerSpecies { get; set; }
 
-    [JsonProperty]
     public bool AllowSpeciesToNotMigrate { get; set; }
 
-    [JsonProperty]
     public int LowBiodiversityLimit { get; set; }
 
-    [JsonProperty]
     public float SpeciesSplitByMutationThresholdPopulationFraction { get; set; }
 
-    [JsonProperty]
     public int SpeciesSplitByMutationThresholdPopulationAmount { get; set; }
 
-    [JsonProperty]
     public float BiodiversityAttemptFillChance { get; set; }
 
-    [JsonProperty]
     public bool UseBiodiversityForceSplit { get; set; }
 
-    [JsonProperty]
     public float BiodiversityFromNeighbourPatchChance { get; set; }
 
-    [JsonProperty]
     public bool BiodiversityNearbyPatchIsFreePopulation { get; set; }
 
-    [JsonProperty]
     public int NewBiodiversityIncreasingSpeciesPopulation { get; set; }
 
-    [JsonProperty]
     public bool BiodiversitySplitIsMutated { get; set; }
 
-    [JsonProperty]
     public bool StrictNicheCompetition { get; set; }
 
-    /// <summary>
-    ///   Maximum number of species kept in a patch at the end of auto-evo.
-    /// </summary>
-    /// <remarks>
-    ///   <para>
-    ///     Always ignores the player species, and may ignore new cells and migrations.
-    ///   </para>
-    /// </remarks>
-    [JsonProperty]
     public int MaximumSpeciesInPatch { get; set; }
 
-    /// <summary>
-    ///   If true newly created species can't be forced to go extinct in the same auto-evo cycle
-    /// </summary>
-    [JsonProperty]
     public bool ProtectNewCellsFromSpeciesCap { get; set; }
 
-    /// <summary>
-    ///   TODO: this is meant to protect migrating species from forced extinction, however this is currently only
-    ///   assumes that migrations don't happen and works with population numbers as if they weren't there, which
-    ///   doesn't really guarantee that this does anything useful
-    /// </summary>
-    [JsonProperty]
     public bool ProtectMigrationsFromSpeciesCap { get; set; }
 
-    /// <summary>
-    ///   Whether or not a migration wiped by a force extinction should be refunded in the original patch.
-    /// </summary>
-    [JsonProperty]
     public bool RefundMigrationsInExtinctions { get; set; }
-
-    /// <summary>
-    ///   Unused
-    /// </summary>
-    public string InternalName { get; set; } = null!;
-
-    public void Check(string name)
-    {
-        if (MutationsPerSpecies < 0)
-        {
-            throw new InvalidRegistryDataException("AutoEvoConfiguration", GetType().Name,
-                "Mutations per species must be positive");
-        }
-
-        if (MoveAttemptsPerSpecies < 0)
-        {
-            throw new InvalidRegistryDataException("AutoEvoConfiguration", GetType().Name,
-                "Move attempts per species must be positive");
-        }
-
-        if (SpeciesSplitByMutationThresholdPopulationFraction is < 0 or > 1)
-        {
-            throw new InvalidRegistryDataException("AutoEvoConfiguration", GetType().Name,
-                "SpeciesSplitByMutationThresholdPopulationFraction not between 0 and 1");
-        }
-
-        if (SpeciesSplitByMutationThresholdPopulationFraction <= 0 ||
-            SpeciesSplitByMutationThresholdPopulationAmount <= 0)
-        {
-            SpeciesSplitByMutationThresholdPopulationFraction = 0;
-            SpeciesSplitByMutationThresholdPopulationAmount = 0;
-        }
-    }
-
-    public void ApplyTranslations()
-    {
-    }
-
-    public object Clone()
-    {
-        return new AutoEvoConfiguration
-        {
-            AllowSpeciesToNotMutate = AllowSpeciesToNotMutate,
-            AllowSpeciesToNotMigrate = AllowSpeciesToNotMigrate,
-            BiodiversityAttemptFillChance = BiodiversityAttemptFillChance,
-            BiodiversityFromNeighbourPatchChance = BiodiversityFromNeighbourPatchChance,
-            BiodiversityNearbyPatchIsFreePopulation = BiodiversityNearbyPatchIsFreePopulation,
-            BiodiversitySplitIsMutated = BiodiversitySplitIsMutated,
-            InternalName = InternalName,
-            LowBiodiversityLimit = LowBiodiversityLimit,
-            MaximumSpeciesInPatch = MaximumSpeciesInPatch,
-            MoveAttemptsPerSpecies = MoveAttemptsPerSpecies,
-            MutationsPerSpecies = MutationsPerSpecies,
-            NewBiodiversityIncreasingSpeciesPopulation = NewBiodiversityIncreasingSpeciesPopulation,
-            ProtectMigrationsFromSpeciesCap = ProtectMigrationsFromSpeciesCap,
-            ProtectNewCellsFromSpeciesCap = ProtectNewCellsFromSpeciesCap,
-            RefundMigrationsInExtinctions = RefundMigrationsInExtinctions,
-            StrictNicheCompetition = StrictNicheCompetition,
-            SpeciesSplitByMutationThresholdPopulationAmount = SpeciesSplitByMutationThresholdPopulationAmount,
-            SpeciesSplitByMutationThresholdPopulationFraction = SpeciesSplitByMutationThresholdPopulationFraction,
-            UseBiodiversityForceSplit = UseBiodiversityForceSplit,
-        };
-    }
 }

--- a/src/auto-evo/AutoEvoExploringTool.cs
+++ b/src/auto-evo/AutoEvoExploringTool.cs
@@ -297,7 +297,7 @@ public class AutoEvoExploringTool : NodeWithInput
         exitConfirmationDialog = GetNode<CustomConfirmationDialog>(ExitConfirmationDialogPath);
 
         // Init game
-        autoEvoConfiguration = (AutoEvoConfiguration)SimulationParameters.Instance.AutoEvoConfiguration.Clone();
+        autoEvoConfiguration = SimulationParameters.Instance.AutoEvoConfiguration.Clone();
         gameProperties = GameProperties.StartNewMicrobeGame(new WorldGenerationSettings
             { AutoEvoConfiguration = autoEvoConfiguration });
 

--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -13,7 +13,7 @@ using Thread = System.Threading.Thread;
 /// </summary>
 public class AutoEvoRun
 {
-    protected readonly AutoEvoConfiguration configuration;
+    protected readonly IAutoEvoConfiguration configuration;
 
     /// <summary>
     ///   Results are stored here until the simulation is complete and then applied

--- a/src/auto-evo/IAutoEvoConfiguration.cs
+++ b/src/auto-evo/IAutoEvoConfiguration.cs
@@ -1,0 +1,118 @@
+﻿/// <summary>
+///   Auto-evo configuration parameters to be used
+/// </summary>
+[SupportsCustomizedRegistryType(typeof(AutoEvoConfiguration))]
+public interface IAutoEvoConfiguration : IRegistryAssignable
+{
+    public int MutationsPerSpecies { get; }
+
+    public bool AllowSpeciesToNotMutate { get; }
+
+    public int MoveAttemptsPerSpecies { get; }
+
+    public bool AllowSpeciesToNotMigrate { get; }
+
+    public int LowBiodiversityLimit { get; }
+
+    public float SpeciesSplitByMutationThresholdPopulationFraction { get; }
+
+    public int SpeciesSplitByMutationThresholdPopulationAmount { get; }
+
+    public float BiodiversityAttemptFillChance { get; }
+
+    public bool UseBiodiversityForceSplit { get; }
+
+    public float BiodiversityFromNeighbourPatchChance { get; }
+
+    public bool BiodiversityNearbyPatchIsFreePopulation { get; }
+
+    public int NewBiodiversityIncreasingSpeciesPopulation { get; }
+
+    public bool BiodiversitySplitIsMutated { get; }
+
+    public bool StrictNicheCompetition { get; }
+
+    /// <summary>
+    ///   Maximum number of species kept in a patch at the end of auto-evo.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     Always ignores the player species, and may ignore new cells and migrations.
+    ///   </para>
+    /// </remarks>
+    public int MaximumSpeciesInPatch { get; }
+
+    /// <summary>
+    ///   If true newly created species can't be forced to go extinct in the same auto-evo cycle
+    /// </summary>
+    public bool ProtectNewCellsFromSpeciesCap { get; }
+
+    /// <summary>
+    ///   TODO: this is meant to protect migrating species from forced extinction, however this is currently only
+    ///   assumes that migrations don't happen and works with population numbers as if they weren't there, which
+    ///   doesn't really guarantee that this does anything useful
+    /// </summary>
+    public bool ProtectMigrationsFromSpeciesCap { get; }
+
+    /// <summary>
+    ///   Whether or not a migration wiped by a force extinction should be refunded in the original patch.
+    /// </summary>
+    public bool RefundMigrationsInExtinctions { get; }
+}
+
+public static class AutoEvoConfigurationHelpers
+{
+    public static void Check(this IAutoEvoConfiguration configuration)
+    {
+        if (configuration.MutationsPerSpecies < 0)
+        {
+            throw new InvalidRegistryDataException("AutoEvoConfiguration", configuration.GetType().Name,
+                "Mutations per species must be positive");
+        }
+
+        if (configuration.MoveAttemptsPerSpecies < 0)
+        {
+            throw new InvalidRegistryDataException("AutoEvoConfiguration", configuration.GetType().Name,
+                "Move attempts per species must be positive");
+        }
+
+        if (configuration.SpeciesSplitByMutationThresholdPopulationFraction is < 0 or > 1)
+        {
+            throw new InvalidRegistryDataException("AutoEvoConfiguration", configuration.GetType().Name,
+                "SpeciesSplitByMutationThresholdPopulationFraction not between 0 and 1");
+        }
+
+        if (configuration.SpeciesSplitByMutationThresholdPopulationAmount is < 0)
+        {
+            throw new InvalidRegistryDataException("AutoEvoConfiguration", configuration.GetType().Name,
+                "SpeciesSplitByMutationThresholdPopulationAmount is negative");
+        }
+    }
+
+    public static AutoEvoConfiguration Clone(this IAutoEvoConfiguration configuration)
+    {
+        return new AutoEvoConfiguration
+        {
+            AllowSpeciesToNotMutate = configuration.AllowSpeciesToNotMutate,
+            AllowSpeciesToNotMigrate = configuration.AllowSpeciesToNotMigrate,
+            BiodiversityAttemptFillChance = configuration.BiodiversityAttemptFillChance,
+            BiodiversityFromNeighbourPatchChance = configuration.BiodiversityFromNeighbourPatchChance,
+            BiodiversityNearbyPatchIsFreePopulation = configuration.BiodiversityNearbyPatchIsFreePopulation,
+            BiodiversitySplitIsMutated = configuration.BiodiversitySplitIsMutated,
+            LowBiodiversityLimit = configuration.LowBiodiversityLimit,
+            MaximumSpeciesInPatch = configuration.MaximumSpeciesInPatch,
+            MoveAttemptsPerSpecies = configuration.MoveAttemptsPerSpecies,
+            MutationsPerSpecies = configuration.MutationsPerSpecies,
+            NewBiodiversityIncreasingSpeciesPopulation = configuration.NewBiodiversityIncreasingSpeciesPopulation,
+            ProtectMigrationsFromSpeciesCap = configuration.ProtectMigrationsFromSpeciesCap,
+            ProtectNewCellsFromSpeciesCap = configuration.ProtectNewCellsFromSpeciesCap,
+            RefundMigrationsInExtinctions = configuration.RefundMigrationsInExtinctions,
+            StrictNicheCompetition = configuration.StrictNicheCompetition,
+            SpeciesSplitByMutationThresholdPopulationAmount =
+                configuration.SpeciesSplitByMutationThresholdPopulationAmount,
+            SpeciesSplitByMutationThresholdPopulationFraction =
+                configuration.SpeciesSplitByMutationThresholdPopulationFraction,
+            UseBiodiversityForceSplit = configuration.UseBiodiversityForceSplit,
+        };
+    }
+}

--- a/src/auto-evo/PredefinedAutoEvoConfiguration.cs
+++ b/src/auto-evo/PredefinedAutoEvoConfiguration.cs
@@ -1,0 +1,76 @@
+﻿using Newtonsoft.Json;
+
+/// <summary>
+///   Settings for auto-evo that are loaded from the configuration JSON
+/// </summary>
+[JSONAlwaysDynamicType]
+public class PredefinedAutoEvoConfiguration : IAutoEvoConfiguration, IRegistryType
+{
+    [JsonProperty]
+    public int MutationsPerSpecies { get; private set; }
+
+    [JsonProperty]
+    public bool AllowSpeciesToNotMutate { get; private set; }
+
+    [JsonProperty]
+    public int MoveAttemptsPerSpecies { get; private set; }
+
+    [JsonProperty]
+    public bool AllowSpeciesToNotMigrate { get; private set; }
+
+    [JsonProperty]
+    public int LowBiodiversityLimit { get; private set; }
+
+    [JsonProperty]
+    public float SpeciesSplitByMutationThresholdPopulationFraction { get; private set; }
+
+    [JsonProperty]
+    public int SpeciesSplitByMutationThresholdPopulationAmount { get; private set; }
+
+    [JsonProperty]
+    public float BiodiversityAttemptFillChance { get; private set; }
+
+    [JsonProperty]
+    public bool UseBiodiversityForceSplit { get; private set; }
+
+    [JsonProperty]
+    public float BiodiversityFromNeighbourPatchChance { get; private set; }
+
+    [JsonProperty]
+    public bool BiodiversityNearbyPatchIsFreePopulation { get; private set; }
+
+    [JsonProperty]
+    public int NewBiodiversityIncreasingSpeciesPopulation { get; private set; }
+
+    [JsonProperty]
+    public bool BiodiversitySplitIsMutated { get; private set; }
+
+    [JsonProperty]
+    public bool StrictNicheCompetition { get; private set; }
+
+    [JsonProperty]
+    public int MaximumSpeciesInPatch { get; private set; }
+
+    [JsonProperty]
+    public bool ProtectNewCellsFromSpeciesCap { get; private set; }
+
+    [JsonProperty]
+    public bool ProtectMigrationsFromSpeciesCap { get; private set; }
+
+    [JsonProperty]
+    public bool RefundMigrationsInExtinctions { get; private set; }
+
+    /// <summary>
+    ///   Set to <see cref="SimulationParameters.AUTO_EVO_CONFIGURATION_NAME"/> to make saving and loading work
+    /// </summary>
+    public string InternalName { get; set; } = null!;
+
+    public void ApplyTranslations()
+    {
+    }
+
+    public void Check(string name)
+    {
+        this.Check();
+    }
+}

--- a/src/auto-evo/simulation/PopulationSimulation.cs
+++ b/src/auto-evo/simulation/PopulationSimulation.cs
@@ -140,7 +140,7 @@
 
         private static void RunSimulationStep(SimulationConfiguration parameters, List<Species> species,
             IEnumerable<KeyValuePair<int, Patch>> patchesToSimulate, Random random, SimulationCache cache,
-            AutoEvoConfiguration autoEvoConfiguration)
+            IAutoEvoConfiguration autoEvoConfiguration)
         {
             foreach (var entry in patchesToSimulate)
             {
@@ -156,7 +156,7 @@
         /// </summary>
         private static void SimulatePatchStep(SimulationConfiguration simulationConfiguration, Patch patch,
             IEnumerable<Species> genericSpecies, Random random, SimulationCache cache,
-            AutoEvoConfiguration autoEvoConfiguration)
+            IAutoEvoConfiguration autoEvoConfiguration)
         {
             _ = random;
 

--- a/src/auto-evo/simulation/SimulationConfiguration.cs
+++ b/src/auto-evo/simulation/SimulationConfiguration.cs
@@ -8,7 +8,7 @@
     /// </summary>
     public class SimulationConfiguration
     {
-        public SimulationConfiguration(AutoEvoConfiguration autoEvoConfiguration, PatchMap initialConditions,
+        public SimulationConfiguration(IAutoEvoConfiguration autoEvoConfiguration, PatchMap initialConditions,
             WorldGenerationSettings worldSettings, int steps = 1)
         {
             AutoEvoConfiguration = autoEvoConfiguration;
@@ -17,7 +17,7 @@
             StepsLeft = Math.Max(1, steps);
         }
 
-        public AutoEvoConfiguration AutoEvoConfiguration { get; }
+        public IAutoEvoConfiguration AutoEvoConfiguration { get; }
         public PatchMap OriginalMap { get; }
         public WorldGenerationSettings WorldSettings { get; }
         public int StepsLeft { get; set; }

--- a/src/auto-evo/steps/CalculatePopulation.cs
+++ b/src/auto-evo/steps/CalculatePopulation.cs
@@ -7,14 +7,14 @@
     /// </summary>
     public class CalculatePopulation : IRunStep
     {
-        private readonly AutoEvoConfiguration configuration;
+        private readonly IAutoEvoConfiguration configuration;
         private readonly PatchMap map;
         private readonly WorldGenerationSettings worldSettings;
         private readonly List<Species>? extraSpecies;
         private readonly List<Species>? excludedSpecies;
         private readonly bool collectEnergyInfo;
 
-        public CalculatePopulation(AutoEvoConfiguration configuration, WorldGenerationSettings worldSettings,
+        public CalculatePopulation(IAutoEvoConfiguration configuration, WorldGenerationSettings worldSettings,
             PatchMap map, List<Species>? extraSpecies = null, List<Species>? excludedSpecies = null,
             bool collectEnergyInfo = false)
         {

--- a/src/auto-evo/steps/FindBestMigration.cs
+++ b/src/auto-evo/steps/FindBestMigration.cs
@@ -8,14 +8,14 @@
     /// </summary>
     public class FindBestMigration : VariantTryingStep
     {
-        private readonly AutoEvoConfiguration configuration;
+        private readonly IAutoEvoConfiguration configuration;
         private readonly WorldGenerationSettings worldSettings;
         private readonly PatchMap map;
         private readonly Species species;
         private readonly Random random;
         private readonly SimulationCache cache;
 
-        public FindBestMigration(AutoEvoConfiguration configuration, WorldGenerationSettings worldSettings,
+        public FindBestMigration(IAutoEvoConfiguration configuration, WorldGenerationSettings worldSettings,
             PatchMap map, Species species, Random random, int migrationsToTry,
             bool allowNoMigration) : base(migrationsToTry, allowNoMigration)
         {

--- a/src/auto-evo/steps/FindBestMutation.cs
+++ b/src/auto-evo/steps/FindBestMutation.cs
@@ -9,7 +9,7 @@
     /// </summary>
     public class FindBestMutation : VariantTryingStep
     {
-        private readonly AutoEvoConfiguration configuration;
+        private readonly IAutoEvoConfiguration configuration;
         private readonly WorldGenerationSettings worldSettings;
         private readonly PatchMap map;
         private readonly Species species;
@@ -19,7 +19,7 @@
 
         private readonly Mutations mutations = new();
 
-        public FindBestMutation(AutoEvoConfiguration configuration,
+        public FindBestMutation(IAutoEvoConfiguration configuration,
             WorldGenerationSettings worldSettings, PatchMap map, Species species,
             int mutationsToTry, bool allowNoMutation,
             float splitThresholdFraction, int splitThresholdAmount)

--- a/src/auto-evo/steps/ForceExtinction.cs
+++ b/src/auto-evo/steps/ForceExtinction.cs
@@ -17,9 +17,9 @@
     public class ForceExtinction : IRunStep
     {
         private readonly List<Patch> patches;
-        private readonly AutoEvoConfiguration configuration;
+        private readonly IAutoEvoConfiguration configuration;
 
-        public ForceExtinction(List<Patch> patches, AutoEvoConfiguration configuration)
+        public ForceExtinction(List<Patch> patches, IAutoEvoConfiguration configuration)
         {
             this.patches = patches;
             this.configuration = configuration;

--- a/src/auto-evo/steps/IncreaseBiodiversity.cs
+++ b/src/auto-evo/steps/IncreaseBiodiversity.cs
@@ -12,7 +12,7 @@
     {
         private readonly PatchMap map;
         private readonly Patch patch;
-        private readonly AutoEvoConfiguration configuration;
+        private readonly IAutoEvoConfiguration configuration;
         private readonly Random random;
         private readonly SimulationCache cache;
 
@@ -23,7 +23,7 @@
 
         private WorldGenerationSettings worldSettings;
 
-        public IncreaseBiodiversity(AutoEvoConfiguration configuration,
+        public IncreaseBiodiversity(IAutoEvoConfiguration configuration,
             WorldGenerationSettings worldSettings, PatchMap map, Patch patch, Random random)
         {
             this.worldSettings = worldSettings;

--- a/src/general/CustomDifficulty.cs
+++ b/src/general/CustomDifficulty.cs
@@ -1,0 +1,16 @@
+﻿/// <summary>
+///   Customized difficulty setting
+/// </summary>
+[CustomizedRegistryType]
+public class CustomDifficulty : IDifficulty
+{
+    public float MPMultiplier { get; set; }
+    public float AIMutationMultiplier { get; set; }
+    public float CompoundDensity { get; set; }
+    public float PlayerDeathPopulationPenalty { get; set; }
+    public float GlucoseDecay { get; set; }
+    public float OsmoregulationMultiplier { get; set; }
+    public bool FreeGlucoseCloud { get; set; }
+    public bool PassiveReproduction { get; set; }
+    public bool LimitGrowthRate { get; set; }
+}

--- a/src/general/DifficultyPreset.cs
+++ b/src/general/DifficultyPreset.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 ///     Values for each difficulty preset, as given in difficulty_presets.json
 ///   </para>
 /// </remarks>
-public class DifficultyPreset : IRegistryType
+public class DifficultyPreset : IDifficulty, IRegistryType
 {
     /// <summary>
     ///   User readable name
@@ -17,55 +17,42 @@ public class DifficultyPreset : IRegistryType
     [TranslateFrom(nameof(untranslatedName))]
     public string Name = null!;
 
-    /// <summary>
-    ///   Index for this difficulty preset in the preset menu
-    /// </summary>
-    public int Index;
-
-    /// <summary>
-    ///   Multiplier for MP costs in the editor
-    /// </summary>
-    public float MPMultiplier;
-
-    /// <summary>
-    ///   Multiplier for AI species mutation rate
-    /// </summary>
-    public float AIMutationMultiplier;
-
-    /// <summary>
-    ///   Multiplier for compound cloud density in the environment
-    /// </summary>
-    public float CompoundDensity;
-
-    /// <summary>
-    ///   Multiplier for player species population loss after player death
-    /// </summary>
-    public float PlayerDeathPopulationPenalty;
-
-    /// <summary>
-    ///   Multiplier for rate of glucose decay in the environment
-    /// </summary>
-    public float GlucoseDecay;
-
-    /// <summary>
-    ///   Multiplier for player species osmoregulation cost
-    /// </summary>
-    public float OsmoregulationMultiplier;
-
-    /// <summary>
-    ///  Whether the player starts with a free glucose cloud each time they exit the editor
-    /// </summary>
-    public bool FreeGlucoseCloud;
-
-    /// <inheritdoc cref="WorldGenerationSettings.PassiveGainOfReproductionCompounds"/>
-    public bool PassiveReproduction;
-
-    /// <inheritdoc cref="WorldGenerationSettings.LimitReproductionCompoundUseSpeed"/>
-    public bool LimitGrowthRate;
-
 #pragma warning disable 169,649 // Used through reflection
     private string? untranslatedName;
 #pragma warning restore 169,649
+
+    /// <summary>
+    ///   Index for this difficulty preset in the preset menu
+    /// </summary>
+    [JsonProperty]
+    public int Index { get; private set; }
+
+    [JsonProperty]
+    public float MPMultiplier { get; private set; }
+
+    [JsonProperty]
+    public float AIMutationMultiplier { get; private set; }
+
+    [JsonProperty]
+    public float CompoundDensity { get; private set; }
+
+    [JsonProperty]
+    public float PlayerDeathPopulationPenalty { get; private set; }
+
+    [JsonProperty]
+    public float GlucoseDecay { get; private set; }
+
+    [JsonProperty]
+    public float OsmoregulationMultiplier { get; private set; }
+
+    [JsonProperty]
+    public bool FreeGlucoseCloud { get; private set; }
+
+    [JsonProperty]
+    public bool PassiveReproduction { get; private set; }
+
+    [JsonProperty]
+    public bool LimitGrowthRate { get; private set; }
 
     public string InternalName { get; set; } = null!;
 
@@ -84,6 +71,7 @@ public class DifficultyPreset : IRegistryType
             throw new InvalidRegistryDataException(name, GetType().Name, "Index is negative");
 
         // All presets other than custom must have valid values set for every parameter
+        // Custom is used just as a placeholder item that is replaced with CustomDifficulty when used.
         if (InternalName == "custom")
             return;
 

--- a/src/general/IDifficulty.cs
+++ b/src/general/IDifficulty.cs
@@ -1,0 +1,86 @@
+﻿/// <summary>
+///   Game difficulty data
+/// </summary>
+[SupportsCustomizedRegistryType(typeof(CustomDifficulty))]
+public interface IDifficulty : IRegistryAssignable
+{
+    /// <summary>
+    ///   Multiplier for MP costs in the editor
+    /// </summary>
+    public float MPMultiplier { get; }
+
+    /// <summary>
+    ///   Multiplier for AI species mutation rate
+    /// </summary>
+    public float AIMutationMultiplier { get; }
+
+    /// <summary>
+    ///   Multiplier for compound cloud density in the environment
+    /// </summary>
+    public float CompoundDensity { get; }
+
+    /// <summary>
+    ///   Multiplier for player species population loss after player death
+    /// </summary>
+    public float PlayerDeathPopulationPenalty { get; }
+
+    /// <summary>
+    ///   Multiplier for rate of glucose decay in the environment
+    /// </summary>
+    public float GlucoseDecay { get; }
+
+    /// <summary>
+    ///   Multiplier for player species osmoregulation cost
+    /// </summary>
+    public float OsmoregulationMultiplier { get; }
+
+    /// <summary>
+    ///  Whether the player starts with a free glucose cloud each time they exit the editor
+    /// </summary>
+    public bool FreeGlucoseCloud { get; }
+
+    /// <summary>
+    ///   Whether microbes get free reproduction compounds at a steady background rate
+    /// </summary>
+    public bool PassiveReproduction { get; }
+
+    /// <summary>
+    ///   Whether microbes are limited in how fast they can consume reproduction compounds to grow
+    /// </summary>
+    public bool LimitGrowthRate { get; }
+}
+
+public static class DifficultyHelpers
+{
+    public static CustomDifficulty Clone(this IDifficulty difficulty)
+    {
+        return new CustomDifficulty
+        {
+            MPMultiplier = difficulty.MPMultiplier,
+            AIMutationMultiplier = difficulty.AIMutationMultiplier,
+            CompoundDensity = difficulty.CompoundDensity,
+            PlayerDeathPopulationPenalty = difficulty.PlayerDeathPopulationPenalty,
+            GlucoseDecay = difficulty.GlucoseDecay,
+            OsmoregulationMultiplier = difficulty.OsmoregulationMultiplier,
+            FreeGlucoseCloud = difficulty.FreeGlucoseCloud,
+            PassiveReproduction = difficulty.PassiveReproduction,
+            LimitGrowthRate = difficulty.LimitGrowthRate,
+        };
+    }
+
+    public static string GetDescriptionString(this IDifficulty difficulty)
+    {
+        if (difficulty is DifficultyPreset preset)
+            return $"{preset.InternalName} preset";
+
+        return $"custom: MP multiplier: {difficulty.MPMultiplier}" +
+            $", AI mutation multiplier: {difficulty.AIMutationMultiplier}" +
+            $", Compound density: {difficulty.CompoundDensity}" +
+            $", Player death population penalty: {difficulty.PlayerDeathPopulationPenalty}" +
+            $", Glucose decay: {difficulty.GlucoseDecay}" +
+            $", Osmoregulation multiplier: {difficulty.OsmoregulationMultiplier}" +
+            $", Free glucose cloud: {difficulty.FreeGlucoseCloud}" +
+            $", Passive Reproduction: {difficulty.PassiveReproduction}" +
+            $", Limit Growth Rate: {difficulty.LimitGrowthRate}";
+    }
+}

--- a/src/general/NewGameSettings.cs
+++ b/src/general/NewGameSettings.cs
@@ -168,7 +168,7 @@ public class NewGameSettings : ControlWithInput
 
     private SelectedOptionsTab selectedOptionsTab;
 
-    private WorldGenerationSettings settings = null!;
+    private int latestValidSeed;
 
     private IEnumerable<DifficultyPreset> difficultyPresets = null!;
     private DifficultyPreset normal = null!;
@@ -241,7 +241,6 @@ public class NewGameSettings : ControlWithInput
 
         var simulationParameters = SimulationParameters.Instance;
 
-        settings = new WorldGenerationSettings();
         difficultyPresets = simulationParameters.GetAllDifficultyPresets();
         normal = simulationParameters.GetDifficultyPreset("normal");
         custom = simulationParameters.GetDifficultyPreset("custom");
@@ -321,7 +320,7 @@ public class NewGameSettings : ControlWithInput
         bool valid = int.TryParse(text, out int seed) && seed > 0;
         ReportValidityOfGameSeed(valid);
         if (valid)
-            settings.Seed = seed;
+            latestValidSeed = seed;
     }
 
     /// <summary>
@@ -410,20 +409,35 @@ public class NewGameSettings : ControlWithInput
     {
         GUICommon.Instance.PlayButtonPressSound();
 
-        settings.Difficulty = SimulationParameters.Instance.GetDifficultyPresetByIndex(difficultyPresetButton.Selected);
+        var settings = new WorldGenerationSettings();
+
+        var difficulty = SimulationParameters.Instance.GetDifficultyPresetByIndex(difficultyPresetButton.Selected);
+
+        if (difficulty.InternalName == custom.InternalName)
+        {
+            var customDifficulty = new CustomDifficulty
+            {
+                MPMultiplier = (float)mpMultiplier.Value,
+                AIMutationMultiplier = (float)aiMutationRate.Value,
+                CompoundDensity = (float)compoundDensity.Value,
+                PlayerDeathPopulationPenalty = (float)playerDeathPopulationPenalty.Value,
+                GlucoseDecay = (float)glucoseDecayRate.Value * 0.01f,
+                OsmoregulationMultiplier = (float)osmoregulationMultiplier.Value,
+                FreeGlucoseCloud = freeGlucoseCloudButton.Pressed,
+                PassiveReproduction = passiveReproductionButton.Pressed,
+                LimitGrowthRate = limitGrowthRateButton.Pressed,
+            };
+
+            settings.Difficulty = customDifficulty;
+        }
+        else
+        {
+            settings.Difficulty = difficulty;
+        }
+
         settings.Origin = (WorldGenerationSettings.LifeOrigin)lifeOriginButton.Selected;
         settings.LAWK = lawkButton.Pressed;
-        SetSeed(gameSeed.Text);
-
-        settings.MPMultiplier = (float)mpMultiplier.Value;
-        settings.AIMutationMultiplier = (float)aiMutationRate.Value;
-        settings.CompoundDensity = (float)compoundDensity.Value;
-        settings.PlayerDeathPopulationPenalty = (float)playerDeathPopulationPenalty.Value;
-        settings.GlucoseDecay = (float)glucoseDecayRate.Value * 0.01f;
-        settings.OsmoregulationMultiplier = (float)osmoregulationMultiplier.Value;
-        settings.FreeGlucoseCloud = freeGlucoseCloudButton.Pressed;
-        settings.PassiveGainOfReproductionCompounds = passiveReproductionButton.Pressed;
-        settings.LimitReproductionCompoundUseSpeed = limitGrowthRateButton.Pressed;
+        settings.Seed = latestValidSeed;
 
         settings.MapType = MapTypeIndexToValue(mapTypeButton.Selected);
 
@@ -469,7 +483,6 @@ public class NewGameSettings : ControlWithInput
         difficultyPresetAdvancedButton.Selected = index;
 
         var preset = SimulationParameters.Instance.GetDifficultyPresetByIndex(index);
-        settings.Difficulty = preset;
 
         // If custom was selected, open the advanced view to the difficulty tab
         if (preset.InternalName == custom.InternalName)
@@ -543,7 +556,6 @@ public class NewGameSettings : ControlWithInput
     {
         amount = Math.Round(amount, 1);
         mpMultiplierReadout.Text = amount.ToString(CultureInfo.CurrentCulture);
-        settings.MPMultiplier = (float)amount;
 
         UpdateSelectedDifficultyPresetControl();
     }
@@ -552,7 +564,6 @@ public class NewGameSettings : ControlWithInput
     {
         amount = Math.Round(amount, 1);
         aiMutationRateReadout.Text = amount.ToString(CultureInfo.CurrentCulture);
-        settings.AIMutationMultiplier = (float)amount;
 
         UpdateSelectedDifficultyPresetControl();
     }
@@ -561,7 +572,6 @@ public class NewGameSettings : ControlWithInput
     {
         amount = Math.Round(amount, 1);
         compoundDensityReadout.Text = amount.ToString(CultureInfo.CurrentCulture);
-        settings.CompoundDensity = (float)amount;
 
         UpdateSelectedDifficultyPresetControl();
     }
@@ -570,7 +580,6 @@ public class NewGameSettings : ControlWithInput
     {
         amount = Math.Round(amount, 1);
         playerDeathPopulationPenaltyReadout.Text = amount.ToString(CultureInfo.CurrentCulture);
-        settings.PlayerDeathPopulationPenalty = (float)amount;
 
         UpdateSelectedDifficultyPresetControl();
     }
@@ -579,7 +588,6 @@ public class NewGameSettings : ControlWithInput
     {
         percentage = Math.Round(percentage, 2);
         glucoseDecayRateReadout.Text = TranslationServer.Translate("PERCENTAGE_VALUE").FormatSafe(percentage);
-        settings.GlucoseDecay = (float)percentage * 0.01f;
 
         UpdateSelectedDifficultyPresetControl();
     }
@@ -588,29 +596,25 @@ public class NewGameSettings : ControlWithInput
     {
         amount = Math.Round(amount, 1);
         osmoregulationMultiplierReadout.Text = amount.ToString(CultureInfo.CurrentCulture);
-        settings.OsmoregulationMultiplier = (float)amount;
 
         UpdateSelectedDifficultyPresetControl();
     }
 
     private void OnFreeGlucoseCloudToggled(bool pressed)
     {
-        settings.FreeGlucoseCloud = pressed;
-
+        _ = pressed;
         UpdateSelectedDifficultyPresetControl();
     }
 
     private void OnPassiveReproductionToggled(bool pressed)
     {
-        settings.PassiveGainOfReproductionCompounds = pressed;
-
+        _ = pressed;
         UpdateSelectedDifficultyPresetControl();
     }
 
     private void OnGrowthRateToggled(bool pressed)
     {
-        settings.LimitReproductionCompoundUseSpeed = pressed;
-
+        _ = pressed;
         UpdateSelectedDifficultyPresetControl();
     }
 
@@ -619,13 +623,13 @@ public class NewGameSettings : ControlWithInput
         // Set both buttons here as we only received a signal from one of them
         lifeOriginButton.Selected = index;
         lifeOriginButtonAdvanced.Selected = index;
-
-        settings.Origin = (WorldGenerationSettings.LifeOrigin)index;
     }
 
+    // This and a few other callbacks are not currently needed to detect anything, but I left them in in case we
+    // need them in the future / this is refactored to build the custom difficulty object in steps - hhyyrylainen
     private void OnMapTypeSelected(int index)
     {
-        settings.MapType = MapTypeIndexToValue(index);
+        _ = index;
     }
 
     private WorldGenerationSettings.PatchMapType MapTypeIndexToValue(int index)
@@ -647,8 +651,6 @@ public class NewGameSettings : ControlWithInput
         // Set both buttons here as we only received a signal from one of them
         lawkButton.Pressed = pressed;
         lawkAdvancedButton.Pressed = pressed;
-
-        settings.LAWK = lawkButton.Pressed;
 
         UpdateLifeOriginOptions(pressed);
     }
@@ -694,11 +696,11 @@ public class NewGameSettings : ControlWithInput
 
     private void OnIncludeMulticellularToggled(bool pressed)
     {
-        settings.IncludeMulticellular = pressed;
+        _ = pressed;
     }
 
     private void OnEasterEggsToggled(bool pressed)
     {
-        settings.EasterEggs = pressed;
+        _ = pressed;
     }
 }

--- a/src/general/WorldGenerationSettings.cs
+++ b/src/general/WorldGenerationSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Godot;
 using Newtonsoft.Json;
 
 /// <summary>
@@ -9,7 +10,18 @@ public class WorldGenerationSettings
     [JsonConstructor]
     public WorldGenerationSettings(IDifficulty difficulty)
     {
-        Difficulty = difficulty;
+        if (difficulty is DifficultyPreset preset && preset.InternalName ==
+            SimulationParameters.Instance.GetDifficultyPreset("custom").InternalName)
+        {
+            GD.PrintErr(
+                $"Ignoring setting custom difficulty preset object to {nameof(WorldGenerationSettings)} " +
+                "(using normal instead). This should only happen when loading older saves");
+            Difficulty = SimulationParameters.Instance.GetDifficultyPreset("normal");
+        }
+        else
+        {
+            Difficulty = difficulty;
+        }
     }
 
     public WorldGenerationSettings()

--- a/src/general/WorldGenerationSettings.cs
+++ b/src/general/WorldGenerationSettings.cs
@@ -1,11 +1,16 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 /// <summary>
 ///   Player configurable options for creating the game world
 /// </summary>
 public class WorldGenerationSettings
 {
-    private DifficultyPreset difficulty = null!;
+    [JsonConstructor]
+    public WorldGenerationSettings(IDifficulty difficulty)
+    {
+        Difficulty = difficulty;
+    }
 
     public WorldGenerationSettings()
     {
@@ -32,29 +37,9 @@ public class WorldGenerationSettings
     public bool LAWK { get; set; }
 
     /// <summary>
-    ///   Chosen difficulty preset for this game
+    ///   Chosen difficulty for this game
     /// </summary>
-    public DifficultyPreset Difficulty
-    {
-        get => difficulty;
-        set
-        {
-            difficulty = value;
-
-            if (value.InternalName == "custom")
-                return;
-
-            MPMultiplier = value.MPMultiplier;
-            AIMutationMultiplier = value.AIMutationMultiplier;
-            CompoundDensity = value.CompoundDensity;
-            PlayerDeathPopulationPenalty = value.PlayerDeathPopulationPenalty;
-            GlucoseDecay = value.GlucoseDecay;
-            OsmoregulationMultiplier = value.OsmoregulationMultiplier;
-            FreeGlucoseCloud = value.FreeGlucoseCloud;
-            PassiveGainOfReproductionCompounds = value.PassiveReproduction;
-            LimitReproductionCompoundUseSpeed = value.LimitGrowthRate;
-        }
-    }
+    public IDifficulty Difficulty { get; set; }
 
     /// <summary>
     ///   Origin of life (starting location) on this planet
@@ -66,50 +51,33 @@ public class WorldGenerationSettings
     /// </summary>
     public int Seed { get; set; } = new Random().Next();
 
-    /// <summary>
-    ///   Multiplier for MP costs in the editor
-    /// </summary>
-    public float MPMultiplier { get; set; }
+    // The following are helper proxies to the values from the difficulty
+    [JsonIgnore]
+    public float MPMultiplier => Difficulty.MPMultiplier;
 
-    /// <summary>
-    ///   Multiplier for AI species mutation rate
-    /// </summary>
-    public float AIMutationMultiplier { get; set; }
+    [JsonIgnore]
+    public float AIMutationMultiplier => Difficulty.AIMutationMultiplier;
 
-    /// <summary>
-    ///   Multiplier for compound cloud density in the environment
-    /// </summary>
-    public float CompoundDensity { get; set; }
+    [JsonIgnore]
+    public float CompoundDensity => Difficulty.CompoundDensity;
 
-    /// <summary>
-    ///   Multiplier for player species population loss after player death
-    /// </summary>
-    public float PlayerDeathPopulationPenalty { get; set; }
+    [JsonIgnore]
+    public float PlayerDeathPopulationPenalty => Difficulty.PlayerDeathPopulationPenalty;
 
-    /// <summary>
-    ///   Multiplier for rate of glucose decay in the environment
-    /// </summary>
-    public float GlucoseDecay { get; set; }
+    [JsonIgnore]
+    public float GlucoseDecay => Difficulty.GlucoseDecay;
 
-    /// <summary>
-    ///   Multiplier for player species osmoregulation cost
-    /// </summary>
-    public float OsmoregulationMultiplier { get; set; }
+    [JsonIgnore]
+    public float OsmoregulationMultiplier => Difficulty.OsmoregulationMultiplier;
 
-    /// <summary>
-    ///  Whether the player starts with a free glucose cloud each time they exit the editor
-    /// </summary>
-    public bool FreeGlucoseCloud { get; set; }
+    [JsonIgnore]
+    public bool FreeGlucoseCloud => Difficulty.FreeGlucoseCloud;
 
-    /// <summary>
-    ///  Whether microbes get free reproduction compounds at a steady background rate
-    /// </summary>
-    public bool PassiveGainOfReproductionCompounds { get; set; } = true;
+    [JsonIgnore]
+    public bool PassiveGainOfReproductionCompounds => Difficulty.PassiveReproduction;
 
-    /// <summary>
-    ///  Whether microbes are limited in how fast they can consume reproduction compounds to grow
-    /// </summary>
-    public bool LimitReproductionCompoundUseSpeed { get; set; } = true;
+    [JsonIgnore]
+    public bool LimitReproductionCompoundUseSpeed => Difficulty.LimitGrowthRate;
 
     /// <summary>
     ///  Basic patch map generation type (procedural or the static classic map)
@@ -129,24 +97,16 @@ public class WorldGenerationSettings
     /// <summary>
     ///   The auto-evo configuration this world uses
     /// </summary>
-    public AutoEvoConfiguration AutoEvoConfiguration { get; set; } = SimulationParameters.Instance.AutoEvoConfiguration;
+    public IAutoEvoConfiguration AutoEvoConfiguration { get; set; } =
+        SimulationParameters.Instance.AutoEvoConfiguration;
 
     public override string ToString()
     {
         return "World generation settings: [" +
             $"LAWK: {LAWK}" +
-            $", Difficulty preset: {Difficulty}" +
+            $", Difficulty: {Difficulty.GetDescriptionString()}" +
             $", Life origin: {Origin}" +
             $", Seed: {Seed}" +
-            $", MP multiplier: {MPMultiplier}" +
-            $", AI mutation multiplier: {AIMutationMultiplier}" +
-            $", Compound density: {CompoundDensity}" +
-            $", Player death population penalty: {PlayerDeathPopulationPenalty}" +
-            $", Glucose decay: {GlucoseDecay}" +
-            $", Osmoregulation multiplier: {OsmoregulationMultiplier}" +
-            $", Free glucose cloud: {FreeGlucoseCloud}" +
-            $", Passive Reproduction: {PassiveGainOfReproductionCompounds}" +
-            $", Limit Growth Rate: {LimitReproductionCompoundUseSpeed}" +
             $", Map type: {MapType}" +
             $", Include Multicellular: {IncludeMulticellular}" +
             $", Easter eggs: {EasterEggs}" +

--- a/src/saving/serializers/RegistryTypeConverter.cs
+++ b/src/saving/serializers/RegistryTypeConverter.cs
@@ -4,12 +4,12 @@ using System.Reflection;
 using Newtonsoft.Json;
 
 /// <summary>
-///   Deserializes registry types from strings or objects (for supported types)
+///   Serializes registry types as strings or objects (for supported types)
 /// </summary>
 /// <remarks>
 ///   <para>
-///     To support both the proper registry types and also the full objects, this class is split into two: the reader
-///     and writer as they need to act on different type interfaces.
+///     See the <see cref="SupportsCustomizedRegistryTypeAttribute"/> for info on the full object serialization this
+///     supports.
 ///   </para>
 /// </remarks>
 public class RegistryTypeConverter : BaseThriveConverter
@@ -107,7 +107,7 @@ public class RegistryTypeConverter : BaseThriveConverter
         else
         {
             // Support writing the customized versions of objects for the registry types
-            // Note the type of value must have
+            // Note the type of value must have CustomizedRegistryTypeAttribute otherwise we run into a stackoverflow
             serializer.Serialize(writer, value, value.GetType());
         }
     }

--- a/src/saving/serializers/SerializationBinder.cs
+++ b/src/saving/serializers/SerializationBinder.cs
@@ -11,7 +11,8 @@ public class SerializationBinder : DefaultSerializationBinder
 {
     private static readonly Type DynamicTypeAllowedAttribute = typeof(JSONDynamicTypeAllowedAttribute);
     private static readonly Type AlwaysDynamicTypeAttribute = typeof(JSONAlwaysDynamicTypeAttribute);
-    private static readonly Type SceneLoadedClassAttribute1 = typeof(SceneLoadedClassAttribute);
+    private static readonly Type SceneLoadedClassAttribute = typeof(SceneLoadedClassAttribute);
+    private static readonly Type CustomizedRegistryTypeAttribute = typeof(CustomizedRegistryTypeAttribute);
 
     public override Type BindToType(string? assemblyName, string typeName)
     {
@@ -22,8 +23,8 @@ public class SerializationBinder : DefaultSerializationBinder
             type = type.GetElementType() ?? throw new Exception("Array type doesn't have element type");
 
         if (type.CustomAttributes.Any(attr => attr.AttributeType == DynamicTypeAllowedAttribute ||
-                attr.AttributeType == AlwaysDynamicTypeAttribute ||
-                attr.AttributeType == SceneLoadedClassAttribute1))
+                attr.AttributeType == AlwaysDynamicTypeAttribute || attr.AttributeType == SceneLoadedClassAttribute ||
+                attr.AttributeType == CustomizedRegistryTypeAttribute))
         {
             // Allowed type
             return originalType;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Basically I ended up setting up a system where a customized version of a registry type can be created that can be edited freely while making saving and loading work both with the customized and default instances.

This also now makes it so that we can update difficulty related numbers and old saves will benefit.

As far as I could test this doesn't seem to introduce any save compatibility problems

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #3706
closes #3707

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
