### PR TITLE
Remove unused ComputeRandomRadianRotation function and '%' suffix for compounds in patch details

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -442,10 +442,6 @@ file_logging/max_log_files=8
 
 limits/message_queue/max_size_kb=8192
 
-[mono]
-
-project/assembly_name="Thrive"
-
 [physics]
 
 3d/default_gravity=9.81

--- a/project.godot
+++ b/project.godot
@@ -442,6 +442,10 @@ file_logging/max_log_files=8
 
 limits/message_queue/max_size_kb=8192
 
+[mono]
+
+project/assembly_name="Thrive"
+
 [physics]
 
 3d/default_gravity=9.81

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -477,26 +477,6 @@ public class SpawnSystem : ISpawnSystem
         entity.EntityNode.AddToGroup(Constants.SPAWNED_GROUP);
     }
 
-    /// <summary>
-    ///   Returns a random rotation (in radians)
-    ///   If weighted, it is more likely to return a rotation closer to the target rotation than not
-    /// </summary>
-    private float ComputeRandomRadianRotation(float targetRotation, bool weighted)
-    {
-        float rotation1 = random.NextFloat() * 2 * Mathf.Pi;
-
-        if (weighted)
-        {
-            targetRotation = WithNegativesToNormalRadians(targetRotation);
-            float rotation2 = random.NextFloat() * 2 * Mathf.Pi;
-
-            if (DistanceBetweenRadians(rotation2, targetRotation) < DistanceBetweenRadians(rotation1, targetRotation))
-                return NormalToWithNegativesRadians(rotation2);
-        }
-
-        return NormalToWithNegativesRadians(rotation1);
-    }
-
     // TODO Could use to be moved to mathUtils?
     private float NormalToWithNegativesRadians(float radian)
     {

--- a/src/microbe_stage/gui/PatchDetailsPanel.cs
+++ b/src/microbe_stage/gui/PatchDetailsPanel.cs
@@ -281,14 +281,19 @@ public class PatchDetailsPanel : PanelContainer
 
         // Compounds
         hydrogenSulfide.Text =
-            Math.Round(GetCompoundAmount(SelectedPatch, hydrogensulfideCompound.InternalName), 3).ToString();
+            Math.Round(GetCompoundAmount(SelectedPatch, hydrogensulfideCompound.InternalName), 3)
+            .ToString(System.Globalization.CultureInfo.CurrentCulture);
         ammonia.Text =
-            Math.Round(GetCompoundAmount(SelectedPatch, ammoniaCompound.InternalName), 3).ToString();
+            Math.Round(GetCompoundAmount(SelectedPatch, ammoniaCompound.InternalName), 3)
+            .ToString(System.Globalization.CultureInfo.CurrentCulture);
         glucose.Text =
-            Math.Round(GetCompoundAmount(SelectedPatch, glucoseCompound.InternalName), 3).ToString();
+            Math.Round(GetCompoundAmount(SelectedPatch, glucoseCompound.InternalName), 3)
+            .ToString(System.Globalization.CultureInfo.CurrentCulture);
         phosphate.Text =
-            Math.Round(GetCompoundAmount(SelectedPatch, phosphatesCompound.InternalName), 3).ToString();
-        iron.Text = GetCompoundAmount(SelectedPatch, ironCompound.InternalName).ToString();
+            Math.Round(GetCompoundAmount(SelectedPatch, phosphatesCompound.InternalName), 3)
+            .ToString(System.Globalization.CultureInfo.CurrentCulture);
+        iron.Text = GetCompoundAmount(SelectedPatch, ironCompound.InternalName)
+            .ToString(System.Globalization.CultureInfo.CurrentCulture);
 
         var label = speciesListBox.GetItem<CustomRichTextLabel>("SpeciesList");
         var speciesList = new StringBuilder(100);

--- a/src/microbe_stage/gui/PatchDetailsPanel.cs
+++ b/src/microbe_stage/gui/PatchDetailsPanel.cs
@@ -281,16 +281,14 @@ public class PatchDetailsPanel : PanelContainer
 
         // Compounds
         hydrogenSulfide.Text =
-            percentageFormat.FormatSafe(
-                Math.Round(GetCompoundAmount(SelectedPatch, hydrogensulfideCompound.InternalName), 3));
+            Math.Round(GetCompoundAmount(SelectedPatch, hydrogensulfideCompound.InternalName), 3).ToString();
         ammonia.Text =
-            percentageFormat.FormatSafe(Math.Round(GetCompoundAmount(SelectedPatch, ammoniaCompound.InternalName), 3));
+            Math.Round(GetCompoundAmount(SelectedPatch, ammoniaCompound.InternalName), 3).ToString();
         glucose.Text =
-            percentageFormat.FormatSafe(Math.Round(GetCompoundAmount(SelectedPatch, glucoseCompound.InternalName), 3));
+            Math.Round(GetCompoundAmount(SelectedPatch, glucoseCompound.InternalName), 3).ToString();
         phosphate.Text =
-            percentageFormat.FormatSafe(
-                Math.Round(GetCompoundAmount(SelectedPatch, phosphatesCompound.InternalName), 3));
-        iron.Text = percentageFormat.FormatSafe(GetCompoundAmount(SelectedPatch, ironCompound.InternalName));
+            Math.Round(GetCompoundAmount(SelectedPatch, phosphatesCompound.InternalName), 3).ToString();
+        iron.Text = GetCompoundAmount(SelectedPatch, ironCompound.InternalName).ToString();
 
         var label = speciesListBox.GetItem<CustomRichTextLabel>("SpeciesList");
         var speciesList = new StringBuilder(100);

--- a/src/microbe_stage/gui/PatchDetailsPanel.cs
+++ b/src/microbe_stage/gui/PatchDetailsPanel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Godot;
@@ -282,18 +283,18 @@ public class PatchDetailsPanel : PanelContainer
         // Compounds
         hydrogenSulfide.Text =
             Math.Round(GetCompoundAmount(SelectedPatch, hydrogensulfideCompound.InternalName), 3)
-                .ToString(System.Globalization.CultureInfo.CurrentCulture);
+                .ToString(CultureInfo.CurrentCulture);
         ammonia.Text =
             Math.Round(GetCompoundAmount(SelectedPatch, ammoniaCompound.InternalName), 3)
-                .ToString(System.Globalization.CultureInfo.CurrentCulture);
+                .ToString(CultureInfo.CurrentCulture);
         glucose.Text =
             Math.Round(GetCompoundAmount(SelectedPatch, glucoseCompound.InternalName), 3)
-                .ToString(System.Globalization.CultureInfo.CurrentCulture);
+                .ToString(CultureInfo.CurrentCulture);
         phosphate.Text =
             Math.Round(GetCompoundAmount(SelectedPatch, phosphatesCompound.InternalName), 3)
-                .ToString(System.Globalization.CultureInfo.CurrentCulture);
+                .ToString(CultureInfo.CurrentCulture);
         iron.Text = GetCompoundAmount(SelectedPatch, ironCompound.InternalName)
-            .ToString(System.Globalization.CultureInfo.CurrentCulture);
+            .ToString(CultureInfo.CurrentCulture);
 
         var label = speciesListBox.GetItem<CustomRichTextLabel>("SpeciesList");
         var speciesList = new StringBuilder(100);

--- a/src/microbe_stage/gui/PatchDetailsPanel.cs
+++ b/src/microbe_stage/gui/PatchDetailsPanel.cs
@@ -282,16 +282,16 @@ public class PatchDetailsPanel : PanelContainer
         // Compounds
         hydrogenSulfide.Text =
             Math.Round(GetCompoundAmount(SelectedPatch, hydrogensulfideCompound.InternalName), 3)
-            .ToString(System.Globalization.CultureInfo.CurrentCulture);
+                .ToString(System.Globalization.CultureInfo.CurrentCulture);
         ammonia.Text =
             Math.Round(GetCompoundAmount(SelectedPatch, ammoniaCompound.InternalName), 3)
-            .ToString(System.Globalization.CultureInfo.CurrentCulture);
+                .ToString(System.Globalization.CultureInfo.CurrentCulture);
         glucose.Text =
             Math.Round(GetCompoundAmount(SelectedPatch, glucoseCompound.InternalName), 3)
-            .ToString(System.Globalization.CultureInfo.CurrentCulture);
+                .ToString(System.Globalization.CultureInfo.CurrentCulture);
         phosphate.Text =
             Math.Round(GetCompoundAmount(SelectedPatch, phosphatesCompound.InternalName), 3)
-            .ToString(System.Globalization.CultureInfo.CurrentCulture);
+                .ToString(System.Globalization.CultureInfo.CurrentCulture);
         iron.Text = GetCompoundAmount(SelectedPatch, ironCompound.InternalName)
             .ToString(System.Globalization.CultureInfo.CurrentCulture);
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Removes the unused ComputeRandomRadianRotation function from SpawnSystem.cs and also removes the '%' format from compounds in the patch details menu. 

**Related Issues**

Closes #3883 
Closes #3909 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (In progress - all I have at the moment is GitPod.)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
