### PR TITLE
Allow other cells in colonies to use slime jets

### DIFF
--- a/src/early_multicellular_stage/Microbe.Multicellular.cs
+++ b/src/early_multicellular_stage/Microbe.Multicellular.cs
@@ -132,9 +132,9 @@ public partial class Microbe
     }
 
     /// <summary>
-    ///   Perform an action for all members of this cell's colony other than this cell.
+    ///   Perform an action for all members of this cell's colony other than this cell if this is the colony leader.
     /// </summary>
-    public void PerformForAllColonyMembers(Action<Microbe> action)
+    public void PerformForOtherColonyMembersIfWeAreLeader(Action<Microbe> action)
     {
         if (Colony?.Master == this)
         {

--- a/src/early_multicellular_stage/Microbe.Multicellular.cs
+++ b/src/early_multicellular_stage/Microbe.Multicellular.cs
@@ -131,6 +131,23 @@ public partial class Microbe
         }
     }
 
+    /// <summary>
+    ///   Perform an action for all members of this cell's colony other than this cell.
+    /// </summary>
+    public void PerformForAllColonyMembers(Action<Microbe> action)
+    {
+        if (Colony?.Master == this)
+        {
+            foreach (var cell in Colony.ColonyMembers)
+            {
+                if (cell == this)
+                    continue;
+
+                action(cell);
+            }
+        }
+    }
+
     private void HandleMulticellularReproduction(float elapsedSinceLastUpdate)
     {
         compoundsUsedForMulticellularGrowth ??= new Dictionary<Compound, float>();

--- a/src/early_multicellular_stage/Microbe.Multicellular.cs
+++ b/src/early_multicellular_stage/Microbe.Multicellular.cs
@@ -131,23 +131,6 @@ public partial class Microbe
         }
     }
 
