### PR TITLE
NaN compound value

### DIFF
--- a/src/microbe_stage/CompoundBag.cs
+++ b/src/microbe_stage/CompoundBag.cs
@@ -50,8 +50,9 @@ public class CompoundBag : ICompoundStorage
 
     public float GetCompoundAmount(Compound compound)
     {
-        Compounds.TryGetValue(compound, out var amount);
-
+        if (!Compounds.TryGetValue(compound, out var amount))
+            return 0.0f;
+        
         return amount;
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

If a microbe's compound capacity is zero, it prevents the compound from being spread out to all microbes. As a result, setting the compound amount to NaN is prevented (division by zero).

PS: during testing I encountered the ingested matter bar turning to NaN, this PR does might not compass the ingested matter bar, as I couldn't find a way to replicate that bug.


**Related Issues**

#3201

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
