### PR TITLE
Fixed membrane alpha issues

### DIFF
--- a/src/microbe_stage/Membrane.cs
+++ b/src/microbe_stage/Membrane.cs
@@ -193,7 +193,8 @@ public class Membrane : MeshInstance, IComputedMembraneData
             // According to stack overflow HSV and HSB are the same thing
             value.ToHsv(out var hue, out var saturation, out var brightness);
 
-            value = Color.FromHsv(hue, saturation * 0.75f, brightness);
+            value = Color.FromHsv(hue, saturation * 0.75f, brightness,
+                Mathf.Clamp(value.a, 0.4f - brightness * 0.3f, 1.0f));
 
             if (tint == value)
                 return;


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR addresses issue #3832 and #3833 by adding alpha handling to Tint under the Membrane class. It also adds a value ramped floor and max value of 1.0f limiting valid alpha.

**Related Issues**

fixes #3832
closes #3833

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
