### PR TITLE
Fix infinite compound venting due to having compounds over capacity in the cell

### DIFF
--- a/src/microbe_stage/CompoundCloudPlane.cs
+++ b/src/microbe_stage/CompoundCloudPlane.cs
@@ -400,6 +400,9 @@ public class CompoundCloudPlane : CSGMesh, ISaveLoadedTracked
     /// <returns>The amount of compound taken</returns>
     public float TakeCompound(Compound compound, int x, int y, float fraction = 1.0f)
     {
+        if (fraction < 0.0f)
+            return 0.0f;
+
         float amountInCloud = HackyAddress(Density[x, y], GetCompoundIndex(compound));
         var amountToGive = amountInCloud * fraction;
 

--- a/src/microbe_stage/CompoundCloudPlane.cs
+++ b/src/microbe_stage/CompoundCloudPlane.cs
@@ -400,6 +400,8 @@ public class CompoundCloudPlane : CSGMesh, ISaveLoadedTracked
     /// <returns>The amount of compound taken</returns>
     public float TakeCompound(Compound compound, int x, int y, float fraction = 1.0f)
     {
+        // TODO: change to throwing an error once we've fixed cells requesting negative compounds
+        // https://github.com/Revolutionary-Games/Thrive/issues/3927
         if (fraction < 0.0f)
             return 0.0f;
 

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -693,10 +693,10 @@ public partial class Microbe
             {
                 amountToVent -= EjectCompound(type, amountToVent, Vector3.Back);
             }
-            else if (Compounds.GetCompoundAmount(type) > Compounds.Capacity)
+            else if (Compounds.GetCompoundAmount(type) > 2 * Compounds.Capacity)
             {
                 // Vent the part that went over
-                float toVent = Compounds.GetCompoundAmount(type) - Compounds.Capacity;
+                float toVent = Compounds.GetCompoundAmount(type) - (2 * Compounds.Capacity);
 
                 amountToVent -= EjectCompound(type, Math.Min(toVent, amountToVent), Vector3.Back);
             }

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -693,10 +693,10 @@ public partial class Microbe
             {
                 amountToVent -= EjectCompound(type, amountToVent, Vector3.Back);
             }
-            else if (Compounds.GetCompoundAmount(type) > 2 * Compounds.Capacity)
+            else if (Compounds.GetCompoundAmount(type) > Compounds.Capacity)
             {
                 // Vent the part that went over
-                float toVent = Compounds.GetCompoundAmount(type) - (2 * Compounds.Capacity);
+                float toVent = Compounds.GetCompoundAmount(type) - Compounds.Capacity;
 
                 amountToVent -= EjectCompound(type, Math.Min(toVent, amountToVent), Vector3.Back);
             }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Prevents taking negative compounds from the cloud system, which was causing another infinite compound venting glitch. Also fixes compound venting to seemingly prevent a cell ending up with more compounds than it can contain.

**Related Issues**

N/A

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
