### PR TITLE
New mucilage and slime jet icons

### DIFF
--- a/assets/textures/gui/bevel/mucilage.png
+++ b/assets/textures/gui/bevel/mucilage.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fdfe7eec8131c7a910d4099d722dd05a42360dc8b6400ae4a181b44d674fa3de
-size 8677
+oid sha256:88ad89fe81b3312c99c5313359e3726416bfb85112ac72bd926453d903e9bce4
+size 7120

--- a/assets/textures/gui/bevel/parts/SlimeJetIcon.png
+++ b/assets/textures/gui/bevel/parts/SlimeJetIcon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a9bdc2044b986a63d00c45d8d2a7ad64eabe55c201fe53c427821d2f143a7fb
-size 16040
+oid sha256:77b91be4f0533683b45cb94ee6b8cb055083bd243d7e2fdb0c14bd0e6d62cc58
+size 73249


### PR DESCRIPTION
**Brief Description of What This PR Does**

Replaces the icons for the mucilage compound and slime jet organelle with upgraded versions.

**Related Issues**

N/A

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
