### PR TITLE
Graceful fossil error handling

### DIFF
--- a/src/thriveopedia/fossilisation/FossilisedSpecies.cs
+++ b/src/thriveopedia/fossilisation/FossilisedSpecies.cs
@@ -118,7 +118,7 @@ public class FossilisedSpecies
     ///   Loads a fossilised species by its filename.
     /// </summary>
     /// <param name="fossilName">The name of the .thrivefossil file (including extension)</param>
-    /// <returns>The species saved in the provided file</returns>
+    /// <returns>The species saved in the provided file, or null if the file doesn't exist or is corrupt</returns>
     public static FossilisedSpecies? LoadSpeciesFromFile(string fossilName)
     {
         var target = Path.Combine(Constants.FOSSILISED_SPECIES_FOLDER, fossilName);
@@ -133,7 +133,7 @@ public class FossilisedSpecies
         }
         catch (Exception e)
         {
-            // This fossil is corrupt, so just don't bother showing it
+            // This fossil doesn't exist or is corrupt, so just don't bother showing it
             GD.PrintErr($"Error loading fossil: {e}");
             return null;
         }

--- a/src/thriveopedia/fossilisation/FossilisedSpecies.cs
+++ b/src/thriveopedia/fossilisation/FossilisedSpecies.cs
@@ -131,9 +131,10 @@ public class FossilisedSpecies
                 PreviewImage = previewImage,
             };
         }
-        catch (Exception)
+        catch (Exception e)
         {
             // This fossil is corrupt, so just don't bother showing it
+            GD.PrintErr($"Error loading fossil: {e}");
             return null;
         }
     }

--- a/src/thriveopedia/fossilisation/FossilisedSpecies.cs
+++ b/src/thriveopedia/fossilisation/FossilisedSpecies.cs
@@ -119,15 +119,23 @@ public class FossilisedSpecies
     /// </summary>
     /// <param name="fossilName">The name of the .thrivefossil file (including extension)</param>
     /// <returns>The species saved in the provided file</returns>
-    public static FossilisedSpecies LoadSpeciesFromFile(string fossilName)
+    public static FossilisedSpecies? LoadSpeciesFromFile(string fossilName)
     {
         var target = Path.Combine(Constants.FOSSILISED_SPECIES_FOLDER, fossilName);
-        var (fossilisedInfo, species, previewImage) = LoadFromFile(target);
-
-        return new FossilisedSpecies(fossilisedInfo, species, Path.GetFileNameWithoutExtension(fossilName))
+        try
         {
-            PreviewImage = previewImage,
-        };
+            var (fossilisedInfo, species, previewImage) = LoadFromFile(target);
+
+            return new FossilisedSpecies(fossilisedInfo, species, Path.GetFileNameWithoutExtension(fossilName))
+            {
+                PreviewImage = previewImage,
+            };
+        }
+        catch (Exception)
+        {
+            // This fossil is corrupt, so just don't bother showing it
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/thriveopedia/pages/ThriveopediaMuseumPage.cs
+++ b/src/thriveopedia/pages/ThriveopediaMuseumPage.cs
@@ -59,10 +59,13 @@ public class ThriveopediaMuseumPage : ThriveopediaPage
 
         foreach (var speciesName in FossilisedSpecies.CreateListOfFossils(true))
         {
-            var card = (MuseumCard)museumCardScene.Instance();
-
             var savedSpecies = FossilisedSpecies.LoadSpeciesFromFile(speciesName);
 
+            // Don't add cards for corrupt fossils
+            if (savedSpecies == null)
+                continue;
+
+            var card = (MuseumCard)museumCardScene.Instance();
             card.SavedSpecies = savedSpecies.Species;
             card.FossilPreviewImage = savedSpecies.PreviewImage;
             card.Connect(nameof(MuseumCard.OnSpeciesSelected), this, nameof(UpdateSpeciesPreview));


### PR DESCRIPTION
**Brief Description of What This PR Does**

Ignores corrupt fossil files to prevent crashes when opening the Thriveopedia.

I went for the nuclear option of just wrapping the whole loading process in a try-catch block and printing the error. That may lead to error spam if a user with a corrupt fossil repeatedly opens and closes the Thriveopedia.

**Related Issues**

Closes https://github.com/Revolutionary-Games/Thrive/issues/3861

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
