### PR TITLE
Skip post startup when in editor, include callstack in InstanceNotLoadedYetException

### DIFF
--- a/src/engine/InstanceNotLoadedYetException.cs
+++ b/src/engine/InstanceNotLoadedYetException.cs
@@ -7,7 +7,10 @@ using System.Runtime.Serialization;
 [Serializable]
 public class InstanceNotLoadedYetException : InvalidOperationException
 {
-    public InstanceNotLoadedYetException() { }
+    public InstanceNotLoadedYetException() : base(
+        $"Instance not loaded yet, called from:\n{Environment.StackTrace}\nend of not loaded yet stacktrace")
+    {
+    }
 
     protected InstanceNotLoadedYetException(SerializationInfo serializationInfo,
         StreamingContext streamingContext) : base(serializationInfo, streamingContext)

--- a/src/engine/PostStartupActions.cs
+++ b/src/engine/PostStartupActions.cs
@@ -8,6 +8,12 @@ public class PostStartupActions : Node
 {
     private PostStartupActions()
     {
+        if (Engine.EditorHint)
+        {
+            // Skip these actions when running in the Godot editor
+            return;
+        }
+
         // Queue window title set as setting it in the autoloads doesn't work yet
         Invoke.Instance.Perform(() => { OS.SetWindowTitle("Thrive - " + Constants.Version); });
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

I was planning on fixing stuff where the editor loads our code and causes errors to be printed.
So I added callstack to the exception we usually get's message and skipped one problematic operation that was printing error messages.

Turns out that I couldn't find anymore instances of the exception from temporary mono objects... so this PR is pretty small as a result and doesn't fundamentally fix anything, but should make future fixing much easier if the problems come back.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
