### PR TITLE
Show patch name overlay over key prompts tutorial

### DIFF
--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -351,7 +351,7 @@ MenuPath = NodePath("../PauseMenu")
 AtpLabelPath = NodePath("BottomRight/DataValue/Margin/VBox/ATPValue")
 HpLabelPath = NodePath("BottomRight/DataValue/Margin/VBox/HPValue")
 PopulationLabelPath = NodePath("BottomRight/VBoxContainer/PopulationData/Value")
-PatchOverlayPath = NodePath("PatchNameOverlay")
+PatchOverlayPath = NodePath("../PatchNameOverlay")
 EditorButtonPath = NodePath("BottomRight/EditorButton")
 EnvironmentPanelPath = NodePath("BottomLeft/LeftPanels/EnvironmentPanel")
 OxygenBarPath = NodePath("BottomLeft/LeftPanels/EnvironmentPanel/VBoxContainer/Body/BarContainer/Oxygen")
@@ -2022,13 +2022,13 @@ __meta__ = {
 "_editor_description_": "PLACEHOLDER"
 }
 
-[node name="PatchNameOverlay" parent="MicrobeHUD" instance=ExtResource( 85 )]
-visible = false
-
 [node name="StagePrototypeConfirm" parent="MicrobeHUD" instance=ExtResource( 88 )]
 rect_min_size = Vector2( 450, 0 )
 
 [node name="TutorialGUI" parent="." instance=ExtResource( 74 )]
+visible = false
+
+[node name="PatchNameOverlay" parent="." instance=ExtResource( 85 )]
 visible = false
 
 [node name="RadialPopup" parent="." instance=ExtResource( 87 )]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Reorder the patch name overlay so that they no longer rendered behind the movement tutorial's key prompts.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
