### PR TITLE
Include player species progression in evolutionary tree

### DIFF
--- a/src/auto-evo/AutoEvoExploringTool.cs
+++ b/src/auto-evo/AutoEvoExploringTool.cs
@@ -326,7 +326,7 @@ public class AutoEvoExploringTool : NodeWithInput
 
         InitFirstGeneration();
 
-        evolutionaryTree.Init(gameProperties.GameWorld.PlayerSpecies);
+        evolutionaryTree.Init((Species)gameProperties.GameWorld.PlayerSpecies.Clone());
 
         InitConfigControls();
 
@@ -429,7 +429,7 @@ public class AutoEvoExploringTool : NodeWithInput
         runResultsList.Add(new LocalizedStringBuilder());
         speciesHistoryList.Add(new Dictionary<uint, Species>
         {
-            { gameProperties.GameWorld.PlayerSpecies.ID, gameProperties.GameWorld.PlayerSpecies },
+            { gameProperties.GameWorld.PlayerSpecies.ID, (Species)gameProperties.GameWorld.PlayerSpecies.Clone() },
         });
         patchHistoryList.Add(gameProperties.GameWorld.Map.Patches.ToDictionary(pair => pair.Key,
             pair => (PatchSnapshot)pair.Value.CurrentSnapshot.Clone()));
@@ -633,8 +633,11 @@ public class AutoEvoExploringTool : NodeWithInput
         autoEvoRun.ApplyAllResultsAndEffects(true);
 
         // Add run results, this must be called after results are applied to generate unique species ID
-        evolutionaryTree.UpdateEvolutionaryTreeWithRunResults(results.CloneSpeciesResults(), ++currentGeneration,
-            gameProperties.GameWorld.TotalPassedTime);
+        evolutionaryTree.UpdateEvolutionaryTreeWithRunResults(
+            results.CloneSpeciesResults(),
+            ++currentGeneration,
+            gameProperties.GameWorld.TotalPassedTime,
+            gameProperties.GameWorld.PlayerSpecies.ID);
         speciesHistoryList.Add(
             gameProperties.GameWorld.Species.ToDictionary(pair => pair.Key, pair => (Species)pair.Value.Clone()));
         patchHistoryList.Add(gameProperties.GameWorld.Map.Patches.ToDictionary(pair => pair.Key,

--- a/src/auto-evo/EvolutionaryTree.cs
+++ b/src/auto-evo/EvolutionaryTree.cs
@@ -156,12 +156,12 @@ public class EvolutionaryTree : Control
         latoSmallRegular = (Font)GD.Load("res://src/gui_common/fonts/Lato-Regular-Small.tres");
     }
 
-    public void Init(Species luca)
+    public void Init(Species luca, string? updatedName = null)
     {
         SetupTreeNode(luca, null, 0);
 
         speciesOrigin.Add(luca.ID, (uint.MaxValue, 0));
-        speciesNames.Add(luca.ID, luca.FormattedName);
+        speciesNames.Add(luca.ID, updatedName ?? luca.FormattedName);
         generationTimes.Add(0, 0);
 
         dirty = true;
@@ -196,7 +196,8 @@ public class EvolutionaryTree : Control
     public void UpdateEvolutionaryTreeWithRunResults(
         System.Collections.Generic.Dictionary<Species, RunResults.SpeciesResult> results,
         int generation,
-        double time)
+        double time,
+        uint playerSpeciesID)
     {
         foreach (var speciesResultPair in results.OrderBy(r => r.Value.Species.ID))
         {
@@ -222,6 +223,12 @@ public class EvolutionaryTree : Control
             else if (result.MutatedProperties != null)
             {
                 SetupTreeNode(result.MutatedProperties,
+                    speciesNodes[species.ID].Last(), generation);
+            }
+            else if (species.ID == playerSpeciesID)
+            {
+                // Always add nodes for the player species
+                SetupTreeNode(species,
                     speciesNodes[species.ID].Last(), generation);
             }
 

--- a/src/auto-evo/GenerationRecord.cs
+++ b/src/auto-evo/GenerationRecord.cs
@@ -1,6 +1,8 @@
 ﻿namespace AutoEvo
 {
     using System.Collections.Generic;
+    using System.Linq;
+    using Godot;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -44,5 +46,27 @@
         /// </summary>
         [JsonProperty]
         public Dictionary<uint, Species> AllSpecies { get; private set; }
+
+        /// <summary>
+        ///   Replaces species data for a given species in this generation. Primarily used for updating data for the
+        ///   player species once the player has left the editor.
+        /// </summary>
+        /// <param name="species">Updated species</param>
+        public void UpdateSpeciesData(Species species)
+        {
+            if (AllSpecies.ContainsKey(species.ID) && AutoEvoResults.Any(r => r.Key.ID == species.ID))
+            {
+                var speciesClone = (Species)species.Clone();
+                AllSpecies[species.ID] = speciesClone;
+                AutoEvoResults = AutoEvoResults.ToDictionary(
+                    r => r.Key.ID == species.ID ? speciesClone : r.Key,
+                    r => r.Key.ID == species.ID ? r.Value.Clone(species) : r.Value);
+            }
+            else
+            {
+                GD.PrintErr($"Unable to find species with ID {species.ID} in existing species");
+                return;
+            }
+        }
     }
 }

--- a/src/auto-evo/GenerationRecord.cs
+++ b/src/auto-evo/GenerationRecord.cs
@@ -65,7 +65,6 @@
             else
             {
                 GD.PrintErr($"Unable to find species with ID {species.ID} in existing species");
-                return;
             }
         }
     }

