### PR TITLE
Weight contribution to entity limit by size of cells

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -682,14 +682,14 @@ public static class Constants
 
     // These control how many game entities can exist at once
     // TODO: bump these back up once we resolve the performance bottleneck
-    public const int TINY_MAX_SPAWNED_ENTITIES = 25;
-    public const int VERY_SMALL_MAX_SPAWNED_ENTITIES = 40;
-    public const int SMALL_MAX_SPAWNED_ENTITIES = 55;
-    public const int NORMAL_MAX_SPAWNED_ENTITIES = 70;
-    public const int LARGE_MAX_SPAWNED_ENTITIES = 85;
-    public const int VERY_LARGE_MAX_SPAWNED_ENTITIES = 100;
-    public const int HUGE_MAX_SPAWNED_ENTITIES = 115;
-    public const int EXTREME_MAX_SPAWNED_ENTITIES = 130;
+    public const int TINY_MAX_SPAWNED_ENTITIES = 100;
+    public const int VERY_SMALL_MAX_SPAWNED_ENTITIES = 200;
+    public const int SMALL_MAX_SPAWNED_ENTITIES = 300;
+    public const int NORMAL_MAX_SPAWNED_ENTITIES = 400;
+    public const int LARGE_MAX_SPAWNED_ENTITIES = 500;
+    public const int VERY_LARGE_MAX_SPAWNED_ENTITIES = 600;
+    public const int HUGE_MAX_SPAWNED_ENTITIES = 700;
+    public const int EXTREME_MAX_SPAWNED_ENTITIES = 800;
 
     /// <summary>
     ///   Controls how fast entities are allowed to spawn
@@ -699,7 +699,12 @@ public static class Constants
     /// <summary>
     ///   Delete a max of this many entities per step to reduce lag from deleting tons of entities at once.
     /// </summary>
-    public const int MAX_DESPAWNS_PER_FRAME = 4;
+    public const int MAX_DESPAWNS_PER_FRAME = 10;
+
+    /// <summary>
+    ///   Multiplier for how much organelles inside spawned cells contribute to the entity count.
+    /// </summary>
+    public const float ORGANELLE_ENTITY_WEIGHT = 0.5f;
 
     /// <summary>
     ///   How often despawns happen on top of the normal despawns that are part of the spawn cycle

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -698,8 +698,10 @@ public static class Constants
 
     /// <summary>
     ///   Delete a max of this many entities per step to reduce lag from deleting tons of entities at once.
+    ///   Note that this is a raw count and not a weighted count as game instability is probably related to the number
+    ///   of deleted world child Nodes and not their complexity.
     /// </summary>
-    public const int MAX_DESPAWNS_PER_FRAME = 10;
+    public const int MAX_DESPAWNS_PER_FRAME = 4;
 
     /// <summary>
     ///   Multiplier for how much organelles inside spawned cells contribute to the entity count.

--- a/src/engine/DebugOverlays.PerformanceMetrics.cs
+++ b/src/engine/DebugOverlays.PerformanceMetrics.cs
@@ -21,17 +21,17 @@ public partial class DebugOverlays
     // TODO: make this time based
     private const int SpawnHistoryLength = 300;
 
-    private readonly Deque<int> spawnHistory = new(SpawnHistoryLength);
-    private readonly Deque<int> despawnHistory = new(SpawnHistoryLength);
+    private readonly Deque<float> spawnHistory = new(SpawnHistoryLength);
+    private readonly Deque<float> despawnHistory = new(SpawnHistoryLength);
 
     private Label fpsLabel = null!;
     private Label deltaLabel = null!;
     private Label metricsText = null!;
 
-    private int entities;
+    private float entities;
     private int children;
-    private int currentSpawned;
-    private int currentDespawned;
+    private float currentSpawned;
+    private float currentDespawned;
 
     public bool PerformanceMetricsVisible
     {
@@ -45,18 +45,18 @@ public partial class DebugOverlays
         }
     }
 
-    public void ReportEntities(int totalEntities, int otherChildren)
+    public void ReportEntities(float totalEntities, int otherChildren)
     {
         entities = totalEntities;
         children = otherChildren;
     }
 
-    public void ReportSpawns(int newSpawns)
+    public void ReportSpawns(float newSpawns)
     {
         currentSpawned += newSpawns;
     }
 
-    public void ReportDespawns(int newDespawns)
+    public void ReportDespawns(float newDespawns)
     {
         currentDespawned += newDespawns;
     }
@@ -83,7 +83,8 @@ public partial class DebugOverlays
         metricsText.Text =
             new LocalizedString("METRICS_CONTENT", Performance.GetMonitor(Performance.Monitor.TimeProcess),
                     Performance.GetMonitor(Performance.Monitor.TimePhysicsProcess),
-                    entities, children, spawnHistory.Sum(), despawnHistory.Sum(),
+                    Math.Round(entities, 1), children,
+                    Math.Round(spawnHistory.Sum(), 1), Math.Round(despawnHistory.Sum(), 1),
                     Performance.GetMonitor(Performance.Monitor.ObjectNodeCount),
                     OS.GetName() == Constants.OS_WINDOWS_NAME ?
                         TranslationServer.Translate("UNKNOWN_ON_WINDOWS") :
@@ -99,7 +100,7 @@ public partial class DebugOverlays
                     Performance.GetMonitor(Performance.Monitor.AudioOutputLatency) * 1000, threads, processorTime)
                 .ToString();
 
-        entities = 0;
+        entities = 0.0f;
         children = 0;
 
         spawnHistory.AddToBack(currentSpawned);
@@ -111,7 +112,7 @@ public partial class DebugOverlays
         while (despawnHistory.Count > SpawnHistoryLength)
             despawnHistory.RemoveFromFront();
 
