### PR TITLE
Ignore GlobalTranslation and rotation when saving or loading to fix a warning

### DIFF
--- a/src/saving/serializers/BaseNodeConverter.cs
+++ b/src/saving/serializers/BaseNodeConverter.cs
@@ -33,8 +33,10 @@ public class BaseNodeConverter : BaseThriveConverter
             case "DynamicObject":
             case "Gizmo":
             // Ignore the extra rotation and translation related stuff that just duplicates what Transform has
+            case "GlobalTranslation":
             case "Translation":
             case "RotationDegrees":
+            case "GlobalRotation":
             case "Rotation":
             case "Scale":
             // Ignore this as this is parent relative and probably causes problems loading


### PR DESCRIPTION
as these properties are anyway derived from the others these make no sense to save and these started to cause warnings after update to Godot 3.5

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #3680

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
