### PR TITLE
Fix infinite compound ejection glitch

### DIFF
--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -1453,6 +1453,7 @@ public partial class Microbe
 
             var containedCompounds = engulfable.Compounds;
             var additionalCompounds = engulfedObject.AdditionalEngulfableCompounds;
+            containedCompounds.FixNaNCompounds();
 
             var totalAmountLeft = 0.0f;
 

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -1453,6 +1453,10 @@ public partial class Microbe
 
             var containedCompounds = engulfable.Compounds;
             var additionalCompounds = engulfedObject.AdditionalEngulfableCompounds;
+
+            // Workaround to avoid NaN compounds in engulfed objects, leading to glitches like infinite compound
+            // ejection and incorrect ingested matter display
+            // https://github.com/Revolutionary-Games/Thrive/issues/3548
             containedCompounds.FixNaNCompounds();
 
             var totalAmountLeft = 0.0f;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes cells infinitely spawning compounds due to corrupted engulfed objects by setting all NaN values to zero.

Based on the suggestion [here](https://github.com/Revolutionary-Games/Thrive/issues/3548#issuecomment-1321201278). Seems to fix the issue and the related problem of ingested matter not appearing in the UI in a save in this corrupted state.

**Related Issues**

Mitigates (but might not wholly fix) https://github.com/Revolutionary-Games/Thrive/issues/3548 and https://github.com/Revolutionary-Games/Thrive/issues/3201

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
