### PR TITLE
Fix process panel not updating after cell reproduces

### DIFF
--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -1220,6 +1220,9 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
             }
         }
 
+        // Recreate tracking for running processes
+        ProcessStatistics = new ProcessStatistics();
+
         processesDirty = false;
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Recreates `ProcessStatistics` when processes need refreshing to fix the process panel freezing once the player reproduces.

I'll admit, I'm not 100% sure why this works and feel there must a better way. But it's definitely something in this area. I won't be surprised if this change is rejected in favour of something else.

**Related Issues**

Fixes https://github.com/Revolutionary-Games/Thrive/issues/3898

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
