### PR TITLE
Made the max spawned setting use a different JSON name

### DIFF
--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.17.1" />
-    <PackageReference Include="Karambolo.PO" Version="1.8.0" />
+    <PackageReference Include="Karambolo.PO" Version="1.9.0" />
   </ItemGroup>
 
 </Project>

--- a/doc/style_guide.md
+++ b/doc/style_guide.md
@@ -530,6 +530,16 @@ Godot usage
 - All images used in the GUI should have mipmaps on in the import
   options.
 
+Other recommended approaches
+----------------------------
+
+- When changing the meaning of a game setting in a major way that is
+  incompatible with previous values, the updated setting should use a
+  different name when saved in JSON to avoid problems. For example:
+  `[JsonProperty(PropertyName = "MaxSpawnedEntitiesV2")]`. This way
+  the options menu doesn't need complicated adapting logic as
+  otherwise it would show misleading values to the player.
+
 Other files
 -----------
 

--- a/src/engine/Settings.cs
+++ b/src/engine/Settings.cs
@@ -212,6 +212,7 @@ public class Settings
     /// <summary>
     ///   Sets the maximum number of entities that can exist at one time.
     /// </summary>
+    [JsonProperty(PropertyName = "MaxSpawnedEntitiesV2")]
     public SettingValue<int> MaxSpawnedEntities { get; set; } = new(Constants.NORMAL_MAX_SPAWNED_ENTITIES);
 
     // Misc Properties


### PR DESCRIPTION
**Brief Description of What This PR Does**

this is to ensure we don't get bug reports from people who are seeing misleading values in the options menu otherwise

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
follow up to #3801

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
