### PR TITLE
Keep alpha value on mutation

### DIFF
--- a/src/general/Mutations.cs
+++ b/src/general/Mutations.cs
@@ -110,7 +110,7 @@ public class Mutations
         }
 
         // preserve Alpha on mutation.
-        mutated.Colour = new(colour.r, colour.g, colour.b, mutated.Colour.a);
+        mutated.Colour = new Color(colour.r, colour.g, colour.b, mutated.Colour.a);
 
         mutated.MembraneRigidity = Math.Max(Math.Min(parent.MembraneRigidity +
             random.Next(-25, 26) / 100.0f, 1), -1);

--- a/src/general/Mutations.cs
+++ b/src/general/Mutations.cs
@@ -109,7 +109,8 @@ public class Mutations
             mutated.MembraneType = parent.MembraneType;
         }
 
-        mutated.Colour = colour;
+        // preserve Alpha on mutation.
+        mutated.Colour = new(colour.r, colour.g, colour.b, mutated.Colour.a);
 
         mutated.MembraneRigidity = Math.Max(Math.Min(parent.MembraneRigidity +
             random.Next(-25, 26) / 100.0f, 1), -1);


### PR DESCRIPTION
**Brief Description of What This PR Does**

During Mutation based on different Microbial parameters colors are generated randomly.
By keeping the old Alpha value from the original species we avoid mutating the Alpha value.

**Related Issues**

fixes #3675 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