-        currentSpawned = 0;
-        currentDespawned = 0;
+        currentSpawned = 0.0f;
+        currentDespawned = 0.0f;
     }
 }

--- a/src/engine/Settings.cs
+++ b/src/engine/Settings.cs
@@ -801,7 +801,13 @@ public class Settings
 
         try
         {
-            return JsonConvert.DeserializeObject<Settings>(text);
+            var settings = JsonConvert.DeserializeObject<Settings>(text);
+
+            if (settings == null)
+                return settings;
+
+            EnsureLoadedSettingsAreValid(settings);
+            return settings;
         }
         catch
         {
@@ -812,6 +818,15 @@ public class Settings
             settings.Save();
 
             return settings;
+        }
+    }
+
+    private static void EnsureLoadedSettingsAreValid(Settings settings)
+    {
+        if (settings.MaxSpawnedEntities.Value < Constants.TINY_MAX_SPAWNED_ENTITIES)
+        {
+            GD.PrintErr($"{nameof(MaxSpawnedEntities)} is below the minimum value, resetting to normal");
+            settings.MaxSpawnedEntities.Value = Constants.NORMAL_MAX_SPAWNED_ENTITIES;
         }
     }
 

--- a/src/general/StageBase.cs
+++ b/src/general/StageBase.cs
@@ -252,9 +252,9 @@ public abstract class StageBase<TPlayer> : NodeWithInput, IStage, IGodotEarlyNod
 
         if (debugOverlay.PerformanceMetricsVisible)
         {
-            var entities = rootOfDynamicallySpawned.GetChildrenToProcess<ISpawned>(Constants.SPAWNED_GROUP).Count();
+            var entities = rootOfDynamicallySpawned.GetChildrenToProcess<ISpawned>(Constants.SPAWNED_GROUP).ToList();
             var childCount = rootOfDynamicallySpawned.GetChildCount();
-            debugOverlay.ReportEntities(entities, childCount - entities);
+            debugOverlay.ReportEntities(entities.Sum(e => e.EntityWeight), childCount - entities.Count);
         }
     }
 

--- a/src/general/StageBase.cs
+++ b/src/general/StageBase.cs
@@ -252,9 +252,17 @@ public abstract class StageBase<TPlayer> : NodeWithInput, IStage, IGodotEarlyNod
 
         if (debugOverlay.PerformanceMetricsVisible)
         {
-            var entities = rootOfDynamicallySpawned.GetChildrenToProcess<ISpawned>(Constants.SPAWNED_GROUP).ToList();
+            float totalEntityWeight = 0;
+            int totalEntityCount = 0;
+
+            foreach (var entity in rootOfDynamicallySpawned.GetChildrenToProcess<ISpawned>(Constants.SPAWNED_GROUP))
+            {
+                totalEntityWeight += entity.EntityWeight;
+                ++totalEntityCount;
+            }
+
             var childCount = rootOfDynamicallySpawned.GetChildCount();
-            debugOverlay.ReportEntities(entities.Sum(e => e.EntityWeight), childCount - entities.Count);
+            debugOverlay.ReportEntities(totalEntityWeight, childCount - totalEntityCount);
         }
     }
 

--- a/src/late_multicellular_stage/MulticellularCreature.cs
+++ b/src/late_multicellular_stage/MulticellularCreature.cs
@@ -97,6 +97,12 @@ public class MulticellularCreature : RigidBody, ISpawned, IProcessable, ISaveLoa
 
     public int DespawnRadiusSquared { get; set; }
 
+    /// <summary>
+    ///   TODO: adjust entity weight once fleshed out
+    /// </summary>
+    [JsonIgnore]
+    public float EntityWeight => 1.0f;
+
     [JsonIgnore]
     public bool IsLoadedFromSave { get; set; }
 

--- a/src/microbe_stage/FloatingChunk.cs
+++ b/src/microbe_stage/FloatingChunk.cs
@@ -65,6 +65,9 @@ public class FloatingChunk : RigidBody, ISpawned, IEngulfable
     public int DespawnRadiusSquared { get; set; }
 
     [JsonIgnore]
+    public float EntityWeight => 1.0f;
+
+    [JsonIgnore]
     public Spatial EntityNode => this;
 
     [JsonIgnore]

--- a/src/microbe_stage/ISpawned.cs
+++ b/src/microbe_stage/ISpawned.cs
@@ -8,4 +8,9 @@ public interface ISpawned : IEntity
     ///   greater than this, it is despawned.
     /// </summary>
     int DespawnRadiusSquared { get; set; }
+
+    /// <summary>
+    ///   How much this entity contributes to the entity limit relative to a single node
+    /// </summary>
+    float EntityWeight { get; }
 }

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -204,6 +204,13 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
     public int DespawnRadiusSquared { get; set; }
 
     /// <summary>
+    ///   Entity weight for microbes counts all organelles with a scaling factor.
+    /// </summary>
+    [JsonIgnore]
+    public float EntityWeight => organelles?.Count * Constants.ORGANELLE_ENTITY_WEIGHT ??
+        throw new InvalidOperationException("Organelles not initialised on microbe spawn");
+
+    /// <summary>
     ///   If true this shifts the purpose of this cell for visualizations-only
     ///   (Completely stops the normal functioning of the cell).
     /// </summary>


### PR DESCRIPTION
**Brief Description of What This PR Does**

A cell now contributes x to the entity count, where x is the number of organelles it contains.

Made this a while ago but forgot to push it. This does appear to have a small impact on performance, but not a massive one. It does have a gameplay impact since fewer cells will spawn in general, especially if they're large.

I'd appreciate some testing and feedback from both performance and gameplay perspectives. This isn't a necessary change, but if it works, it would be nice. Especially for something so simple.

**Related Issues**

N/A

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
