### PR TITLE
Fix crash by normalising cell rotation for slime jets

### DIFF
--- a/src/microbe_stage/organelle_components/SlimeJetComponent.cs
+++ b/src/microbe_stage/organelle_components/SlimeJetComponent.cs
@@ -78,7 +78,7 @@ public class SlimeJetComponent : ExternallyPositionedComponent
         if (!Active)
             return Vector3.Zero;
 
-        var currentCellRotation = microbe.GlobalTransform.basis.Quat();
+        var currentCellRotation = microbe.GlobalTransform.basis.Quat().Normalized();
         var direction = GetDirection();
 
         // Preview the amount of mucilage we'll eject to calculate force here


### PR DESCRIPTION
**Brief Description of What This PR Does**

Normalises cell rotation before using it to calculate movement force from the slime jet, preventing a crash.

**Related Issues**

Fixes https://github.com/Revolutionary-Games/Thrive/issues/3874

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