--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -1186,9 +1186,11 @@
             ///     This doesn't clone everything, only species, and should not be used as a full clone method.
             ///   </para>
             /// </remarks>
-            public SpeciesResult Clone()
+            /// <param name="updatedSpecies">Updated species to use as the species associated with this result</param>
+            public SpeciesResult Clone(Species? updatedSpecies = null)
             {
-                return new SpeciesResult((Species)Species.Clone())
+                updatedSpecies ??= Species;
+                return new SpeciesResult((Species)updatedSpecies.Clone())
                 {
                     NewPopulationInPatches = NewPopulationInPatches,
                     MutatedProperties = (Species?)MutatedProperties?.Clone(),

--- a/src/general/GameWorld.cs
+++ b/src/general/GameWorld.cs
@@ -77,6 +77,14 @@ public class GameWorld : ISaveLoadable
 
         // Apply initial populations
         Map.UpdateGlobalPopulations();
+
+        var playerSpeciesClone = (Species)PlayerSpecies.Clone();
+        GenerationHistory.Add(0, new GenerationRecord(
+            0,
+            0,
+            new() {{playerSpeciesClone, new(playerSpeciesClone)}},
+            new() {{PlayerSpecies.ID, playerSpeciesClone}}
+        ));
     }
 
     /// <summary>

--- a/src/general/GameWorld.cs
+++ b/src/general/GameWorld.cs
@@ -78,13 +78,13 @@ public class GameWorld : ISaveLoadable
         // Apply initial populations
         Map.UpdateGlobalPopulations();
 
+        // Create the initial generation by adding only the player species
         var playerSpeciesClone = (Species)PlayerSpecies.Clone();
         GenerationHistory.Add(0, new GenerationRecord(
             0,
             0,
-            new() {{playerSpeciesClone, new(playerSpeciesClone)}},
-            new() {{PlayerSpecies.ID, playerSpeciesClone}}
-        ));
+            new Dictionary<Species, RunResults.SpeciesResult> { { playerSpeciesClone, new(playerSpeciesClone) } },
+            new Dictionary<uint, Species> { { PlayerSpecies.ID, playerSpeciesClone } }));
     }
 
     /// <summary>

--- a/src/general/StageBase.cs
+++ b/src/general/StageBase.cs
@@ -285,6 +285,9 @@ public abstract class StageBase<TPlayer> : NodeWithInput, IStage, IGodotEarlyNod
         if (CurrentGame == null)
             throw new InvalidOperationException("Returning to stage from editor without a game setup");
 
+        // Update the generation history with the newly edited player species
+        GameWorld.GenerationHistory.Last().Value.UpdateSpeciesData(GameWorld.PlayerSpecies);
+
         // Now the editor increases the generation so we don't do that here anymore
 
         // Make sure player is spawned

