### PR TITLE
Print world seed when map generation fails

### DIFF
--- a/src/microbe_stage/PatchMapGenerator.cs
+++ b/src/microbe_stage/PatchMapGenerator.cs
@@ -146,10 +146,10 @@ public static class PatchMapGenerator
         BuildPatchesInRegions(map, random);
 
         if (vents == null)
-            throw new InvalidOperationException("No vent patch created");
+            throw new InvalidOperationException($"No vent patch created for seed {settings.Seed}");
 
         if (tidepool == null)
-            throw new InvalidOperationException("No tidepool patch created");
+            throw new InvalidOperationException($"No tidepool patch created for seed {settings.Seed}");
 
         // This uses random so this affects the edge subtraction, but this doesn't depend on the selected start type
         // so this makes the same map be generated anyway


### PR DESCRIPTION
**Brief Description of What This PR Does**

Just experienced a rare crash (as no such report since patch generation system was written) where no tidepool was generated, ending in an exception (and I forgot to look at its seed). It would be good if seed is included in the exception message so that we can reproduce the bug easily.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
