### PR TITLE
Reduce frequency of light level updates

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -184,6 +184,8 @@ public static class Constants
     public const int TRANSLATION_VERY_INCOMPLETE_THRESHOLD = 30;
     public const int TRANSLATION_INCOMPLETE_THRESHOLD = 70;
 
+    public const float LIGHT_LEVEL_UPDATE_INTERVAL = 0.1f;
+
     /// <summary>
     ///   How often the microbe AI processes each microbe
     /// </summary>


### PR DESCRIPTION
**Brief Description of What This PR Does**

Reduces the frequency of light level and other biome data updates to 10 times a second.=.

**Related Issues**

Closes https://github.com/Revolutionary-Games/Thrive/issues/3892

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