-    /// <summary>
-    ///   Perform an action for all members of this cell's colony other than this cell if this is the colony leader.
-    /// </summary>
-    public void PerformForOtherColonyMembersIfWeAreLeader(Action<Microbe> action)
-    {
-        if (Colony?.Master == this)
-        {
-            foreach (var cell in Colony.ColonyMembers)
-            {
-                if (cell == this)
-                    continue;
-
-                action(cell);
-            }
-        }
-    }
-
     private void HandleMulticellularReproduction(float elapsedSinceLastUpdate)
     {
         compoundsUsedForMulticellularGrowth ??= new Dictionary<Compound, float>();

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -342,6 +342,17 @@ public partial class Microbe
 
     public void QueueSecreteSlime(float duration)
     {
+        if (Colony?.Master == this)
+        {
+            foreach (var cell in Colony.ColonyMembers)
+            {
+                if (cell == this)
+                    continue;
+
+                cell.QueueSecreteSlime(duration);
+            }
+        }
+
         queuedSlimeSecretionTime += duration;
     }
 
@@ -895,13 +906,13 @@ public partial class Microbe
 
         if (GameWorld.WorldSettings.LimitReproductionCompoundUseSpeed)
         {
-            remainingAllowedCompoundUse = Constants.MICROBE_REPRODUCTION_MAX_COMPOUND_USE * delta;
+            remainingAllowedCompoundUse = Constants.MICROBE_REPRODUCTION_MAX_COMPOUND_USE * delta * 100;
         }
 
         if (GameWorld.WorldSettings.PassiveGainOfReproductionCompounds)
         {
             // TODO: make the current patch affect this?
-            remainingFreeCompounds = Constants.MICROBE_REPRODUCTION_FREE_COMPOUNDS * delta;
+            remainingFreeCompounds = Constants.MICROBE_REPRODUCTION_FREE_COMPOUNDS * delta * 100;
         }
 
         return (remainingAllowedCompoundUse, remainingFreeCompounds);

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -261,7 +261,7 @@ public partial class Microbe
 
         agentType ??= SimulationParameters.Instance.GetCompound("oxytoxy");
 
-        PerformForAllColonyMembers(m => m.EmitToxin(agentType));
+        PerformForOtherColonyMembersIfWeAreLeader(m => m.EmitToxin(agentType));
 
         if (AgentEmissionCooldown > 0)
             return;
@@ -333,7 +333,10 @@ public partial class Microbe
 
     public void QueueSecreteSlime(float duration)
     {
-        PerformForAllColonyMembers(m => m.QueueSecreteSlime(duration));
+        PerformForOtherColonyMembersIfWeAreLeader(m => m.QueueSecreteSlime(duration));
+
+        if (SlimeJets.Count < 1)
+            return;
 
         queuedSlimeSecretionTime += duration;
     }

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -906,13 +906,13 @@ public partial class Microbe
 
         if (GameWorld.WorldSettings.LimitReproductionCompoundUseSpeed)
         {
-            remainingAllowedCompoundUse = Constants.MICROBE_REPRODUCTION_MAX_COMPOUND_USE * delta * 100;
+            remainingAllowedCompoundUse = Constants.MICROBE_REPRODUCTION_MAX_COMPOUND_USE * delta;
         }
 
         if (GameWorld.WorldSettings.PassiveGainOfReproductionCompounds)
         {
             // TODO: make the current patch affect this?
-            remainingFreeCompounds = Constants.MICROBE_REPRODUCTION_FREE_COMPOUNDS * delta * 100;
+            remainingFreeCompounds = Constants.MICROBE_REPRODUCTION_FREE_COMPOUNDS * delta;
         }
 
         return (remainingAllowedCompoundUse, remainingFreeCompounds);

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -259,16 +259,9 @@ public partial class Microbe
         if (PhagocytosisStep != PhagocytosisPhase.None)
             return;
 
-        if (Colony?.Master == this)
-        {
-            foreach (var cell in Colony.ColonyMembers)
-            {
-                if (cell == this)
-                    continue;
+        agentType ??= SimulationParameters.Instance.GetCompound("oxytoxy");
 
-                cell.EmitToxin(agentType);
-            }
-        }
+        PerformForAllColonyMembers(m => m.EmitToxin(agentType));
 
         if (AgentEmissionCooldown > 0)
             return;
@@ -276,8 +269,6 @@ public partial class Microbe
         // Only shoot if you have an agent vacuole.
         if (AgentVacuoleCount < 1)
             return;
-
-        agentType ??= SimulationParameters.Instance.GetCompound("oxytoxy");
 
         float amountAvailable = Compounds.GetCompoundAmount(agentType);
 
@@ -342,16 +333,7 @@ public partial class Microbe
 
     public void QueueSecreteSlime(float duration)
     {
-        if (Colony?.Master == this)
-        {
-            foreach (var cell in Colony.ColonyMembers)
-            {
-                if (cell == this)
-                    continue;
-
-                cell.QueueSecreteSlime(duration);
-            }
-        }
+        PerformForAllColonyMembers(m => m.QueueSecreteSlime(duration));
 
         queuedSlimeSecretionTime += duration;
     }

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -629,6 +629,23 @@ public partial class Microbe
         return result;
     }
 
+    /// <summary>
+    ///   Perform an action for all members of this cell's colony other than this cell if this is the colony leader.
+    /// </summary>
+    private void PerformForOtherColonyMembersIfWeAreLeader(Action<Microbe> action)
+    {
+        if (Colony?.Master == this)
+        {
+            foreach (var cell in Colony.ColonyMembers)
+            {
+                if (cell == this)
+                    continue;
+
+                action(cell);
+            }
+        }
+    }
+
     private void HandleCompoundAbsorbing(float delta)
     {
         if (PhagocytosisStep != PhagocytosisPhase.None)

--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -74,8 +74,7 @@ public class PlayerMicrobeInput : NodeWithInput
     [RunOnKey("g_secrete_slime")]
     public void SecreteSlime(float delta)
     {
-        if (stage.Player?.SlimeJets.Count > 0)
-            stage.Player.QueueSecreteSlime(delta);
+        stage.Player?.QueueSecreteSlime(delta);
     }
 
     [RunOnKeyDown("g_toggle_engulf")]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes a bug where only the lead cell would use slime jets in multicellular.

**Related Issues**

N/A

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
