### PR TITLE
Convert save screenshot without using temporary file

### DIFF
--- a/src/saving/Save.cs
+++ b/src/saving/Save.cs
@@ -8,7 +8,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Directory = Godot.Directory;
 using File = Godot.File;
-using Path = System.IO.Path;
 
 /// <summary>
 ///   A class representing a single saved game

--- a/src/saving/Save.cs
+++ b/src/saving/Save.cs
@@ -253,9 +253,9 @@ public class Save
 
         if (screenshot != null)
         {
-            byte[]? data = screenshot.SavePngToBuffer();
+            byte[] data = screenshot.SavePngToBuffer();
 
-            if (data?.Length > 0)
+            if (data.Length > 0)
                 OutputEntry(tar, SAVE_SCREENSHOT, data);
         }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Save screenshot is now converted to PNG in memory instead of using temporary file.

**Related Issues**

Resolves #3672

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
