### PR TITLE
New auto-evo exploring tool controller adjustment and a typo fix

### DIFF
--- a/doc/making_guis.md
+++ b/doc/making_guis.md
@@ -29,7 +29,7 @@ when parts are hidden and others are shown, there's always an active
 grabber that makes sense.
 
 For a Control to be focusable it needs to be set to accept "all" focus
-instead on "none"
+instead of "none"
 
 Navigation Directions
 ---------------------
@@ -48,7 +48,7 @@ Even if a GUI is not made to be controller navigable, there should at
 least be an exit button that is made focused by a `FocusGrabber` (and
 it should have all the navigation directions set to itself to avoid
 navigating away from it). This way a controller user can at least
-exist the screen without having to force close the game or reach for a
+exit the screen without having to force close the game or reach for a
 mouse.
 
 Making Tabs

--- a/src/auto-evo/AutoEvoExploringTool.tscn
+++ b/src/auto-evo/AutoEvoExploringTool.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://src/auto-evo/AutoEvoExploringTool.cs" type="Script" id=1]
 [ext_resource path="res://src/gui_common/thrive_theme.tres" type="Theme" id=2]
@@ -19,6 +19,8 @@
 [ext_resource path="res://src/microbe_stage/gui/PatchDetailsPanel.tscn" type="PackedScene" id=17]
 [ext_resource path="res://assets/textures/gui/bevel/plusButton.png" type="Texture" id=18]
 [ext_resource path="res://assets/textures/gui/bevel/plusButtonHover.png" type="Texture" id=19]
+[ext_resource path="res://src/gui_common/FocusGrabber.tscn" type="PackedScene" id=20]
+[ext_resource path="res://src/gui_common/TabButtons.tscn" type="PackedScene" id=21]
 
 [sub_resource type="ButtonGroup" id=1]
 resource_name = "TabsButtonGroup"
@@ -101,7 +103,9 @@ margin_right = 1230.0
 margin_bottom = 690.0
 custom_constants/separation = 10
 
-[node name="TabButtons" type="HBoxContainer" parent="GUI/VBoxContainer"]
+[node name="TabButtons" parent="GUI/VBoxContainer" instance=ExtResource( 21 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
 margin_right = 1180.0
 margin_bottom = 35.0
 
@@ -1049,6 +1053,12 @@ margin_bottom = 660.0
 margin_right = 62.0
 margin_bottom = 35.0
 text = "BACK"
+
+[node name="FocusGrabber" parent="GUI/VBoxContainer/HBoxContainer" instance=ExtResource( 20 )]
+margin_left = 66.0
+margin_right = 66.0
+margin_bottom = 35.0
+NodeToGiveFocusTo = NodePath("../BackButton")
 
 [node name="ExitConfirmationDialog" parent="." instance=ExtResource( 11 )]
 rect_min_size = Vector2( 400, 0 )

--- a/src/gui_common/TabButtons.cs
+++ b/src/gui_common/TabButtons.cs
@@ -320,6 +320,11 @@ public class TabButtons : HBoxContainer
                 // button.EmitSignal("button_down");
                 // button.EmitSignal("button_up");
 
+                // If the button doesn't move to pressed state, set it here. This makes some differently made tab
+                // controlled buttons work (auto-evo exploring tool, for example)
+                if (button.Pressed != true)
+                    button.Pressed = true;
+
                 break;
             default:
                 throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
**Brief Description of What This PR Does**
Adjusts the new auto-evo exploring tool GUI to use the new tab control. And fixes a few typos from my changes in the controller GUI navigation PR

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
