### PR TITLE
Fix sessile organisms moving towards the player when they spawn

### DIFF
--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -103,6 +103,8 @@ public class MicrobeAI
     private float SpeciesFocus => microbe.Species.Behaviour.Focus;
     private float SpeciesOpportunism => microbe.Species.Behaviour.Opportunism;
 
+    private bool IsSessile => SpeciesActivity < Constants.MAX_SPECIES_ACTIVITY / 10;
+
     public void Think(float delta, Random random, MicrobeAICommonData data)
     {
         // Disable most AI in a colony
@@ -227,7 +229,9 @@ public class MicrobeAI
             var player = data.AllMicrobes.Where(otherMicrobe => otherMicrobe.IsPlayerMicrobe).FirstOrDefault();
             if (player != null)
             {
-                if (DistanceFromMe(player.GlobalTransform.origin) > Math.Pow(Constants.SPAWN_SECTOR_SIZE, 2) * 0.75f)
+                // Only move if we aren't sessile
+                if (DistanceFromMe(player.GlobalTransform.origin) > Math.Pow(Constants.SPAWN_SECTOR_SIZE, 2) * 0.75f &&
+                    !IsSessile)
                 {
                     MoveToLocation(player.GlobalTransform.origin);
                     return;
@@ -264,7 +268,7 @@ public class MicrobeAI
         microbe.State = Microbe.MicrobeState.Normal;
 
         // Otherwise just wander around and look for compounds
-        if (SpeciesActivity > Constants.MAX_SPECIES_ACTIVITY / 10)
+        if (!IsSessile)
         {
             SeekCompounds(random, data);
         }


### PR DESCRIPTION
**Brief Description of What This PR Does**

The AI makes cells move towards the player when they first spawn to make the immediate environment more interesting, but when sessile organisms do it, they move on screen and stop, which is a bit weird. This PR fixes that.

**Related Issues**

N/A

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