--- a/src/thriveopedia/pages/ThriveopediaEvolutionaryTreePage.cs
+++ b/src/thriveopedia/pages/ThriveopediaEvolutionaryTreePage.cs
@@ -85,20 +85,26 @@ public class ThriveopediaEvolutionaryTreePage : ThriveopediaPage
         // TODO: fix the tree for freebuild
         if (CurrentGame.FreeBuild)
         {
-            evolutionaryTree.Visible = false;
-            disabledWarning.Visible = true;
+            OnTreeFailedToBuild("Tree opened in freebuild mode");
             return;
         }
 
         // Building the tree relies on the existence of a full history of generations stored in the current game. Since
         // we only started adding these in 0.6.0, it's impossible to build a tree in older saves.
         // TODO: avoid an ugly try/catch block by actually checking the original save version?
+        var generationHistory = CurrentGame.GameWorld.GenerationHistory;
+        if (generationHistory.Count < 1)
+        {
+            OnTreeFailedToBuild("Generation history is empty");
+            return;
+        }
+
         try
         {
             evolutionaryTree.Clear();
             speciesHistoryList.Clear();
 
-            foreach (var generation in CurrentGame.GameWorld.GenerationHistory)
+            foreach (var generation in generationHistory)
             {
                 var record = generation.Value;
 
@@ -124,10 +130,15 @@ public class ThriveopediaEvolutionaryTreePage : ThriveopediaPage
         }
         catch (KeyNotFoundException e)
         {
-            GD.PrintErr($"Evolutionary tree failed to build with error {e}");
-            evolutionaryTree.Visible = false;
-            disabledWarning.Visible = true;
+            OnTreeFailedToBuild(e.ToString());
         }
+    }
+
+    private void OnTreeFailedToBuild(string error)
+    {
+        GD.PrintErr($"Evolutionary tree failed to build with error: {error}");
+        evolutionaryTree.Visible = false;
+        disabledWarning.Visible = true;
     }
 
     private void UpdateSpeciesPreview(Species species)

--- a/src/thriveopedia/pages/ThriveopediaEvolutionaryTreePage.cs
+++ b/src/thriveopedia/pages/ThriveopediaEvolutionaryTreePage.cs
@@ -98,15 +98,27 @@ public class ThriveopediaEvolutionaryTreePage : ThriveopediaPage
             evolutionaryTree.Clear();
             speciesHistoryList.Clear();
 
-            evolutionaryTree.Init(CurrentGame.GameWorld.PlayerSpecies);
-            InitFirstGeneration();
-
-            // A possible next step would be to rebuild only when the Thriveopedia as a whole is opened.
             foreach (var generation in CurrentGame.GameWorld.GenerationHistory)
             {
                 var record = generation.Value;
+
+                if (record.Generation == 0)
+                {
+                    var playerSpeciesID = CurrentGame!.GameWorld.PlayerSpecies.ID;
+                    var playerSpecies = record.AllSpecies[playerSpeciesID];
+                    evolutionaryTree.Init(playerSpecies, CurrentGame.GameWorld.PlayerSpecies.FormattedName);
+                    speciesHistoryList.Add(new Dictionary<uint, Species>
+                    {
+                        { playerSpeciesID, playerSpecies },
+                    });
+                    continue;
+                }
+
                 evolutionaryTree.UpdateEvolutionaryTreeWithRunResults(
-                    record.AutoEvoResults, record.Generation, record.TimeElapsed);
+                    record.AutoEvoResults,
+                    record.Generation,
+                    record.TimeElapsed,
+                    CurrentGame.GameWorld.PlayerSpecies.ID);
                 speciesHistoryList.Add(record.AllSpecies);
             }
         }
@@ -116,15 +128,6 @@ public class ThriveopediaEvolutionaryTreePage : ThriveopediaPage
             evolutionaryTree.Visible = false;
             disabledWarning.Visible = true;
         }
-    }
-
-    private void InitFirstGeneration()
-    {
-        // TODO: fix this so it shows player species progression rather than current state
-        speciesHistoryList.Add(new Dictionary<uint, Species>
-        {
-            { CurrentGame!.GameWorld.PlayerSpecies.ID, CurrentGame.GameWorld.PlayerSpecies },
-        });
     }
 
     private void UpdateSpeciesPreview(Species species)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds evolutionary tree nodes every generation for the player species. As part of this, I replaced the original tree initialisation with a zeroth generation and, on leaving the editor, updated the player species in the most recent generation to ensure the world stays in sync with the player's experience.

Saves made on the fossilisation branch will have a broken tree in this branch and vice versa.

**Related Issues**

N/A

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
