### PR TITLE
Added in proper prevention of absorbing negative compound amounts

### DIFF
--- a/src/microbe_stage/CompoundBag.cs
+++ b/src/microbe_stage/CompoundBag.cs
@@ -56,7 +56,7 @@ public class CompoundBag : ICompoundStorage
     }
 
     /// <summary>
-    ///   The space available for a compound of type. If not useful no free space is ever reported
+    ///   The space available for a compound of given type. If not useful no free space is ever reported.
     /// </summary>
     /// <param name="compound">The compound type to check</param>
     /// <returns>The free space available</returns>

--- a/src/microbe_stage/CompoundBag.cs
+++ b/src/microbe_stage/CompoundBag.cs
@@ -55,6 +55,17 @@ public class CompoundBag : ICompoundStorage
         return amount;
     }
 
+    /// <summary>
+    ///   The space available for a compound of type. If not useful no free space is ever reported
+    /// </summary>
+    /// <param name="compound">The compound type to check</param>
+    /// <returns>The free space available</returns>
+    public float GetFreeSpaceForCompound(Compound compound)
+    {
+        // Due to venting not triggering immediately at capacity, we use max here to avoid negative free space
+        return Math.Max(GetCapacityForCompound(compound) - GetCompoundAmount(compound), 0);
+    }
+
     public float TakeCompound(Compound compound, float amount)
     {
         if (!Compounds.TryGetValue(compound, out var existingAmount) || amount <= 0.0f)

--- a/src/microbe_stage/CompoundCloudSystem.cs
+++ b/src/microbe_stage/CompoundCloudSystem.cs
@@ -172,6 +172,9 @@ public class CompoundCloudSystem : Node, ISaveLoadedTracked
     /// <param name="fraction">The fraction of compound to take. Should be &lt;= 1</param>
     public float TakeCompound(Compound compound, Vector3 worldPosition, float fraction)
     {
+        if (fraction < 0.0f)
+            throw new ArgumentException("Fraction to take can't be negative");
+
         foreach (var cloud in clouds)
         {
             if (cloud.ContainsPosition(worldPosition, out var x, out var y))

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -667,7 +667,7 @@ public partial class Microbe
         {
             var usefulCompounds = SimulationParameters.Instance.GetCloudCompounds().Where(Compounds.IsUseful);
             foreach (var usefulCompound in usefulCompounds)
-                Compounds.AddCompound(usefulCompound, Compounds.Capacity - Compounds.GetCompoundAmount(usefulCompound));
+                Compounds.AddCompound(usefulCompound, Compounds.GetFreeSpaceForCompound(usefulCompound));
         }
     }
 

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -176,8 +176,7 @@ public class MicrobeAI
         if (atpThreshold > 0.0f)
         {
             if (microbe.Compounds.GetCompoundAmount(atp) < microbe.Compounds.Capacity * atpThreshold
-                && microbe.Compounds.Where(compound => IsVitalCompound(compound.Key) && compound.Value > 0.0f)
-                    .Count() > 0)
+                && microbe.Compounds.Any(compound => IsVitalCompound(compound.Key) && compound.Value > 0.0f))
             {
                 SetMoveSpeed(0.0f);
                 return;


### PR DESCRIPTION
**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
removes the bandaid and fixes #3927

also I couldn't help sneaking in a change Rider automatically suggested as a cleaner code alternative to one line in the AI code.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
