### PR TITLE
Remove use of meta in Thriveopedia

### DIFF
--- a/src/thriveopedia/Thriveopedia.cs
+++ b/src/thriveopedia/Thriveopedia.cs
@@ -289,7 +289,8 @@ public class Thriveopedia : ControlWithInput
 
     private void OnPageSelectedFromPageTree()
     {
-        var name = allPages.First(p => p.Value == pageTree.GetSelected()).Key.PageName;
+        var selected = pageTree.GetSelected();
+        var name = allPages.First(p => p.Value == selected).Key.PageName;
         ChangePage(name);
     }
 

--- a/src/thriveopedia/Thriveopedia.cs
+++ b/src/thriveopedia/Thriveopedia.cs
@@ -269,9 +269,6 @@ public class Thriveopedia : ControlWithInput
     {
         var pageInTree = pageTree.CreateItem(parentName != null ? allPages[GetPage(parentName)] : null);
 
-        // Set the name of the tree item so we can reference it later
-        pageInTree.SetMeta("name", page.PageName);
-
         // Godot doesn't appear to have a left margin for text in items, so add some manual padding
         pageInTree.SetText(0, "  " + page.TranslatedPageName);
 
@@ -292,7 +289,7 @@ public class Thriveopedia : ControlWithInput
 
     private void OnPageSelectedFromPageTree()
     {
-        var name = (string)pageTree.GetSelected().GetMeta("name");
+        var name = allPages.First(p => p.Value == pageTree.GetSelected()).Key.PageName;
         ChangePage(name);
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Changes indexing of pages in the Thriveopedia page tree to avoid use of Godot meta.

I think this was a holdover from before a refactor I did partway through the Thriveopedia PR. Due to the constraints on Godot's `PageTree` and `TreeItem`, I believe making a custom version of `TreeItem` isn't possible, so we can't use C# properties. Besides, I had a dictionary of Thriveopedia pages and items lying around anyway, so it's easy to use that.

**Related Issues**

Closes https://github.com/Revolutionary-Games/Thrive/issues/3944

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
