### PR TITLE
Fixed the evolutionary tree end being off screen when zoomed out fully.

### DIFF
--- a/src/auto-evo/EvolutionaryTree.cs
+++ b/src/auto-evo/EvolutionaryTree.cs
@@ -414,7 +414,7 @@ public class EvolutionaryTree : Control
     {
         // TreeSize may be less than RectSize, so the later Min and Max is not merged into Clamp.
         // Note that dragOffset's x and y should both be negative.
-        var start = RectSize / sizeFactor - TreeSize;
+        var start = tree.RectSize / sizeFactor - TreeSize;
 
         float x = dragOffset.x;
         x = Math.Max(x, start.x);


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR does some stuff...

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
