### PR TITLE
Added the main website posts news feed to the main menu

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -145,6 +145,7 @@
     <Compile Include="src\general\AssetType.cs" />
     <Compile Include="src\general\CustomDifficulty.cs" />
     <Compile Include="src\general\DictionaryWithFallback.cs" />
+    <Compile Include="src\general\HtmlToBbCodeConverter.cs" />
     <Compile Include="src\general\IDifficulty.cs" />
     <Compile Include="src\general\MultiCollection.cs" />
     <Compile Include="src\general\ThriveNewsFeed.cs" />
@@ -157,6 +158,7 @@
     <Compile Include="src\gui_common\SpeciesDetailsPanel.cs" />
     <Compile Include="src\gui_common\TabButtons.cs" />
     <Compile Include="src\gui_common\TabLevel.cs" />
+    <Compile Include="src\gui_common\ThriveFeedDisplayer.cs" />
     <Compile Include="src\microbe_stage\AvailableUpgrade.cs" />
     <Compile Include="src\microbe_stage\CellHexesPhotoBuilder.cs" />
     <Compile Include="src\microbe_stage\CellHexesPreview.cs" />

--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -147,6 +147,7 @@
     <Compile Include="src\general\DictionaryWithFallback.cs" />
     <Compile Include="src\general\IDifficulty.cs" />
     <Compile Include="src\general\MultiCollection.cs" />
+    <Compile Include="src\general\ThriveNewsFeed.cs" />
     <Compile Include="src\gui_common\art_gallery\TextureThumbnailResource.cs" />
     <Compile Include="src\gui_common\DismissibleNotice.cs" />
     <Compile Include="src\gui_common\FocusFlowDynamicChildrenHelper.cs" />
@@ -609,8 +610,14 @@
     <Folder Include="src\auto-evo\simulation\" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AngleSharp">
+      <Version>1.0.1</Version>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.2</Version>
+    </PackageReference>
+    <PackageReference Include="System.Net.Http">
+      <Version>4.3.4</Version>
     </PackageReference>
     <PackageReference Include="System.Numerics.Vectors">
       <Version>4.5.0</Version>

--- a/locale/af.po
+++ b/locale/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -194,7 +194,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -330,8 +330,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -586,27 +586,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -865,19 +865,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1230,11 +1230,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1242,11 +1242,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1417,7 +1417,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1591,15 +1591,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1652,6 +1652,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1700,7 +1708,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1750,7 +1758,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1758,7 +1766,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1784,6 +1792,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1865,7 +1889,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1961,7 +1985,7 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1969,11 +1993,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2249,7 +2273,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2465,7 +2489,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2623,7 +2647,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2751,7 +2775,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2781,12 +2806,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2986,7 +3011,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3183,11 +3208,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3273,11 +3298,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3501,15 +3526,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3609,7 +3638,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3621,7 +3650,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3651,7 +3680,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3670,8 +3699,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3684,15 +3713,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3763,11 +3792,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3972,7 +4001,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4030,8 +4059,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4081,7 +4110,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4154,7 +4183,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4208,7 +4237,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4252,11 +4281,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4296,7 +4325,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4430,7 +4459,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4516,11 +4545,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4876,7 +4905,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4926,7 +4955,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5041,15 +5070,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5089,7 +5118,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5204,7 +5233,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5212,7 +5241,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5271,7 +5300,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5418,7 +5447,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5561,7 +5590,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5745,7 +5774,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5757,7 +5786,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5910,7 +5939,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/af.po
+++ b/locale/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -29,7 +29,7 @@ msgstr ""
 msgid "3D_MOVEMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -60,7 +60,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -145,11 +145,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -174,11 +174,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -246,7 +246,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -254,8 +254,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -280,7 +280,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -317,7 +317,7 @@ msgstr ""
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -330,9 +330,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -468,7 +468,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -658,7 +658,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -748,7 +748,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -789,15 +789,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -865,23 +865,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr ""
 
@@ -907,7 +907,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -986,7 +986,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -999,11 +999,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1011,11 +1011,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1095,7 +1095,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1218,7 +1218,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1230,11 +1230,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1242,11 +1242,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1318,7 +1318,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1358,31 +1358,31 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1417,7 +1417,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1648,15 +1648,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1688,11 +1688,11 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1708,7 +1708,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1758,7 +1758,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1766,7 +1766,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1794,19 +1794,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1927,7 +1927,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1957,7 +1957,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -1985,23 +1985,23 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2054,11 +2054,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2066,7 +2066,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2078,7 +2078,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2100,11 +2100,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2128,7 +2128,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr ""
 
@@ -2200,7 +2200,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2253,8 +2253,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2273,7 +2273,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2281,19 +2281,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2473,19 +2473,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2647,7 +2647,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2715,7 +2715,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2727,31 +2727,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2775,7 +2775,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2806,12 +2806,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2884,15 +2884,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3011,7 +3011,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3145,7 +3145,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3208,11 +3208,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3298,11 +3298,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3355,11 +3355,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3468,7 +3468,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3480,7 +3480,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3500,9 +3500,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3534,11 +3534,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3603,7 +3603,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3650,7 +3650,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3667,7 +3667,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3713,15 +3713,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3752,7 +3752,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3776,7 +3776,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3792,11 +3792,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4001,7 +4001,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4134,7 +4134,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4146,23 +4146,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4325,7 +4325,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4378,7 +4378,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4386,23 +4386,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4459,7 +4459,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4491,7 +4491,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4545,19 +4545,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4649,20 +4649,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4775,20 +4775,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4837,7 +4841,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4877,7 +4881,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5070,15 +5074,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5118,7 +5122,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5233,7 +5237,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5241,7 +5245,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5296,11 +5300,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5447,7 +5451,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5509,7 +5513,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5590,11 +5594,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5619,7 +5623,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5639,7 +5643,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5651,7 +5655,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5659,7 +5663,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5699,7 +5703,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5715,7 +5719,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5723,11 +5727,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5753,7 +5757,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr ""
 
@@ -5762,11 +5766,11 @@ msgstr ""
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5774,7 +5778,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5786,7 +5790,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5806,7 +5810,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5911,7 +5915,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5919,15 +5923,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/ar.po
+++ b/locale/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-11-17 16:00+0000\n"
 "Last-Translator: Omar Aglan <omar.aglan91@yahoo.com>\n"
 "Language-Team: Arabic <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ar/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr ""
 msgid "3D_MOVEMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -147,11 +147,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -176,11 +176,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -196,7 +196,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -256,8 +256,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -282,7 +282,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -319,7 +319,7 @@ msgstr ""
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -332,9 +332,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -470,7 +470,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -661,7 +661,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -792,15 +792,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -816,7 +816,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -868,23 +868,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr ""
 
@@ -910,7 +910,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -989,7 +989,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1002,11 +1002,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1014,11 +1014,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1098,7 +1098,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1233,11 +1233,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1245,11 +1245,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1330,7 +1330,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1362,31 +1362,31 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1568,7 +1568,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1641,7 +1641,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1653,15 +1653,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1693,11 +1693,11 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1713,7 +1713,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1763,7 +1763,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1771,7 +1771,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1799,19 +1799,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1933,7 +1933,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1963,7 +1963,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -1992,23 +1992,23 @@ msgstr "عام"
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2061,11 +2061,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2073,7 +2073,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2085,7 +2085,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2107,11 +2107,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2135,7 +2135,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr ""
 
@@ -2207,7 +2207,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2260,8 +2260,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2288,19 +2288,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2480,19 +2480,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2655,7 +2655,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2723,7 +2723,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2735,31 +2735,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2815,12 +2815,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2893,15 +2893,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3022,7 +3022,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3160,7 +3160,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3224,11 +3224,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3314,11 +3314,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3371,11 +3371,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3484,7 +3484,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "موسيقى"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3516,9 +3516,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3550,11 +3550,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3619,7 +3619,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3683,7 +3683,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3729,15 +3729,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3784,7 +3784,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3792,7 +3792,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3808,11 +3808,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4017,7 +4017,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4067,7 +4067,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4150,7 +4150,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4162,23 +4162,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4297,11 +4297,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4394,7 +4394,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4402,23 +4402,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4427,7 +4427,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4475,7 +4475,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4507,7 +4507,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4561,19 +4561,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4665,20 +4665,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4775,7 +4775,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4791,20 +4791,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4853,7 +4857,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4893,7 +4897,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5086,15 +5090,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5134,7 +5138,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5257,7 +5261,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5312,11 +5316,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5463,7 +5467,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5525,7 +5529,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5607,11 +5611,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5636,7 +5640,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5656,7 +5660,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5668,7 +5672,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5676,7 +5680,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5716,7 +5720,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5732,7 +5736,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5740,11 +5744,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5770,7 +5774,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr ""
 
@@ -5779,11 +5783,11 @@ msgstr ""
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5791,7 +5795,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5823,7 +5827,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5928,7 +5932,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5936,15 +5940,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -5956,7 +5960,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/ar.po
+++ b/locale/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-11-17 16:00+0000\n"
 "Last-Translator: Omar Aglan <omar.aglan91@yahoo.com>\n"
 "Language-Team: Arabic <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ar/>\n"
@@ -196,7 +196,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -332,8 +332,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -588,27 +588,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -868,19 +868,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1233,11 +1233,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1245,11 +1245,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1596,15 +1596,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1657,6 +1657,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1705,7 +1713,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1755,7 +1763,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1763,7 +1771,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1789,6 +1797,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1871,7 +1895,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1968,7 +1992,7 @@ msgstr "عام"
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1976,11 +2000,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2256,7 +2280,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2472,7 +2496,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2631,7 +2655,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2759,7 +2783,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2790,12 +2815,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2997,7 +3022,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3199,11 +3224,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3289,11 +3314,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3517,15 +3542,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3625,7 +3654,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3637,7 +3666,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3667,7 +3696,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3686,8 +3715,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3700,15 +3729,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3779,11 +3808,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3988,7 +4017,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4046,8 +4075,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4097,7 +4126,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4170,7 +4199,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4224,7 +4253,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4268,11 +4297,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4312,7 +4341,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4446,7 +4475,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4532,11 +4561,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4892,7 +4921,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4942,7 +4971,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5057,15 +5086,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5105,7 +5134,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5220,7 +5249,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5228,7 +5257,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5287,7 +5316,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5434,7 +5463,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5578,7 +5607,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5762,7 +5791,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5774,7 +5803,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5927,7 +5956,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/bg.po
+++ b/locale/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-11-17 16:00+0000\n"
 "Last-Translator: Georgi Georgiev (RacerBG) <g.georgiev.shumen@gmail.com>\n"
 "Language-Team: Bulgarian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/bg/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "Триизмерен редактор"
 msgid "3D_MOVEMENT"
 msgstr "Триизмерно движение"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "Последното действие не е завършено"
 msgid "ACTIVE"
 msgstr "Енергично"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Текущи нишки:"
 
@@ -144,7 +144,7 @@ msgstr "Характеристика"
 msgid "ALT"
 msgstr "Клавиш „Alt“"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Околна среда"
 
@@ -155,11 +155,11 @@ msgstr "Околна среда"
 msgid "AMMONIA"
 msgstr "Амоняк"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Брой на автоматичните записи:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Брой на бързите записи:"
 
@@ -184,11 +184,11 @@ msgstr "Прилагане"
 msgid "APRIL"
 msgstr "Април"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Сигурни ли сте, че искате да възстановите настройките по подразбиране?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Сигурни ли сте, че искате да възстановите контролите по подразбиране?"
 
@@ -204,7 +204,7 @@ msgstr "„{0}“ — {1}"
 msgid "ART_BY"
 msgstr "От: {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Галерия"
 
@@ -216,7 +216,7 @@ msgstr "Изисква се основното „Assembly“"
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "Изисква се „Assembly“, когато използвате „Harmony“"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Включване на хипернишковата технология"
 
@@ -258,7 +258,7 @@ msgstr "Създаването е неуспешно. Наименованиет
 msgid "AT_CURSOR"
 msgstr "Под курсора:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Изходно устройство:"
 
@@ -266,8 +266,8 @@ msgstr "Изходно устройство:"
 msgid "AUGUST"
 msgstr "Август"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Автоматична"
 
@@ -294,7 +294,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1} % на стъпка {1:n0} от {2:n0}."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Автоматичен запис по време на игра"
 
@@ -302,7 +302,7 @@ msgstr "Автоматичен запис по време на игра"
 msgid "AUTO_EVO"
 msgstr "Автоматична еволюция"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Еволюционен редактор"
 
@@ -332,7 +332,7 @@ msgstr "Състояние:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Автономно напред"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Автоматична ({0}x{1})"
 
@@ -345,9 +345,9 @@ msgid "AWAKEN"
 msgstr "Пробуждане"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -483,7 +483,7 @@ msgstr "Това е първата стъпка към многоклетъчн�
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Свързването е възможно само с индивиди от Вашите създания чрез доближаване до тях. Режимът на свързване се включва с натискане на [thrive:input]g_toggle_binding[/thrive:input]. Клетъчната колония може да се разпадне с натискане на [thrive:input]g_unbind_all[/thrive:input]. Докато сте част от нея, възпроизвеждането не е възможно."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr "Свързване на осите"
 
@@ -545,7 +545,7 @@ msgstr "Това е мембрана с здрава обвивка от кал�
 msgid "CAMERA"
 msgstr "Камера"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -673,7 +673,7 @@ msgstr "Промяна на симетрията"
 msgid "CHEATS"
 msgstr "Кодове"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Активиране на кодовете"
 
@@ -763,7 +763,7 @@ msgstr "Произвежда [thrive:compound type=\"glucose\"]глюкоза[/t
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Наименованието „{0}“ вече съществува. Презаписване?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Хроматична аберация:"
 
@@ -804,15 +804,15 @@ msgstr "Изтриване на старите записи"
 msgid "CLOSE"
 msgstr "Затваряне"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Затваряне настройките?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Делител на облачната резолюция:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Минимален интервал на облачната симулация:"
 
@@ -828,7 +828,7 @@ msgstr "Фигури на обектите"
 msgid "COLOUR"
 msgstr "Цвят"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Корекция за цветна слепота:"
 
@@ -889,23 +889,23 @@ msgstr "Наситеност — количеството на сивото в �
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Стойност (яркост) — интензивността на цвета"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr "Обществен форум"
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Отваряне на обществения форум на „Thrive“"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr "Обществена Уикипедия"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Отваряне на обществената Уикипедия на „Thrive“"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr "Създадена на:"
 
@@ -931,7 +931,7 @@ msgstr "Има химични съединения:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Баланс на химичните съединения"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Облаци"
 
@@ -1016,7 +1016,7 @@ msgstr "Искате ли да продължите?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr "Визуализатор на осите:"
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr "Мъртви зони"
 
@@ -1031,11 +1031,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr "Мъртва зона:"
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr "Чувствителност на контролера"
 
@@ -1043,11 +1043,11 @@ msgstr "Чувствителност на контролера"
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Копиране на грешката в клипборда"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Протанопия (червено и зелено)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Тританопия (синьо и жълто)"
 
@@ -1103,7 +1103,7 @@ msgstr "Създаване..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Създаване на обектите от записа"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Екип"
 
@@ -1129,7 +1129,7 @@ msgstr "Текущи разработчици"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Характеристика"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Потребителско име:"
 
@@ -1194,7 +1194,7 @@ msgstr "Отстраняване на грешки"
 msgid "DECEMBER"
 msgstr "Декември"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "По подразбиране"
 
@@ -1256,7 +1256,7 @@ msgstr "Описанието е твърде дълго"
 msgid "DESPAWN_ENTITIES"
 msgstr "Прочистване"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Ядра:"
 
@@ -1271,11 +1271,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Разработчици"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr "Частен форум"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Отваряне на частния форум на „Thrive“"
 
@@ -1283,11 +1283,11 @@ msgstr "Отваряне на частния форум на „Thrive“"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Разработката се поддържа от „Revolutionary Games Studio“ ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr "Частна Уикипедия"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Отваряне на частната Уикипедия на „Thrive“"
 
@@ -1369,7 +1369,7 @@ msgstr "Наляво"
 msgid "DIRECTIONR"
 msgstr "Надясно"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Изключено"
 
@@ -1377,7 +1377,7 @@ msgstr "Изключено"
 msgid "DISABLE_ALL"
 msgstr "Изключване на всички"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Отхвърляне и продължаване"
 
@@ -1415,33 +1415,33 @@ msgstr ""
 "Има органели, които не са свързани с останалите.\n"
 "Моля, свържете ги или отменете Вашите промени."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr "Отваряне на сървъра ни в „Discord“"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Отхвърлени съобщения:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 "Това е броят на отхвърлените съобщения.\n"
 "Ако желаете да ги възстановите, натиснете бутона „Нулиране“."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr "Отхвърляне на съобщението"
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Лента на способностите"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Фонови частици"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Наименования на органелите"
 
@@ -1476,7 +1476,7 @@ msgstr "Натиснете двукратно за преглед на цял е
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Това е мембрана с два слоя, която осигурява по-добра защита и се нуждае от по-малко енергия за да не се деформира. Недостатъците ѝ са, че клетката става по-бавна, както и усвояването на хранителните вещества."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Не предупреждавай за това отново"
 
@@ -1629,7 +1629,7 @@ msgstr ""
 "\n"
 "За да преминете към следващия раздел, натиснете бутона „НАПРЕД“, който се намира долу вдясно."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8 пъти"
 
@@ -1645,7 +1645,7 @@ msgstr "Включване на съвместимите модификации"
 msgid "ENABLE_EDITOR"
 msgstr "Активиране на редактора"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Светлинни ефекти"
 
@@ -1702,7 +1702,7 @@ msgstr "Превключване на околната среда"
 msgid "EPIPELAGIC"
 msgstr "Епипелагиал"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Грешка"
 
@@ -1714,16 +1714,16 @@ msgstr "Грешка при създаване на папката на моди
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Грешка при създаване на информационния файл на модификацията"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Грешка: Неуспешно запазване на промените в конфигурационния файл."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(на произволен принцип)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Грешка при създаване на информационния файл на модификацията"
@@ -1759,11 +1759,11 @@ msgstr ""
 "\n"
 "Ако виждате този текст, поради друга причина, моля, докладвайте за проблема и приложете дневниците на играта към Вашия доклад."
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr "Версия на „Thrive“:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Това е кодовото наименование на текущата версия на „Thrive“"
 
@@ -1779,7 +1779,7 @@ msgstr "Грешка по време на зареждането на запаз
 msgid "EXIT"
 msgstr "Изход"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Стартираща програма"
 
@@ -1831,7 +1831,7 @@ msgstr "изчезнаха от зоната"
 msgid "EXTINCT_SPECIES"
 msgstr "Изчезнали създания"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Екстри"
 
@@ -1839,7 +1839,7 @@ msgstr "Екстри"
 msgid "EXTRA_OPTIONS"
 msgstr "Допълнителни опции"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Отваряне на страницата ни във „Facebook“"
 
@@ -1871,12 +1871,12 @@ msgstr "Включено"
 msgid "FEBRUARY"
 msgstr "Февруари"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Стартирането на „Steam“ е неуспешно"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1898,11 +1898,11 @@ msgstr ""
 "Общо време на ЦП:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2026,7 +2026,7 @@ msgstr "Вкаменяване на тези създания (вече са в�
 msgid "FOSSILISE"
 msgstr "Вкаменяване"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4 пъти"
 
@@ -2056,7 +2056,7 @@ msgstr "Създаване на облак от глюкоза при излиз
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(създава облак от глюкоза близо до Вашето създание след всяко отваряне на редактора)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Цял екран"
 
@@ -2084,23 +2084,23 @@ msgstr "Поколение"
 msgid "GENERATION_COLON"
 msgstr "Поколение:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr "Отваряне на хранилището ни в „GitHub“"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Предупреждение за GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "В момента „Thrive“ се изпълнява с GLES2. Това не е препоръчително и може да доведе до проблеми. Моля, обновете Вашите графични драйвери или използвайте графичните карти на „AMD“ или „Nvidia“."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr "GLES3"
 
@@ -2153,11 +2153,11 @@ msgstr "Разбрах"
 msgid "GPL_LICENSE_HEADING"
 msgstr "Общ публичен лиценз:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "Видеокарта:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Графика"
 
@@ -2165,7 +2165,7 @@ msgstr "Графика"
 msgid "GRAPHICS_TEAM"
 msgstr "Артисти"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "Интерфейс"
 
@@ -2182,7 +2182,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} хил"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Интерфейс"
 
@@ -2204,11 +2204,11 @@ msgstr "Ръководство"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Отваряне на ръководството"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(по-високите стойности подобряват производителността)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(по-високите стойности понижават производителността)"
 
@@ -2232,7 +2232,7 @@ msgstr "Задръжте [thrive:input]g_free_cursor[/thrive:input] за пок�
 msgid "HOME"
 msgstr "Начало"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr "Хоризонтална:"
 
@@ -2305,7 +2305,7 @@ msgstr "Погълнати обекти"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Отваряне на сървъра ни в „Discord“"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Контроли"
 
@@ -2358,8 +2358,8 @@ msgstr "Невалиден формат на връзката"
 msgid "INVALID_URL_SCHEME"
 msgstr "Невалидна връзка"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr "Обръщане"
 
@@ -2382,7 +2382,7 @@ msgstr "Желязо"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Желязна хемолитоавтотрофия"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr "Отваряне на страницата ни в „Itch.io“"
 
@@ -2390,19 +2390,19 @@ msgstr "Отваряне на страницата ни в „Itch.io“"
 msgid "JANUARY"
 msgstr "Януари"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "Режим за отстраняване на грешки:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Включен"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Автоматичен"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Изключен"
 
@@ -2584,19 +2584,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Език:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Този превод е завършен на {0} %"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Този превод е в процес на разработка и е завършен на {0} %"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Този превод е в начален етап на разработка и е завършен на {0} %!"
 
@@ -2758,7 +2758,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Ляв бутон"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Лицензи"
 
@@ -2826,7 +2826,7 @@ msgstr "Нощ"
 msgid "LIGHT_MAX"
 msgstr "Максимална светлина"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Екстремен"
 
@@ -2838,31 +2838,31 @@ msgstr "Ограничаване на растежа"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(ограничава скоростта на растеж на създанията)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Огромен"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Голям"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Умерен"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Малък"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Миниатюрен"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Много голям"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Много малък"
 
@@ -2886,7 +2886,7 @@ msgstr "Зареждане"
 msgid "LOADING"
 msgstr "Зареждане"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Зареждане..."
@@ -2917,12 +2917,12 @@ msgstr "Натиснете бутона „Отмяна“ в редактора
 msgid "LOAD_FINISHED"
 msgstr "Зареждането приключи"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Зареждане"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Зареждане на запазените игри"
 
@@ -2996,7 +2996,7 @@ msgstr "Март"
 msgid "MARINE_SNOW"
 msgstr "Морски сняг"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Основен звук"
 
@@ -3004,15 +3004,15 @@ msgstr "Основен звук"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Максимален брой на създанията преди измиране в зоната"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Максимална ЧКС:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Неограничена"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Максимален брой на обектите:"
 
@@ -3199,7 +3199,7 @@ msgstr "Всяко поколение разполага със 100 мутаци
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "По време на възпроизвеждане, микробният редактор ще бъде отворен, в него може да променяте Вашето създание (като добавяте, премествате или премахвате органели) за да увеличите шанса му за оцеляване. Всяко отваряне на редактора е равно на [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] милиона години еволюция."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Микробен редактор"
 
@@ -3383,7 +3383,7 @@ msgstr "Минимална:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Не е възможно показването на по-малко от {0} набор(а) от данни!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Разни"
 
@@ -3446,11 +3446,11 @@ msgstr "Свойства на органела"
 msgid "MODIFY_TYPE"
 msgstr "Свойства"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Модификации"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Налични са инсталирани модификации, които не са включени.\n"
@@ -3539,11 +3539,11 @@ msgstr "Наименование на папката:"
 msgid "MOD_LICENSE"
 msgstr "Лиценз:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Грешка по време на зареждането на модификацията"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Възникна грешка по време на зареждането на една или повече модификации. За повече информация, вижте дневниците на играта."
 
@@ -3596,11 +3596,11 @@ msgstr "Версия:"
 msgid "MORE_INFO"
 msgstr "Свойства"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr "Чувствителност на мишката"
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr "Мащабиране на чувствителността според размера на прозореца"
 
@@ -3714,7 +3714,7 @@ msgstr "Няколко кълба"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Няколко органела"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Множествено изглаждане:"
 
@@ -3729,7 +3729,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Музика"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Музика"
 
@@ -3749,9 +3749,9 @@ msgstr "(определя разхода на мутационни точки в
 msgid "MUTATION_POINTS"
 msgstr "Мутационни точки"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Заглушаване"
 
@@ -3787,11 +3787,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Начална популация на създанията, увеличаващи биоразнообразието"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Нова игра"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Започване на нова игра"
 
@@ -3856,7 +3856,7 @@ msgstr "Пластидът за азотна фиксация е протеин,
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Превръща [thrive:compound type=\"atp\"]АТФ[/thrive:compound] в [thrive:compound type=\"ammonia\"]амоняк[/thrive:compound]. Количеството зависи от концентрацията на [thrive:compound type=\"nitrogen\"]азот[/thrive:compound] и [thrive:compound type=\"oxygen\"]кислород[/thrive:compound] в околната среда."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Няма"
 
@@ -3904,7 +3904,7 @@ msgstr "Няма записани събития"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Папката с записи не съществува"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr "Няма включени модификации"
 
@@ -3921,7 +3921,7 @@ msgstr "Няма създадени записи"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Папката с записи не съществува"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Папката със снимки не съществува"
 
@@ -3969,15 +3969,15 @@ msgstr "Няма МТ"
 msgid "OCTOBER"
 msgstr "Октомври"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr "Официален сайт"
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Отваряне на официалния сайт на „Revolutionary Games“"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4015,7 +4015,7 @@ msgstr "Отваряне на ръководството"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Отваряне в редактора"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Местоположение на дневниците"
 
@@ -4031,7 +4031,7 @@ msgstr "Отваряне на контекстното меню"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Отваряне на папката с записи"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Местоположение на снимките"
 
@@ -4039,7 +4039,7 @@ msgstr "Местоположение на снимките"
 msgid "OPEN_THE_MENU"
 msgstr "Отваряне на менюто"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Допринасяне към превода"
 
@@ -4058,11 +4058,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Самонадеяно"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Настройки"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Отваряне на настройките"
 
@@ -4271,7 +4271,7 @@ msgstr "Произволна"
 msgid "PATCH_NAME"
 msgstr "{0} — {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr "Отваряне на страницата ни в „Patreon“"
 
@@ -4321,7 +4321,7 @@ msgstr "Пасивно"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0} %"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Производителност"
 
@@ -4410,7 +4410,7 @@ msgstr "Удвояване"
 msgid "PLAYER_EXTINCT"
 msgstr "измиране на създанията"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "измиране на създанията"
@@ -4425,23 +4425,23 @@ msgstr ""
 "Вашата\n"
 "скорост"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Начално видео"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Начално видео при започване на нова игра"
 
@@ -4560,11 +4560,11 @@ msgstr "Бързо зареждане"
 msgid "QUICK_SAVE"
 msgstr "Бързо записване"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Изход"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Излизане от играта"
@@ -4606,7 +4606,7 @@ msgstr "Готова"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Препоръчителна:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr "Отваряне на общността ни в „Reddit“"
 
@@ -4659,7 +4659,7 @@ msgstr "Видове:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Нуждае се от ядро"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Нулиране"
 
@@ -4667,23 +4667,23 @@ msgstr "Нулиране"
 msgid "RESET_DEADZONES"
 msgstr "Нулиране"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr "Нулиране"
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Възстановяване на контролите по подразбиране?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr "Нулиране на контролите"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "По подразбиране"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Възстановяване на настройките по подразбиране?"
 
@@ -4692,7 +4692,7 @@ msgstr "Възстановяване на настройките по подра
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr "Предпазва от повечето ензими"
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Резолюция:"
 
@@ -4742,7 +4742,7 @@ msgstr ""
 "Сигурни ли сте, че искате да се върнете в главното меню?\n"
 "Всички незапазени промени ще бъдат изгубени."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Отваряне на официалните сайтове на „Revolutionary Games“"
 
@@ -4774,7 +4774,7 @@ msgstr "Завъртане надясно"
 msgid "ROTATION_COLON"
 msgstr "Завъртане:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Автоматична еволюция по време на игра"
 
@@ -4829,7 +4829,7 @@ msgstr "Рустицианинът е протеин, който използв�
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Превръща [thrive:compound type=\"iron\"]желязото[/thrive:compound] в [thrive:compound type=\"atp\"]АТФ[/thrive:compound]. Количеството зависи от концентрацията на [thrive:compound type=\"carbondioxide\"]въглероден диоксид[/thrive:compound] и [thrive:compound type=\"oxygen\"]кислород[/thrive:compound] в околната среда."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "„Thrive“ е в безопасен режим поради предишно неуспешно стартиране.\n"
@@ -4841,15 +4841,15 @@ msgstr ""
 "\n"
 "Ако проблемът продължи, ще трябва да рестартирате и да причините срив на играта няколко пъти, за да се върнете в безопасен режим."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr "Играта е стартирана в безопасен режим"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Запазване"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Запазване на промените"
 
@@ -4947,20 +4947,20 @@ msgstr "Запазването в момента не е възможно пор
 msgid "SAVING_SUCCEEDED"
 msgstr "Запазването е успешно"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr "Изключено"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr "Включено"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr "Обратно"
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "за да увеличи скоростта"
@@ -5058,7 +5058,7 @@ msgstr "Мудно"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Промяната на тази стойност се прилага при започване на нова игра"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Ефекти"
 
@@ -5074,21 +5074,25 @@ msgstr "Отваряне на ръководството"
 msgid "SHOW_TUTORIALS"
 msgstr "Показване на упътването"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Упътване (в текущата игра)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Упътване (при започване на нова игра)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Предупреждение при излизане от играта"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Превключване на предупреждението при излизане от играта."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5136,7 +5140,7 @@ msgstr "Силициева"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Това е мембрана с здрава стена от силициев диоксид, която осигурява най-добрата защита и се нуждае от по-малко енергия за да не се деформира. Недостатъците ѝ са, че клетката става прекалено бавна, както и усвояването на хранителните вещества."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16 пъти"
 
@@ -5176,7 +5180,7 @@ msgstr "Превръща [thrive:compound type=\"glucose\"]глюкозата[/t
 msgid "SMALL_IRON_CHUNK"
 msgstr "Малък железен фрагмент"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Звук"
 
@@ -5379,17 +5383,17 @@ msgstr "„Steam“ не е достъпен в момента, моля, опи
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Неизвестна грешка на „Steam“"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Стартирането на „Steam“ е неуспешно"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Надграждането на записа е неуспешно поради следната грешка:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr "Отваряне на страницата ни в „Steam“"
 
@@ -5429,7 +5433,7 @@ msgstr "Съхранение"
 msgid "STORAGE_COLON"
 msgstr "Съхранение:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Влезли сте като: {0}"
 
@@ -5546,7 +5550,7 @@ msgstr "Темп."
 msgid "TESTING_TEAM"
 msgstr "Изпитатели"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Благодарим Ви за покупката на „Thrive“!\n"
@@ -5562,7 +5566,7 @@ msgstr ""
 "\n"
 "Ще се радваме да споделите за „Thrive“ и на Вашите приятели."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr "Благодарим Ви"
 
@@ -5617,11 +5621,11 @@ msgstr "Тази модификация е от локален източник"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Тази модификация е изтеглена от „Steam Workshop“"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Нишки:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Трайвопедия"
 
@@ -5777,7 +5781,7 @@ msgstr "Прекъсване на играта"
 msgid "TOGGLE_UNBINDING"
 msgstr "Отделяне"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Инструменти"
 
@@ -5842,7 +5846,7 @@ msgstr "Трябва да направите няколко снимки!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Трябва да направите поне един запис!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Трябва да направите няколко снимки!"
 
@@ -6004,11 +6008,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Преглед"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr "Отваряне на страницата ни в „Twitter“"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2 пъти"
 
@@ -6033,7 +6037,7 @@ msgstr "Разпадане"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Режим на отделяне"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr "Версия за отстраняване на грешки"
 
@@ -6053,7 +6057,7 @@ msgstr "Отмяна на последното действие"
 msgid "UNKNOWN"
 msgstr "Неизвестен клавиш"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Неизвестен"
 
@@ -6065,7 +6069,7 @@ msgstr "Неизвестен бутон"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Неизвестна"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "Неизвестна версия"
 
@@ -6073,7 +6077,7 @@ msgstr "Неизвестна версия"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Неизвестен идентификационен № за работилницата"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Вашите промени не са запазени и ще бъдат отхвърлени.\n"
@@ -6117,7 +6121,7 @@ msgstr "Качването е успешно"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Лицензи и използвани материали"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "Визуализатор:"
 
@@ -6133,7 +6137,7 @@ msgstr "Използване на „Harmony“"
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Автоматично зареждане на „Harmony“ от „Assembly“"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Персонализирано потребителско име"
 
@@ -6141,11 +6145,11 @@ msgstr "Персонализирано потребителско име"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "Създанията, увеличаващи биоразнообразието, използват популацията на техните съперници"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Ръчно определяне на броя на фоновите нишки"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr "Използване на виртуалния размер"
 
@@ -6171,7 +6175,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Версия:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr "Вертикална:"
 
@@ -6180,11 +6184,11 @@ msgstr "Вертикална:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Вертикална ос: {0}"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "Използвана графична памет:"
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0} МиБ"
 
@@ -6192,7 +6196,7 @@ msgstr "{0} МиБ"
 msgid "VIEWER"
 msgstr "Преглед"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Изходен код"
 
@@ -6204,7 +6208,7 @@ msgstr "Значими поддръжници"
 msgid "VISIBLE"
 msgstr "Видима"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Предложения"
 
@@ -6224,7 +6228,7 @@ msgstr "Клавиш „Volume Mute“"
 msgid "VOLUMEUP"
 msgstr "Клавиш „Volume Up“"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "Вертикална синхронизация"
 
@@ -6333,7 +6337,7 @@ msgstr ""
 "Включване на следващите етапи на играта: {0}\n"
 "Включване на тайните обекти на играта: {1}"
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "за да увеличи скоростта"
@@ -6342,15 +6346,15 @@ msgstr "за да увеличи скоростта"
 msgid "WORST_PATCH_COLON"
 msgstr "Изчезва:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6362,7 +6366,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "години"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Отваряне на канала ни в „YouTube“"
 

--- a/locale/bg.po
+++ b/locale/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-11-17 16:00+0000\n"
 "Last-Translator: Georgi Georgiev (RacerBG) <g.georgiev.shumen@gmail.com>\n"
 "Language-Team: Bulgarian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/bg/>\n"
@@ -204,7 +204,7 @@ msgstr "„{0}“ — {1}"
 msgid "ART_BY"
 msgstr "От: {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Галерия"
 
@@ -302,7 +302,7 @@ msgstr "Автоматичен запис по време на игра"
 msgid "AUTO_EVO"
 msgstr "Автоматична еволюция"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Еволюционен редактор"
 
@@ -345,8 +345,8 @@ msgid "AWAKEN"
 msgstr "Пробуждане"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -601,27 +601,27 @@ msgstr "Клавиш „Caps Lock“"
 msgid "CARBON_DIOXIDE"
 msgstr "Въглероден диоксид"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "в изобилно количество"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "в задоволително количество"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "в ограничено количество"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "в обилно количество"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "в умерено количество"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "в оскъдно количество"
 
@@ -889,19 +889,19 @@ msgstr "Наситеност — количеството на сивото в �
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Стойност (яркост) — интензивността на цвета"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr "Обществен форум"
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Отваряне на обществения форум на „Thrive“"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr "Обществена Уикипедия"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Отваряне на обществената Уикипедия на „Thrive“"
 
@@ -1103,7 +1103,7 @@ msgstr "Създаване..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Създаване на обектите от записа"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Екип"
 
@@ -1271,11 +1271,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Разработчици"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr "Частен форум"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Отваряне на частния форум на „Thrive“"
 
@@ -1283,11 +1283,11 @@ msgstr "Отваряне на частния форум на „Thrive“"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Разработката се поддържа от „Revolutionary Games Studio“ ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr "Частна Уикипедия"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Отваряне на частната Уикипедия на „Thrive“"
 
@@ -1415,7 +1415,7 @@ msgstr ""
 "Има органели, които не са свързани с останалите.\n"
 "Моля, свържете ги или отменете Вашите промени."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr "Отваряне на сървъра ни в „Discord“"
 
@@ -1429,7 +1429,7 @@ msgstr ""
 "Това е броят на отхвърлените съобщения.\n"
 "Ако желаете да ги възстановите, натиснете бутона „Нулиране“."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr "Отхвърляне на съобщението"
 
@@ -1476,7 +1476,7 @@ msgstr "Натиснете двукратно за преглед на цял е
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Това е мембрана с два слоя, която осигурява по-добра защита и се нуждае от по-малко енергия за да не се деформира. Недостатъците ѝ са, че клетката става по-бавна, както и усвояването на хранителните вещества."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Не предупреждавай за това отново"
 
@@ -1657,15 +1657,15 @@ msgstr "{0}: -{1} АТФ"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} АТФ"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Енергийни стойности в {0} на {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Източници на енергия:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "Некоригираната популация на Вашите създания ({2}) се определя от общата усвоена енергийна стойност ({0}), разделена на индивидуалния разход ({1})"
 
@@ -1718,6 +1718,16 @@ msgstr "Грешка при създаване на информационния
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Грешка: Неуспешно запазване на промените в конфигурационния файл."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(на произволен принцип)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Грешка при създаване на информационния файл на модификацията"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Грешка по време на зареждането"
@@ -1769,7 +1779,7 @@ msgstr "Грешка по време на зареждането на запаз
 msgid "EXIT"
 msgstr "Изход"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Стартираща програма"
 
@@ -1821,7 +1831,7 @@ msgstr "изчезнаха от зоната"
 msgid "EXTINCT_SPECIES"
 msgstr "Изчезнали създания"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Екстри"
 
@@ -1829,7 +1839,7 @@ msgstr "Екстри"
 msgid "EXTRA_OPTIONS"
 msgstr "Допълнителни опции"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Отваряне на страницата ни във „Facebook“"
 
@@ -1860,6 +1870,41 @@ msgstr "Включено"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Февруари"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Стартирането на „Steam“ е неуспешно"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Процесорно време: {0} с\n"
+"Физическо време: {1} с\n"
+"Обекти: {2} Други: {3}\n"
+"Създадени: {4} Премахнати: {5}\n"
+"Използвани възли: {6}\n"
+"Използвана памет: {7}\n"
+"Графична памет: {8}\n"
+"Изобразени обекти: {9}\n"
+"Общо обекти: {10} Двуизмерни: {11}\n"
+"Изобразени върхове: {12}\n"
+"Материални изменения: {13}\n"
+"Шейдърни изменения: {14}\n"
+"Неизползвани възли: {15}\n"
+"Звуково забавяне: {16} мс\n"
+"Общо нишки: {17}\n"
+"Общо време на ЦП:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1943,7 +1988,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Хранителна верига"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0}: усвоена енергийна стойност {1} със стойност на усвояване {2} и обща енергийна стойност {3} с обща стойност на усвояване {4}"
 
@@ -2039,7 +2084,7 @@ msgstr "Поколение"
 msgid "GENERATION_COLON"
 msgstr "Поколение:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr "Отваряне на хранилището ни в „GitHub“"
 
@@ -2047,11 +2092,11 @@ msgstr "Отваряне на хранилището ни в „GitHub“"
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Предупреждение за GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "В момента „Thrive“ се изпълнява с GLES2. Това не е препоръчително и може да доведе до проблеми. Моля, обновете Вашите графични драйвери или използвайте графичните карти на „AMD“ или „Nvidia“."
 
@@ -2337,7 +2382,7 @@ msgstr "Желязо"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Желязна хемолитоавтотрофия"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr "Отваряне на страницата ни в „Itch.io“"
 
@@ -2555,7 +2600,7 @@ msgstr "Този превод е в процес на разработка и е
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Този превод е в начален етап на разработка и е завършен на {0} %!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "Последният органел не може да бъде премахнат"
 
@@ -2713,7 +2758,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Ляв бутон"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Лицензи"
 
@@ -2841,7 +2886,8 @@ msgstr "Зареждане"
 msgid "LOADING"
 msgstr "Зареждане"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Зареждане..."
 
@@ -2871,12 +2917,12 @@ msgstr "Натиснете бутона „Отмяна“ в редактора
 msgid "LOAD_FINISHED"
 msgstr "Зареждането приключи"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Зареждане"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Зареждане на запазените игри"
 
@@ -3153,7 +3199,7 @@ msgstr "Всяко поколение разполага със 100 мутаци
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "По време на възпроизвеждане, микробният редактор ще бъде отворен, в него може да променяте Вашето създание (като добавяте, премествате или премахвате органели) за да увеличите шанса му за оцеляване. Всяко отваряне на редактора е равно на [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] милиона години еволюция."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Микробен редактор"
 
@@ -3400,11 +3446,11 @@ msgstr "Свойства на органела"
 msgid "MODIFY_TYPE"
 msgstr "Свойства"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Модификации"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Налични са инсталирани модификации, които не са включени.\n"
@@ -3493,11 +3539,11 @@ msgstr "Наименование на папката:"
 msgid "MOD_LICENSE"
 msgstr "Лиценз:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Грешка по време на зареждането на модификацията"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Възникна грешка по време на зареждането на една или повече модификации. За повече информация, вижте дневниците на играта."
 
@@ -3733,15 +3779,19 @@ msgstr ""
 "Този запис е от по-нова версия на „Thrive“ и е несъвместим.\n"
 "Искате ли да го заредите въпреки това?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Начална популация на създанията, увеличаващи биоразнообразието"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Нова игра"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Започване на нова игра"
 
@@ -3841,7 +3891,7 @@ msgid "NO_AI"
 msgstr "Самота"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Няма данни"
 
@@ -3854,7 +3904,7 @@ msgstr "Няма записани събития"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Папката с записи не съществува"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr "Няма включени модификации"
 
@@ -3884,7 +3934,7 @@ msgstr "Няма"
 msgid "NUCLEUS"
 msgstr "Ядро"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 "Ядрото е необратима еволюция и не може да бъде премахнато,\n"
@@ -3905,8 +3955,8 @@ msgstr "Клавиш „Num Lock“"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "Няма"
@@ -3919,15 +3969,15 @@ msgstr "Няма МТ"
 msgid "OCTOBER"
 msgstr "Октомври"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr "Официален сайт"
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Отваряне на официалния сайт на „Revolutionary Games“"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4008,11 +4058,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Самонадеяно"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Настройки"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Отваряне на настройките"
 
@@ -4221,7 +4271,7 @@ msgstr "Произволна"
 msgid "PATCH_NAME"
 msgstr "{0} — {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr "Отваряне на страницата ни в „Patreon“"
 
@@ -4279,8 +4329,8 @@ msgstr "Производителност"
 msgid "PERFORM_UNBINDING"
 msgstr "Извършване на отделяне"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/в секунда"
 
@@ -4336,7 +4386,7 @@ msgstr "Създаването на планетата е в процес на �
 msgid "PLANET_RANDOM_SEED"
 msgstr "Произволен идентификатор на планетата"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Вашето създание"
 
@@ -4412,7 +4462,7 @@ msgstr "популация:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "текуща популация в зоните:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4466,7 +4516,7 @@ msgstr "предишна:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Обработка на заредените обекти"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "при"
 
@@ -4510,11 +4560,11 @@ msgstr "Бързо зареждане"
 msgid "QUICK_SAVE"
 msgstr "Бързо записване"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Изход"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Излизане от играта"
@@ -4556,7 +4606,7 @@ msgstr "Готова"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Препоръчителна:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr "Отваряне на общността ни в „Reddit“"
 
@@ -4692,7 +4742,7 @@ msgstr ""
 "Сигурни ли сте, че искате да се върнете в главното меню?\n"
 "Всички незапазени промени ще бъдат изгубени."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Отваряне на официалните сайтове на „Revolutionary Games“"
 
@@ -4779,7 +4829,7 @@ msgstr "Рустицианинът е протеин, който използв�
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Превръща [thrive:compound type=\"iron\"]желязото[/thrive:compound] в [thrive:compound type=\"atp\"]АТФ[/thrive:compound]. Количеството зависи от концентрацията на [thrive:compound type=\"carbondioxide\"]въглероден диоксид[/thrive:compound] и [thrive:compound type=\"oxygen\"]кислород[/thrive:compound] в околната среда."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "„Thrive“ е в безопасен режим поради предишно неуспешно стартиране.\n"
@@ -4791,7 +4841,7 @@ msgstr ""
 "\n"
 "Ако проблемът продължи, ще трябва да рестартирате и да причините срив на играта няколко пъти, за да се върнете в безопасен режим."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr "Играта е стартирана в безопасен режим"
 
@@ -5154,7 +5204,7 @@ msgstr "Създаване на амоняк"
 msgid "SPAWN_ENEMY"
 msgstr "Съперничество"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Съперничеството в тази зона не е възможно, защото няма други създания"
 
@@ -5214,7 +5264,7 @@ msgstr "Наименование..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Наименованието е твърде дълго!"
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} ({1} индивида)"
 
@@ -5329,17 +5379,17 @@ msgstr "„Steam“ не е достъпен в момента, моля, опи
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Неизвестна грешка на „Steam“"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Стартирането на „Steam“ е неуспешно"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Надграждането на записа е неуспешно поради следната грешка:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr "Отваряне на страницата ни в „Steam“"
 
@@ -5379,7 +5429,7 @@ msgstr "Съхранение"
 msgid "STORAGE_COLON"
 msgstr "Съхранение:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Влезли сте като: {0}"
 
@@ -5496,7 +5546,7 @@ msgstr "Темп."
 msgid "TESTING_TEAM"
 msgstr "Изпитатели"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Благодарим Ви за покупката на „Thrive“!\n"
@@ -5512,7 +5562,7 @@ msgstr ""
 "\n"
 "Ще се радваме да споделите за „Thrive“ и на Вашите приятели."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr "Благодарим Ви"
 
@@ -5571,7 +5621,7 @@ msgstr "Тази модификация е изтеглена от „Steam Work
 msgid "THREADS"
 msgstr "Нишки:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Трайвопедия"
 
@@ -5727,7 +5777,7 @@ msgstr "Прекъсване на играта"
 msgid "TOGGLE_UNBINDING"
 msgstr "Отделяне"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Инструменти"
 
@@ -5954,7 +6004,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Преглед"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr "Отваряне на страницата ни в „Twitter“"
 
@@ -6142,7 +6192,7 @@ msgstr "{0} МиБ"
 msgid "VIEWER"
 msgstr "Преглед"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Изходен код"
 
@@ -6154,7 +6204,7 @@ msgstr "Значими поддръжници"
 msgid "VISIBLE"
 msgstr "Видима"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Предложения"
 
@@ -6312,7 +6362,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "години"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Отваряне на канала ни в „YouTube“"
 

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-09-23 11:38+0000\n"
 "Last-Translator: aleixcoma <aleixcoma@gmail.com>\n"
 "Language-Team: Catalan <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ca/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "Editor 3D"
 msgid "3D_MOVEMENT"
 msgstr "Moviment 3D"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -63,7 +63,7 @@ msgstr "Acció bloquejada mentre una altra s'està duent a terme"
 msgid "ACTIVE"
 msgstr "Actiu"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Fils actuals:"
 
@@ -146,7 +146,7 @@ msgstr "Estadístiques de la Cèl·lula"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Volum de l'ambient"
 
@@ -157,11 +157,11 @@ msgstr "Volum de l'ambient"
 msgid "AMMONIA"
 msgstr "Amoníac"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Màxim nombre d'arxius d'autoguardat:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Màxim nombre d'arxius de guardat ràpid:"
 
@@ -186,11 +186,11 @@ msgstr "Aplicar Canvis"
 msgid "APRIL"
 msgstr "Abril"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Esteu segur que voleu resetejar TOTA la configuració als seus valors per defecte?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Esteu segur que voleu resetejar els inputs de configuració a valors per defecte?"
 
@@ -206,7 +206,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Art per {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Galeria d'art"
 
@@ -218,7 +218,7 @@ msgstr "Es requereix la classe de l'ensamblatge del mod quan s'especifica l'ensa
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "Es requereix l'ensamblatge de mod quan auto harmony està activat"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Assumir que la CPU té activat el hyperthreading"
 
@@ -260,7 +260,7 @@ msgstr "L'intent d'escriure aquest arxiu de guardat ha fallat. És possible que 
 msgid "AT_CURSOR"
 msgstr "A sota del Cursor:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Dispositiu de sortida d'àudio:"
 
@@ -268,8 +268,8 @@ msgstr "Dispositiu de sortida d'àudio:"
 msgid "AUGUST"
 msgstr "Agost"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Auto"
 
@@ -296,7 +296,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% fet. {1:n0}/{2:n0} passos."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Guardat automàtic durant el joc"
 
@@ -304,7 +304,7 @@ msgstr "Guardat automàtic durant el joc"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "estat d'execució:"
@@ -334,7 +334,7 @@ msgstr "Estat d'Auto-Evo:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Moviment automàtic cap endavant"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Auto ({0}x{1})"
 
@@ -347,9 +347,9 @@ msgid "AWAKEN"
 msgstr "Despertar"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -490,7 +490,7 @@ msgstr "Permet unir-te amb altres cèl·lules. Aquest és el primer pas cap a es
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Pressiona la tecla [thrive:input]g_toggle_binding[/thrive:input] per entrar al mode d'unió. Quan siguis en aquest mode, et pots unir a altres cèl·lules de la teva espècie entrant-hi en contacte. Per abandonar una colònia, pressiona la tecla [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -552,7 +552,7 @@ msgstr "Aquesta membrana té una capa dura de Carbonat de Calci. Té una gran re
 msgid "CAMERA"
 msgstr "Càmera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -680,7 +680,7 @@ msgstr "Canviar la simetria"
 msgid "CHEATS"
 msgstr "Trucs"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Trucs activats"
 
@@ -770,7 +770,7 @@ msgstr "Produeix [thrive:compound type=\"glucose\"][/thrive:compound]. La veloci
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "El nom de l'arxiu ({0}) ja existeix. Voleu sobreescriure?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Aberració cromàtica:"
 
@@ -811,15 +811,15 @@ msgstr "Netejar els arxius de guardat antics"
 msgid "CLOSE"
 msgstr "Tancar"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Tancar opcions?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Divisor de resolució dels núvols:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Mínim interval de simulació de núvols:"
 
@@ -835,7 +835,7 @@ msgstr "Generar entitats amb formes de col·lisió"
 msgid "COLOUR"
 msgstr "Color"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Correcció per daltonisme:"
 
@@ -896,26 +896,26 @@ msgstr "Valor de saturació, la quantitat de gris en un color particular"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Valor (brillantor) valor, brillantor o intensitat del color"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Entrar a l'editor i modificar la teva espècie"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "la nostra Wiki"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Sortir del joc"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Compostos:"
@@ -943,7 +943,7 @@ msgstr "Compostos:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Equilibri de Compostos"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Núvols de Compostos"
 
@@ -1029,7 +1029,7 @@ msgstr "Continuar als prototips d'altres estadis?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1043,11 +1043,11 @@ msgstr "Aquest tauler mostra els nombres que fa servir l'algorisme auto-evo per 
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1055,11 +1055,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Copiar l'Error al Porta-Retalls"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanòpia (Vermell-Verd)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanopia (Blau-Groc)"
 
@@ -1115,7 +1115,7 @@ msgstr "Creant..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Creant objectes a partir de l'arxiu guardat"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Crèdits"
 
@@ -1140,7 +1140,7 @@ msgstr "Món Actual"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Estadístiques de la Cèl·lula"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Nom d'usuari propi:"
 
@@ -1209,7 +1209,7 @@ msgstr "Tauler de Depuració"
 msgid "DECEMBER"
 msgstr "Desembre"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Aparell d'output per defecte"
 
@@ -1272,7 +1272,7 @@ msgstr "La descripció és massa llarga"
 msgid "DESPAWN_ENTITIES"
 msgstr "Màxim nombre d'entitats:"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Detectat compte CPU:"
 
@@ -1285,12 +1285,12 @@ msgstr "Partidaris Devbuilds"
 msgid "DEVELOPERS"
 msgstr "Desenvolupadors"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Desenvolupament a càrred de Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Entrar a l'editor i modificar la teva espècie"
@@ -1299,12 +1299,12 @@ msgstr "Entrar a l'editor i modificar la teva espècie"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Desenvolupament a càrred de Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Desenvolupadors"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Ajuda"
@@ -1378,7 +1378,7 @@ msgstr "Esquerra"
 msgid "DIRECTIONR"
 msgstr "Dreta"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Inhabilitat"
 
@@ -1386,7 +1386,7 @@ msgstr "Inhabilitat"
 msgid "DISABLE_ALL"
 msgstr "Inhabilitar Tot"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Descartar i continuar"
 
@@ -1424,17 +1424,17 @@ msgstr ""
 "Hi ha orgànuls que no han estat físicament connectats a la resta.\n"
 "Siusplau, connecta tots els orgànuls o bé desfés els teus canvis."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Han passat: {0:#,#} anys"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Velocitat de Digestió:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
@@ -1442,19 +1442,19 @@ msgstr ""
 "i és possible que siguin molt més ambiciosos respecte a uns mateixos recursos.\n"
 "Els microbis sensibles canviaran d'objectius més aviat."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Mostrar barra d'habilitats"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Mostrar partícules de fons"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Mostrar noms de botons de selecció de parts"
 
@@ -1489,7 +1489,7 @@ msgstr "Doble clic per mostrar en pantalla completa"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Una membrana cel·lular formada per dues capes, que ofereix millor protecció i consumeix menys energia. No obstant, fa que la cèl·lula esdevingui més lenta. També redueix la velocitat a la qual s'absorbeixen els nutrients en entrar-hi en contacte."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1643,7 +1643,7 @@ msgstr ""
 "\n"
 "Quan estiguis a punt, fes clic al botó \"següent\", a baix a la dreta."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1659,7 +1659,7 @@ msgstr "Habilitar Tots els Mods Compatibles"
 msgid "ENABLE_EDITOR"
 msgstr "Habilitar l'editor"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Habilitar efectes de llum del GUI"
 
@@ -1717,7 +1717,7 @@ msgstr "Mostrar / amagar l'entorn i els compostos"
 msgid "EPIPELAGIC"
 msgstr "Zona epipelàgica"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Error"
 
@@ -1729,16 +1729,16 @@ msgstr "Error creant una carpeta per al mod"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Error creant l'arxiu d'informació del mod"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Error: No s'ha pogut guardar la nova configuració."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(secrets aleatòriament generats al joc)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Error creant l'arxiu d'informació del mod"
@@ -1773,12 +1773,12 @@ msgstr "Per Revolutionary Games Studio"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Per Revolutionary Games Studio"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Versió:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Automàticament carregar els ecosistemes Harmony de l'Ensamblatge (no requereix especificar una classe de mod)"
@@ -1795,7 +1795,7 @@ msgstr "S'ha produït un problema mentre es carregaven les dades de guardat"
 msgid "EXIT"
 msgstr "Sortir"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Llançar E"
@@ -1848,7 +1848,7 @@ msgstr "s'ha extingit de l'ecosistema"
 msgid "EXTINCT_SPECIES"
 msgstr "EXTINCIÓ"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extres"
 
@@ -1856,7 +1856,7 @@ msgstr "Extres"
 msgid "EXTRA_OPTIONS"
 msgstr "Opcions Extra"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Pausar el joc"
@@ -1891,12 +1891,12 @@ msgstr "Trucs activats"
 msgid "FEBRUARY"
 msgstr "Febrer"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Error en la inicialització de la llibreria de client d'Steam"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1918,11 +1918,11 @@ msgstr ""
 "Temps de CPU Total:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr "Sèssil"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2083,7 +2083,7 @@ msgstr "Núvol de glucosa gratuït quan s'abandona l'editor"
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(comença cada generació amb un núvol de glucosa gratuït proper)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Pantalla completa"
 
@@ -2112,24 +2112,24 @@ msgstr "Generació:"
 msgid "GENERATION_COLON"
 msgstr "Generació:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Sortir del joc"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Mode d'Alerta GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Esteu executant el programa Thrive amb GLES2. Aquesta tecnologia encara no ha estat del tot validada i, per tant, pot originar alguns problemes. Intenteu actualitzar els vostres drivers de vídeo i/o forçar l'ús de gràfics AMD o Nvidia per executar Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2182,12 +2182,12 @@ msgstr "Ho he entès tot"
 msgid "GPL_LICENSE_HEADING"
 msgstr "Text de la llicència GPL:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Gràfics"
 
@@ -2195,7 +2195,7 @@ msgstr "Gràfics"
 msgid "GRAPHICS_TEAM"
 msgstr "Equip de gràfics"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "GUI"
 
@@ -2212,7 +2212,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} K"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Volum del GUI"
 
@@ -2234,11 +2234,11 @@ msgstr "Ajuda"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Ajuda"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(valors més alts augmenten el rendiment)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(valors més alts empitjoren el rendiment)"
 
@@ -2263,7 +2263,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Menú principal"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Versió:"
@@ -2336,7 +2336,7 @@ msgstr "Matèria Ingerida"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Crear un nou món"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Entrades"
 
@@ -2389,8 +2389,8 @@ msgstr "Format d'URL invàlid"
 msgid "INVALID_URL_SCHEME"
 msgstr "Esquema URL invàlid"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr "Ferro"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Quimiolitoautotròfia basada en Ferro"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Sortir del joc"
@@ -2422,19 +2422,19 @@ msgstr "Sortir del joc"
 msgid "JANUARY"
 msgstr "Gener"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "Mode debug de JSON:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Sempre"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automàticament"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Mai"
 
@@ -2616,19 +2616,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Llengua:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Aquest idioma s'ha traduït al {0}%"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Aquesta llengua encara és una feina en progrés ({0}% completat)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Aquesta traducció encara és incomplerta ({0}% traduït) siusplau ajuda'ns a completar-la!"
 
@@ -2791,7 +2791,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Click esquerre del ratolí"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Llicències"
 
@@ -2861,7 +2861,7 @@ msgstr "Rodeta dreta"
 msgid "LIGHT_MAX"
 msgstr "Llum"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Extrem"
 
@@ -2875,31 +2875,31 @@ msgstr "Normal"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(velocitat a la qual les espècies de la IA muten)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Enorme"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Gran"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Normal"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Petit"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Minúscul"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Molt gran"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Molt petit"
 
@@ -2923,7 +2923,7 @@ msgstr "Carregar"
 msgid "LOADING"
 msgstr "Carregant"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Carregant..."
@@ -2954,12 +2954,12 @@ msgstr "Prem el botó de 'desfer' per tal de corregir qualsevol equivocació"
 msgid "LOAD_FINISHED"
 msgstr "Càrrega completada"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Carregar una partida"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Carregar arxius de guardat previs"
 
@@ -3033,7 +3033,7 @@ msgstr "Març"
 msgid "MARINE_SNOW"
 msgstr "Neu marina"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Volum General"
 
@@ -3042,15 +3042,15 @@ msgstr "Volum General"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "s'ha extingit de l'ecosistema"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Màxims FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Il·limitat"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Màxim nombre d'entitats:"
 
@@ -3236,7 +3236,7 @@ msgstr "Cada generació, pots gastar fins a 100 punts de mutació (PM), i cada c
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Cada vegada que et reprodueixis entraràs a l'editor de microbi, on podràs fer canvis a la teva espècie (afegir, moure o treure orgànuls) per tal de millorar-la. Cada sessió de l'editor de microbi representa [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milions d'anys d'evolució."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor Lliure de Microbi"
 
@@ -3422,7 +3422,7 @@ msgstr "Mínim:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "No està permès mostrar menys de {0} dataset(s)!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Misc"
 
@@ -3486,11 +3486,11 @@ msgstr "Modificar orgànul"
 msgid "MODIFY_TYPE"
 msgstr "Modificar Tipus"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3576,11 +3576,11 @@ msgstr "Nom Intern (de Carpeta):"
 msgid "MOD_LICENSE"
 msgstr "Llicència del Mod:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Errors en Carregar el Mod"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Hi han hagut errors en carregar un o més mods. Els logs poden tenir més informació."
 
@@ -3633,11 +3633,11 @@ msgstr "Versió del Mod:"
 msgid "MORE_INFO"
 msgstr "Mostrar Més Informació"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3762,7 +3762,7 @@ msgstr "Múltiples Metaboles"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Múltiples Orgànuls"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Antialiàsing Multimostres (MSAA):"
 
@@ -3774,7 +3774,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Música"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Volum de la música"
 
@@ -3795,9 +3795,9 @@ msgstr "(cost d'orgànuls, membranes i altres elements a l'editor)"
 msgid "MUTATION_POINTS"
 msgstr "Punts de Mutació"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Mut"
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Nova partida"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Començar un nou joc"
 
@@ -3902,7 +3902,7 @@ msgstr "El Plast de Fixació de Nitrogen és una proteïna que produeix Amoníac
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Transforma [thrive:compound type=\"atp\"][/thrive:compound] en [thrive:compound type=\"ammonia\"][/thrive:compound]. La velocitat és proporcional a la concentració de [thrive:compound type=\"nitrogen\"][/thrive:compound] i [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Cap"
 
@@ -3951,7 +3951,7 @@ msgstr "Cap esdeveniment registrat"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "No s'ha trobar el directori d'arxius de guardat"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Inhabilitat"
@@ -3969,7 +3969,7 @@ msgstr "No s'han trobat arxius de guardat"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "No s'ha trobar el directori d'arxius de guardat"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "No s'ha trobat cap directori de captures de pantalla"
 
@@ -4017,16 +4017,16 @@ msgstr "S'han esgotat els Punts de Mutació"
 msgid "OCTOBER"
 msgstr "Octubre"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Suicidi"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4063,7 +4063,7 @@ msgstr "Obrir pantalla d'ajuda"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Construcció lliure"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Obrir Carpeta de Registres"
 
@@ -4079,7 +4079,7 @@ msgstr "Obrir menú d'orgànul"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Obrir el directori de guardats"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Obrir la carpeta de captures de pantalla"
 
@@ -4087,7 +4087,7 @@ msgstr "Obrir la carpeta de captures de pantalla"
 msgid "OPEN_THE_MENU"
 msgstr "Obrir el menú"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Ajuda'ns a traduïr el joc"
 
@@ -4107,11 +4107,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunístic"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opcions"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Canviar la configuració"
 
@@ -4324,7 +4324,7 @@ msgstr "Procedural"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Pausar el joc"
@@ -4376,7 +4376,7 @@ msgstr "Pacífic"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Rendiment"
 
@@ -4460,7 +4460,7 @@ msgstr "Jugador Duplicat"
 msgid "PLAYER_EXTINCT"
 msgstr "Jugador extingit"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Jugador extingit"
@@ -4475,23 +4475,23 @@ msgstr ""
 "Jugador\n"
 "Velocitat"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Mostra el vídeo introductori"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Mostrar la cinemàtica d'entrada a l'Estadi de Microbi en una nova partida"
 
@@ -4610,11 +4610,11 @@ msgstr "Càrrega ràpida"
 msgid "QUICK_SAVE"
 msgstr "Guardat ràpid"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Sortir"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Sortir del joc"
@@ -4658,7 +4658,7 @@ msgstr "Fils:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Recomanat Thrive:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Reprendre el joc"
@@ -4712,7 +4712,7 @@ msgstr "Reproducció:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Requereix nucli"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Reset"
 
@@ -4721,24 +4721,24 @@ msgstr "Reset"
 msgid "RESET_DEADZONES"
 msgstr "Resetejar als valors per defecte?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Resetejar els inputs a valors per defecte?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Resetejar Inputs"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Per defecte"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Resetejar als valors per defecte?"
 
@@ -4747,7 +4747,7 @@ msgstr "Resetejar als valors per defecte?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Resolució:"
 
@@ -4797,7 +4797,7 @@ msgstr ""
 "Estàs segur que vols sortir al menú principal?\n"
 "Perdràs tot el progrés no guardat."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Per Revolutionary Games Studio"
@@ -4830,7 +4830,7 @@ msgstr "Rotar cap a la dreta"
 msgid "ROTATION_COLON"
 msgstr "Rotació:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Activa la simulació auto-evo durant el joc"
 
@@ -4885,7 +4885,7 @@ msgstr "La Rusticianina és una proteïna capaç d'oxidar blocs de Ferro i, per 
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Transforma [thrive:compound type=\"iron\"][/thrive:compound] en [thrive:compound type=\"atp\"][/thrive:compound]. La velocitat és proporcional a la concentració de [thrive:compound type=\"carbondioxide\"][/thrive:compound] i [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4894,16 +4894,16 @@ msgstr ""
 "Els microbis valents no se senten intimidats per depredadors propers\n"
 "i és més probable que contraataquin si són agredits."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Eliminar Dades Locals"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Guardar"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Guardar i continuar"
 
@@ -5001,21 +5001,21 @@ msgstr "No és possible guardar actualment degut a:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Acció de guardat exitosa"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr "Agent de Senyalització"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "per augmentar la"
@@ -5116,7 +5116,7 @@ msgstr "Sèssil"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Aquest valor només s'aplicarà a les partides iniciades després de canviar la opció"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Volum SFX"
 
@@ -5132,21 +5132,25 @@ msgstr "Mostrar tauler d'ajuda"
 msgid "SHOW_TUTORIALS"
 msgstr "Mostrar tutorials"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Mostrar tutorials (a la partida actual)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Mostrar tutorials (en noves partides)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Mostra avís de progrés no guardat"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Habilitar / deshabilitar la finestreta d'avís de progrés no guardat quan el jugador intenta sortir del joc."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5194,7 +5198,7 @@ msgstr "Silici"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Aquesta membrana té una forta paret de silici. Pot resistir les agressions externes, sobretot les de naturalesa física. També consumeix poca energia. No obstant, fa que la cèl·lula esdevingui lenta, i que absorbeixi els nutrients a poc a poc."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5236,7 +5240,7 @@ msgstr "Augmenta la velocitat de gir de grans cèl·lules."
 msgid "SMALL_IRON_CHUNK"
 msgstr "Petit tros de Ferro"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Só"
 
@@ -5441,17 +5445,17 @@ msgstr "Steam no està disponible actualment, siusplau torna-ho a provar"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Hi ha hagut un error d'Steam desconegut"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Error en la inicialització de la llibreria de client d'Steam"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Actualitzar l'arxiu de guardat especificat degut al següent error:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Pausar el joc"
@@ -5492,7 +5496,7 @@ msgstr "Emmagatzematge"
 msgid "STORAGE_COLON"
 msgstr "Emmagatzematge:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Registrat com a: {0}"
 
@@ -5609,7 +5613,7 @@ msgstr "Temperatura"
 msgid "TESTING_TEAM"
 msgstr "Equip de proves"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5624,7 +5628,7 @@ msgstr ""
 "\n"
 "Si has gaudit del joc, siusplau explica-ho als teus amics."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "HAS ACONSEGUIT PROSPERAR!"
@@ -5680,11 +5684,11 @@ msgstr "Aquest és un mod instal·lat localment"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Aquest mod s'ha descarregat des del Workshop d'Steam"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Fils:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5831,7 +5835,7 @@ msgstr "Pausa"
 msgid "TOGGLE_UNBINDING"
 msgstr "Desactivar el mode d'unió"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Eines"
 
@@ -5896,7 +5900,7 @@ msgstr "Intenta fer algunes captures de pantalla!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Intenta guardar una partida!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Intenta fer algunes captures de pantalla!"
 
@@ -6049,12 +6053,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Veure ara"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Han passat: {0:#,#} anys"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6079,7 +6083,7 @@ msgstr "Desunir totes les cèl·lules"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Mode de Desunió"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6102,7 +6106,7 @@ msgstr "Desfer la darrera acció"
 msgid "UNKNOWN"
 msgstr "Desconegut"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Mostrar noms de botons de selecció de parts"
@@ -6115,7 +6119,7 @@ msgstr "Desconegut ratolí"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Desconegut a Windows"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Versió del Mod:"
@@ -6124,7 +6128,7 @@ msgstr "Versió del Mod:"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "ID del Workshop Desconegut Per Aquest Mod"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Hi ha canvis no guardats. Si continueu, es perdran tots.\n"
@@ -6168,7 +6172,7 @@ msgstr "Càrrega amb èxit"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Llicències i llibreries utilitzades"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6184,7 +6188,7 @@ msgstr "Utilitzar Càrrega Auto Harmony"
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Automàticament carregar els ecosistemes Harmony de l'Ensamblatge (no requereix especificar una classe de mod)"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Fer servir un nom d'usuari propi"
 
@@ -6192,11 +6196,11 @@ msgstr "Fer servir un nom d'usuari propi"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Manualment establir nombre de fils del fons"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6222,7 +6226,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Versió:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Versió:"
@@ -6233,11 +6237,11 @@ msgstr "Versió:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Nou nom:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6245,7 +6249,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Visor"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Veure Codi Font"
 
@@ -6257,7 +6261,7 @@ msgstr "Partidaris VIP"
 msgid "VISIBLE"
 msgstr "Visible"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6277,7 +6281,7 @@ msgstr "Treure volum"
 msgid "VOLUMEUP"
 msgstr "Apujar volum"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "V-Sync"
 
@@ -6383,7 +6387,7 @@ msgstr "Estadístiques Generals del Món Actual"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "per augmentar la"
@@ -6392,15 +6396,15 @@ msgstr "per augmentar la"
 msgid "WORST_PATCH_COLON"
 msgstr "Pitjor Medi:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6412,7 +6416,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "anys"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Pausar el joc"

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-09-23 11:38+0000\n"
 "Last-Translator: aleixcoma <aleixcoma@gmail.com>\n"
 "Language-Team: Catalan <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ca/>\n"
@@ -206,7 +206,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Art per {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Galeria d'art"
 
@@ -304,7 +304,7 @@ msgstr "Guardat automàtic durant el joc"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "estat d'execució:"
@@ -347,8 +347,8 @@ msgid "AWAKEN"
 msgstr "Despertar"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -608,27 +608,27 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Diòxid de Carboni"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "en abundància"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "una quantitat justa"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "poc"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "una mica"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "un xic"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "molt poc"
 
@@ -896,21 +896,21 @@ msgstr "Valor de saturació, la quantitat de gris en un color particular"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Valor (brillantor) valor, brillantor o intensitat del color"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Entrar a l'editor i modificar la teva espècie"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "la nostra Wiki"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Sortir del joc"
@@ -1115,7 +1115,7 @@ msgstr "Creant..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Creant objectes a partir de l'arxiu guardat"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Crèdits"
 
@@ -1285,12 +1285,12 @@ msgstr "Partidaris Devbuilds"
 msgid "DEVELOPERS"
 msgstr "Desenvolupadors"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Desenvolupament a càrred de Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Entrar a l'editor i modificar la teva espècie"
@@ -1299,12 +1299,12 @@ msgstr "Entrar a l'editor i modificar la teva espècie"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Desenvolupament a càrred de Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Desenvolupadors"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Ajuda"
@@ -1424,7 +1424,7 @@ msgstr ""
 "Hi ha orgànuls que no han estat físicament connectats a la resta.\n"
 "Siusplau, connecta tots els orgànuls o bé desfés els teus canvis."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Han passat: {0:#,#} anys"
@@ -1442,7 +1442,7 @@ msgstr ""
 "i és possible que siguin molt més ambiciosos respecte a uns mateixos recursos.\n"
 "Els microbis sensibles canviaran d'objectius més aviat."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr "Doble clic per mostrar en pantalla completa"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Una membrana cel·lular formada per dues capes, que ofereix millor protecció i consumeix menys energia. No obstant, fa que la cèl·lula esdevingui més lenta. També redueix la velocitat a la qual s'absorbeixen els nutrients en entrar-hi en contacte."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1671,15 +1671,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Energia a {0} per {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Fonts d'energia:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "L'energia total recol·lectada és {0} amb un cost individual de {1} resultant en una població no ajustada de {2}"
 
@@ -1733,6 +1733,16 @@ msgstr "Error creant l'arxiu d'informació del mod"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Error: No s'ha pogut guardar la nova configuració."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(secrets aleatòriament generats al joc)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Error creant l'arxiu d'informació del mod"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Error durant la càrrega"
@@ -1785,7 +1795,7 @@ msgstr "S'ha produït un problema mentre es carregaven les dades de guardat"
 msgid "EXIT"
 msgstr "Sortir"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Llançar E"
@@ -1838,7 +1848,7 @@ msgstr "s'ha extingit de l'ecosistema"
 msgid "EXTINCT_SPECIES"
 msgstr "EXTINCIÓ"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extres"
 
@@ -1846,7 +1856,7 @@ msgstr "Extres"
 msgid "EXTRA_OPTIONS"
 msgstr "Opcions Extra"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Pausar el joc"
@@ -1880,6 +1890,41 @@ msgstr "Trucs activats"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Febrer"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Error en la inicialització de la llibreria de client d'Steam"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Temps de procès: {0} s\n"
+"Temps de físiques: {1} s\n"
+"Entitats: {2} Other: {3}\n"
+"Aparegudes: {4} Desaparegudes: {5}\n"
+"Nodes utilitzats: {6}\n"
+"Memòria utilitzada: {7}\n"
+"Memòria GPU: {8}\n"
+"Objectes renderitzats: {9}\n"
+"Trucades sortejades: {10} 2D: {11}\n"
+"Vèrtexs renderitzats: {12}\n"
+"Canvis de material: {13}\n"
+"Canvis de Shader: {14}\n"
+"Nodes orfes: {15}\n"
+"Latència d'Audio: {16} ms\n"
+"Fils total: {17}\n"
+"Temps de CPU Total:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1963,7 +2008,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Cadena Alimentària o Tròfica"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0} energia: {1} (rendiment: {2}) energia total disponible: {3} (rendiment total: {4})"
 
@@ -2067,7 +2112,7 @@ msgstr "Generació:"
 msgid "GENERATION_COLON"
 msgstr "Generació:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Sortir del joc"
@@ -2076,11 +2121,11 @@ msgstr "Sortir del joc"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Mode d'Alerta GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Esteu executant el programa Thrive amb GLES2. Aquesta tecnologia encara no ha estat del tot validada i, per tant, pot originar alguns problemes. Intenteu actualitzar els vostres drivers de vídeo i/o forçar l'ús de gràfics AMD o Nvidia per executar Thrive."
 
@@ -2368,7 +2413,7 @@ msgstr "Ferro"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Quimiolitoautotròfia basada en Ferro"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Sortir del joc"
@@ -2587,7 +2632,7 @@ msgstr "Aquesta llengua encara és una feina en progrés ({0}% completat)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Aquesta traducció encara és incomplerta ({0}% traduït) siusplau ajuda'ns a completar-la!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "No es pot eliminar l'últim orgànul"
 
@@ -2746,7 +2791,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Click esquerre del ratolí"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Llicències"
 
@@ -2878,7 +2923,8 @@ msgstr "Carregar"
 msgid "LOADING"
 msgstr "Carregant"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Carregant..."
 
@@ -2908,12 +2954,12 @@ msgstr "Prem el botó de 'desfer' per tal de corregir qualsevol equivocació"
 msgid "LOAD_FINISHED"
 msgstr "Càrrega completada"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Carregar una partida"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Carregar arxius de guardat previs"
 
@@ -3190,7 +3236,7 @@ msgstr "Cada generació, pots gastar fins a 100 punts de mutació (PM), i cada c
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Cada vegada que et reprodueixis entraràs a l'editor de microbi, on podràs fer canvis a la teva espècie (afegir, moure o treure orgànuls) per tal de millorar-la. Cada sessió de l'editor de microbi representa [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milions d'anys d'evolució."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor Lliure de Microbi"
 
@@ -3440,11 +3486,11 @@ msgstr "Modificar orgànul"
 msgid "MODIFY_TYPE"
 msgstr "Modificar Tipus"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3530,11 +3576,11 @@ msgstr "Nom Intern (de Carpeta):"
 msgid "MOD_LICENSE"
 msgstr "Llicència del Mod:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Errors en Carregar el Mod"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Hi han hagut errors en carregar un o més mods. Els logs poden tenir més informació."
 
@@ -3779,15 +3825,19 @@ msgstr ""
 "Aquest arxiu de guardat pertany a una versió de Thrive més nova que l'actual i, probablement, sigui incompatible.\n"
 "Voleu intentar carregar l'arxiu igualment?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Nova partida"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Començar un nou joc"
 
@@ -3888,7 +3938,7 @@ msgid "NO_AI"
 msgstr "No IA"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "No hi ha dades a mostrar"
 
@@ -3901,7 +3951,7 @@ msgstr "Cap esdeveniment registrat"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "No s'ha trobar el directori d'arxius de guardat"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Inhabilitat"
@@ -3932,7 +3982,7 @@ msgstr "Cap Mod Seleccionat"
 msgid "NUCLEUS"
 msgstr "Nucli"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 "No es pot eliminar el nucli, ja que aquesta és una evolució irreversible.\n"
@@ -3953,8 +4003,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -3967,16 +4017,16 @@ msgstr "S'han esgotat els Punts de Mutació"
 msgid "OCTOBER"
 msgstr "Octubre"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Suicidi"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4057,11 +4107,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunístic"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opcions"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Canviar la configuració"
 
@@ -4274,7 +4324,7 @@ msgstr "Procedural"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Pausar el joc"
@@ -4334,8 +4384,8 @@ msgstr "Rendiment"
 msgid "PERFORM_UNBINDING"
 msgstr "Dur a terme la desunió"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/segon"
 
@@ -4386,7 +4436,7 @@ msgstr "Pròximament, generació planetària!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Llavor de planeta aleatòria"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Cèl·lula del jugador"
 
@@ -4462,7 +4512,7 @@ msgstr "població:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "població a les zones:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4516,7 +4566,7 @@ msgstr "previ:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Processant objectes carregats"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4560,11 +4610,11 @@ msgstr "Càrrega ràpida"
 msgid "QUICK_SAVE"
 msgstr "Guardat ràpid"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Sortir"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Sortir del joc"
@@ -4608,7 +4658,7 @@ msgstr "Fils:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Recomanat Thrive:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Reprendre el joc"
@@ -4747,7 +4797,7 @@ msgstr ""
 "Estàs segur que vols sortir al menú principal?\n"
 "Perdràs tot el progrés no guardat."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Per Revolutionary Games Studio"
@@ -4835,7 +4885,7 @@ msgstr "La Rusticianina és una proteïna capaç d'oxidar blocs de Ferro i, per 
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Transforma [thrive:compound type=\"iron\"][/thrive:compound] en [thrive:compound type=\"atp\"][/thrive:compound]. La velocitat és proporcional a la concentració de [thrive:compound type=\"carbondioxide\"][/thrive:compound] i [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4844,7 +4894,7 @@ msgstr ""
 "Els microbis valents no se senten intimidats per depredadors propers\n"
 "i és més probable que contraataquin si són agredits."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Eliminar Dades Locals"
@@ -5214,7 +5264,7 @@ msgstr "Fer aparéixer Amoníac"
 msgid "SPAWN_ENEMY"
 msgstr "Generar Enemic"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "No es pot fer servir el truc de generar un enemic ja que aquest medi no conté cap espècie enemiga"
 
@@ -5276,7 +5326,7 @@ msgstr "Nom de l'Espècie..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Nom de l'Espècie..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5391,17 +5441,17 @@ msgstr "Steam no està disponible actualment, siusplau torna-ho a provar"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Hi ha hagut un error d'Steam desconegut"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Error en la inicialització de la llibreria de client d'Steam"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Actualitzar l'arxiu de guardat especificat degut al següent error:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Pausar el joc"
@@ -5442,7 +5492,7 @@ msgstr "Emmagatzematge"
 msgid "STORAGE_COLON"
 msgstr "Emmagatzematge:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Registrat com a: {0}"
 
@@ -5559,7 +5609,7 @@ msgstr "Temperatura"
 msgid "TESTING_TEAM"
 msgstr "Equip de proves"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5574,7 +5624,7 @@ msgstr ""
 "\n"
 "Si has gaudit del joc, siusplau explica-ho als teus amics."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "HAS ACONSEGUIT PROSPERAR!"
@@ -5634,7 +5684,7 @@ msgstr "Aquest mod s'ha descarregat des del Workshop d'Steam"
 msgid "THREADS"
 msgstr "Fils:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5781,7 +5831,7 @@ msgstr "Pausa"
 msgid "TOGGLE_UNBINDING"
 msgstr "Desactivar el mode d'unió"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Eines"
 
@@ -5999,7 +6049,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Veure ara"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Han passat: {0:#,#} anys"
@@ -6195,7 +6245,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Visor"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Veure Codi Font"
 
@@ -6207,7 +6257,7 @@ msgstr "Partidaris VIP"
 msgid "VISIBLE"
 msgstr "Visible"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6362,7 +6412,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "anys"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Pausar el joc"

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-11-17 16:00+0000\n"
 "Last-Translator: Lukas Kusy <lukas.kusyit@gmail.com>\n"
 "Language-Team: Czech <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/cs/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "3D Editor"
 msgid "3D_MOVEMENT"
 msgstr "3D Pohyb"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "Akce je zablokována zatímco probíhá jiná akce"
 msgid "ACTIVE"
 msgstr "Aktivnost"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Současná vlákna:"
 
@@ -144,7 +144,7 @@ msgstr "Statistika organizmu"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Hlasitost prostředí"
 
@@ -155,11 +155,11 @@ msgstr "Hlasitost prostředí"
 msgid "AMMONIA"
 msgstr "Amoniak"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Počet autosave k zachování:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Počet rychlouložení k zachování:"
 
@@ -184,11 +184,11 @@ msgstr "Použít změny"
 msgid "APRIL"
 msgstr "Duben"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Opravdu chceš resetovat VŠECHNA nastavení ?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Jseš si jistý/á, že chceš resetovat ovládání ?"
 
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Ilustraci vytvořil(a) {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Galerie"
 
@@ -216,7 +216,7 @@ msgstr "Třída sestavy modu je potřebná když je soustava specifikovaná"
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "Sestava modu je potřebná když je povoleno auto Harmony"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Předpokládat, že CPU má povolený hyperthreading"
 
@@ -258,7 +258,7 @@ msgstr "Pokus o zapsání úložného souboru selhalo. Jméno uložené hry mů�
 msgid "AT_CURSOR"
 msgstr "Na kurzoru:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Výstupní audio zařízení:"
 
@@ -266,8 +266,8 @@ msgstr "Výstupní audio zařízení:"
 msgid "AUGUST"
 msgstr "Srpen"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Automaticky"
 
@@ -294,7 +294,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% splněno. {1:n0}/{2:n0} kroků."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Automatické ukládání během hry"
 
@@ -302,7 +302,7 @@ msgstr "Automatické ukládání během hry"
 msgid "AUTO_EVO"
 msgstr "Automatická evoluce"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Nástroj Průzkumu Auto-Evo"
 
@@ -332,7 +332,7 @@ msgstr "status spuštění:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Automatický pohyb kupředu"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Automatické ({0}x{1})"
 
@@ -345,9 +345,9 @@ msgid "AWAKEN"
 msgstr "Probudit se"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -483,7 +483,7 @@ msgstr "Umožňuje spojení s ostatními buňkami. Toto je první krůček k mno
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Stiskněte [thrive:input]g_toggle_binding[/thrive:input] pro zapnutí spojovacího režimu. Ve spojovacím režimu můžete spojit svou buňku s jinými buňkami stejného druhu tím, že do nich narazíte. Pro opuštění kolonie stiskněte [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr "Tato membrána má silnou skořápku vyrobenou z uhličitanu vápenatéh
 msgid "CAMERA"
 msgstr "Kamera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -673,7 +673,7 @@ msgstr "Změnit symetrii"
 msgid "CHEATS"
 msgstr "Cheaty"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Povolit podvádění (cheaty)"
 
@@ -763,7 +763,7 @@ msgstr "Produkuje [thrive:compound type=\"glucose\"][/thrive:compound]. Rychlost
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Soubor se jménem ({0}) již existuje. Přejete si jej nahradit?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Chromatická aberace:"
 
@@ -804,15 +804,15 @@ msgstr "Vyčistit stará uložení"
 msgid "CLOSE"
 msgstr "Zavřít"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Zavřít možnosti?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Oddělovač rozlišení mraků:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Minimální interval simulace mračen:"
 
@@ -828,7 +828,7 @@ msgstr "Spawnování entit s tvary kolizí"
 msgid "COLOUR"
 msgstr "Barva"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Korekce barev:"
 
@@ -889,26 +889,26 @@ msgstr "Saturace (sytost)"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Jas (intenzita barvy)"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Vstupte do editoru a upravte svůj druh"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "naše Wiki"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Opustit hru"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Sloučeniny:"
@@ -936,7 +936,7 @@ msgstr "Sloučeniny:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Balanc sloučenin"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Mračna sloučenin"
 
@@ -1021,7 +1021,7 @@ msgstr "Pokračovat k prototypům období?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1036,11 +1036,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr "Mrtvá zóna:"
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1048,11 +1048,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Kopírovat chybu do schránky"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanopie (Červená-Zelená)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanopie (Modrá-Žlutá)"
 
@@ -1108,7 +1108,7 @@ msgstr "Vytváření..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Vytváření objektů z uložené pozice"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Poděkování"
 
@@ -1134,7 +1134,7 @@ msgstr "Současní vývojáři"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Statistika organizmu"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Vlastní uživatelské jméno:"
 
@@ -1201,7 +1201,7 @@ msgstr "Debugovací Panel"
 msgid "DECEMBER"
 msgstr "Prosinec"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Výchozí výstupní zařízení"
 
@@ -1263,7 +1263,7 @@ msgstr "Popis je příliš dlouhý"
 msgid "DESPAWN_ENTITIES"
 msgstr "Zlikvidovat všechny věci"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Detekovaný počet CPU:"
 
@@ -1276,12 +1276,12 @@ msgstr "Sponzoři Devbuild"
 msgid "DEVELOPERS"
 msgstr "Vývojáři"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Vývoj podpořen týmem Revolutionary Games Studio"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Vstupte do editoru a upravte svůj druh"
@@ -1290,12 +1290,12 @@ msgstr "Vstupte do editoru a upravte svůj druh"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Vývoj podpořen týmem Revolutionary Games Studio"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Vývojáři"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Nápověda"
@@ -1378,7 +1378,7 @@ msgstr "Vlevo"
 msgid "DIRECTIONR"
 msgstr "Vpravo"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Vypnuto"
 
@@ -1386,7 +1386,7 @@ msgstr "Vypnuto"
 msgid "DISABLE_ALL"
 msgstr "Zakázat vše"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Zahodit a pokračovat"
 
@@ -1424,16 +1424,16 @@ msgstr ""
 "Jsou zde umístěny organely, které nejsou spojeny se zbytkem.\n"
 "Propoj všechny umístěné organely navzájem nebo zruš změny."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr "Připoj se na náš komunitní Discord server"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Rychlost trávení:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
@@ -1441,19 +1441,19 @@ msgstr ""
 "a mohou být mnohem náročnější na kusy.\n"
 "Reagující mikroby se dříve přepnou na nové cíle."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Zobrazit panel schopností"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Zobrazení částic v pozadí"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Zobrazit jména tlačítek výběru částí"
 
@@ -1488,7 +1488,7 @@ msgstr "Dvojklikem zobrazíte v celé obrazovce"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Membrána se dvěma vrstvami má lepší ochranu proti poškození a potřebuje méně energie k zabránění deformace. Avšak zpomaluje buňku a snižuje rychlost, kterou může absorbovat zdroje."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1642,7 +1642,7 @@ msgstr ""
 "\n"
 "Až budete chtít pokračovat, zmáčkněte tlačítko \"Další\" v pravém dolním rohu."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1658,7 +1658,7 @@ msgstr "Povolit všechny kompatibilní mody"
 msgid "ENABLE_EDITOR"
 msgstr "Zapnout editor"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Povolit světelné efekty rozhraní"
 
@@ -1716,7 +1716,7 @@ msgstr "Zobrazit / skrýt prostředí a sloučeniny"
 msgid "EPIPELAGIC"
 msgstr "Epipelagický"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Chyba"
 
@@ -1728,16 +1728,16 @@ msgstr "Chyba při vytváření složky pro mod"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Chyba při vytváření souboru mod info"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Chyba: Nepodařilo se uložit nové nastavení."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(náhodně spawnuté překvapení ve hře)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Chyba při vytváření souboru mod info"
@@ -1771,12 +1771,12 @@ msgstr "Evoluční strom"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Evoluční strom"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Verze:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Automaticky načítat Harmony patche ze sestavy (nepotřebuje specifikování třídy modu)"
@@ -1793,7 +1793,7 @@ msgstr "Při načítání uložených dat došlo k výjimce"
 msgid "EXIT"
 msgstr "Odejít"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Spustit E"
@@ -1846,7 +1846,7 @@ msgstr "vyhynulý v tomto prostředí"
 msgid "EXTINCT_SPECIES"
 msgstr "Vyhynulé druhy"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Ostatní"
 
@@ -1854,7 +1854,7 @@ msgstr "Ostatní"
 msgid "EXTRA_OPTIONS"
 msgstr "Extra nastavení"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Navštiv naší Facebook stránku"
 
@@ -1888,12 +1888,12 @@ msgstr "Povolit podvádění (cheaty)"
 msgid "FEBRUARY"
 msgstr "Únor"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Inicializace knihovny klienta služby Steam se nezdařila"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1915,11 +1915,11 @@ msgstr ""
 "Totalální čas CPU:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2050,7 +2050,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr "Přisedlost"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2080,7 +2080,7 @@ msgstr "Bonusový oblak glukózy při opuštění editoru"
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(začnete s bonusovým oblakem glukózy poblíž každé generace)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Celá obrazovka"
 
@@ -2108,23 +2108,23 @@ msgstr "Generace"
 msgid "GENERATION_COLON"
 msgstr "Generace:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr "Navštiv náš GitHub repozitář"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Varování režimu GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Spouštíte Thrive pomocí OpenGLES2. Tato možnost není otestovaná a může způsobovat problémy. Zkuste aktualizovat grafické ovladače nebo vynutit použití AMD nebo Nvidia grafiky pro spuštění Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr "GLES3"
 
@@ -2177,11 +2177,11 @@ msgstr "Rozumím"
 msgid "GPL_LICENSE_HEADING"
 msgstr "Následuje text GPL licence:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "GPU:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafika"
 
@@ -2189,7 +2189,7 @@ msgstr "Grafika"
 msgid "GRAPHICS_TEAM"
 msgstr "Grafici"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "GUI"
 
@@ -2206,7 +2206,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} k"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Hlasitost GUI"
 
@@ -2228,11 +2228,11 @@ msgstr "Nápověda"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Nápověda"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(vyšší hodnoty zvyšují výkon)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(Vyšší hodnota může zhoršit výkon)"
 
@@ -2258,7 +2258,7 @@ msgstr "Podržte [thrive:input]g_free_cursor[/thrive:input] pro kurzor"
 msgid "HOME"
 msgstr "Home"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Verze:"
@@ -2332,7 +2332,7 @@ msgstr "Strávená hmota"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Připoj se na náš komunitní Discord server"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Ovládání"
 
@@ -2385,8 +2385,8 @@ msgstr "Neplatný formát URL"
 msgid "INVALID_URL_SCHEME"
 msgstr "Neplatné schéma adresy URL"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2409,7 +2409,7 @@ msgstr "Železo"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Chemolithoautotrofie železa"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Opustit hru"
@@ -2418,19 +2418,19 @@ msgstr "Opustit hru"
 msgid "JANUARY"
 msgstr "Leden"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "JSON debug mod:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Vždy"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automaticky"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Nikdy"
 
@@ -2612,19 +2612,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Jazyk:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Tento jazyk je přeložen z {0}%"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Na překladu do tohoto jazyku se ještě pracuje ({0} hotovo)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Tento překlad není kompletní ({0}% dokončeno) prosím, pomozte nám s ním!"
 
@@ -2787,7 +2787,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Levé tlačítko myši"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licence"
 
@@ -2857,7 +2857,7 @@ msgstr "Kolečkem vpravo"
 msgid "LIGHT_MAX"
 msgstr "Světlo"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Extrémní"
 
@@ -2869,31 +2869,31 @@ msgstr "Limit využití růstových sloučenin"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(zapnutí limituje rychlost růstu, při vypnutí na rychlost růstu mají efekt pouze dostupné sloučeniny)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Obří"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Velký"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Normální"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Malý"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Drobný"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Obrovský"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Maličký"
 
@@ -2917,7 +2917,7 @@ msgstr "Načíst"
 msgid "LOADING"
 msgstr "Načítání"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Nahrávání..."
@@ -2948,12 +2948,12 @@ msgstr "Chybu opravíš stisknutím tlačítka Zpět v editoru"
 msgid "LOAD_FINISHED"
 msgstr "Načítání dokončeno"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Nahrát hru"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Načíst předešlé uložené hry"
 
@@ -3027,7 +3027,7 @@ msgstr "Březen"
 msgid "MARINE_SNOW"
 msgstr "Mořský sníh"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Celková hlasitost"
 
@@ -3035,15 +3035,15 @@ msgstr "Celková hlasitost"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Maximální počet druhů v daném prostředí před nuceným vyhynutím"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Maximální FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Neomezené"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Maximální počet entit:"
 
@@ -3217,7 +3217,7 @@ msgstr "Každou generaci máte k dispozici 100 bodů mutace (MP) a každá změn
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Vždy, když zahájíš reprodukci, vstoupíš do editoru mikrobů, kde můžeš provádět změny tvého druhu (přidáním, přesunutím nebo odstraněním organel) ke zvýšení úspěšnosti. Každá návštěva editoru v mikrobiální fázi představuje [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milionů let evoluce."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor mikrobů"
 
@@ -3401,7 +3401,7 @@ msgstr "Minimum:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Není povoleno zobrazit méně než {0} datových sad!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Ostatní"
 
@@ -3465,11 +3465,11 @@ msgstr "Modifikovat organelu"
 msgid "MODIFY_TYPE"
 msgstr "Upravit typ"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mody"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3555,11 +3555,11 @@ msgstr "Interní název (složky):"
 msgid "MOD_LICENSE"
 msgstr "Licence módu:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Chyby načítání módu"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Při načítání jednoho nebo více módů došlo k chybám. Protokoly mohou obsahovat další informace."
 
@@ -3612,11 +3612,11 @@ msgstr "Verze modu:"
 msgid "MORE_INFO"
 msgstr "Zobrazit více info"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3740,7 +3740,7 @@ msgstr "Více metaballů"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Více organel"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Vícevzorové vyhlazování:"
 
@@ -3752,7 +3752,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Hudba"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Hlasitost hudby"
 
@@ -3772,9 +3772,9 @@ msgstr "(cena organel, membrán a jiných věcí v editoru)"
 msgid "MUTATION_POINTS"
 msgstr "Body mutace"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Ztišit"
 
@@ -3810,11 +3810,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Počáteční populace pro druhy zvyšující biodiverzitu"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Nová hra"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Začít novou hru"
 
@@ -3879,7 +3879,7 @@ msgstr "Dusík fixující plastid je protein schopný využít plynný [thrive:c
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Přeměňuje [thrive:compound type=\"atp\"][/thrive:compound] na [thrive:compound type=\"ammonia\"][/thrive:compound]. Rychlost je úměrná koncentraci [thrive:compound type=\"nitrogen\"][/thrive:compound] a [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Žádná"
 
@@ -3927,7 +3927,7 @@ msgstr "Žádné zaznamenané události"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Složka uložených pozic nebyla nalezena"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Vypnuto"
@@ -3945,7 +3945,7 @@ msgstr "Nebyly nalezeny žádné uložené hry"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Složka uložených pozic nebyla nalezena"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Složka se snímky obrazovky nebyla nalezena"
 
@@ -3993,16 +3993,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr "Říjen"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr "Oficiální stránka"
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Spáchat sebevraždu"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4039,7 +4039,7 @@ msgstr "Otevřít nápovědu"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Volné stavění"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Otevřít složku protokolů"
 
@@ -4055,7 +4055,7 @@ msgstr "Otevřít nabídku organel"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Otevřít složku uložení"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Otevřít screenshoty"
 
@@ -4063,7 +4063,7 @@ msgstr "Otevřít screenshoty"
 msgid "OPEN_THE_MENU"
 msgstr "Otevřít menu"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Pomozte přeložit hru"
 
@@ -4082,11 +4082,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunismus"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Nastavení"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Změna nastavení"
 
@@ -4297,7 +4297,7 @@ msgstr "Procedurální"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr "Navštivte náš Patreon"
 
@@ -4347,7 +4347,7 @@ msgstr "Mírumilovnost"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Výkon"
 
@@ -4431,7 +4431,7 @@ msgstr "Duplicitní hráč"
 msgid "PLAYER_EXTINCT"
 msgstr "Hráč vyhynul"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Hráč vyhynul"
@@ -4446,23 +4446,23 @@ msgstr ""
 "Hráč\n"
 "Rychlost"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Přehrát úvodní video"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Spustit úvod do mikrobů v nové hře"
 
@@ -4581,11 +4581,11 @@ msgstr "Rychlé načtení"
 msgid "QUICK_SAVE"
 msgstr "Rychlé uložení"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Ukončit"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Opustit hru"
@@ -4627,7 +4627,7 @@ msgstr "Připraveno"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Doporučené Thrive:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr "Navštiv náš subreddit"
 
@@ -4680,7 +4680,7 @@ msgstr "Reprodukce:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Potřebuje jádro"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Resetovat"
 
@@ -4688,24 +4688,24 @@ msgstr "Resetovat"
 msgid "RESET_DEADZONES"
 msgstr "Resetovat Mrtvý Úhel"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Resetovat ovládání ?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Resetovat ovládání"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Výchozí"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Obnovit výchozí nastavení?"
 
@@ -4714,7 +4714,7 @@ msgstr "Obnovit výchozí nastavení?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Rozlišení:"
 
@@ -4764,7 +4764,7 @@ msgstr ""
 "Jste si jistý, že chcete odejít do hlavního menu?\n"
 "Ztratíte veškerý neuložený postup."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Vytvořeno týmem Revolutionary Games Studio"
@@ -4797,7 +4797,7 @@ msgstr "Otočit doprava"
 msgid "ROTATION_COLON"
 msgstr "Rotace:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Spustit automatickou evoluci běhen hry"
 
@@ -4852,7 +4852,7 @@ msgstr "Rusticyanin je protein schopný využít plynný [thrive:compound type=\
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Přeměňuje [thrive:compound type=\"iron\"][/thrive:compound] na [thrive:compound type=\"atp\"][/thrive:compound]. Rychlost je úměrná koncentraci [thrive:compound type=\"carbondioxide\"][/thrive:compound] a [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4861,16 +4861,16 @@ msgstr ""
 "Odvážní mikrobi se nenechají zastrašit blízkými predátory \n"
 "a spíše zaútočí zpět."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Odstranit místní data"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Uložit"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Uložit a pokračovat"
 
@@ -4968,21 +4968,21 @@ msgstr "Uložení není momentálně k dispozici z důvodu:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Ukládání provedeno"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr "Signalizující Prvek"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "ke zvýšení pohyblivosti"
@@ -5080,7 +5080,7 @@ msgstr "Přisedlost"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Tato hodnota se aplikuje pouze na nové hry započaté až po změně"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Hlasitost SFX"
 
@@ -5096,21 +5096,25 @@ msgstr "Zobrazit nápovědu"
 msgid "SHOW_TUTORIALS"
 msgstr "Zobrazit tutoriál"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Zobrazit tutoriály (v aktuální hře)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Zobrazit tutoriály (v nových hrách)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Zobrazení upozornění na neuložený postup"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Povoluje / zakazuje vyskakovací okno s upozorněním na neuložený postup, když se hráč pokusí ukončit hru."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5158,7 +5162,7 @@ msgstr "Oxid křemičitý"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Tato membrána má silnou křemičitou stěnu. Dokáže dobře odolat celkovému poškození a je velmi odolný proti fyzickému poškození. Pro udržení své formy vyžaduje také méně energie. Avšak velice zpomaluje buňku a buňka absorbuje zdroje sníženou rychlostí."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5200,7 +5204,7 @@ msgstr "Zvyšuje rychlost otáčení velkých buněk."
 msgid "SMALL_IRON_CHUNK"
 msgstr "Malý kus železa"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Zvuky"
 
@@ -5404,17 +5408,17 @@ msgstr "Steam je momentálně nedostupný, prosím zkuste znovu"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Nastala neznámá chyba služby Steam"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Inicializace knihovny klienta služby Steam se nezdařila"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Převod vybrané uložené hry na novější verzi selhal kvůli následující chybě:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Pozastavit hru"
@@ -5455,7 +5459,7 @@ msgstr "Úložný prostor"
 msgid "STORAGE_COLON"
 msgstr "Úložný prostor:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Přihlášen jako: {0}"
 
@@ -5572,7 +5576,7 @@ msgstr "Teplota."
 msgid "TESTING_TEAM"
 msgstr "Teststeři"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5587,7 +5591,7 @@ msgstr ""
 "\n"
 "Pokud se vám líbí, řekněte o nás i Vašim přátelům, prosím."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "PROSPERUJEŠ!"
@@ -5643,11 +5647,11 @@ msgstr "Jedná se o lokálně nainstalovaný mod"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Tento mod si můžete stáhnout ze služby Steam Workshop"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Vlákna:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thriveopedie"
 
@@ -5794,7 +5798,7 @@ msgstr "Pozastavit"
 msgid "TOGGLE_UNBINDING"
 msgstr "Přepnout rozpojování"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Nástroje"
 
@@ -5859,7 +5863,7 @@ msgstr "Zkuste udělat snímek obrazovky!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Zkus vytvořit uloženou pozici!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Zkuste udělat snímek obrazovky!"
 
@@ -6016,11 +6020,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Podívat se na tutoriál"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr "Navštiv náš Twitter"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6045,7 +6049,7 @@ msgstr "Rozpojit všechny"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Rozpojovací mód"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6068,7 +6072,7 @@ msgstr "Vrátit zpět poslední akci"
 msgid "UNKNOWN"
 msgstr "Neznámý"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Neznámý"
 
@@ -6080,7 +6084,7 @@ msgstr "Neznámá myš"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Neznáme na Windows"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Verze modu:"
@@ -6089,7 +6093,7 @@ msgstr "Verze modu:"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Neznámé Workshop ID pro tento mod"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Máš neuložené změny, které budou zahozeny.\n"
@@ -6133,7 +6137,7 @@ msgstr "Nahrání bylo úspěšné"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Licence a použité knihovny"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "Použitý renderer:"
 
@@ -6149,7 +6153,7 @@ msgstr "Použít Auto Harmony Loading"
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Automaticky načítat Harmony patche ze sestavy (nepotřebuje specifikování třídy modu)"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Použij vlastní jméno"
 
@@ -6157,11 +6161,11 @@ msgstr "Použij vlastní jméno"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "Druhy zvyšující biodiverzitu kradou populaci existujícím druhům"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Manuálně nastavit počet vláken procesoru na pozadí"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6187,7 +6191,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Verze:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Verze:"
@@ -6197,11 +6201,11 @@ msgstr "Verze:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Vertikální (Osa: {0})"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "Právě využitá video paměť:"
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0} MiB"
 
@@ -6209,7 +6213,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Prohlížeč"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Zdrojový kód"
 
@@ -6221,7 +6225,7 @@ msgstr "VIP Podporovatelé"
 msgid "VISIBLE"
 msgstr "Viditelné"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6241,7 +6245,7 @@ msgstr "Ztlumit"
 msgid "VOLUMEUP"
 msgstr "Zhlasit"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSync"
 
@@ -6348,7 +6352,7 @@ msgstr "Statistika organizmu"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "ke zvýšení pohyblivosti"
@@ -6357,15 +6361,15 @@ msgstr "ke zvýšení pohyblivosti"
 msgid "WORST_PATCH_COLON"
 msgstr "Nejhorší oblast:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6377,7 +6381,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "roky"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Navštiv náš YouTube kanál"
 

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-11-17 16:00+0000\n"
 "Last-Translator: Lukas Kusy <lukas.kusyit@gmail.com>\n"
 "Language-Team: Czech <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/cs/>\n"
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Ilustraci vytvořil(a) {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Galerie"
 
@@ -302,7 +302,7 @@ msgstr "Automatické ukládání během hry"
 msgid "AUTO_EVO"
 msgstr "Automatická evoluce"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Nástroj Průzkumu Auto-Evo"
 
@@ -345,8 +345,8 @@ msgid "AWAKEN"
 msgstr "Probudit se"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -601,27 +601,27 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Oxid uhličitý"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "hojnost"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "dostatečné množství"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "málo"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "docela dost"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "něco"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "velmi málo"
 
@@ -889,21 +889,21 @@ msgstr "Saturace (sytost)"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Jas (intenzita barvy)"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Vstupte do editoru a upravte svůj druh"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "naše Wiki"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Opustit hru"
@@ -1108,7 +1108,7 @@ msgstr "Vytváření..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Vytváření objektů z uložené pozice"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Poděkování"
 
@@ -1276,12 +1276,12 @@ msgstr "Sponzoři Devbuild"
 msgid "DEVELOPERS"
 msgstr "Vývojáři"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Vývoj podpořen týmem Revolutionary Games Studio"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Vstupte do editoru a upravte svůj druh"
@@ -1290,12 +1290,12 @@ msgstr "Vstupte do editoru a upravte svůj druh"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Vývoj podpořen týmem Revolutionary Games Studio"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Vývojáři"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Nápověda"
@@ -1424,7 +1424,7 @@ msgstr ""
 "Jsou zde umístěny organely, které nejsou spojeny se zbytkem.\n"
 "Propoj všechny umístěné organely navzájem nebo zruš změny."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr "Připoj se na náš komunitní Discord server"
 
@@ -1441,7 +1441,7 @@ msgstr ""
 "a mohou být mnohem náročnější na kusy.\n"
 "Reagující mikroby se dříve přepnou na nové cíle."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1488,7 +1488,7 @@ msgstr "Dvojklikem zobrazíte v celé obrazovce"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Membrána se dvěma vrstvami má lepší ochranu proti poškození a potřebuje méně energie k zabránění deformace. Avšak zpomaluje buňku a snižuje rychlost, kterou může absorbovat zdroje."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1670,15 +1670,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Energie v {0} pro {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Zdroje energie:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "Celková získaná energie je {0} s individuálními náklady {1}, což vede k nekorigované populaci {2}"
 
@@ -1732,6 +1732,16 @@ msgstr "Chyba při vytváření souboru mod info"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Chyba: Nepodařilo se uložit nové nastavení."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(náhodně spawnuté překvapení ve hře)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Chyba při vytváření souboru mod info"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Chyba v načítání"
@@ -1783,7 +1793,7 @@ msgstr "Při načítání uložených dat došlo k výjimce"
 msgid "EXIT"
 msgstr "Odejít"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Spustit E"
@@ -1836,7 +1846,7 @@ msgstr "vyhynulý v tomto prostředí"
 msgid "EXTINCT_SPECIES"
 msgstr "Vyhynulé druhy"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Ostatní"
 
@@ -1844,7 +1854,7 @@ msgstr "Ostatní"
 msgid "EXTRA_OPTIONS"
 msgstr "Extra nastavení"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Navštiv naší Facebook stránku"
 
@@ -1877,6 +1887,41 @@ msgstr "Povolit podvádění (cheaty)"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Únor"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Inicializace knihovny klienta služby Steam se nezdařila"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Čas procesu: {0} s\n"
+"Čas fyzyky: {1} s\n"
+"Entity: {2} Jiné: {3}\n"
+"Spawnuto: {4} Despawnuto: {5}\n"
+"Použito uzlů: {6}\n"
+"Použito paměti: {7}\n"
+"Paměť GPU: {8}\n"
+"Vyrenderované objekty: {9}\n"
+"Zavolání vykreslení: {10} 2D: {11}\n"
+"Vyrenderovaných vertices: {12}\n"
+"Změny materiálů: {13}\n"
+"Změny shaderů: {14}\n"
+"Opuštěné uzly: {15}\n"
+"Latence audia: {16} ms\n"
+"Totální počet vláken: {17}\n"
+"Totalální čas CPU:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1960,7 +2005,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Potravní řetězec"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0} energie: {1} (fitness: {2}) celková dostupná energie: {3} (celková zdatnost: {4})"
 
@@ -2063,7 +2108,7 @@ msgstr "Generace"
 msgid "GENERATION_COLON"
 msgstr "Generace:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr "Navštiv náš GitHub repozitář"
 
@@ -2071,11 +2116,11 @@ msgstr "Navštiv náš GitHub repozitář"
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Varování režimu GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Spouštíte Thrive pomocí OpenGLES2. Tato možnost není otestovaná a může způsobovat problémy. Zkuste aktualizovat grafické ovladače nebo vynutit použití AMD nebo Nvidia grafiky pro spuštění Thrive."
 
@@ -2364,7 +2409,7 @@ msgstr "Železo"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Chemolithoautotrofie železa"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Opustit hru"
@@ -2583,7 +2628,7 @@ msgstr "Na překladu do tohoto jazyku se ještě pracuje ({0} hotovo)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Tento překlad není kompletní ({0}% dokončeno) prosím, pomozte nám s ním!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "Nelze smazat poslední organelu"
 
@@ -2742,7 +2787,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Levé tlačítko myši"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licence"
 
@@ -2872,7 +2917,8 @@ msgstr "Načíst"
 msgid "LOADING"
 msgstr "Načítání"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Nahrávání..."
 
@@ -2902,12 +2948,12 @@ msgstr "Chybu opravíš stisknutím tlačítka Zpět v editoru"
 msgid "LOAD_FINISHED"
 msgstr "Načítání dokončeno"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Nahrát hru"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Načíst předešlé uložené hry"
 
@@ -3171,7 +3217,7 @@ msgstr "Každou generaci máte k dispozici 100 bodů mutace (MP) a každá změn
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Vždy, když zahájíš reprodukci, vstoupíš do editoru mikrobů, kde můžeš provádět změny tvého druhu (přidáním, přesunutím nebo odstraněním organel) ke zvýšení úspěšnosti. Každá návštěva editoru v mikrobiální fázi představuje [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milionů let evoluce."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor mikrobů"
 
@@ -3419,11 +3465,11 @@ msgstr "Modifikovat organelu"
 msgid "MODIFY_TYPE"
 msgstr "Upravit typ"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mody"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3509,11 +3555,11 @@ msgstr "Interní název (složky):"
 msgid "MOD_LICENSE"
 msgstr "Licence módu:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Chyby načítání módu"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Při načítání jednoho nebo více módů došlo k chybám. Protokoly mohou obsahovat další informace."
 
@@ -3756,15 +3802,19 @@ msgstr ""
 "Tato uložená hra pochází z novější verze Thrive a je velmi pravděpodobně nekompatibilní.\n"
 "Chceš přesto zkusit načíst hru?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Počáteční populace pro druhy zvyšující biodiverzitu"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Nová hra"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Začít novou hru"
 
@@ -3864,7 +3914,7 @@ msgid "NO_AI"
 msgstr "Žádné AI"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Žádná data k zobrazení"
 
@@ -3877,7 +3927,7 @@ msgstr "Žádné zaznamenané události"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Složka uložených pozic nebyla nalezena"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Vypnuto"
@@ -3908,7 +3958,7 @@ msgstr "Žádný vybraný mod"
 msgid "NUCLEUS"
 msgstr "Jádro"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 "Nelze vymazat jádro, jelikož toto je nevratná evoluce.\n"
@@ -3929,8 +3979,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -3943,16 +3993,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr "Říjen"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr "Oficiální stránka"
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Spáchat sebevraždu"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4032,11 +4082,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunismus"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Nastavení"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Změna nastavení"
 
@@ -4247,7 +4297,7 @@ msgstr "Procedurální"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr "Navštivte náš Patreon"
 
@@ -4305,8 +4355,8 @@ msgstr "Výkon"
 msgid "PERFORM_UNBINDING"
 msgstr "Rozpojit"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/sekund"
 
@@ -4357,7 +4407,7 @@ msgstr "Generováni planet již brzy!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Náhodný seed planety"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Hráčská buňka"
 
@@ -4433,7 +4483,7 @@ msgstr "populace:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "populace v prostředích:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4487,7 +4537,7 @@ msgstr "předchozí:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Zpracování načtených objektů"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4531,11 +4581,11 @@ msgstr "Rychlé načtení"
 msgid "QUICK_SAVE"
 msgstr "Rychlé uložení"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Ukončit"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Opustit hru"
@@ -4577,7 +4627,7 @@ msgstr "Připraveno"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Doporučené Thrive:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr "Navštiv náš subreddit"
 
@@ -4714,7 +4764,7 @@ msgstr ""
 "Jste si jistý, že chcete odejít do hlavního menu?\n"
 "Ztratíte veškerý neuložený postup."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Vytvořeno týmem Revolutionary Games Studio"
@@ -4802,7 +4852,7 @@ msgstr "Rusticyanin je protein schopný využít plynný [thrive:compound type=\
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Přeměňuje [thrive:compound type=\"iron\"][/thrive:compound] na [thrive:compound type=\"atp\"][/thrive:compound]. Rychlost je úměrná koncentraci [thrive:compound type=\"carbondioxide\"][/thrive:compound] a [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4811,7 +4861,7 @@ msgstr ""
 "Odvážní mikrobi se nenechají zastrašit blízkými predátory \n"
 "a spíše zaútočí zpět."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Odstranit místní data"
@@ -5178,7 +5228,7 @@ msgstr "Spawnout Amoniak"
 msgid "SPAWN_ENEMY"
 msgstr "Spawni nepřítele"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Nelze využít cheat ke spawnutí nepřítele, jelikož v tomto prostředí se nenachází žádné nepřátelské druhy"
 
@@ -5239,7 +5289,7 @@ msgstr "Jméno druhu..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Jméno druhu..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5354,17 +5404,17 @@ msgstr "Steam je momentálně nedostupný, prosím zkuste znovu"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Nastala neznámá chyba služby Steam"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Inicializace knihovny klienta služby Steam se nezdařila"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Převod vybrané uložené hry na novější verzi selhal kvůli následující chybě:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Pozastavit hru"
@@ -5405,7 +5455,7 @@ msgstr "Úložný prostor"
 msgid "STORAGE_COLON"
 msgstr "Úložný prostor:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Přihlášen jako: {0}"
 
@@ -5522,7 +5572,7 @@ msgstr "Teplota."
 msgid "TESTING_TEAM"
 msgstr "Teststeři"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5537,7 +5587,7 @@ msgstr ""
 "\n"
 "Pokud se vám líbí, řekněte o nás i Vašim přátelům, prosím."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "PROSPERUJEŠ!"
@@ -5597,7 +5647,7 @@ msgstr "Tento mod si můžete stáhnout ze služby Steam Workshop"
 msgid "THREADS"
 msgstr "Vlákna:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thriveopedie"
 
@@ -5744,7 +5794,7 @@ msgstr "Pozastavit"
 msgid "TOGGLE_UNBINDING"
 msgstr "Přepnout rozpojování"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Nástroje"
 
@@ -5966,7 +6016,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Podívat se na tutoriál"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr "Navštiv náš Twitter"
 
@@ -6159,7 +6209,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Prohlížeč"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Zdrojový kód"
 
@@ -6171,7 +6221,7 @@ msgstr "VIP Podporovatelé"
 msgid "VISIBLE"
 msgstr "Viditelné"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6327,7 +6377,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "roky"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Navštiv náš YouTube kanál"
 

--- a/locale/da.po
+++ b/locale/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-07-20 09:20+0000\n"
 "Last-Translator: Magnus Norling Svane <magn665e@icloud.com>\n"
 "Language-Team: Danish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/da/>\n"
@@ -196,7 +196,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -332,8 +332,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -588,27 +588,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -867,19 +867,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1232,11 +1232,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1244,11 +1244,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1594,15 +1594,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1655,6 +1655,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1703,7 +1711,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1753,7 +1761,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1761,7 +1769,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1787,6 +1795,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1868,7 +1892,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1964,7 +1988,7 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1972,11 +1996,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2252,7 +2276,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2468,7 +2492,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2626,7 +2650,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2754,7 +2778,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2784,12 +2809,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2989,7 +3014,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3186,11 +3211,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3276,11 +3301,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3504,15 +3529,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3612,7 +3641,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3624,7 +3653,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3654,7 +3683,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3673,8 +3702,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3687,15 +3716,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3766,11 +3795,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3975,7 +4004,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4033,8 +4062,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4084,7 +4113,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4157,7 +4186,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4211,7 +4240,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4255,11 +4284,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4299,7 +4328,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4433,7 +4462,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4519,11 +4548,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4879,7 +4908,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4929,7 +4958,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5044,15 +5073,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5092,7 +5121,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5207,7 +5236,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5215,7 +5244,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5274,7 +5303,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5421,7 +5450,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5564,7 +5593,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5748,7 +5777,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5760,7 +5789,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5913,7 +5942,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/da.po
+++ b/locale/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-07-20 09:20+0000\n"
 "Last-Translator: Magnus Norling Svane <magn665e@icloud.com>\n"
 "Language-Team: Danish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/da/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.13.1\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr ""
 msgid "3D_MOVEMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -147,11 +147,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -176,11 +176,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -196,7 +196,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -256,8 +256,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -282,7 +282,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -319,7 +319,7 @@ msgstr ""
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -332,9 +332,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -470,7 +470,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -660,7 +660,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -791,15 +791,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -815,7 +815,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -867,23 +867,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr ""
 
@@ -909,7 +909,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1001,11 +1001,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1013,11 +1013,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1162,7 +1162,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1220,7 +1220,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1232,11 +1232,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1244,11 +1244,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1361,31 +1361,31 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1639,7 +1639,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1651,15 +1651,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1691,11 +1691,11 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1711,7 +1711,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1761,7 +1761,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1769,7 +1769,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1797,19 +1797,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1960,7 +1960,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -1988,23 +1988,23 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2069,7 +2069,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2081,7 +2081,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2103,11 +2103,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2131,7 +2131,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2256,8 +2256,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2276,7 +2276,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2284,19 +2284,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2476,19 +2476,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2650,7 +2650,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2718,7 +2718,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2730,31 +2730,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2778,7 +2778,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2809,12 +2809,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2879,7 +2879,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2887,15 +2887,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3014,7 +3014,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3148,7 +3148,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3211,11 +3211,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3301,11 +3301,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3358,11 +3358,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3471,7 +3471,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3483,7 +3483,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Musik"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3503,9 +3503,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3537,11 +3537,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3606,7 +3606,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3653,7 +3653,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3670,7 +3670,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3716,15 +3716,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3755,7 +3755,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3771,7 +3771,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3779,7 +3779,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3795,11 +3795,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4004,7 +4004,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4054,7 +4054,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4137,7 +4137,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4149,23 +4149,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4284,11 +4284,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4328,7 +4328,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4381,7 +4381,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4389,23 +4389,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4414,7 +4414,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4462,7 +4462,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4548,19 +4548,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4652,20 +4652,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4762,7 +4762,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4778,20 +4778,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4840,7 +4844,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4880,7 +4884,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5073,15 +5077,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5121,7 +5125,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5236,7 +5240,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5244,7 +5248,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5299,11 +5303,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5450,7 +5454,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5512,7 +5516,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5593,11 +5597,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5642,7 +5646,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5654,7 +5658,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5702,7 +5706,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5718,7 +5722,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5726,11 +5730,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5756,7 +5760,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr ""
 
@@ -5765,11 +5769,11 @@ msgstr ""
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5777,7 +5781,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5789,7 +5793,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5922,15 +5926,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -5942,7 +5946,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/de.po
+++ b/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2023-01-30 07:23+0000\n"
 "Last-Translator: Alice König <alice.purple-rose@outlook.com>\n"
 "Language-Team: German <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/de/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "Dreidimensionaler Editor"
 msgid "3D_MOVEMENT"
 msgstr "Dreidimensionale Bewegung"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "Aktion ist blockiert während eine andere im Gange ist"
 msgid "ACTIVE"
 msgstr "Aktiv"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Aktuelle Threads:"
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Umgebungslautstärke"
 
@@ -166,11 +166,11 @@ msgstr "Umgebungslautstärke"
 msgid "AMMONIA"
 msgstr "Ammoniak"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Anzahl der Autospeicherungen:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Anzahl der Schnellspeicherungen:"
 
@@ -195,11 +195,11 @@ msgstr "Änderungen übernehmen"
 msgid "APRIL"
 msgstr "April"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Bist du sicher, dass du ALLE Einstellungen auf ihre Standardwerte zurücksetzen willst?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Bist du sicher, dass du die Eingaben auf ihre Standardwerte zurücksetzen willst?"
 
@@ -215,7 +215,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Grafiken von {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Kunstgalerie"
 
@@ -227,7 +227,7 @@ msgstr "Klasse der Programmbibliothek ist erforderlich, wenn angegeben"
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "Mod Assembler ist erforderlich wenn Auto Harmony aktiviert ist"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Annehmen, dass die CPU Hyperthreading hat"
 
@@ -269,7 +269,7 @@ msgstr "Der Versuch zu speichern ist missglückt. Möglicherweise ist der Speich
 msgid "AT_CURSOR"
 msgstr "Am Zeiger:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Ausgabegerät:"
 
@@ -277,8 +277,8 @@ msgstr "Ausgabegerät:"
 msgid "AUGUST"
 msgstr "August"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Auto"
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% fertig. {1:n0}/{2:n0} Schritte."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Automatisches speichern während des Spieles"
 
@@ -313,7 +313,7 @@ msgstr "Automatisches speichern während des Spieles"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Auto-Evo Exploration"
 
@@ -343,7 +343,7 @@ msgstr "Laufstatus:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Automatisch vorwärts bewegen"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "automatisch ({0}x{1})"
 
@@ -356,9 +356,9 @@ msgid "AWAKEN"
 msgstr "Erwachen"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -494,7 +494,7 @@ msgstr "Ermöglicht die Verbindung mit anderen Zellen. Dies ist der erste Schrit
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Drücke [thrive:input]g_toggle_binding[/thrive:input], um den Bindungsmodus umzuschalten. Im Bindungsmodus kannst du andere Zellen deiner Spezies mit deiner Kolonie verbinden, indem du dich in sie hineinbewegst. Um eine Kolonie zu verlassen, drücke [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr "Achsen verbinden"
 
@@ -556,7 +556,7 @@ msgstr "Diese Membran hat eine starke Schale aus Kalziumkarbonat. Sie kann Besch
 msgid "CAMERA"
 msgstr "Kamera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -684,7 +684,7 @@ msgstr "Ändern der Symmetrie"
 msgid "CHEATS"
 msgstr "Cheats"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Cheat-Tasten aktiviert"
 
@@ -774,7 +774,7 @@ msgstr "Produziert [thrive:compound type=\"glucose\"][/thrive:compound]. Die Rat
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Der gewählte Dateiname ({0}) existiert bereits. Überschreiben?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Farbabweichung:"
 
@@ -815,15 +815,15 @@ msgstr "Alte Speicherstände aufräumen"
 msgid "CLOSE"
 msgstr "Schließen"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Optionen schließen?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Wolkenauflösungsteiler:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Wolkensimulation Minimumintervall:"
 
@@ -839,7 +839,7 @@ msgstr "Erzeuge Entitäten mit Kollisionskonturen"
 msgid "COLOUR"
 msgstr "Farbe"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Farbenblindheits-Korrektur:"
 
@@ -900,23 +900,23 @@ msgstr "Sättigungswert, der Anteil an Grau in einer bestimmten Farbe"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Hellwert, Helligkeit oder Intensität der Farbe"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr "Community-Forum"
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Tritt der Thrive Gemeinschaft über unser Forum bei"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr "Gemeinschafts-Wiki"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Besuche unser Gemeinschafts-Wiki"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr "Erstellt am:"
 
@@ -942,7 +942,7 @@ msgstr "Substanzen:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Verbindungsbalance"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Verbindungswolken"
 
@@ -1027,7 +1027,7 @@ msgstr "Mit Prototyp Stadien fortfahren?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr "Controllerachsenvisualisierer:"
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr "Totzonen kalibrieren"
 
@@ -1041,11 +1041,11 @@ msgstr "Diese Tafel zeigt die Werte an, mit denen die Auto-Evo-Vorhersage arbeit
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr "Totzone:"
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr "Controllerempfindlichkeit"
 
@@ -1053,11 +1053,11 @@ msgstr "Controllerempfindlichkeit"
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Fehler in die Zwischenablage kopieren"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Rotblindheit (Rot-Grün)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Blaublindheit (Blau-Gelb)"
 
@@ -1113,7 +1113,7 @@ msgstr "Erstelle..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Objekte aus Speicherstand erstellen"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Abspann"
 
@@ -1138,7 +1138,7 @@ msgstr "Aktuelle Welt"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Organismus-Statistik"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Eigener Nutzername:"
 
@@ -1203,7 +1203,7 @@ msgstr "Debug-Fenster"
 msgid "DECEMBER"
 msgstr "Dezember"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Standardausgabegerät"
 
@@ -1265,7 +1265,7 @@ msgstr "Beschreibung ist zu lang"
 msgid "DESPAWN_ENTITIES"
 msgstr "Alle Objekte entfernen"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Ermittelte CPU-Anzahl:"
 
@@ -1280,11 +1280,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Entwickler(innen)"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr "Entwickler Forum"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Sieh Dir Entwicklerupdates in unserem Entwicklerforum an"
 
@@ -1292,11 +1292,11 @@ msgstr "Sieh Dir Entwicklerupdates in unserem Entwicklerforum an"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Entwicklung unterstützt von Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr "Entwickler-Wiki"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Besuche unser Entwickler-Wiki"
 
@@ -1378,7 +1378,7 @@ msgstr "Links"
 msgid "DIRECTIONR"
 msgstr "Rechts"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Deaktiviert"
 
@@ -1386,7 +1386,7 @@ msgstr "Deaktiviert"
 msgid "DISABLE_ALL"
 msgstr "Alle deaktivieren"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Verwerfen und fortfahren"
 
@@ -1424,33 +1424,33 @@ msgstr ""
 "Es gibt Organellen, die nicht mit dem Rest verbunden sind.\n"
 "Bitte verbinde alle platzierten Organellen miteinander oder mach deine Änderungen rückgängig."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr "Tritt unserem Discord Server bei"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Versteckte Pop-ups:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 "Dies zeigt an, wie viele Popups vom Spieler dauerhaft ausgeblendet wurden.\n"
 "Wenn einige davon wieder sichtbar werden sollen, können mit der Schaltfläche neben dieser alle ausgeblendeten Popups wieder angezeigt werden."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr "Dies' nicht wieder anzeigen"
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Fähigkeitenleiste anzeigen"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Hintergrundpartikel anzeigen"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Namen der Teile Schaltflächen anzeigen"
 
@@ -1485,7 +1485,7 @@ msgstr "Doppelklicken zum Betrachten"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Als zweischichtige Membran bietet sie besseren Schutz vor Beschädigungen und benötigt weniger Energie, um sich nicht zu verformen. Allerdings verlangsamt sie die Zelle etwas und senkt die Geschwindigkeit, mit der sie Ressourcen absorbieren kann."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Diese Warnung nicht mehr anzeigen"
 
@@ -1638,7 +1638,7 @@ msgstr ""
 "\n"
 "Wenn du bereit bist, drücke die \"Nächste\"-Schaltfläche unten rechts."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1654,7 +1654,7 @@ msgstr "Alle kompatiblen Mods aktivieren"
 msgid "ENABLE_EDITOR"
 msgstr "Editor aktivieren"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "GUI-Lichteffekte aktivieren"
 
@@ -1711,7 +1711,7 @@ msgstr "Umgebung und Substanzen ein-/ausblenden"
 msgid "EPIPELAGIC"
 msgstr "Epipelagial"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Fehler"
 
@@ -1723,16 +1723,16 @@ msgstr "Fehler beim Erstellen des Ordners für den Mod"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Fehler beim Erstellen der Modinformationsdatei"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Fehler: Das Speichern neuer Einstellungen in der Konfigurationsdatei ist fehlgeschlagen."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(zufällig generierte Geheimnisse im Spielverlauf)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Fehler beim Erstellen der Modinformationsdatei"
@@ -1768,11 +1768,11 @@ msgstr ""
 "\n"
 "Trifft keins von beidem zu, ist ein Fehler aufgetreten. Bitte benachrichtige das Entwickler Team und stelle Log Dateien zur Verfügung."
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr "Genaue Thrive Version:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Dies ist die exakte Version dieser Thrive Instanz"
 
@@ -1788,7 +1788,7 @@ msgstr "Beim Laden der Speicherdaten ist ein Fehler aufgetreten"
 msgid "EXIT"
 msgstr "Verlassen"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Beenden zum Launcher"
 
@@ -1839,7 +1839,7 @@ msgstr "ist im Gebiet ausgestorben"
 msgid "EXTINCT_SPECIES"
 msgstr "Ausgestorbene Spezies"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1847,7 +1847,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr "Zusätzliche Optionen"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Besuche unsere Facebook Seite"
 
@@ -1879,12 +1879,12 @@ msgstr "Aktiviert"
 msgid "FEBRUARY"
 msgstr "Februar"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Initialisierung der Steam-Client-Bibliothek fehlgeschlagen"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1906,11 +1906,11 @@ msgstr ""
 "Gesamte CPU-Zeit:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2034,7 +2034,7 @@ msgstr "Diese Art fossilisieren (ist bereits fossilisiert)"
 msgid "FOSSILISE"
 msgstr "Versteinern"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2064,7 +2064,7 @@ msgstr "Verfügbare Glukosewolke beim Verlassen des Editors"
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(Starte jede Generation mit einer Gratis-Glukosewolke in der Nähe)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Vollbild"
 
@@ -2092,23 +2092,23 @@ msgstr "Generationen"
 msgid "GENERATION_COLON"
 msgstr "Generation:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr "Besuche unser GitHub Repositorium"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2-Modus-Warnung"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Du betreibst Thrive mit GLES2. Dies ist schwerwiegend ungetestet und wird wahrscheinlich Probleme verursachen. Versuche deine Grafiktreiber zu aktualisieren und/oder die Verwendung von AMD- oder Nvidia-Grafiken zur Ausführung von Thrive zu erzwingen."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr "GLES3"
 
@@ -2161,11 +2161,11 @@ msgstr "Verstanden"
 msgid "GPL_LICENSE_HEADING"
 msgstr "GPL-Lizenztext folgt:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "Grafikkarte:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafik"
 
@@ -2173,7 +2173,7 @@ msgstr "Grafik"
 msgid "GRAPHICS_TEAM"
 msgstr "Grafikteam"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "Benutzeroberfläche"
 
@@ -2190,7 +2190,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} Tsd"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Menülautstärke"
 
@@ -2212,11 +2212,11 @@ msgstr "Hilfe"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Hilfe"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(höhere Werte verbessern die Leistung)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(höhere Werte verschlechtern die Leistung)"
 
@@ -2241,7 +2241,7 @@ msgstr "Halte [thrive:input]g_free_cursor[/thrive:input] für Mauszeiger"
 msgid "HOME"
 msgstr "Pos1"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr "Horizontal:"
 
@@ -2313,7 +2313,7 @@ msgstr "Aufgenommene Materie"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Neue Welt erstellen"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Eingaben"
 
@@ -2367,8 +2367,8 @@ msgstr "Ungültiges URL-Format"
 msgid "INVALID_URL_SCHEME"
 msgstr "Ungültiges URL-Format"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr "Invertiert"
 
@@ -2390,7 +2390,7 @@ msgstr "Eisen"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Eisen-Chemolithoautotrophie"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr "Besuche unsere Itch.io Seite"
 
@@ -2398,19 +2398,19 @@ msgstr "Besuche unsere Itch.io Seite"
 msgid "JANUARY"
 msgstr "Januar"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "JSON Debug-Modus:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Immer"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automatisch"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Niemals"
 
@@ -2592,19 +2592,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Sprache:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Diese Übersetzung ist zu {0}% vollständig"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Diese Übersetzung ist noch in Arbeit ({0}% vollständig)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Diese Übersetzung ist sehr unvollständig ({0}% fertig). Bitte helfe uns dabei!"
 
@@ -2766,7 +2766,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Linke Maus"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Lizenzen"
 
@@ -2834,7 +2834,7 @@ msgstr "Nacht"
 msgid "LIGHT_MAX"
 msgstr "Licht Maximum"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Extrem"
 
@@ -2847,31 +2847,31 @@ msgstr "Beschränke die Nutzung von Wachstums-Substanzen"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(Aktivierung beschränkt die Wachstums-Geschwindigkeit; Deaktivierung lässt nur die verfügbaren Substanzen das Wachstum beeinflussen)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Riesig"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Gross"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Normal"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Klein"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Winzig"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Sehr gross"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Sehr klein"
 
@@ -2895,7 +2895,7 @@ msgstr "Laden"
 msgid "LOADING"
 msgstr "Lädt"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Lädt..."
@@ -2926,12 +2926,12 @@ msgstr "Drücke die Rückgängig-Schaltfläche im Editor, um einen Fehler zu kor
 msgid "LOAD_FINISHED"
 msgstr "Laden beendet"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Spiel laden"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Ein zuvor gespeichertes Spiel laden"
 
@@ -3006,7 +3006,7 @@ msgstr "März"
 msgid "MARINE_SNOW"
 msgstr "Meeresschnee"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Gesamtlautstärke"
 
@@ -3014,15 +3014,15 @@ msgstr "Gesamtlautstärke"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Maximale Anzahl an Arten in einem Bereich vor dem erzwungenen Aussterben"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Maximale FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Maximale FPS"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Maximale Anzahl an Entitäten:"
 
@@ -3195,7 +3195,7 @@ msgstr "Für jede Generation kannst du 100 Mutationspunkte (MP) ausgeben. Jede �
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Jedes Mal, wenn du dich reproduzierst, gelangst du in den Mikroben-Editor, wo du Änderungen an deiner Spezies vornehmen kannst (durch Hinzufügen, Verschieben oder Entfernen von Organellen), um den Erfolg deiner Spezies zu steigern. Jeder Besuch des Editors in der Mikrobenphase repräsentiert [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] Millionen Jahre Evolution."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Mikroben-Sandboxeditor"
 
@@ -3379,7 +3379,7 @@ msgstr "Minimum:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Nicht erlaubt, weniger als {0} Datensatz(e) anzuzeigen!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Sonstiges"
 
@@ -3442,11 +3442,11 @@ msgstr "Organelle modifizieren"
 msgid "MODIFY_TYPE"
 msgstr "Typ modifizieren"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Modifikationen"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Installierte Mods wurden erkannt, aber es sind keine Mods aktiviert.\n"
@@ -3535,11 +3535,11 @@ msgstr "Interner (Ordner-)Name:"
 msgid "MOD_LICENSE"
 msgstr "Mod-Lizenz:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Fehler beim Laden der Mods"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Ein Fehler trat beim Laden einer oder mehreren Modifikationen auf. Das Fehlerprotokoll enthält eventuell weitere informationen."
 
@@ -3592,11 +3592,11 @@ msgstr "Modversion:"
 msgid "MORE_INFO"
 msgstr "Mehr Informationen"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr "Mausempfindlichkeit"
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr "Mausempfindlichkeit mit Fenstergröße skalieren"
 
@@ -3710,7 +3710,7 @@ msgstr "Mehrere Metabälle"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Mehrere Organellen"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Multisample Anti-Aliasing:"
 
@@ -3725,7 +3725,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Musik"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Musiklautstärke"
 
@@ -3745,9 +3745,9 @@ msgstr "(Kosten für Organellen, Membranen und andere Gegenstände im Editor)"
 msgid "MUTATION_POINTS"
 msgstr "Mutationspunkte"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Stumm"
 
@@ -3783,11 +3783,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Startpopulation einer Biodiversität erhöhenden Spezies"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Neues Spiel"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Neues Spiel starten"
 
@@ -3852,7 +3852,7 @@ msgstr "Das Stickstofffixier-Plastid ist ein Protein, das gasförmigen Stickstof
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Wandelt [thrive:compound type=\"atp\"][/thrive:compound] in [thrive:compound type=\"ammonia\"][/thrive:compound] um. Die Rate hängt von der Konzentration von [thrive:compound type=\"nitrogen\"][/thrive:compound] und [thrive:compound type=\"oxygen\"][/thrive:compound] ab."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Nichts"
 
@@ -3899,7 +3899,7 @@ msgstr "Keine Ereignisse aufgezeichnet"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Kein Fossilienverzeichnis gefunden"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr "Keine Mods aktiv"
 
@@ -3916,7 +3916,7 @@ msgstr "keine Speicherstände gefunden"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Kein Speicherverzeichnis gefunden"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Kein Bildschirmfotoverzeichnis gefunden"
 
@@ -3964,15 +3964,15 @@ msgstr "N/V MP"
 msgid "OCTOBER"
 msgstr "Oktober"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr "Offizielle Website"
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Revolutionary Games website besuchen"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4009,7 +4009,7 @@ msgstr "Hilfemenü öffnen"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Im Sandboxmodus öffnen"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Logverzeichnis öffnen"
 
@@ -4025,7 +4025,7 @@ msgstr "Organellenmenü öffnen"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Speicherverzeichnis öffnen"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Bildschirmfotoverzeichnis öffnen"
 
@@ -4033,7 +4033,7 @@ msgstr "Bildschirmfotoverzeichnis öffnen"
 msgid "OPEN_THE_MENU"
 msgstr "Das Menü öffnen"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Hilf das Spiel zu übersetzen"
 
@@ -4052,11 +4052,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunistisch"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Einstellungen"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Einstellungen ändern"
 
@@ -4265,7 +4265,7 @@ msgstr "Prozedural"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr "Besuche unsere Patreon Seite"
 
@@ -4315,7 +4315,7 @@ msgstr "Friedlich"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Leistung"
 
@@ -4404,7 +4404,7 @@ msgstr "Spieler duplizieren"
 msgid "PLAYER_EXTINCT"
 msgstr "Spieler ist ausgestorben"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Spieler ist ausgestorben"
@@ -4419,23 +4419,23 @@ msgstr ""
 "Spieler\n"
 "Tempo"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Intro-Video abspielen"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Mikroben-Intro bei neuem Spiel abspielen"
 
@@ -4554,11 +4554,11 @@ msgstr "Schnellladen"
 msgid "QUICK_SAVE"
 msgstr "Schnellspeichern"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Verlassen"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Spiel beenden"
@@ -4600,7 +4600,7 @@ msgstr "Bereit"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Empfohlenes Thrive:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr "Besuche unseren Subreddit"
 
@@ -4653,7 +4653,7 @@ msgstr "Reproduktion:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Benötigt Nukleus"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Zurücksetzen"
 
@@ -4661,23 +4661,23 @@ msgstr "Zurücksetzen"
 msgid "RESET_DEADZONES"
 msgstr "Totzonen zurücksetzen"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr "Versteckte Pop-ups zurücksetzen"
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Standardeingaben laden?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr "Tastenkombinationen zurücksetzen"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Standardeinstellungen"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Auf Standardeinstellungen zurücksetzen?"
 
@@ -4686,7 +4686,7 @@ msgstr "Auf Standardeinstellungen zurücksetzen?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr "Widersteht einfacher Verschlingung"
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Auflösung:"
 
@@ -4736,7 +4736,7 @@ msgstr ""
 "Bist du sicher, dass du zum Hauptmenü zurückkehren willst?\n"
 "Alle nicht gespeicherten Fortschritte gehen verloren."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Zeige offizielle Revolutionary Games Seiten.."
 
@@ -4768,7 +4768,7 @@ msgstr "Nach links rotieren"
 msgid "ROTATION_COLON"
 msgstr "Drehung:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Auto-Evo während des Spielens ausführen"
 
@@ -4823,7 +4823,7 @@ msgstr "Rusticyanin ist ein Protein, welches in der Lage ist [thrive:compound ty
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Wandelt [thrive:compound type=\"iron\"][/thrive:compound] in [thrive:compound type=\"atp\"][/thrive:compound] um. Rate skaliert mit der Konzentration von [thrive:compound type=\"carbondioxide\"][/thrive:compound] und [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive wurde aufgrund eines Fehlstarts im abgesicherten Modus gestartet.\n"
@@ -4835,15 +4835,15 @@ msgstr ""
 "\n"
 "Wenn das Problem, das den Startfehler verursacht, nicht behoben wird, müssen Sie Thrive mehrmals neu starten und abstürzen lassen, um wieder in den abgesicherten Modus zu gelangen."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive im abgesicherten Modus gestartet"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Speichern"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Speichern und fortfahren"
 
@@ -4943,20 +4943,20 @@ msgstr "Speichern ist aus folgenden Gründen nicht möglich:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Speichern erfolgreich"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr "deaktiviert"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr "skaliert"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr "invers skaliert"
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "um die Mobilität zu erhöhen"
@@ -5054,7 +5054,7 @@ msgstr "Sessil"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Diese Option wird erst nach einem Neustart angewendet"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Effektlautstärke"
 
@@ -5070,21 +5070,25 @@ msgstr "Hilfe anzeigen"
 msgid "SHOW_TUTORIALS"
 msgstr "Einführung anzeigen"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Tutorials anzeigen (im aktuellen Spiel)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Tutorials anzeigen (in neuen Spielen)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Warnung vor ungesichertem Fortschritt anzeigen"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Aktiviert/deaktiviert das Popup-Fenster mit der Warnung vor ungespeichertem Fortschritt, wenn der Spieler versucht, das Spiel zu beenden."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5132,7 +5136,7 @@ msgstr "Siliciumdioxid"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Diese Membran hat eine starke Wand aus Siliciumdioxid. Sie widersteht gut gegen allgemeine Beschädigungen und ist sehr widerstandsfähig gegen physische Schäden. Sie benötigt auch weniger Energie, um ihre Form zu erhalten. Allerdings verlangsamt sie die Zelle um einen großen Faktor und die Zelle absorbiert Ressourcen mit einer reduzierten Geschwindigkeit."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5172,7 +5176,7 @@ msgstr "Wandelt [thrive:compound type=\"glucose\"][/thrive:compound] in [thrive:
 msgid "SMALL_IRON_CHUNK"
 msgstr "Kleiner Eisenbrocken"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Sound"
 
@@ -5375,18 +5379,18 @@ msgstr "Steam ist momentan nicht erreichbar, bitte versuche es erneut"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Unbekannter Steam-Fehler ist aufgetreten"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Initialisierung der Steam-Client-Bibliothek fehlgeschlagen"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Initialisierung der Steam-Client-Bibliothek fehlgeschlagen. Steam-Funktionen sind nicht verfügbar.\n"
 "Bitte stellen Sie sicher, dass Steam läuft und Sie mit dem richtigen Account angemeldet sind. Bitte starten Sie das Spiel mittels der Steam-Client-Software, wenn dieser Fehler nicht anders verschwindet."
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr "Unsere Steam Seite besuchen"
 
@@ -5426,7 +5430,7 @@ msgstr "Speicher"
 msgid "STORAGE_COLON"
 msgstr "Speicherplatz:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Angemeldet als: {0}"
 
@@ -5543,7 +5547,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Test Team"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Vielen Dank, dass du die Entwicklung von Thrive durch deinen Kauf dieser Steam-Version unterstützt.\n"
@@ -5559,7 +5563,7 @@ msgstr ""
 "\n"
 "Falls du das Spiel genossen hast, erzähle bitte deinen Freunden von uns."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr "Vielen Dank"
 
@@ -5614,11 +5618,11 @@ msgstr "Dies ist ein lokal installierter Mod"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Dieser Mod wurde vom Steam-Workshop heruntergeladen"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Threads:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thriveopedia"
 
@@ -5774,7 +5778,7 @@ msgstr "Pausieren/Fortsetzen"
 msgid "TOGGLE_UNBINDING"
 msgstr "Verbinden umschalten"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Werkzeuge"
 
@@ -5838,7 +5842,7 @@ msgstr "Versuche ein paar Fossilien zu machen!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Versuche das Spiel zu speichern!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Versuche ein paar Screenshots zu machen!"
 
@@ -6003,11 +6007,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Tutorial ansehen"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr "Besuche unseren Twitter Feed"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6032,7 +6036,7 @@ msgstr "Alle Verbindungen lösen"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Entbindungsmodus"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr "Dies ist eine Debug-Version und die Info unten ist vermutlich nicht aktuell"
 
@@ -6052,7 +6056,7 @@ msgstr "Letzte Aktion rückgängig machen"
 msgid "UNKNOWN"
 msgstr "Unbekannt"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Unbekannt"
 
@@ -6064,7 +6068,7 @@ msgstr "Unbekannte Maus"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Für Windows unbekannt"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "Unbekannte Version"
 
@@ -6072,7 +6076,7 @@ msgstr "Unbekannte Version"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Unbekannte Workshop-ID für diesen Mod"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Es wurden ungespeicherte Änderungen vorgenommen.\n"
@@ -6116,7 +6120,7 @@ msgstr "Hochladen erfolgreich"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Lizenzen und verwendete Bibliotheken"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "Verwendeter Renderer:"
 
@@ -6132,7 +6136,7 @@ msgstr "Nutze Auto Harmony Laden"
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Harmony Updates automatisch vom Assembler laden (Mod class muss nicht spezifiziert werden)"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Eigenen Nutzernamen verwenden"
 
@@ -6140,11 +6144,11 @@ msgstr "Eigenen Nutzernamen verwenden"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "Schaffung einer Spezies, die die Artenvielfalt erhöht entzieht, der bestehenden Art Population"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Anzahl der Hintergrund-Threads manuell einstellen"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr "Verwende virtuelle Fenstergröße"
 
@@ -6170,7 +6174,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Version:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr "Vertikal:"
 
@@ -6179,11 +6183,11 @@ msgstr "Vertikal:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "vertikal (Axis: {0})"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "Derzeit belegter Grafikspeicher:"
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0} MiB"
 
@@ -6191,7 +6195,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Beobachter"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Quellcode anschauen"
 
@@ -6203,7 +6207,7 @@ msgstr "VIP Unterstützer"
 msgid "VISIBLE"
 msgstr "Sichtbar"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Schlage eine Funktion vor"
 
@@ -6223,7 +6227,7 @@ msgstr "Lautstärke stumm"
 msgid "VOLUMEUP"
 msgstr "Lautstärke hoch"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSync"
 
@@ -6330,7 +6334,7 @@ msgstr ""
 "Prototypen späterer Phasen miteinbeziehen: {0}\n"
 "Easter eggs miteinbeziehen: {1}"
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "um die Mobilität zu erhöhen"
@@ -6339,15 +6343,15 @@ msgstr "um die Mobilität zu erhöhen"
 msgid "WORST_PATCH_COLON"
 msgstr "Schlechtestes Gebiet:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6359,7 +6363,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "Jahre"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Besuche unseren YouTube Kanal"
 

--- a/locale/de.po
+++ b/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2023-01-30 07:23+0000\n"
 "Last-Translator: Alice König <alice.purple-rose@outlook.com>\n"
 "Language-Team: German <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/de/>\n"
@@ -215,7 +215,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Grafiken von {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Kunstgalerie"
 
@@ -313,7 +313,7 @@ msgstr "Automatisches speichern während des Spieles"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Auto-Evo Exploration"
 
@@ -356,8 +356,8 @@ msgid "AWAKEN"
 msgstr "Erwachen"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -612,27 +612,27 @@ msgstr "Feststelltaste"
 msgid "CARBON_DIOXIDE"
 msgstr "Kohlendioxid"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "eine Fülle"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "ein gutes Stück"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "wenig"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "ziemlich viel"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "etwas"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "sehr wenig"
 
@@ -900,19 +900,19 @@ msgstr "Sättigungswert, der Anteil an Grau in einer bestimmten Farbe"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Hellwert, Helligkeit oder Intensität der Farbe"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr "Community-Forum"
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Tritt der Thrive Gemeinschaft über unser Forum bei"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr "Gemeinschafts-Wiki"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Besuche unser Gemeinschafts-Wiki"
 
@@ -1113,7 +1113,7 @@ msgstr "Erstelle..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Objekte aus Speicherstand erstellen"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Abspann"
 
@@ -1280,11 +1280,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Entwickler(innen)"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr "Entwickler Forum"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Sieh Dir Entwicklerupdates in unserem Entwicklerforum an"
 
@@ -1292,11 +1292,11 @@ msgstr "Sieh Dir Entwicklerupdates in unserem Entwicklerforum an"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Entwicklung unterstützt von Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr "Entwickler-Wiki"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Besuche unser Entwickler-Wiki"
 
@@ -1424,7 +1424,7 @@ msgstr ""
 "Es gibt Organellen, die nicht mit dem Rest verbunden sind.\n"
 "Bitte verbinde alle platzierten Organellen miteinander oder mach deine Änderungen rückgängig."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr "Tritt unserem Discord Server bei"
 
@@ -1438,7 +1438,7 @@ msgstr ""
 "Dies zeigt an, wie viele Popups vom Spieler dauerhaft ausgeblendet wurden.\n"
 "Wenn einige davon wieder sichtbar werden sollen, können mit der Schaltfläche neben dieser alle ausgeblendeten Popups wieder angezeigt werden."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr "Dies' nicht wieder anzeigen"
 
@@ -1485,7 +1485,7 @@ msgstr "Doppelklicken zum Betrachten"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Als zweischichtige Membran bietet sie besseren Schutz vor Beschädigungen und benötigt weniger Energie, um sich nicht zu verformen. Allerdings verlangsamt sie die Zelle etwas und senkt die Geschwindigkeit, mit der sie Ressourcen absorbieren kann."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Diese Warnung nicht mehr anzeigen"
 
@@ -1666,15 +1666,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Energie in {0} für {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Energiequellen:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "Die gesammelte Gesamtenergie beträgt {0} mit individuellen Kosten von {1}, was zu einer unbereinigten Bevölkerung von {2} führt"
 
@@ -1727,6 +1727,16 @@ msgstr "Fehler beim Erstellen der Modinformationsdatei"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Fehler: Das Speichern neuer Einstellungen in der Konfigurationsdatei ist fehlgeschlagen."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(zufällig generierte Geheimnisse im Spielverlauf)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Fehler beim Erstellen der Modinformationsdatei"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Fehler beim Laden"
@@ -1778,7 +1788,7 @@ msgstr "Beim Laden der Speicherdaten ist ein Fehler aufgetreten"
 msgid "EXIT"
 msgstr "Verlassen"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Beenden zum Launcher"
 
@@ -1829,7 +1839,7 @@ msgstr "ist im Gebiet ausgestorben"
 msgid "EXTINCT_SPECIES"
 msgstr "Ausgestorbene Spezies"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1837,7 +1847,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr "Zusätzliche Optionen"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Besuche unsere Facebook Seite"
 
@@ -1868,6 +1878,41 @@ msgstr "Aktiviert"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Februar"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Initialisierung der Steam-Client-Bibliothek fehlgeschlagen"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Zeit des Prozesses: {0} s\n"
+"Zeit des Physikprozesses: {1} s\n"
+"Entitäten: {2} Andere: {3}\n"
+"Erzeugt: {4} Entfernt: {5}\n"
+"Benutzte Knoten: {6}\n"
+"Benutzter Speicher: {7}\n"
+"Grafikspeicher: {8}\n"
+"Erzeugte Objekte: {9}\n"
+"Zeichnungsaufrufe: {10} 2D: {11}\n"
+"Erzeugte Eckpunkte: {12}\n"
+"Materialänderungen: {13}\n"
+"Shader-Änderungen: {14}\n"
+"Verwaiste Knoten: {15}\n"
+"Audio-Latenz: {16} ms\n"
+"Gesamtanzahl Threads: {17}\n"
+"Gesamte CPU-Zeit:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1951,7 +1996,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Nahrungskette"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0}Energie:{1}(Fitness:{2})insgesamt verfügbare Energie:{3} (gesamte Fitness:{4})"
 
@@ -2047,7 +2092,7 @@ msgstr "Generationen"
 msgid "GENERATION_COLON"
 msgstr "Generation:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr "Besuche unser GitHub Repositorium"
 
@@ -2055,11 +2100,11 @@ msgstr "Besuche unser GitHub Repositorium"
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2-Modus-Warnung"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Du betreibst Thrive mit GLES2. Dies ist schwerwiegend ungetestet und wird wahrscheinlich Probleme verursachen. Versuche deine Grafiktreiber zu aktualisieren und/oder die Verwendung von AMD- oder Nvidia-Grafiken zur Ausführung von Thrive zu erzwingen."
 
@@ -2345,7 +2390,7 @@ msgstr "Eisen"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Eisen-Chemolithoautotrophie"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr "Besuche unsere Itch.io Seite"
 
@@ -2563,7 +2608,7 @@ msgstr "Diese Übersetzung ist noch in Arbeit ({0}% vollständig)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Diese Übersetzung ist sehr unvollständig ({0}% fertig). Bitte helfe uns dabei!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "Letztes Organell kann nicht gelöscht werden"
 
@@ -2721,7 +2766,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Linke Maus"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Lizenzen"
 
@@ -2850,7 +2895,8 @@ msgstr "Laden"
 msgid "LOADING"
 msgstr "Lädt"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Lädt..."
 
@@ -2880,12 +2926,12 @@ msgstr "Drücke die Rückgängig-Schaltfläche im Editor, um einen Fehler zu kor
 msgid "LOAD_FINISHED"
 msgstr "Laden beendet"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Spiel laden"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Ein zuvor gespeichertes Spiel laden"
 
@@ -3149,7 +3195,7 @@ msgstr "Für jede Generation kannst du 100 Mutationspunkte (MP) ausgeben. Jede �
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Jedes Mal, wenn du dich reproduzierst, gelangst du in den Mikroben-Editor, wo du Änderungen an deiner Spezies vornehmen kannst (durch Hinzufügen, Verschieben oder Entfernen von Organellen), um den Erfolg deiner Spezies zu steigern. Jeder Besuch des Editors in der Mikrobenphase repräsentiert [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] Millionen Jahre Evolution."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Mikroben-Sandboxeditor"
 
@@ -3396,11 +3442,11 @@ msgstr "Organelle modifizieren"
 msgid "MODIFY_TYPE"
 msgstr "Typ modifizieren"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Modifikationen"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Installierte Mods wurden erkannt, aber es sind keine Mods aktiviert.\n"
@@ -3489,11 +3535,11 @@ msgstr "Interner (Ordner-)Name:"
 msgid "MOD_LICENSE"
 msgstr "Mod-Lizenz:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Fehler beim Laden der Mods"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Ein Fehler trat beim Laden einer oder mehreren Modifikationen auf. Das Fehlerprotokoll enthält eventuell weitere informationen."
 
@@ -3729,15 +3775,19 @@ msgstr ""
 "Dieser Speicherstand stammt aus einer neueren Version von Thrive und ist sehr wahrscheinlich inkompatibel.\n"
 "Möchtest du trotzdem versuchen, den Spielstand zu laden?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Startpopulation einer Biodiversität erhöhenden Spezies"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Neues Spiel"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Neues Spiel starten"
 
@@ -3837,7 +3887,7 @@ msgid "NO_AI"
 msgstr "Keine KI"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Keine Daten zu zeigen"
 
@@ -3849,7 +3899,7 @@ msgstr "Keine Ereignisse aufgezeichnet"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Kein Fossilienverzeichnis gefunden"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr "Keine Mods aktiv"
 
@@ -3879,7 +3929,7 @@ msgstr "Kein Mod ausgewählt"
 msgid "NUCLEUS"
 msgstr "Nukleus"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 "Der Zellkern kann nicht gelöscht werden, da es sich um eine irreversible Evolution handelt.\n"
@@ -3900,8 +3950,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/V"
@@ -3914,15 +3964,15 @@ msgstr "N/V MP"
 msgid "OCTOBER"
 msgstr "Oktober"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr "Offizielle Website"
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Revolutionary Games website besuchen"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4002,11 +4052,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunistisch"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Einstellungen"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Einstellungen ändern"
 
@@ -4215,7 +4265,7 @@ msgstr "Prozedural"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr "Besuche unsere Patreon Seite"
 
@@ -4273,8 +4323,8 @@ msgstr "Leistung"
 msgid "PERFORM_UNBINDING"
 msgstr "Entbinden durchführen"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/Sekunde"
 
@@ -4330,7 +4380,7 @@ msgstr "Planetenerstellung kommt bald!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Planetensamen Nummer (Zufallswert):"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Spielerzelle"
 
@@ -4406,7 +4456,7 @@ msgstr "Gesamtbevölkerung:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "Bevölkerung in Gebieten:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4460,7 +4510,7 @@ msgstr "vorherige:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Verarbeitung geladener Objekte"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4504,11 +4554,11 @@ msgstr "Schnellladen"
 msgid "QUICK_SAVE"
 msgstr "Schnellspeichern"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Verlassen"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Spiel beenden"
@@ -4550,7 +4600,7 @@ msgstr "Bereit"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Empfohlenes Thrive:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr "Besuche unseren Subreddit"
 
@@ -4686,7 +4736,7 @@ msgstr ""
 "Bist du sicher, dass du zum Hauptmenü zurückkehren willst?\n"
 "Alle nicht gespeicherten Fortschritte gehen verloren."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Zeige offizielle Revolutionary Games Seiten.."
 
@@ -4773,7 +4823,7 @@ msgstr "Rusticyanin ist ein Protein, welches in der Lage ist [thrive:compound ty
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Wandelt [thrive:compound type=\"iron\"][/thrive:compound] in [thrive:compound type=\"atp\"][/thrive:compound] um. Rate skaliert mit der Konzentration von [thrive:compound type=\"carbondioxide\"][/thrive:compound] und [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive wurde aufgrund eines Fehlstarts im abgesicherten Modus gestartet.\n"
@@ -4785,7 +4835,7 @@ msgstr ""
 "\n"
 "Wenn das Problem, das den Startfehler verursacht, nicht behoben wird, müssen Sie Thrive mehrmals neu starten und abstürzen lassen, um wieder in den abgesicherten Modus zu gelangen."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive im abgesicherten Modus gestartet"
 
@@ -5150,7 +5200,7 @@ msgstr "Ammoniak erzeugen"
 msgid "SPAWN_ENEMY"
 msgstr "Gegner spawnen"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Der Cheat Code zum Spawnen von Gegnern kann in diesem Gebiet nicht genutzt werden, da hier keine feindlichen Spezies leben"
 
@@ -5210,7 +5260,7 @@ msgstr "Speziesname..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Artenname ist zu lang!"
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5325,18 +5375,18 @@ msgstr "Steam ist momentan nicht erreichbar, bitte versuche es erneut"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Unbekannter Steam-Fehler ist aufgetreten"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Initialisierung der Steam-Client-Bibliothek fehlgeschlagen"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Initialisierung der Steam-Client-Bibliothek fehlgeschlagen. Steam-Funktionen sind nicht verfügbar.\n"
 "Bitte stellen Sie sicher, dass Steam läuft und Sie mit dem richtigen Account angemeldet sind. Bitte starten Sie das Spiel mittels der Steam-Client-Software, wenn dieser Fehler nicht anders verschwindet."
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr "Unsere Steam Seite besuchen"
 
@@ -5376,7 +5426,7 @@ msgstr "Speicher"
 msgid "STORAGE_COLON"
 msgstr "Speicherplatz:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Angemeldet als: {0}"
 
@@ -5493,7 +5543,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Test Team"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Vielen Dank, dass du die Entwicklung von Thrive durch deinen Kauf dieser Steam-Version unterstützt.\n"
@@ -5509,7 +5559,7 @@ msgstr ""
 "\n"
 "Falls du das Spiel genossen hast, erzähle bitte deinen Freunden von uns."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr "Vielen Dank"
 
@@ -5568,7 +5618,7 @@ msgstr "Dieser Mod wurde vom Steam-Workshop heruntergeladen"
 msgid "THREADS"
 msgstr "Threads:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thriveopedia"
 
@@ -5724,7 +5774,7 @@ msgstr "Pausieren/Fortsetzen"
 msgid "TOGGLE_UNBINDING"
 msgstr "Verbinden umschalten"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Werkzeuge"
 
@@ -5953,7 +6003,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Tutorial ansehen"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr "Besuche unseren Twitter Feed"
 
@@ -6141,7 +6191,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Beobachter"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Quellcode anschauen"
 
@@ -6153,7 +6203,7 @@ msgstr "VIP Unterstützer"
 msgid "VISIBLE"
 msgstr "Sichtbar"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Schlage eine Funktion vor"
 
@@ -6309,7 +6359,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "Jahre"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Besuche unseren YouTube Kanal"
 

--- a/locale/el.po
+++ b/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-03-31 05:02+0000\n"
 "Last-Translator: Apostolos Paschidis <tolissius@gmail.com>\n"
 "Language-Team: Greek <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/el/>\n"
@@ -198,7 +198,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -334,8 +334,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -590,27 +590,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -869,19 +869,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1075,7 +1075,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1234,11 +1234,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1246,11 +1246,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1596,15 +1596,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1657,6 +1657,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1705,7 +1713,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1755,7 +1763,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1763,7 +1771,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1789,6 +1797,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1870,7 +1894,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1966,7 +1990,7 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1974,11 +1998,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2254,7 +2278,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2470,7 +2494,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2628,7 +2652,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2756,7 +2780,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2786,12 +2811,12 @@ msgstr "Πατήστε το πλήκτρο αναίρεσης στον επεξ�
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2995,7 +3020,7 @@ msgstr "Σε κάθε γενεά, έχετε 100 πόντους μετάλλαξ
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Κάθε φορά που αναπαράγεσθε, εισέρχεσθε στον Επεξεργαστή Μικροβίων, όπου μπορείτε να πραγματοποιήσετε αλλαγές στο είδος σας (προσθέτοντας, μετακινώντας ή αφαιρώντας οργανίδια) για να αυξήσετε την επιτυχία τού είδους σας. Κάθε επίσκεψη στον επεξεργαστή κατά το Στάδιο Μικροβίων αντιστοιχεί σε [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant]εκατομμύρια έτη εξέλιξης."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3206,11 +3231,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3296,11 +3321,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3524,15 +3549,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3632,7 +3661,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3644,7 +3673,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3674,7 +3703,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3693,8 +3722,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3707,15 +3736,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3786,11 +3815,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3995,7 +4024,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4053,8 +4082,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4104,7 +4133,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4177,7 +4206,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4231,7 +4260,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4275,11 +4304,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4319,7 +4348,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4453,7 +4482,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4539,11 +4568,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4899,7 +4928,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4949,7 +4978,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5064,15 +5093,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5112,7 +5141,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5227,7 +5256,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5235,7 +5264,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5294,7 +5323,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5441,7 +5470,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5584,7 +5613,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5768,7 +5797,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5780,7 +5809,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5933,7 +5962,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/el.po
+++ b/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-03-31 05:02+0000\n"
 "Last-Translator: Apostolos Paschidis <tolissius@gmail.com>\n"
 "Language-Team: Greek <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/el/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.11.2\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr "Σε κάθε γενεά, έχετε 100 πόντους μετάλλαξ
 msgid "3D_MOVEMENT"
 msgstr "Κίνηση"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -64,7 +64,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -138,7 +138,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -149,11 +149,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -178,11 +178,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -198,7 +198,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -210,7 +210,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -258,8 +258,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -284,7 +284,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -321,7 +321,7 @@ msgstr ""
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -334,9 +334,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -472,7 +472,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -534,7 +534,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -662,7 +662,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -793,15 +793,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -817,7 +817,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -869,23 +869,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -990,7 +990,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1003,11 +1003,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1015,11 +1015,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1075,7 +1075,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1222,7 +1222,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1234,11 +1234,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1246,11 +1246,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1330,7 +1330,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1362,31 +1362,31 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1568,7 +1568,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1641,7 +1641,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1653,15 +1653,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1693,11 +1693,11 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1713,7 +1713,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1763,7 +1763,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1771,7 +1771,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1799,19 +1799,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1932,7 +1932,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1962,7 +1962,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -1990,23 +1990,23 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2059,11 +2059,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2071,7 +2071,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2105,11 +2105,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2133,7 +2133,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr ""
 
@@ -2205,7 +2205,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2258,8 +2258,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2278,7 +2278,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2286,19 +2286,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2478,19 +2478,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2652,7 +2652,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2720,7 +2720,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2732,31 +2732,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2780,7 +2780,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2811,12 +2811,12 @@ msgstr "Πατήστε το πλήκτρο αναίρεσης στον επεξ�
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2882,7 +2882,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2890,15 +2890,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3020,7 +3020,7 @@ msgstr "Σε κάθε γενεά, έχετε 100 πόντους μετάλλαξ
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Κάθε φορά που αναπαράγεσθε, εισέρχεσθε στον Επεξεργαστή Μικροβίων, όπου μπορείτε να πραγματοποιήσετε αλλαγές στο είδος σας (προσθέτοντας, μετακινώντας ή αφαιρώντας οργανίδια) για να αυξήσετε την επιτυχία τού είδους σας. Κάθε επίσκεψη στον επεξεργαστή κατά το Στάδιο Μικροβίων αντιστοιχεί σε [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant]εκατομμύρια έτη εξέλιξης."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3168,7 +3168,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3231,11 +3231,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3321,11 +3321,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3378,11 +3378,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3491,7 +3491,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3503,7 +3503,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3523,9 +3523,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3557,11 +3557,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3626,7 +3626,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3673,7 +3673,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3736,15 +3736,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3775,7 +3775,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3791,7 +3791,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3799,7 +3799,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3815,11 +3815,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4024,7 +4024,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4074,7 +4074,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4157,7 +4157,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4169,23 +4169,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4304,11 +4304,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4348,7 +4348,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4409,23 +4409,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4434,7 +4434,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4482,7 +4482,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4514,7 +4514,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4568,19 +4568,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4672,20 +4672,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4782,7 +4782,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4798,20 +4798,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4860,7 +4864,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4900,7 +4904,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5093,15 +5097,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5141,7 +5145,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5256,7 +5260,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5264,7 +5268,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5319,11 +5323,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5470,7 +5474,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5532,7 +5536,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5613,11 +5617,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5642,7 +5646,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5674,7 +5678,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5682,7 +5686,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5722,7 +5726,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5738,7 +5742,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5746,11 +5750,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5776,7 +5780,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr ""
 
@@ -5785,11 +5789,11 @@ msgstr ""
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5797,7 +5801,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5829,7 +5833,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5942,15 +5946,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -5962,7 +5966,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/en.po
+++ b/locale/en.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
-"PO-Revision-Date: 2023-01-31 14:39+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"PO-Revision-Date: 2023-02-02 12:20+0200\n"
 "Last-Translator: Sur3 <sur3@gmx.de>\n"
 "Language-Team: English <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/en/>\n"
 "Language: en\n"
@@ -215,7 +215,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Art by {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Art Gallery"
 
@@ -313,7 +313,7 @@ msgstr "Autosave during the game"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Auto-Evo Exploring Tool"
 
@@ -355,8 +355,8 @@ msgid "AWAKEN"
 msgstr "Awaken"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -611,27 +611,27 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Carbon Dioxide"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "an abundance"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "a fair amount"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "little"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "quite a bit"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "some"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "very little"
 
@@ -899,19 +899,19 @@ msgstr "Saturation value, the amount of gray in a particular colour"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Value (brightness) value, brightness or intensity of the colour"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr "Community Forum"
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Join the Thrive community on our community forum"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr "Community Wiki"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Visit our community wiki"
 
@@ -1113,7 +1113,7 @@ msgstr "Creating..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Creating objects from save"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Credits"
 
@@ -1298,11 +1298,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Developers"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr "Development Forum"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "View development updates on our development forum"
 
@@ -1310,11 +1310,11 @@ msgstr "View development updates on our development forum"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Development Supported By Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr "Development Wiki"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Visit our developer wiki"
 
@@ -1442,7 +1442,7 @@ msgstr ""
 "There are placed organelles, which are not connected to the rest.\n"
 "Please connect all placed organelles with each other or undo your changes."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr "Join our community Discord server"
 
@@ -1456,7 +1456,7 @@ msgstr ""
 "This shows how many popups have been permanently dismissed by the user.\n"
 "If some popups that are actually wanted are dismissed, the button next to this can be used to make all dismissed popups appear again."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr "Don't show this again"
 
@@ -1503,7 +1503,7 @@ msgstr "Double click to view in fullscreen"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "A membrane with two layers, it has better protection against damage and takes less energy to not deform. However, it slows the cell down some and lowers the rate at which it can absorb resources."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Do not warn about this again"
 
@@ -1684,15 +1684,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Energy in {0} for {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Energy Sources:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "Total energy gathered is {0} with individual cost of {1} resulting in unadjusted population of {2}"
 
@@ -1745,6 +1745,14 @@ msgstr "Error creating mod info file"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Error: Failed to save new settings to configuration file."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "Fetching news has failed due to error: {0}"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Error Fetching News"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Error Loading"
@@ -1796,7 +1804,7 @@ msgstr "An exception happened while loading the save data"
 msgid "EXIT"
 msgstr "Exit"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Exit to Launcher"
 
@@ -1846,7 +1854,7 @@ msgstr "extinct in patch"
 msgid "EXTINCT_SPECIES"
 msgstr "Extinct Species"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1854,7 +1862,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr "Extra Options"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Visit our Facebook page"
 
@@ -1885,6 +1893,22 @@ msgstr "Enabled"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "February"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Parsing the content of this feed item has failed."
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr "This feed item is missing its content."
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr "Published at {0}"
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr "This item was truncated due to being too long, please read the original for all content. {0}"
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1968,7 +1992,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Food Chain"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0} energy: {1} (fitness: {2}) total available energy: {3} (total fitness: {4})"
 
@@ -2064,7 +2088,7 @@ msgstr "Generations"
 msgid "GENERATION_COLON"
 msgstr "Generation:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr "Visit our GitHub repository"
 
@@ -2072,11 +2096,11 @@ msgstr "Visit our GitHub repository"
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 Mode Warning"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "You are running Thrive with GLES2. This is severely untested and is likely to cause issues. Try to update your video drivers and/or force AMD or Nvidia graphics to be used to run Thrive."
 
@@ -2360,7 +2384,7 @@ msgstr "Iron"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Iron Chemolithoautotrophy"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr "Visit our Itch.io page"
 
@@ -2578,7 +2602,7 @@ msgstr "This language is still a work in progress ({0}% complete)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "This translation is very incomplete ({0}% done) please help us with it!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "Can't delete the last organelle"
 
@@ -2736,7 +2760,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Left mouse"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licenses"
 
@@ -2864,7 +2888,8 @@ msgstr "Load"
 msgid "LOADING"
 msgstr "Loading"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Loading..."
 
@@ -2894,12 +2919,12 @@ msgstr "Press the undo button in the editor to correct a mistake"
 msgid "LOAD_FINISHED"
 msgstr "Load finished"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Load Game"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Load previously saved games"
 
@@ -3176,7 +3201,7 @@ msgstr "Each generation, you have 100 mutation points (MP) to spend, and each ch
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Every time you reproduce, you will enter the Microbe Editor, where you can make changes to your species (by adding, moving, or removing organelles) to increase your species' success. Each visit to the editor in the Microbe Stage represents [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] million years of evolution."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Microbe Freebuild Editor"
 
@@ -3423,11 +3448,11 @@ msgstr "Modify Organelle"
 msgid "MODIFY_TYPE"
 msgstr "Modify Type"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Installed mods have been detected, but there are no enabled mods.\n"
@@ -3516,11 +3541,11 @@ msgstr "Internal (Folder) Name:"
 msgid "MOD_LICENSE"
 msgstr "Mod License:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Mod Loading Errors"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Errors occurred when loading one or more mods. Logs may contain additional information."
 
@@ -3756,15 +3781,19 @@ msgstr ""
 "This save is from a newer version of Thrive and very likely incompatible.\n"
 "Do you want to try loading the save anyway?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr "NEWS"
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Initial population for biodiversity-increasing species"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "New Game"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Start a new game"
 
@@ -3864,7 +3893,7 @@ msgid "NO_AI"
 msgstr "No AI"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "No Data to Show"
 
@@ -3876,7 +3905,7 @@ msgstr "No events recorded"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "No fossils directory found"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr "No Mods Enabled"
 
@@ -3906,7 +3935,7 @@ msgstr "No Selected Mod"
 msgid "NUCLEUS"
 msgstr "Nucleus"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 "Can't delete the nucleus as this is an irreversible evolution.\n"
@@ -3927,8 +3956,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -3941,15 +3970,15 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr "October"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr "Official Website"
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Visit the official Revolutionary Games website"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4029,11 +4058,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunistic"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Options"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Change your settings"
 
@@ -4242,7 +4271,7 @@ msgstr "Procedural"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr "Visit our Patreon page"
 
@@ -4300,8 +4329,8 @@ msgstr "Performance"
 msgid "PERFORM_UNBINDING"
 msgstr "Perform unbinding"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/second"
 
@@ -4357,7 +4386,7 @@ msgstr "Planet generation coming soon!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Planet random seed"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Player Cell"
 
@@ -4432,7 +4461,7 @@ msgstr "population:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "population in patches:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4486,7 +4515,7 @@ msgstr "previous:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Processing loaded objects"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4530,11 +4559,11 @@ msgstr "Quick load"
 msgid "QUICK_SAVE"
 msgstr "Quick save"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Quit"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Exit the game"
@@ -4576,7 +4605,7 @@ msgstr "Ready"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Recommended Thrive:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr "Visit our subreddit"
 
@@ -4712,7 +4741,7 @@ msgstr ""
 "Are you sure you want to exit to the main menu?\n"
 "You will lose any unsaved progress."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Visit official Revolutionary Games sites"
 
@@ -4798,7 +4827,7 @@ msgstr "Rusticyanin is a protein able to use [thrive:compound type=\"carbondioxi
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Turns [thrive:compound type=\"iron\"][/thrive:compound] into [thrive:compound type=\"atp\"][/thrive:compound]. Rate scales with concentration of [thrive:compound type=\"carbondioxide\"][/thrive:compound] and [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive has started in safe mode due to a previous start failure.\n"
@@ -4810,7 +4839,7 @@ msgstr ""
 "\n"
 "If you don't fix the issue causing the start failure you will need to restart and crash Thrive multiple times to get back to safe mode."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive Started In Safe Mode"
 
@@ -5172,7 +5201,7 @@ msgstr "Spawn ammonia"
 msgid "SPAWN_ENEMY"
 msgstr "Spawn Enemy"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Can't use spawn enemy cheat because this patch does not contain any enemy species"
 
@@ -5232,7 +5261,7 @@ msgstr "Species name..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Species name is too long!"
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5347,17 +5376,17 @@ msgstr "Steam is unavailable currently, please retry"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Unknown Steam error happened"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr "Steam Initialization Failed"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Steam client library initialization has failed. Steam features will be unavailable.\n"
 "Please make sure you have Steam running and are logged in with the right account. Please run the game through the Steam client software if this error does not go away otherwise."
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr "Visit our Steam page"
 
@@ -5397,7 +5426,7 @@ msgstr "Storage"
 msgid "STORAGE_COLON"
 msgstr "Storage:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Logged in as: {0}"
 
@@ -5512,7 +5541,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Testing Team"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Thank you for supporting Thrive development by purchasing this copy of Thrive!\n"
@@ -5528,7 +5557,7 @@ msgstr ""
 "\n"
 "If you enjoyed the game, please tell your friends about us."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr "Thank You"
 
@@ -5587,7 +5616,7 @@ msgstr "This mod is downloaded from the Steam Workshop"
 msgid "THREADS"
 msgstr "Threads:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thriveopedia"
 
@@ -5743,7 +5772,7 @@ msgstr "Pause"
 msgid "TOGGLE_UNBINDING"
 msgstr "Toggle unbinding"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Tools"
 
@@ -5969,7 +5998,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "View Now"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr "Visit our Twitter feed"
 
@@ -6155,7 +6184,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Viewer"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "View Source Code"
 
@@ -6167,7 +6196,7 @@ msgstr "VIP Supporters"
 msgid "VISIBLE"
 msgstr "Visible"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Suggest a Feature"
 
@@ -6322,7 +6351,7 @@ msgstr "Xbox Series X"
 msgid "YEARS"
 msgstr "years"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Visit our YouTube channel"
 

--- a/locale/en.po
+++ b/locale/en.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
-"PO-Revision-Date: 2023-02-02 12:20+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
+"PO-Revision-Date: 2023-02-02 15:23+0200\n"
 "Last-Translator: Sur3 <sur3@gmx.de>\n"
 "Language-Team: English <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/en/>\n"
 "Language: en\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Poedit 3.2.2\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr "2D movement style:"
 
@@ -31,7 +31,7 @@ msgstr "3D Editor"
 msgid "3D_MOVEMENT"
 msgstr "3D Movement"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr "3D movement style:"
 
@@ -62,7 +62,7 @@ msgstr "Action blocked while another is in progress"
 msgid "ACTIVE"
 msgstr "Active"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Current threads:"
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Ambiance volume"
 
@@ -166,11 +166,11 @@ msgstr "Ambiance volume"
 msgid "AMMONIA"
 msgstr "Ammonia"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Amount of autosaves to keep:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Amount of quicksaves to keep:"
 
@@ -195,11 +195,11 @@ msgstr "Apply Changes"
 msgid "APRIL"
 msgstr "April"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Are you sure you want to reset ALL settings to default values?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Are you sure you want to reset the input settings to default values?"
 
@@ -215,7 +215,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Art by {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Art Gallery"
 
@@ -227,7 +227,7 @@ msgstr "Mod assembly class is required when assembly is specified"
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "Mod assembly is required when auto harmony is enabled"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Assume CPU has hyperthreading enabled"
 
@@ -269,7 +269,7 @@ msgstr "The attempt to write this save file has failed. The save name may be too
 msgid "AT_CURSOR"
 msgstr "At Cursor:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Audio output device:"
 
@@ -277,8 +277,8 @@ msgstr "Audio output device:"
 msgid "AUGUST"
 msgstr "August"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Auto"
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% done. {1:n0}/{2:n0} steps."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Autosave during the game"
 
@@ -313,7 +313,7 @@ msgstr "Autosave during the game"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Auto-Evo Exploring Tool"
 
@@ -342,7 +342,7 @@ msgstr "Auto-Evo Status:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Auto move forwards"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Auto ({0}x{1})"
 
@@ -355,9 +355,9 @@ msgid "AWAKEN"
 msgstr "Awaken"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -493,7 +493,7 @@ msgstr "Allows binding with other cells. This is the first step towards multicel
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Press [thrive:input]g_toggle_binding[/thrive:input] to toggle binding mode. When in binding mode you can attach other cells of your species to your colony by moving into them. To leave a colony press [thrive:input]g_unbind_all[/thrive:input]. You cannot enter the editor while bound to other cells."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr "Bind axes together"
 
@@ -555,7 +555,7 @@ msgstr "This membrane has a strong shell made from calcium carbonate. It can eas
 msgid "CAMERA"
 msgstr "Camera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -683,7 +683,7 @@ msgstr "Change the symmetry"
 msgid "CHEATS"
 msgstr "Cheats"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Cheat keys enabled"
 
@@ -773,7 +773,7 @@ msgstr "Produces [thrive:compound type=\"glucose\"][/thrive:compound]. Rate scal
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "The chosen filename ({0}) already exists. Overwrite?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Chromatic aberration:"
 
@@ -814,15 +814,15 @@ msgstr "Clean Up Old Saves"
 msgid "CLOSE"
 msgstr "Close"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Close options?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Cloud resolution divisor:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Cloud simulation minimum interval:"
 
@@ -838,7 +838,7 @@ msgstr "Spawn entities with collision shapes"
 msgid "COLOUR"
 msgstr "Colour"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Colourblind correction:"
 
@@ -899,23 +899,23 @@ msgstr "Saturation value, the amount of gray in a particular colour"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Value (brightness) value, brightness or intensity of the colour"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr "Community Forum"
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Join the Thrive community on our community forum"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr "Community Wiki"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Visit our community wiki"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr "Built at:"
 
@@ -941,7 +941,7 @@ msgstr "Compounds:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Compound Balances"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Compound clouds"
 
@@ -1026,7 +1026,7 @@ msgstr "Continue to stage prototypes?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr "Controller Axis Visualizers:"
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr "Controller Deadzones"
 
@@ -1041,11 +1041,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr "Deadzone:"
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr "Controller button prompts type:"
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr "Controller sensitivity"
 
@@ -1053,11 +1053,11 @@ msgstr "Controller sensitivity"
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Copy Error To Clipboard"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanope (Red-Green)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanope (Blue-Yellow)"
 
@@ -1113,7 +1113,7 @@ msgstr "Creating..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Creating objects from save"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Credits"
 
@@ -1156,7 +1156,7 @@ msgstr ""
 "  Average hex size: {9}\n"
 "[b]Generic Organelle Data:[/b]"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Custom username:"
 
@@ -1221,7 +1221,7 @@ msgstr "Debug Panel"
 msgid "DECEMBER"
 msgstr "December"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Default output device"
 
@@ -1283,7 +1283,7 @@ msgstr "Description is too long"
 msgid "DESPAWN_ENTITIES"
 msgstr "Despawn All Entities"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Detected CPU count:"
 
@@ -1298,11 +1298,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Developers"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr "Development Forum"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "View development updates on our development forum"
 
@@ -1310,11 +1310,11 @@ msgstr "View development updates on our development forum"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Development Supported By Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr "Development Wiki"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Visit our developer wiki"
 
@@ -1396,7 +1396,7 @@ msgstr "Left"
 msgid "DIRECTIONR"
 msgstr "Right"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Disabled"
 
@@ -1404,7 +1404,7 @@ msgstr "Disabled"
 msgid "DISABLE_ALL"
 msgstr "Disable All"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Discard and continue"
 
@@ -1442,33 +1442,33 @@ msgstr ""
 "There are placed organelles, which are not connected to the rest.\n"
 "Please connect all placed organelles with each other or undo your changes."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr "Join our community Discord server"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Dismissed popups:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 "This shows how many popups have been permanently dismissed by the user.\n"
 "If some popups that are actually wanted are dismissed, the button next to this can be used to make all dismissed popups appear again."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr "Don't show this again"
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Display abilities bar"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Display background particles"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Display part selection button names"
 
@@ -1503,7 +1503,7 @@ msgstr "Double click to view in fullscreen"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "A membrane with two layers, it has better protection against damage and takes less energy to not deform. However, it slows the cell down some and lowers the rate at which it can absorb resources."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Do not warn about this again"
 
@@ -1656,7 +1656,7 @@ msgstr ""
 "\n"
 "When you are ready, press the \"next\" button in the bottom right to continue."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1672,7 +1672,7 @@ msgstr "Enable All Compatible Mods"
 msgid "ENABLE_EDITOR"
 msgstr "Enable the editor"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Enable GUI light effects"
 
@@ -1729,7 +1729,7 @@ msgstr "Show / hide environment"
 msgid "EPIPELAGIC"
 msgstr "Epipelagic"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Error"
 
@@ -1741,15 +1741,15 @@ msgstr "Error creating folder for the mod"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Error creating mod info file"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Error: Failed to save new settings to configuration file."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
-msgstr "Fetching news has failed due to error: {0}"
+msgstr "Fetching news has failed due to an error: {0}"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Error Fetching News"
 
@@ -1784,11 +1784,11 @@ msgstr ""
 "\n"
 "If neither of these apply, an error has occurred. Please notify the dev team and supply game logs."
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr "Exact Thrive version:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "This is the exact code commit that this version of Thrive was compiled from"
 
@@ -1804,7 +1804,7 @@ msgstr "An exception happened while loading the save data"
 msgid "EXIT"
 msgstr "Exit"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Exit to Launcher"
 
@@ -1854,7 +1854,7 @@ msgstr "extinct in patch"
 msgid "EXTINCT_SPECIES"
 msgstr "Extinct Species"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1862,7 +1862,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr "Extra Options"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Visit our Facebook page"
 
@@ -1894,19 +1894,19 @@ msgstr "Enabled"
 msgid "FEBRUARY"
 msgstr "February"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Parsing the content of this feed item has failed."
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr "This feed item is missing its content."
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr "Published at {0}"
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr "This item was truncated due to being too long, please read the original for all content. {0}"
 
@@ -2030,7 +2030,7 @@ msgstr "Fossilise this species (already fossilised)"
 msgid "FOSSILISE"
 msgstr "Fossilise"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2060,7 +2060,7 @@ msgstr "Free glucose cloud when leaving editor"
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(start with a free glucose cloud nearby each generation)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Fullscreen"
 
@@ -2088,23 +2088,23 @@ msgstr "Generations"
 msgid "GENERATION_COLON"
 msgstr "Generation:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr "Visit our GitHub repository"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 Mode Warning"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "You are running Thrive with GLES2. This is severely untested and is likely to cause issues. Try to update your video drivers and/or force AMD or Nvidia graphics to be used to run Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr "GLES3"
 
@@ -2157,11 +2157,11 @@ msgstr "Got it"
 msgid "GPL_LICENSE_HEADING"
 msgstr "GPL license text follows:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "GPU:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Graphics"
 
@@ -2169,7 +2169,7 @@ msgstr "Graphics"
 msgid "GRAPHICS_TEAM"
 msgstr "Graphics Team"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "GUI"
 
@@ -2185,7 +2185,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "UI Tab Navigation"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "GUI volume"
 
@@ -2207,11 +2207,11 @@ msgstr "Help"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "How to play the game"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(higher values increase performance)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(higher values worsen performance)"
 
@@ -2235,7 +2235,7 @@ msgstr "Hold [thrive:input]g_free_cursor[/thrive:input] for cursor"
 msgid "HOME"
 msgstr "Home"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr "Horizontal:"
 
@@ -2307,7 +2307,7 @@ msgstr "Ingested Matter"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Create a new world"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Inputs"
 
@@ -2360,8 +2360,8 @@ msgstr "Invalid URL format"
 msgid "INVALID_URL_SCHEME"
 msgstr "Invalid URL scheme"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr "Inverted"
 
@@ -2384,7 +2384,7 @@ msgstr "Iron"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Iron Chemolithoautotrophy"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr "Visit our Itch.io page"
 
@@ -2392,19 +2392,19 @@ msgstr "Visit our Itch.io page"
 msgid "JANUARY"
 msgstr "January"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "JSON debug mode:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Always"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automatically"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Never"
 
@@ -2586,19 +2586,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Language:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "This language is {0}% complete"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "This language is still a work in progress ({0}% complete)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "This translation is very incomplete ({0}% done) please help us with it!"
 
@@ -2760,7 +2760,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Left mouse"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licenses"
 
@@ -2828,7 +2828,7 @@ msgstr "Night"
 msgid "LIGHT_MAX"
 msgstr "Light max"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Extreme"
 
@@ -2840,31 +2840,31 @@ msgstr "Limit growth compound usage"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(when enabled caps growth speed, if disabled only available compounds affect growth speed)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Huge"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Large"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Normal"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Small"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Tiny"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Very large"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Very small"
 
@@ -2888,7 +2888,7 @@ msgstr "Load"
 msgid "LOADING"
 msgstr "Loading"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Loading..."
@@ -2919,12 +2919,12 @@ msgstr "Press the undo button in the editor to correct a mistake"
 msgid "LOAD_FINISHED"
 msgstr "Load finished"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Load Game"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Load previously saved games"
 
@@ -2998,7 +2998,7 @@ msgstr "March"
 msgid "MARINE_SNOW"
 msgstr "Marine snow"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Master volume"
 
@@ -3006,15 +3006,15 @@ msgstr "Master volume"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Maximum species in a patch before forced extinctions"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Max FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Unlimited"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Maximum number of entities:"
 
@@ -3201,7 +3201,7 @@ msgstr "Each generation, you have 100 mutation points (MP) to spend, and each ch
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Every time you reproduce, you will enter the Microbe Editor, where you can make changes to your species (by adding, moving, or removing organelles) to increase your species' success. Each visit to the editor in the Microbe Stage represents [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] million years of evolution."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Microbe Freebuild Editor"
 
@@ -3385,7 +3385,7 @@ msgstr "Minimum:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Not allowed to show less than {0} dataset(s)!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Misc"
 
@@ -3448,11 +3448,11 @@ msgstr "Modify Organelle"
 msgid "MODIFY_TYPE"
 msgstr "Modify Type"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Installed mods have been detected, but there are no enabled mods.\n"
@@ -3541,11 +3541,11 @@ msgstr "Internal (Folder) Name:"
 msgid "MOD_LICENSE"
 msgstr "Mod License:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Mod Loading Errors"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Errors occurred when loading one or more mods. Logs may contain additional information."
 
@@ -3598,11 +3598,11 @@ msgstr "Mod Version:"
 msgid "MORE_INFO"
 msgstr "Show More Info"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr "Mouse look sensitivity"
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr "Mouse sensitivity scaling by window size"
 
@@ -3716,7 +3716,7 @@ msgstr "Multiple Metaballs"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Multiple Organelles"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Multisample anti-aliasing:"
 
@@ -3731,7 +3731,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Music"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Music volume"
 
@@ -3751,9 +3751,9 @@ msgstr "(cost of organelles, membranes and other items in the editor)"
 msgid "MUTATION_POINTS"
 msgstr "Mutation Points"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Mute"
 
@@ -3789,11 +3789,11 @@ msgstr "NEWS"
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Initial population for biodiversity-increasing species"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "New Game"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Start a new game"
 
@@ -3858,7 +3858,7 @@ msgstr "The Nitrogen-Fixing Plastid is a protein able to use gaseous [thrive:com
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Turns [thrive:compound type=\"atp\"][/thrive:compound] into [thrive:compound type=\"ammonia\"][/thrive:compound]. Rate scales with concentration of [thrive:compound type=\"nitrogen\"][/thrive:compound] and [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "None"
 
@@ -3905,7 +3905,7 @@ msgstr "No events recorded"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "No fossils directory found"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr "No Mods Enabled"
 
@@ -3922,7 +3922,7 @@ msgstr "No Saves Found"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "No saves directory found"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "No screenshot directory found"
 
@@ -3970,15 +3970,15 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr "October"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr "Official Website"
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Visit the official Revolutionary Games website"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4015,7 +4015,7 @@ msgstr "Open help screen"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Open in Freebuild"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Open Logs Folder"
 
@@ -4031,7 +4031,7 @@ msgstr "Open organelle menu"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Open Save Directory"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Open Screenshot Folder"
 
@@ -4039,7 +4039,7 @@ msgstr "Open Screenshot Folder"
 msgid "OPEN_THE_MENU"
 msgstr "Open the menu"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Help Translate The Game"
 
@@ -4058,11 +4058,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunistic"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Options"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Change your settings"
 
@@ -4271,7 +4271,7 @@ msgstr "Procedural"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr "Visit our Patreon page"
 
@@ -4321,7 +4321,7 @@ msgstr "Peaceful"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Performance"
 
@@ -4410,7 +4410,7 @@ msgstr "Duplicate Player"
 msgid "PLAYER_EXTINCT"
 msgstr "Player is extinct"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Player relative"
 
@@ -4424,23 +4424,23 @@ msgstr ""
 "Player\n"
 "Speed"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr "PlayStation 3"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr "PlayStation 4"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr "PlayStation 5"
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Play intro video"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Play microbe intro on new game"
 
@@ -4559,11 +4559,11 @@ msgstr "Quick load"
 msgid "QUICK_SAVE"
 msgstr "Quick save"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Quit"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Exit the game"
@@ -4605,7 +4605,7 @@ msgstr "Ready"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Recommended Thrive:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr "Visit our subreddit"
 
@@ -4658,7 +4658,7 @@ msgstr "Reproduction:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Requires nucleus"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Reset"
 
@@ -4666,23 +4666,23 @@ msgstr "Reset"
 msgid "RESET_DEADZONES"
 msgstr "Reset Deadzones"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr "Reset Dismissed Popups"
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Reset inputs to defaults?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr "Reset Keybindings"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Defaults"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Reset to defaults?"
 
@@ -4691,7 +4691,7 @@ msgstr "Reset to defaults?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr "Resistant to basic engulfment"
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Resolution:"
 
@@ -4741,7 +4741,7 @@ msgstr ""
 "Are you sure you want to exit to the main menu?\n"
 "You will lose any unsaved progress."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Visit official Revolutionary Games sites"
 
@@ -4773,7 +4773,7 @@ msgstr "Rotate right"
 msgid "ROTATION_COLON"
 msgstr "Rotation:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Run auto-evo during gameplay"
 
@@ -4827,7 +4827,7 @@ msgstr "Rusticyanin is a protein able to use [thrive:compound type=\"carbondioxi
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Turns [thrive:compound type=\"iron\"][/thrive:compound] into [thrive:compound type=\"atp\"][/thrive:compound]. Rate scales with concentration of [thrive:compound type=\"carbondioxide\"][/thrive:compound] and [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive has started in safe mode due to a previous start failure.\n"
@@ -4839,15 +4839,15 @@ msgstr ""
 "\n"
 "If you don't fix the issue causing the start failure you will need to restart and crash Thrive multiple times to get back to safe mode."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive Started In Safe Mode"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Save"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Save and continue"
 
@@ -4945,20 +4945,20 @@ msgstr "Saving is not currently possible due to:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Saving succeeded"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr "None"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr "Scaled"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr "Inversely scaled"
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "Screen relative"
 
@@ -5055,7 +5055,7 @@ msgstr "Sessile"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "This value only applies to new games started after changing this option"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "SFX volume"
 
@@ -5071,21 +5071,25 @@ msgstr "Show help"
 msgid "SHOW_TUTORIALS"
 msgstr "Show tutorials"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Show tutorials (in current game)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Show tutorials (in new games)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Show unsaved progress warning"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Enables / disables the unsaved progress warning popup for when the player tries to quit the game."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr "Show Thrive news feed (downloads from the internet)"
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5133,7 +5137,7 @@ msgstr "Silica"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "This membrane has a strong wall of silica. It can resist overall damage well and is very resistant to physical damage. It also requires less energy to maintain its form. However, it slows the cell down by a large factor and the cell absorbs resources at a reduced rate."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5173,7 +5177,7 @@ msgstr "Turns [thrive:compound type=\"glucose\"][/thrive:compound] into [thrive:
 msgid "SMALL_IRON_CHUNK"
 msgstr "Small Iron Chunk"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Sound"
 
@@ -5376,17 +5380,17 @@ msgstr "Steam is unavailable currently, please retry"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Unknown Steam error happened"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr "Steam Initialization Failed"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Steam client library initialization has failed. Steam features will be unavailable.\n"
 "Please make sure you have Steam running and are logged in with the right account. Please run the game through the Steam client software if this error does not go away otherwise."
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr "Visit our Steam page"
 
@@ -5426,7 +5430,7 @@ msgstr "Storage"
 msgid "STORAGE_COLON"
 msgstr "Storage:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Logged in as: {0}"
 
@@ -5541,7 +5545,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Testing Team"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Thank you for supporting Thrive development by purchasing this copy of Thrive!\n"
@@ -5557,7 +5561,7 @@ msgstr ""
 "\n"
 "If you enjoyed the game, please tell your friends about us."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr "Thank You"
 
@@ -5612,11 +5616,11 @@ msgstr "This is a locally installed mod"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "This mod is downloaded from the Steam Workshop"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Threads:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thriveopedia"
 
@@ -5772,7 +5776,7 @@ msgstr "Pause"
 msgid "TOGGLE_UNBINDING"
 msgstr "Toggle unbinding"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Tools"
 
@@ -5836,7 +5840,7 @@ msgstr "Try fossilising some species!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Try making a save!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Try taking some screenshots!"
 
@@ -5998,11 +6002,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "View Now"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr "Visit our Twitter feed"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6027,7 +6031,7 @@ msgstr "Unbind all"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Unbind Mode"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr "This is a debug build where the info below is probably not up to date"
 
@@ -6047,7 +6051,7 @@ msgstr "Undo the last action"
 msgid "UNKNOWN"
 msgstr "Unknown"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Unknown"
 
@@ -6059,7 +6063,7 @@ msgstr "Unknown mouse"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Unknown on Windows"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "Unknown version"
 
@@ -6067,7 +6071,7 @@ msgstr "Unknown version"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Unknown Workshop ID For This Mod"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "You have unsaved changes that will be discarded.\n"
@@ -6109,7 +6113,7 @@ msgstr "Upload Succeeded"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Licenses And Used Libraries"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "Used renderer:"
 
@@ -6125,7 +6129,7 @@ msgstr "Use Auto Harmony Loading"
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Automatically load Harmony patches from Assembly (doesn't require specifying mod class)"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Use a custom username"
 
@@ -6133,11 +6137,11 @@ msgstr "Use a custom username"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "Biodiversity-increasing species creation steals population from existing species"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Manually set number of background threads"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr "Use virtual window size"
 
@@ -6163,7 +6167,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Version:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr "Vertical:"
 
@@ -6172,11 +6176,11 @@ msgstr "Vertical:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Vertical (Axis: {0})"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "Currently used video memory:"
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0} MiB"
 
@@ -6184,7 +6188,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Viewer"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "View Source Code"
 
@@ -6196,7 +6200,7 @@ msgstr "VIP Supporters"
 msgid "VISIBLE"
 msgstr "Visible"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Suggest a Feature"
 
@@ -6216,7 +6220,7 @@ msgstr "Volume Mute"
 msgid "VOLUMEUP"
 msgstr "Volume Up"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSync"
 
@@ -6323,7 +6327,7 @@ msgstr ""
 "Include later stage prototypes: {0}\n"
 "Include Easter eggs: {1}"
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "World relative"
 
@@ -6331,15 +6335,15 @@ msgstr "World relative"
 msgid "WORST_PATCH_COLON"
 msgstr "Worst Patch:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr "Xbox 360"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr "Xbox One"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr "Xbox Series X"
 
@@ -6351,7 +6355,7 @@ msgstr "Xbox Series X"
 msgid "YEARS"
 msgstr "years"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Visit our YouTube channel"
 

--- a/locale/eo.po
+++ b/locale/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-03-22 18:22+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Esperanto <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/eo/>\n"
@@ -211,7 +211,7 @@ msgstr "VI PROSPERIS!"
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -310,7 +310,7 @@ msgstr "Aŭtomata konservado dum la ludo"
 msgid "AUTO_EVO"
 msgstr "Aŭto-Evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Lanĉa stato:"
@@ -355,8 +355,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -630,27 +630,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr "Karbona duoksido"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -941,20 +941,20 @@ msgstr "Aldonunovan funkcion por klavo"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -1169,7 +1169,7 @@ msgstr "Serĉado..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Kreante objektojn el konservado"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Kreditoj"
 
@@ -1345,11 +1345,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -1358,11 +1358,11 @@ msgstr "Aldonunovan funkcion por klavo"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -1491,7 +1491,7 @@ msgstr ""
 "Inter metitaj organetoj, estas organetoj kiu ne estas ligitaj al la aliaj.\n"
 "Bonvolu konekti ĉiujn metitajn organetojn unu kun la alia aŭ malfari viajn ŝanĝojn."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -1506,7 +1506,7 @@ msgstr "Rapideco:"
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "{0} loĝantaro ŝanĝiĝis per {1} pro: {2}"
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Membrano kun du tavoloj, ĝi havas pli bonan protekton kontraŭ damaĝo kaj bezonas malpli da energio por ne misformi. Tamen ĝi iom malrapidigas la ĉelon kaj malpliigas la rapidon, per kiu ĝi povas sorbi rimedojn."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1746,15 +1746,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1812,6 +1812,16 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Eraro: Malsukcesis konservi novajn agordojn en agorda dosiero."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "{0} loĝantaro ŝanĝiĝis per {1} pro: {2}"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Eraro de konservado"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Eraro Ŝarĝante"
@@ -1865,7 +1875,7 @@ msgstr "Escepto okazis dum ŝarĝo de la konservadaj datumoj"
 msgid "EXIT"
 msgstr "Eliri"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1920,7 +1930,7 @@ msgstr "formortis de la planedo"
 msgid "EXTINCT_SPECIES"
 msgstr "FORMORTADO"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Ekstraĵoj"
 
@@ -1928,7 +1938,7 @@ msgstr "Ekstraĵoj"
 msgid "EXTRA_OPTIONS"
 msgstr "Ekstraj Agordoj"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -1959,6 +1969,22 @@ msgstr "Trompaĵoj estas ebligitaj"
 #, fuzzy
 msgid "FEBRUARY"
 msgstr "Enmariĝo"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -2043,7 +2069,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Manĝoĉeno"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -2147,7 +2173,7 @@ msgstr "Generacio:"
 msgid "GENERATION_COLON"
 msgstr "Generacio:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -2156,11 +2182,11 @@ msgstr "Aldonunovan funkcion por klavo"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Averto Modo GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Vi uzas Thrive kun GLES2. Ĉi tio estas tre neprovita kaj probable kaŭzas problemojn. Provu ĝisdatigi viajn video-pelilojn kaj/aŭ devigi uzi AMD aŭ Nvidia-grafikaĵojn por ke Thrive funkciu."
 
@@ -2450,7 +2476,7 @@ msgstr "Fero"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Fera Kemolitoaŭtotrofio"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -2678,7 +2704,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2839,7 +2865,7 @@ msgstr "Maldekstra musbutono"
 msgid "LEFT_MOUSE"
 msgstr "Maldekstra musbutono"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2976,7 +3002,8 @@ msgstr "Ŝarĝu"
 msgid "LOADING"
 msgstr "Ŝarĝante"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Ŝarĝante..."
@@ -3009,12 +3036,12 @@ msgstr "Premu la malfaran butonon en la redaktilo por korekti eraron"
 msgid "LOAD_FINISHED"
 msgstr "Ŝarĝo estas finita"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Ŝarĝu"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -3292,7 +3319,7 @@ msgstr "Ĉiu generacio, vi havas 100 mutaciajn punktojn (MP) por elspezi, kaj ĉ
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Ĉiufoje, kiam vi reproduktiĝas, vi eniros la Mikroban Redaktilon, kie vi povas ŝanĝi vian specion (aldonante, movante aŭ forigante organetojn) por pliigi la sukceson de via specio. Ĉiu vizito al la redaktoro en la Mikroba Scenejo reprezentas 100 milionojn da jaroj da evoluo."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Libra Redaktilo de"
 
@@ -3550,11 +3577,11 @@ msgstr "Forigu organeton"
 msgid "MODIFY_TYPE"
 msgstr "Modifi"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3645,11 +3672,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3892,15 +3919,19 @@ msgstr ""
 "Ĉi tiu konservado estas de pli nova versio de Thrive kaj tre probable ne kongruas.\n"
 "Ĉu vi volas provi ŝargi la konservadon ĉiuokaze?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Nova ludo"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -4010,7 +4041,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -4023,7 +4054,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Malfermu Konservadan Adresaron"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Trompaĵoj estas ebligitaj"
@@ -4058,7 +4089,7 @@ msgstr "Elektita(j):"
 msgid "NUCLEUS"
 msgstr "Kerno/Nukleo"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -4081,8 +4112,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 #, fuzzy
 msgid "N_A"
@@ -4096,16 +4127,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4185,11 +4216,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Agordoj"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -4411,7 +4442,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Kaverno"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -4474,8 +4505,8 @@ msgstr "Agado"
 msgid "PERFORM_UNBINDING"
 msgstr "Eraro Ŝarĝante"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/sekundo"
 
@@ -4526,7 +4557,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Ĉelo de la ludanto"
 
@@ -4606,7 +4637,7 @@ msgstr "{0} loĝantaro ŝanĝiĝis per {1} pro: {2}"
 msgid "POPULATION_IN_PATCHES"
 msgstr "POPULACIO:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 #, fuzzy
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "POPULACIO:"
@@ -4665,7 +4696,7 @@ msgstr "Specioj:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Prilaborado de ŝarĝitaj objektoj"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4709,11 +4740,11 @@ msgstr "Rapida ŝarĝo"
 msgid "QUICK_SAVE"
 msgstr "Rapida konservado"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Forlasu"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4757,7 +4788,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Rekomenci"
@@ -4902,7 +4933,7 @@ msgstr "Revenu al Menuo"
 msgid "RETURN_TO_MENU_WARNING"
 msgstr "Revenu al Menuo"
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -4997,12 +5028,12 @@ msgstr "Rusticianino estas proteino kapabla uzi gasan karbonan dioksidon kaj oks
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Rusticianino estas proteino kapabla uzi gasan karbonan dioksidon kaj oksigenon por oksigeni feron de unu kemia stato al alia. Ĉi tiu procezo, nomata Fera Respirado, liberigas energion, kiun la ĉelo tiam povas rikolti."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "{0} loĝantaro ŝanĝiĝis per {1} pro: {2}"
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -5404,7 +5435,7 @@ msgstr "Generu amoniakon"
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -5458,7 +5489,7 @@ msgstr "Specia nomo..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Specia nomo..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 #, fuzzy
 msgid "SPECIES_N_TIMES"
 msgstr "Listo de Specioj"
@@ -5580,17 +5611,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Konservado malsukcesis! Escepto okazis"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "La vakuolo estas interna membraneca organeto uzata por stokado en la ĉelo. Ili estas kunmetitaj de pluraj kunfandiĝitaj vezikoj, pli malgrandaj membranaj strukturoj vaste uzataj en ĉeloj por stokado. Ĝi estas plenigita per akvo, kiu kutimas enhavi molekulojn, enzimojn, solidojn kaj aliajn substancojn. Ilia formo estas flua kaj povas varii inter ĉeloj."
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Rekomenci"
@@ -5633,7 +5664,7 @@ msgstr "Stokado"
 msgid "STORAGE_COLON"
 msgstr "Stokado"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5751,7 +5782,7 @@ msgstr "Tеmp."
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5759,7 +5790,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "VI PROSPERIS!"
@@ -5824,7 +5855,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5981,7 +6012,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Ŝaltu engluton"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Iloj"
 
@@ -6221,7 +6252,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Lernilo"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -6430,7 +6461,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Rigardi Fontkodon"
 
@@ -6442,7 +6473,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6606,7 +6637,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "jaroj"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Rekomenci"

--- a/locale/eo.po
+++ b/locale/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-03-22 18:22+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Esperanto <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/eo/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.11.2\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr "Redaktilo"
 msgid "3D_MOVEMENT"
 msgstr "Movado"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 #, fuzzy
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Konservu kaj"
@@ -149,7 +149,7 @@ msgstr "Organisma Statistiko"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Media Volumo"
 
@@ -160,11 +160,11 @@ msgstr "Media Volumo"
 msgid "AMMONIA"
 msgstr "Amoniako"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Kvanto da aŭtomataj konservadoj:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Kvanto da rapidaj konservadoj:"
 
@@ -189,11 +189,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Ĉu vi certas, ke vi volas restarigi ĈIUJN agordojn al defaŭltaj valoroj?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Ĉu vi certas, ke vi volas reagordi la enirajn agordojn al defaŭltaj valoroj?"
 
@@ -211,7 +211,7 @@ msgstr "VI PROSPERIS!"
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -223,7 +223,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -264,7 +264,7 @@ msgstr "Aŭtomata evolucio malsukcesis"
 msgid "AT_CURSOR"
 msgstr "Ĉe Kursoro(montrilo):"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -272,8 +272,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "aŭtomate"
 
@@ -302,7 +302,7 @@ msgstr "La potencocentro de la ĉelo. La mitokondrio (pluralo: mitokondrioj) est
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% finita. {1:n0}/{2:n0} paŝoj."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Aŭtomata konservado dum la ludo"
 
@@ -310,7 +310,7 @@ msgstr "Aŭtomata konservado dum la ludo"
 msgid "AUTO_EVO"
 msgstr "Aŭto-Evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Lanĉa stato:"
@@ -341,7 +341,7 @@ msgstr "Lanĉa stato:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Antaŭeniĝu aŭtomate"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 #, fuzzy
 msgid "AUTO_RESOLUTION"
 msgstr "Distingivo:"
@@ -355,9 +355,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -510,7 +510,7 @@ msgstr "Nitrogenazo estas proteino kapabla uzi gasan nitrogenon kaj ĉelan energ
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Nitrogenazo estas proteino kapabla uzi gasan nitrogenon kaj ĉelan energion en la formo de ATP por produkti amoniakon, ĉefan kreskonutraĵon por ĉeloj. Ĉi tio estas procezo nomata Anaeroba Nitrogena Fiksado. Ĉar la nitrogenazo estas suspensie en la citoplasmo, la ĉirkaŭa fluidaĵo iom fermentas."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -572,7 +572,7 @@ msgstr "Ĉi tiu membrano havas fortan ŝelon el kalcia karbonato. Ĝi povas faci
 msgid "CAMERA"
 msgstr "Kamerao"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -707,7 +707,7 @@ msgstr "Ŝanĝu la simetrion"
 msgid "CHEATS"
 msgstr "Trompaĵoj"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Trompaĵoj estas ebligitaj"
 
@@ -808,7 +808,7 @@ msgstr "La kloroplasto estas duobla membranstrukturo enhavanta fotosentemajn pig
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "La elektita dosiernomo ({0}) jam ekzistas. Ĉu anstataŭigi?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Kromata Aberacio:"
 
@@ -853,15 +853,15 @@ msgstr "Forigi Malnovajn Konservadojn"
 msgid "CLOSE"
 msgstr "Fermu"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Ĉu fermu agordojn?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Nuba Rezolucia Divizoro:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 "Nuba Simulada Minimumo\n"
@@ -879,7 +879,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr "Koloro"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Kolorblinda o:"
 
@@ -941,25 +941,25 @@ msgstr "Aldonunovan funkcion por klavo"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Kunmetaĵoj:"
@@ -987,7 +987,7 @@ msgstr "Kunmetaĵoj:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Kunmetaĵaj Ekvilibro"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Kunmetitaj nuboj"
 
@@ -1075,7 +1075,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1089,11 +1089,11 @@ msgstr "{0} loĝantaro ŝanĝiĝis per {1} pro: {2}"
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1101,11 +1101,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Kopiu Eraron Al Tondujo"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr "Serĉado..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Kreante objektojn el konservado"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Kreditoj"
 
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Organisma Statistiko"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Via Salutnomo:"
 
@@ -1264,7 +1264,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1332,7 +1332,7 @@ msgstr "Priskribo:"
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 #, fuzzy
 msgid "DETECTED_CPU_COUNT"
 msgstr "Elektita(j):"
@@ -1345,11 +1345,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -1358,11 +1358,11 @@ msgstr "Aldonunovan funkcion por klavo"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -1440,7 +1440,7 @@ msgstr "Priskribo:"
 msgid "DIRECTIONR"
 msgstr "Priskribo:"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1448,7 +1448,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Forĵetu kaj"
 
@@ -1491,35 +1491,35 @@ msgstr ""
 "Inter metitaj organetoj, estas organetoj kiu ne estas ligitaj al la aliaj.\n"
 "Bonvolu konekti ĉiujn metitajn organetojn unu kun la alia aŭ malfari viajn ŝanĝojn."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Rapideco:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "{0} loĝantaro ŝanĝiĝis per {1} pro: {2}"
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 #, fuzzy
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Kapabloj"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "Kapabloj"
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Membrano kun du tavoloj, ĝi havas pli bonan protekton kontraŭ damaĝo kaj bezonas malpli da energio por ne misformi. Tamen ĝi iom malrapidigas la ĉelon kaj malpliigas la rapidon, per kiu ĝi povas sorbi rimedojn."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1714,7 +1714,7 @@ msgstr ""
 "\n"
 "Por iri al la sekva redakta langeto, premu la sekvan butonon en la dekstra fundo."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 #, fuzzy
 msgid "EIGHT_TIMES"
 msgstr "Dekstra musbutono"
@@ -1733,7 +1733,7 @@ msgstr "Elektita konservado ne kongruas"
 msgid "ENABLE_EDITOR"
 msgstr "Ebligu la redaktilon"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 #, fuzzy
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Eksteraj efikoj:"
@@ -1795,7 +1795,7 @@ msgstr "Aldonunovan funkcion por klavo"
 msgid "EPIPELAGIC"
 msgstr "Epipelagika"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Eraro"
 
@@ -1808,16 +1808,16 @@ msgstr "Eraro de konservado"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Eraro: Malsukcesis konservi novajn agordojn en agorda dosiero."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "{0} loĝantaro ŝanĝiĝis per {1} pro: {2}"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Eraro de konservado"
@@ -1851,12 +1851,12 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Generacio:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -1875,7 +1875,7 @@ msgstr "Escepto okazis dum ŝarĝo de la konservadaj datumoj"
 msgid "EXIT"
 msgstr "Eliri"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1930,7 +1930,7 @@ msgstr "formortis de la planedo"
 msgid "EXTINCT_SPECIES"
 msgstr "FORMORTADO"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Ekstraĵoj"
 
@@ -1938,7 +1938,7 @@ msgstr "Ekstraĵoj"
 msgid "EXTRA_OPTIONS"
 msgstr "Ekstraj Agordoj"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -1970,19 +1970,19 @@ msgstr "Trompaĵoj estas ebligitaj"
 msgid "FEBRUARY"
 msgstr "Enmariĝo"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2111,7 +2111,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -2143,7 +2143,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Plenekrane"
 
@@ -2173,24 +2173,24 @@ msgstr "Generacio:"
 msgid "GENERATION_COLON"
 msgstr "Generacio:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Averto Modo GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Vi uzas Thrive kun GLES2. Ĉi tio estas tre neprovita kaj probable kaŭzas problemojn. Provu ĝisdatigi viajn video-pelilojn kaj/aŭ devigi uzi AMD aŭ Nvidia-grafikaĵojn por ke Thrive funkciu."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2244,12 +2244,12 @@ msgstr "Komprenita"
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "Kaverno"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafikaĵoj"
 
@@ -2258,7 +2258,7 @@ msgstr "Grafikaĵoj"
 msgid "GRAPHICS_TEAM"
 msgstr "Grafikaĵoj"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2272,7 +2272,7 @@ msgstr "La potencocentro de la ĉelo. La mitokondrio (pluralo: mitokondrioj) est
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} K"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Interfaca volumo"
 
@@ -2295,11 +2295,11 @@ msgstr "Helpu"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(pli altaj valoroj malpliigas rendimenton)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(pli altaj valoroj plimalbonigas agadon)"
 
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Generacio:"
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Klavoj"
 
@@ -2456,8 +2456,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr "Fero"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Fera Kemolitoaŭtotrofio"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -2485,19 +2485,19 @@ msgstr "Aldonunovan funkcion por klavo"
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2687,20 +2687,20 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Lingvo:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 #, fuzzy
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Helpu Traduki La Ludon"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2865,7 +2865,7 @@ msgstr "Maldekstra musbutono"
 msgid "LEFT_MOUSE"
 msgstr "Maldekstra musbutono"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2936,7 +2936,7 @@ msgstr "Rado dekstre"
 msgid "LIGHT_MAX"
 msgstr "Lumo"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "Ekstraĵoj"
@@ -2951,32 +2951,32 @@ msgstr "KONFIRMU"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "{0} loĝantaro ŝanĝiĝis per {1} pro: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "KONFIRMU"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -3002,7 +3002,7 @@ msgstr "Ŝarĝu"
 msgid "LOADING"
 msgstr "Ŝarĝante"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
@@ -3036,12 +3036,12 @@ msgstr "Premu la malfaran butonon en la redaktilo por korekti eraron"
 msgid "LOAD_FINISHED"
 msgstr "Ŝarĝo estas finita"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Ŝarĝu"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -3122,7 +3122,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr "Mara neĝo"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Ĉefa laŭ t"
 
@@ -3131,16 +3131,16 @@ msgstr "Ĉefa laŭ t"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "formortis de la planedo"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Maks. FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 #, fuzzy
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Maks. FPS:"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3319,7 +3319,7 @@ msgstr "Ĉiu generacio, vi havas 100 mutaciajn punktojn (MP) por elspezi, kaj ĉ
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Ĉiufoje, kiam vi reproduktiĝas, vi eniros la Mikroban Redaktilon, kie vi povas ŝanĝi vian specion (aldonante, movante aŭ forigante organetojn) por pliigi la sukceson de via specio. Ĉiu vizito al la redaktoro en la Mikroba Scenejo reprezentas 100 milionojn da jaroj da evoluo."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Libra Redaktilo de"
 
@@ -3507,7 +3507,7 @@ msgstr "Versio:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Forigi ĉi tiun konservadon ne povas esti malfarita, ĉu vi certas, ke vi volas por ĉiam forigi {0}?"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Aliaj"
 
@@ -3577,11 +3577,11 @@ msgstr "Forigu organeton"
 msgid "MODIFY_TYPE"
 msgstr "Modifi"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3672,11 +3672,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3734,11 +3734,11 @@ msgstr "Versio:"
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3856,7 +3856,7 @@ msgstr "Disloku organeton"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Disloku organeton"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Multekzempla glatigo:"
 
@@ -3868,7 +3868,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Muzika volumo"
 
@@ -3889,9 +3889,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr "Mutaciaj Poentoj"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Silentigi"
 
@@ -3927,11 +3927,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Nova ludo"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -4003,7 +4003,7 @@ msgstr "La Nitrogen-Fiksanta Plastido estas proteino, kiu kapablas uzi gasan nit
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "La Nitrogen-Fiksanta Plastido estas proteino, kiu kapablas uzi gasan nitrogenon kaj oksigenon kaj ĉelan energion en la formo de ATP por produkti amoniakon, ĉefan kreskan nutraĵon por ĉeloj. Ĉi tio estas procezo nomata Aerobia Nitrogena Fiksado."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -4054,7 +4054,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Malfermu Konservadan Adresaron"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Trompaĵoj estas ebligitaj"
@@ -4074,7 +4074,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Malfermu Konservadan Adresaron"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 #, fuzzy
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Malfermu Ekrankopian Dosierujon"
@@ -4127,16 +4127,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4174,7 +4174,7 @@ msgstr "Malfermu helpekranon"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Libera konstruado"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Malfermu Dosierujon de Registroj"
 
@@ -4191,7 +4191,7 @@ msgstr "Forigu organeton"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Malfermu Konservadan Adresaron"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Malfermu Ekrankopian Dosierujon"
 
@@ -4199,7 +4199,7 @@ msgstr "Malfermu Ekrankopian Dosierujon"
 msgid "OPEN_THE_MENU"
 msgstr "Malfermu la menuon"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Helpu Traduki La Ludon"
 
@@ -4216,11 +4216,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Agordoj"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -4442,7 +4442,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Kaverno"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -4496,7 +4496,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Agado"
 
@@ -4584,7 +4584,7 @@ msgstr "ludanto mortis"
 msgid "PLAYER_EXTINCT"
 msgstr "ludanto mortis"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "ludanto mortis"
@@ -4598,23 +4598,23 @@ msgstr "ludanto reproduktita"
 msgid "PLAYER_SPEED"
 msgstr "ludanto mortis"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Ludu enkondukan filmeton"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Ludu Mikroban Enkondukon en ĉiu Nova Ludo"
 
@@ -4740,11 +4740,11 @@ msgstr "Rapida ŝarĝo"
 msgid "QUICK_SAVE"
 msgstr "Rapida konservado"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Forlasu"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4788,7 +4788,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Rekomenci"
@@ -4847,7 +4847,7 @@ msgstr "reproduktis"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Kerno/Nukleo"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Rekomencu"
 
@@ -4856,24 +4856,24 @@ msgstr "Rekomencu"
 msgid "RESET_DEADZONES"
 msgstr "Ĉu restarigu al defaŭltaj?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Ĉu restarigu enirojn al defaŭltaj?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Restarigu"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Defaŭlte"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Ĉu restarigu al defaŭltaj?"
 
@@ -4882,7 +4882,7 @@ msgstr "Ĉu restarigu al defaŭltaj?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Distingivo:"
 
@@ -4933,7 +4933,7 @@ msgstr "Revenu al Menuo"
 msgid "RETURN_TO_MENU_WARNING"
 msgstr "Revenu al Menuo"
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
@@ -4968,7 +4968,7 @@ msgstr "Rotaciu dekstren"
 msgid "ROTATION_COLON"
 msgstr "{0} loĝantaro ŝanĝiĝis per {1} pro: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "aŭtomatan evolucion dum ludado"
 
@@ -5028,20 +5028,20 @@ msgstr "Rusticianino estas proteino kapabla uzi gasan karbonan dioksidon kaj oks
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Rusticianino estas proteino kapabla uzi gasan karbonan dioksidon kaj oksigenon por oksigeni feron de unu kemia stato al alia. Ĉi tiu procezo, nomata Fera Respirado, liberigas energion, kiun la ĉelo tiam povas rikolti."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "{0} loĝantaro ŝanĝiĝis per {1} pro: {2}"
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Konservu"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Konservu kaj"
 
@@ -5143,23 +5143,23 @@ msgstr "Konservado malsukcesis! Escepto okazis"
 msgid "SAVING_SUCCEEDED"
 msgstr "Konservado sukcesis"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr ""
 "Estas konflikto kun {0}.\n"
 "Ĉu vi volas forigi la enigon de {1}?"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "popliigi la movadon"
@@ -5266,7 +5266,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Volumo de sonefektoj"
 
@@ -5283,17 +5283,17 @@ msgstr "Montru helpon"
 msgid "SHOW_TUTORIALS"
 msgstr "Montru lernilojn"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Montru lernilojn (en ĉi tiu ludo)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Montru lernilojn (en novaj ludoj)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 #, fuzzy
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
@@ -5306,6 +5306,10 @@ msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr ""
 "Vi havas nesavitajn ŝanĝojn kiuj estis forĵetotajn.\n"
 " Ĉu vi volas daŭrigi?"
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5364,7 +5368,7 @@ msgstr "Siliko"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Ĉi tiu membrano havas fortan silikan muron. Ĝi povas bone rezisti ĝeneralan damaĝon kaj tre rezistas al fizika damaĝo. Ĝi ankaŭ postulas malpli da energio por konservi sian formon. Tamen ĝi malrapidigas la ĉelon kaj la ĉelo sorbas resurson kun malpli granda rapideco."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -5406,7 +5410,7 @@ msgstr "La gluiĝemaj internaĵoj de ĉelo. La citoplasmo estas la baza miksaĵo
 msgid "SMALL_IRON_CHUNK"
 msgstr "Malgranda Fera Peco"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Sono"
 
@@ -5611,17 +5615,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Konservado malsukcesis! Escepto okazis"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "La vakuolo estas interna membraneca organeto uzata por stokado en la ĉelo. Ili estas kunmetitaj de pluraj kunfandiĝitaj vezikoj, pli malgrandaj membranaj strukturoj vaste uzataj en ĉeloj por stokado. Ĝi estas plenigita per akvo, kiu kutimas enhavi molekulojn, enzimojn, solidojn kaj aliajn substancojn. Ilia formo estas flua kaj povas varii inter ĉeloj."
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Rekomenci"
@@ -5664,7 +5668,7 @@ msgstr "Stokado"
 msgid "STORAGE_COLON"
 msgstr "Stokado"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5782,7 +5786,7 @@ msgstr "Tеmp."
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5790,7 +5794,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "VI PROSPERIS!"
@@ -5851,11 +5855,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -6012,7 +6016,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Ŝaltu engluton"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Iloj"
 
@@ -6082,7 +6086,7 @@ msgstr "Prenu ekrankopion"
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 #, fuzzy
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Prenu ekrankopion"
@@ -6252,12 +6256,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Lernilo"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -6284,7 +6288,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6308,7 +6312,7 @@ msgstr "Malfaru la lastan agon"
 msgid "UNKNOWN"
 msgstr "Nekonata musbutono"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Kapabloj"
@@ -6322,7 +6326,7 @@ msgstr "Nekonata musbutono"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Nekonata musbutono"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Versio:"
@@ -6332,7 +6336,7 @@ msgstr "Versio:"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Nekonata musbutono"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Vi havas nesavitajn ŝanĝojn kiuj estis forĵetotajn.\n"
@@ -6380,7 +6384,7 @@ msgstr "Konservado sukcesis"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6398,7 +6402,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Aldonunovan funkcion por klavo"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Uzu propran salutnomon"
 
@@ -6406,11 +6410,11 @@ msgstr "Uzu propran salutnomon"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6438,7 +6442,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr "Generacio:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Generacio:"
@@ -6449,11 +6453,11 @@ msgstr "Generacio:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Rapideco:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6461,7 +6465,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Rigardi Fontkodon"
 
@@ -6473,7 +6477,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6496,7 +6500,7 @@ msgstr "Volumo de sonefektoj"
 msgid "VOLUMEUP"
 msgstr "Volumo de sonefektoj"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSi"
 
@@ -6607,7 +6611,7 @@ msgstr "Organisma Statistiko"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "popliigi la movadon"
@@ -6617,15 +6621,15 @@ msgstr "popliigi la movadon"
 msgid "WORST_PATCH_COLON"
 msgstr "Specioj:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6637,7 +6641,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "jaroj"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Rekomenci"

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-11-17 16:00+0000\n"
 "Last-Translator: Rubén <chocolateconchurrosyazucar@gmail.com>\n"
 "Language-Team: Spanish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/es/>\n"
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Arte por {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Galeria de arte"
 
@@ -302,7 +302,7 @@ msgstr "Autoguardado durante el juego"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Explorar Auto-Evolución"
 
@@ -345,8 +345,8 @@ msgid "AWAKEN"
 msgstr "Despertar"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -601,27 +601,27 @@ msgstr "Bloq Mayús"
 msgid "CARBON_DIOXIDE"
 msgstr "Dióxido de Carbono"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "En abundancia"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "Suficiente"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "Poco"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "Bastante"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "Algo"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "Muy poco"
 
@@ -889,19 +889,19 @@ msgstr "Saturación"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Brillo"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr "Foro de la comunidad"
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Únete a la comunidad de Thrive en nuestro foro comunitario"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr "Wiki Comunitaria"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Visita nuestra wiki comunitaria"
 
@@ -1103,7 +1103,7 @@ msgstr "Creando..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Creando objetos de la partida guardada"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Créditos"
 
@@ -1272,11 +1272,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Desarrolladores"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr "Foro de Desarrollo"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Lee las noticias sobre el desarrollo del juego en nuestro foro de desarrollo"
 
@@ -1284,11 +1284,11 @@ msgstr "Lee las noticias sobre el desarrollo del juego en nuestro foro de desarr
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Desarrollo apoyado por Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr "Wiki de Desarrollo"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Visita nuestra wiki de desarrollo"
 
@@ -1416,7 +1416,7 @@ msgstr ""
 "Hay orgánulos desconectados del resto de la célula.\n"
 "Por favor conecta todos los orgánulos o deshaz tus cambios."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr "Únete a nuestro servidor de Discord"
 
@@ -1430,7 +1430,7 @@ msgstr ""
 "Esto muestra cuantos popups han sido permanentemente deshabilitados por el usuario.\n"
 "Si alguno de los popups que necesita están deshabilitados, el botón junto a este puede ser utilizado para mostrar todos los popups nuevamente."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1477,7 +1477,7 @@ msgstr "Doble click para ver en pantalla completa"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Una membrana con dos capas; tiene mejor protección y consume menos energía. Sin embargo, reduce un poco la velocidad del movimiento y absorbe recursos más lentamente."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "No mostrar nuevamente"
 
@@ -1658,15 +1658,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Energía en {0} para {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Fuentes de energía:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "La energía total recolectada es {0} con un costo individual de {1} resultando en una población no ajustada de {2}"
 
@@ -1719,6 +1719,16 @@ msgstr "Error al crear el archivo de información del mod"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Error: Fallo al guardar nuevos ajustes al archivo de configuración."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(Crea secretor en el juego aleatoriamente)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Error al crear el archivo de información del mod"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Error al cargar"
@@ -1770,7 +1780,7 @@ msgstr "Una excepción ha ocurrido al cargar los datos guardados"
 msgid "EXIT"
 msgstr "Salir"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Lanzar E"
@@ -1823,7 +1833,7 @@ msgstr "La especie se extinguió de la zona"
 msgid "EXTINCT_SPECIES"
 msgstr "EXTINCIÓN"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1831,7 +1841,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr "Ajustes Extra"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Visita nuestra página de Facebook"
 
@@ -1862,6 +1872,41 @@ msgstr "Activado"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Febrero"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Error en la inicialización de la biblioteca de cliente de Steam"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Tiempo de procesamiento: {0} s\n"
+"Tiempo de motor físico: {1} s\n"
+"Entidades: {2} Otros: {3}\n"
+"Creados: {4} Eliminados: {5}\n"
+"Nodos en uso: {6}\n"
+"Memoria en uso: {7}\n"
+"Memoria de GPU: {8}\n"
+"Objetos renderizados: {9}\n"
+"Draw Calls: {10} 2D: {11}\n"
+"Vehículos renderizados: {12}\n"
+"Cambios en materiales: {13}\n"
+"Cambios de shaders: {14}\n"
+"Nodos huérfanos: {15}\n"
+"Latencia de audio: {16} ms\n"
+"Subprocesos totales: {17}\n"
+"Tiempo total de CPU:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1945,7 +1990,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Cadena Trófica"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "Energía {0}: {1} (rendimiento: {2}) energía total disponible: {3} (rendimiento total: {4})"
 
@@ -2041,7 +2086,7 @@ msgstr "Generaciones"
 msgid "GENERATION_COLON"
 msgstr "Generación:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr "Visita nuestro repositorio de GitHub"
 
@@ -2049,11 +2094,11 @@ msgstr "Visita nuestro repositorio de GitHub"
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Advertencia del modo GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Estás usando Thrive en el Modo GLES2. No está probado y probablemente cause errores. Intenta actualizar tus drivers de video y/o fuerza los gráficos AMD o Nvidia para ser usados al ejecutar Thrive."
 
@@ -2338,7 +2383,7 @@ msgstr "Hierro"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Quimiolitoautotrofía Férrica"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr "Visita nuestra página de itch.io"
 
@@ -2556,7 +2601,7 @@ msgstr "Este idioma aún es un trabajo en progreso ({0}% completado)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "¡Esta traducción está muy incompleta ({0}% hecha) por favor ayúdanos con ella!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "No puedes eliminar tu ultimo orgánulo"
 
@@ -2714,7 +2759,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Clic izquierdo"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licencias"
 
@@ -2844,7 +2889,8 @@ msgstr "Cargar"
 msgid "LOADING"
 msgstr "Cargando"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Cargando..."
 
@@ -2874,12 +2920,12 @@ msgstr "Presiona el botón de deshacer en el editor para corregir un error"
 msgid "LOAD_FINISHED"
 msgstr "Carga terminada"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Cargar partida"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Cargar una partida guardada"
 
@@ -3156,7 +3202,7 @@ msgstr "En cada generación, tienes 100 puntos de mutación (PM) para gastar, y 
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Cada vez que tu célula se reproduce, entrarás al editor de microbio, donde puedes hacerle cambios a tu especie (añadiendo, moviendo y/o quitando orgánulos) para incrementar tus chances de éxito. Cada visita al editor en el estadio de microbio representa [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] millones de años de evolución."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor libre de microbios"
 
@@ -3402,11 +3448,11 @@ msgstr "Modificar orgánulos"
 msgid "MODIFY_TYPE"
 msgstr "Modificar Tipo"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Se ha detectado la instalación de mods, pero no hay mods habilitados.\n"
@@ -3495,11 +3541,11 @@ msgstr "Nombre Interno (de Carpeta):"
 msgid "MOD_LICENSE"
 msgstr "Licencia del Mod:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Errores de carga de mod"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Se produjeron errores al cargar uno o más mods. Los registros pueden contener información adicional."
 
@@ -3735,15 +3781,19 @@ msgstr ""
 "Esta partida guardada es de una versión más nueva de Thrive, y muy probablemente incompatible.\n"
 "¿Deseas intentar cargarla igualmente?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Población inicial para especies creadas para aumentar biodiversidad"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Nueva Partida"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Nueva partida"
 
@@ -3843,7 +3893,7 @@ msgid "NO_AI"
 msgstr "Sin IA"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Sin Datos que Mostrar"
 
@@ -3856,7 +3906,7 @@ msgstr "No hay eventos registrados"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "No se ha encontrado ningún directorio de guardado"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr "No hay mods habilitados"
 
@@ -3886,7 +3936,7 @@ msgstr "Ningún Mod Seleccionado"
 msgid "NUCLEUS"
 msgstr "Núcleo"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 "No puedes eliminar el núcleo, ya que este es una evolución irreversible.\n"
@@ -3907,8 +3957,8 @@ msgstr "Bloq Num"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -3921,15 +3971,15 @@ msgstr "N/A PM"
 msgid "OCTOBER"
 msgstr "Octubre"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr "Sitio oficial"
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Visitar la página web oficial de Revolutionary Games"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4010,11 +4060,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunista"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Ajustes"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Cambiar configuración"
 
@@ -4223,7 +4273,7 @@ msgstr "Generación Procesal"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr "Visita nuestro Patreon"
 
@@ -4281,8 +4331,8 @@ msgstr "Rendimiento"
 msgid "PERFORM_UNBINDING"
 msgstr "Realizar separación"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/segundo"
 
@@ -4336,7 +4386,7 @@ msgstr "Generación de Planeta próximamente!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Semilla de generación del Planeta"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Célula del jugador"
 
@@ -4415,7 +4465,7 @@ msgstr "Población Total:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "Población en biomas:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4469,7 +4519,7 @@ msgstr "anterior:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Procesando objetos cargados"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4513,11 +4563,11 @@ msgstr "Carga rápida"
 msgid "QUICK_SAVE"
 msgstr "Guardado rápido"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Salir"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Salir del juego"
@@ -4559,7 +4609,7 @@ msgstr "Listo"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Versión de Thrive recomendada:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr "Visita nuestra página de Reddit"
 
@@ -4695,7 +4745,7 @@ msgstr ""
 "Estas seguro que quieres volver al menú principal?\n"
 "Perderás todo el progreso que no hayas guardado."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Visita los sitios web oficiales de Revolutionary Games"
 
@@ -4782,7 +4832,7 @@ msgstr "La Rusticianina es una proteína capaz de usar dióxido de carbono gaseo
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Convierte [thrive:compound type=\"iron\"][/thrive:compound] en [thrive:compound type=\"atp\"][/thrive:compound]. La velocidad de conversión es directamente proporcional a la concentración de [thrive:compound type=\"carbondioxide\"][/thrive:compound] y [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive se ha iniciado en modo seguro debido a una error en el inicio del juego.\n"
@@ -4794,7 +4844,7 @@ msgstr ""
 "\n"
 "Si no arreglas el problema que causa el error, necesitarás reiniciar y crashear Thrive multiples veces para volver al modo seguro."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive iniciado en modo seguro"
 
@@ -5157,7 +5207,7 @@ msgstr "Crear amoníaco"
 msgid "SPAWN_ENEMY"
 msgstr "Enemigo aparecido"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "No puedes usar el comando ya que el medio actual no contiene especies enemigas"
 
@@ -5217,7 +5267,7 @@ msgstr "Nombre de la especie..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "El nombre la especie es demasiado largo!"
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5332,17 +5382,17 @@ msgstr "¡UPS!, parece que Steam no se encuentra disponible en este momento. Por
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Se ha producido un error desconocido de Steam"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Error en la inicialización de la biblioteca de cliente de Steam"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Actualizando el archivo de guardado especificado debido al siguiente error:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr "Visita nuestra página de Steam"
 
@@ -5382,7 +5432,7 @@ msgstr "Almacenamiento"
 msgid "STORAGE_COLON"
 msgstr "Almacenamiento:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Conectado como: {0}"
 
@@ -5499,7 +5549,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Equipo de testeo"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5514,7 +5564,7 @@ msgstr ""
 "\n"
 "Si te gustó el juego, cuéntale a tus amigos sobre nosotros."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "¡HAS PROSPERADO!"
@@ -5574,7 +5624,7 @@ msgstr "Este mod fue descargado desde el Workshop de Steam"
 msgid "THREADS"
 msgstr "Hilos:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thrivepedia"
 
@@ -5730,7 +5780,7 @@ msgstr "Pausa"
 msgid "TOGGLE_UNBINDING"
 msgstr "Alternar separación"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Herramientas"
 
@@ -5960,7 +6010,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Ver ahora"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr "Visita nuestra página de Twitter"
 
@@ -6148,7 +6198,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Visualizador"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Ver código fuente"
 
@@ -6160,7 +6210,7 @@ msgstr "Colaboradores VIP"
 msgid "VISIBLE"
 msgstr "Visible"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Sugerir una característica"
 
@@ -6318,7 +6368,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "años"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Visita nuestro canal de YouTube"
 

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-11-17 16:00+0000\n"
 "Last-Translator: Rubén <chocolateconchurrosyazucar@gmail.com>\n"
 "Language-Team: Spanish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/es/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "Editor 3D"
 msgid "3D_MOVEMENT"
 msgstr "Movimiento 3D"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "Acción bloqueada mientras otra esta en progreso"
 msgid "ACTIVE"
 msgstr "Activa"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Hilos actuales:"
 
@@ -144,7 +144,7 @@ msgstr "Estadísticas del Organismo"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Volumen de ambiente"
 
@@ -155,11 +155,11 @@ msgstr "Volumen de ambiente"
 msgid "AMMONIA"
 msgstr "Amoniaco"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Cantidad de autoguardados a almacenar:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Cantidad de guardados rápidos a almacenar:"
 
@@ -184,11 +184,11 @@ msgstr "Aplicar cambios"
 msgid "APRIL"
 msgstr "Abril"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "¿Está seguro de que desea restablecer TODOS las ajustes a los valores predeterminados?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "¿Está seguro de que desea restablecer la configuración de entrada a los valores predeterminados?"
 
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Arte por {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Galeria de arte"
 
@@ -216,7 +216,7 @@ msgstr "Se requiere la clase del ensamblaje del mod cuando se especifica el ensa
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "Se requiere la clase del ensamblaje del mod cuando se especifica el ensamblaje"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Asume que la CPU tiene «hyperthreading» habilitado"
 
@@ -258,7 +258,7 @@ msgstr "El intento de escribir este archivo guardado ha fallado.  El nombre de g
 msgid "AT_CURSOR"
 msgstr "En el puntero:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Dispositivo de salida de audio:"
 
@@ -266,8 +266,8 @@ msgstr "Dispositivo de salida de audio:"
 msgid "AUGUST"
 msgstr "Agosto"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Auto"
 
@@ -294,7 +294,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% hecho. {1:n0}/{2:n0} etapas."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Autoguardado durante el juego"
 
@@ -302,7 +302,7 @@ msgstr "Autoguardado durante el juego"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Explorar Auto-Evolución"
 
@@ -332,7 +332,7 @@ msgstr "Estado de auto-evo:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Moverse automáticamente hacia adelante"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Auto ({0}x{1})"
 
@@ -345,9 +345,9 @@ msgid "AWAKEN"
 msgstr "Despertar"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -483,7 +483,7 @@ msgstr "Permite la unión con otras células. Este es el primer paso hacia un se
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Presiona la tecla [thrive:input]g_toggle_binding[/thrive:input] para entrar al modo Unión. Cuando te encuentres en este modo, puedes unirte a otras células de tu misma especie entrando en contacto con ellas. Cuando desees abandonar una colonia, presiona la tecla [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr "Unir axis"
 
@@ -545,7 +545,7 @@ msgstr "Esta membrana tiene un caparazón resistente hecho de carbonato de calci
 msgid "CAMERA"
 msgstr "Cámara"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -673,7 +673,7 @@ msgstr "Cambiar la simetría"
 msgid "CHEATS"
 msgstr "Trucos"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Cheats activados"
 
@@ -763,7 +763,7 @@ msgstr "Produce [thrive:compound type=\"glucose\"][/thrive:compound]. La tasa de
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "El nombre de archivo ({0}) ya existe. ¿Deseas sobreescribir?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Aberración cromática:"
 
@@ -804,15 +804,15 @@ msgstr "Limpiar archivos de guardado antiguos"
 msgid "CLOSE"
 msgstr "Cerrar"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "¿Cerrar Ajustes?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Divisor de Resolución de Nubes:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Mínimo de intervalo de simulación de nubes:"
 
@@ -828,7 +828,7 @@ msgstr "Crear entidades con cuadros de colisión"
 msgid "COLOUR"
 msgstr "Color"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Corrección de color para daltónicos:"
 
@@ -889,23 +889,23 @@ msgstr "Saturación"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Brillo"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr "Foro de la comunidad"
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Únete a la comunidad de Thrive en nuestro foro comunitario"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr "Wiki Comunitaria"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Visita nuestra wiki comunitaria"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr "Compilado en:"
 
@@ -931,7 +931,7 @@ msgstr "Compuestos:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Balance de compuestos"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Nubes de compuestos"
 
@@ -1016,7 +1016,7 @@ msgstr "Continuar al prototipo de la siguiente etapa?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr "Visualizador del axis del contról:"
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr "Zona muerta del contról"
 
@@ -1031,11 +1031,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr "Zona muerta:"
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr "Sensibilidad del contról"
 
@@ -1043,11 +1043,11 @@ msgstr "Sensibilidad del contról"
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Copiar Error al Portapapeles"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanomalía (Rojo-Verde)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanomalía (Azul-Amarillo)"
 
@@ -1103,7 +1103,7 @@ msgstr "Creando..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Creando objetos de la partida guardada"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Créditos"
 
@@ -1129,7 +1129,7 @@ msgstr "Desarrolladores actuales"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Estadísticas del Organismo"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Nombre personalizado:"
 
@@ -1195,7 +1195,7 @@ msgstr "Panel de Depuración"
 msgid "DECEMBER"
 msgstr "Diciembre"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Dispositivo de salida predeterminado"
 
@@ -1257,7 +1257,7 @@ msgstr "La descripción es demasiado larga"
 msgid "DESPAWN_ENTITIES"
 msgstr "Destruir todas las entidades"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Numero de CPU detectado:"
 
@@ -1272,11 +1272,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Desarrolladores"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr "Foro de Desarrollo"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Lee las noticias sobre el desarrollo del juego en nuestro foro de desarrollo"
 
@@ -1284,11 +1284,11 @@ msgstr "Lee las noticias sobre el desarrollo del juego en nuestro foro de desarr
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Desarrollo apoyado por Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr "Wiki de Desarrollo"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Visita nuestra wiki de desarrollo"
 
@@ -1370,7 +1370,7 @@ msgstr "Izquierda"
 msgid "DIRECTIONR"
 msgstr "Derecha"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Desactivado"
 
@@ -1378,7 +1378,7 @@ msgstr "Desactivado"
 msgid "DISABLE_ALL"
 msgstr "Deshabilitar todo"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Descartar y continuar"
 
@@ -1416,33 +1416,33 @@ msgstr ""
 "Hay orgánulos desconectados del resto de la célula.\n"
 "Por favor conecta todos los orgánulos o deshaz tus cambios."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr "Únete a nuestro servidor de Discord"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Popups deshabilitadps:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 "Esto muestra cuantos popups han sido permanentemente deshabilitados por el usuario.\n"
 "Si alguno de los popups que necesita están deshabilitados, el botón junto a este puede ser utilizado para mostrar todos los popups nuevamente."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Mostrar la barra de habilidades"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Mostrar particular de fondo"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Mostrar nombre de botones durante selección de partes"
 
@@ -1477,7 +1477,7 @@ msgstr "Doble click para ver en pantalla completa"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Una membrana con dos capas; tiene mejor protección y consume menos energía. Sin embargo, reduce un poco la velocidad del movimiento y absorbe recursos más lentamente."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "No mostrar nuevamente"
 
@@ -1630,7 +1630,7 @@ msgstr ""
 "\n"
 "Para ir a la pestaña siguiente en el editor, presiona el botón 'Siguiente' en la parte inferior derecha."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1646,7 +1646,7 @@ msgstr "Activar todos los mods compatibles"
 msgid "ENABLE_EDITOR"
 msgstr "Activar editor"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Habilitar efectos de luz GUI"
 
@@ -1703,7 +1703,7 @@ msgstr "Mostrar / Ocultar medio ambiente"
 msgid "EPIPELAGIC"
 msgstr "Epipelágico"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Error"
 
@@ -1715,16 +1715,16 @@ msgstr "Error al crear la carpeta para el mod"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Error al crear el archivo de información del mod"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Error: Fallo al guardar nuevos ajustes al archivo de configuración."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(Crea secretor en el juego aleatoriamente)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Error al crear el archivo de información del mod"
@@ -1760,11 +1760,11 @@ msgstr ""
 "\n"
 "Si nada de esto se aplica a tu caso, ha sucedido un error. Por favor, notifica al equipo de desarrollo junto con el registro del juego."
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr "Versión exacta de Thrive:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Esta es la commit exacta desde la cual esta versión de Thrive fue compilada"
 
@@ -1780,7 +1780,7 @@ msgstr "Una excepción ha ocurrido al cargar los datos guardados"
 msgid "EXIT"
 msgstr "Salir"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Lanzar E"
@@ -1833,7 +1833,7 @@ msgstr "La especie se extinguió de la zona"
 msgid "EXTINCT_SPECIES"
 msgstr "EXTINCIÓN"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1841,7 +1841,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr "Ajustes Extra"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Visita nuestra página de Facebook"
 
@@ -1873,12 +1873,12 @@ msgstr "Activado"
 msgid "FEBRUARY"
 msgstr "Febrero"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Error en la inicialización de la biblioteca de cliente de Steam"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1900,11 +1900,11 @@ msgstr ""
 "Tiempo total de CPU:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2028,7 +2028,7 @@ msgstr "Fosilizar especie (ya fosilizada)"
 msgid "FOSSILISE"
 msgstr "Fosilizar"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2058,7 +2058,7 @@ msgstr "Nuble de glucosa gratuita al salir del editor"
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(empieza con una nube de glucosa en cada generación)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Pantalla completa"
 
@@ -2086,23 +2086,23 @@ msgstr "Generaciones"
 msgid "GENERATION_COLON"
 msgstr "Generación:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr "Visita nuestro repositorio de GitHub"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Advertencia del modo GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Estás usando Thrive en el Modo GLES2. No está probado y probablemente cause errores. Intenta actualizar tus drivers de video y/o fuerza los gráficos AMD o Nvidia para ser usados al ejecutar Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr "GLES3"
 
@@ -2155,11 +2155,11 @@ msgstr "Entendido"
 msgid "GPL_LICENSE_HEADING"
 msgstr "Texto de la licencia GPL:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "GPU:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Gráficos"
 
@@ -2167,7 +2167,7 @@ msgstr "Gráficos"
 msgid "GRAPHICS_TEAM"
 msgstr "Equipo de diseño grafico"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "GUI"
 
@@ -2184,7 +2184,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} K"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Volumen de la interfaz"
 
@@ -2206,11 +2206,11 @@ msgstr "Ayuda"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Ayuda"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(valores más altos mejoran el rendimiento)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(valores más altos empeoran el rendimiento)"
 
@@ -2234,7 +2234,7 @@ msgstr "Mantener [thrive:input]g_free_cursor[/thrive:input] para mostrar el curs
 msgid "HOME"
 msgstr "Inicio"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr "Horizontal:"
 
@@ -2307,7 +2307,7 @@ msgstr "Material por Digestar"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Únete a nuestro servidor de Discord"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Entradas"
 
@@ -2360,8 +2360,8 @@ msgstr "Formato de URL invalido"
 msgid "INVALID_URL_SCHEME"
 msgstr "Esquema URL inválido"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr "Invertido"
 
@@ -2383,7 +2383,7 @@ msgstr "Hierro"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Quimiolitoautotrofía Férrica"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr "Visita nuestra página de itch.io"
 
@@ -2391,19 +2391,19 @@ msgstr "Visita nuestra página de itch.io"
 msgid "JANUARY"
 msgstr "Enero"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "Modo de depuración JSON:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Siempre"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automáticamente"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Nunca"
 
@@ -2585,19 +2585,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Idioma:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Este lenguaje está traducido en un {0}%"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Este idioma aún es un trabajo en progreso ({0}% completado)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "¡Esta traducción está muy incompleta ({0}% hecha) por favor ayúdanos con ella!"
 
@@ -2759,7 +2759,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Clic izquierdo"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licencias"
 
@@ -2829,7 +2829,7 @@ msgstr "Rueda hacia la derecha"
 msgid "LIGHT_MAX"
 msgstr "Luz"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Extremo"
 
@@ -2841,31 +2841,31 @@ msgstr "Limita el crecimiento del uso de compuestos"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(Si es habilitado, limita la cantidad necesaria de compuestos; si no, solo los compuestos disponibles limitan la velocidad de crecimiento)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Gigante"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Grande"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Normal"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Pequeño"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Minusculo"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Muy grande"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Muy pequeño"
 
@@ -2889,7 +2889,7 @@ msgstr "Cargar"
 msgid "LOADING"
 msgstr "Cargando"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Cargando..."
@@ -2920,12 +2920,12 @@ msgstr "Presiona el botón de deshacer en el editor para corregir un error"
 msgid "LOAD_FINISHED"
 msgstr "Carga terminada"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Cargar partida"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Cargar una partida guardada"
 
@@ -2999,7 +2999,7 @@ msgstr "Marzo"
 msgid "MARINE_SNOW"
 msgstr "Nieve marina"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Volumen general"
 
@@ -3007,15 +3007,15 @@ msgstr "Volumen general"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Forzar extinction en zonas con igual o major cantidad de especies"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "FPS Máximos:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Ilimitado"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Numero máximo de entidades:"
 
@@ -3202,7 +3202,7 @@ msgstr "En cada generación, tienes 100 puntos de mutación (PM) para gastar, y 
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Cada vez que tu célula se reproduce, entrarás al editor de microbio, donde puedes hacerle cambios a tu especie (añadiendo, moviendo y/o quitando orgánulos) para incrementar tus chances de éxito. Cada visita al editor en el estadio de microbio representa [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] millones de años de evolución."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor libre de microbios"
 
@@ -3384,7 +3384,7 @@ msgstr "Versión mínima:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "¡No se pueden mostrar menos de {0} dataset(s)!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Misc."
 
@@ -3448,11 +3448,11 @@ msgstr "Modificar orgánulos"
 msgid "MODIFY_TYPE"
 msgstr "Modificar Tipo"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Se ha detectado la instalación de mods, pero no hay mods habilitados.\n"
@@ -3541,11 +3541,11 @@ msgstr "Nombre Interno (de Carpeta):"
 msgid "MOD_LICENSE"
 msgstr "Licencia del Mod:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Errores de carga de mod"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Se produjeron errores al cargar uno o más mods. Los registros pueden contener información adicional."
 
@@ -3598,11 +3598,11 @@ msgstr "Versión:"
 msgid "MORE_INFO"
 msgstr "Mostrar más información"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr "Sensibilidad del ratón"
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr "Sensibilidad del ratón por escala de ventana"
 
@@ -3716,7 +3716,7 @@ msgstr "Multiples Meatbballs"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Multiples Orgánulos"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "MSAA:"
 
@@ -3731,7 +3731,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Música"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Volumen de la Música"
 
@@ -3751,9 +3751,9 @@ msgstr "(Costo de orgánulos, membranas, y otros objetos en el editor)"
 msgid "MUTATION_POINTS"
 msgstr "Puntos de Mutación"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Silenciar"
 
@@ -3789,11 +3789,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Población inicial para especies creadas para aumentar biodiversidad"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Nueva Partida"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Nueva partida"
 
@@ -3858,7 +3858,7 @@ msgstr "El Nitroplasto es una proteína capaz de usar nitrógeno, oxígeno y ATP
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Convierte [thrive:compound type=\"atp\"][/thrive:compound] en [thrive:compound type=\"ammonia\"][/thrive:compound]. La tasa de conversión depende de la concentración de [thrive:compound type=\"nitrogen\"][/thrive:compound] y [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Ninguna"
 
@@ -3906,7 +3906,7 @@ msgstr "No hay eventos registrados"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "No se ha encontrado ningún directorio de guardado"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr "No hay mods habilitados"
 
@@ -3923,7 +3923,7 @@ msgstr "No se han encontrado partidas guardadas"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "No se ha encontrado ningún directorio de guardado"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Abrir carpeta de capturas de pantalla"
 
@@ -3971,15 +3971,15 @@ msgstr "N/A PM"
 msgid "OCTOBER"
 msgstr "Octubre"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr "Sitio oficial"
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Visitar la página web oficial de Revolutionary Games"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4017,7 +4017,7 @@ msgstr "Abrir pantalla de ayuda"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Abrir en el modo libre"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Abrir carpeta de registros"
 
@@ -4033,7 +4033,7 @@ msgstr "Abrir menu de orgánulos"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Abrir directorio de guardado"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Abrir carpeta de capturas de pantalla"
 
@@ -4041,7 +4041,7 @@ msgstr "Abrir carpeta de capturas de pantalla"
 msgid "OPEN_THE_MENU"
 msgstr "Abrir el menú"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Ayuda a traducir el juego"
 
@@ -4060,11 +4060,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunista"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Ajustes"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Cambiar configuración"
 
@@ -4273,7 +4273,7 @@ msgstr "Generación Procesal"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr "Visita nuestro Patreon"
 
@@ -4323,7 +4323,7 @@ msgstr "Pacífica"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Rendimiento"
 
@@ -4410,7 +4410,7 @@ msgstr "Jugador duplicado"
 msgid "PLAYER_EXTINCT"
 msgstr "El jugador se extinguió"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "El jugador se extinguió"
@@ -4425,26 +4425,26 @@ msgstr ""
 "Velocidad\n"
 "del jugador"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 #, fuzzy
 msgid "PLAYSTATION_3"
 msgstr "población:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 #, fuzzy
 msgid "PLAYSTATION_4"
 msgstr "población:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 #, fuzzy
 msgid "PLAYSTATION_5"
 msgstr "población:"
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Reproducir vídeo introductorio"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Reproducir cinemática de entrada del estadio de Microbio en nueva partida"
 
@@ -4563,11 +4563,11 @@ msgstr "Carga rápida"
 msgid "QUICK_SAVE"
 msgstr "Guardado rápido"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Salir"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Salir del juego"
@@ -4609,7 +4609,7 @@ msgstr "Listo"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Versión de Thrive recomendada:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr "Visita nuestra página de Reddit"
 
@@ -4662,7 +4662,7 @@ msgstr "Reproducción:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Requiere Núcleo"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Restablecer"
 
@@ -4670,23 +4670,23 @@ msgstr "Restablecer"
 msgid "RESET_DEADZONES"
 msgstr "Redefinir zona muerta"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr "Reiniciar ventanas emergentes"
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "¿Restablecer entradas a los valores por defecto?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr "Reiniciar teclas asociadas"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Predeterminado"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "¿Volver a los ajustes predeterminados?"
 
@@ -4695,7 +4695,7 @@ msgstr "¿Volver a los ajustes predeterminados?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr "Resistencia a ser engullido"
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Resolución:"
 
@@ -4745,7 +4745,7 @@ msgstr ""
 "Estas seguro que quieres volver al menú principal?\n"
 "Perderás todo el progreso que no hayas guardado."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Visita los sitios web oficiales de Revolutionary Games"
 
@@ -4777,7 +4777,7 @@ msgstr "Girar a la derecha"
 msgid "ROTATION_COLON"
 msgstr "Rotación:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Ejecutar auto-evo durante el juego"
 
@@ -4832,7 +4832,7 @@ msgstr "La Rusticianina es una proteína capaz de usar dióxido de carbono gaseo
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Convierte [thrive:compound type=\"iron\"][/thrive:compound] en [thrive:compound type=\"atp\"][/thrive:compound]. La velocidad de conversión es directamente proporcional a la concentración de [thrive:compound type=\"carbondioxide\"][/thrive:compound] y [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive se ha iniciado en modo seguro debido a una error en el inicio del juego.\n"
@@ -4844,15 +4844,15 @@ msgstr ""
 "\n"
 "Si no arreglas el problema que causa el error, necesitarás reiniciar y crashear Thrive multiples veces para volver al modo seguro."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive iniciado en modo seguro"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Guardar"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Guardar y continuar"
 
@@ -4950,20 +4950,20 @@ msgstr "No se pudo guardar debido a:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Guardado con éxito"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr "Ninguno"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr "Escalado"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr "Escalado inversamente"
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "para incrementar la velocidad de movimiento"
@@ -5061,7 +5061,7 @@ msgstr "sésil"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Este valor solo se aplica a nuevos juegos empezados tras cambiar esta opción"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Volumen de efectos"
 
@@ -5077,21 +5077,25 @@ msgstr "Mostrar ayuda"
 msgid "SHOW_TUTORIALS"
 msgstr "Mostrar tutoriales"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Mostrar tutoriales (en la partida actual)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Mostrar tutoriales (en nuevas partidas)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Mostrar aviso de progreso sin guardar"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Activa / Desactiva la advertencia de que perderás los datos no guardados si intentas salir del juego."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5139,7 +5143,7 @@ msgstr "Sílice"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Esta membrana tiene una dura pared de sílice. Puede resistir el daño muy bien, especialmente el daño físico. También requiere menos energía. No obstante, ralentiza a la célula drásticamente y absorbe recursos a una velocidad menor."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5179,7 +5183,7 @@ msgstr "Transforma [thrive:compound type=\"glucose\"][/thrive:compound] en [thri
 msgid "SMALL_IRON_CHUNK"
 msgstr "Fragmento de hierro pequeño"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Sonido"
 
@@ -5382,17 +5386,17 @@ msgstr "¡UPS!, parece que Steam no se encuentra disponible en este momento. Por
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Se ha producido un error desconocido de Steam"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Error en la inicialización de la biblioteca de cliente de Steam"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Actualizando el archivo de guardado especificado debido al siguiente error:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr "Visita nuestra página de Steam"
 
@@ -5432,7 +5436,7 @@ msgstr "Almacenamiento"
 msgid "STORAGE_COLON"
 msgstr "Almacenamiento:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Conectado como: {0}"
 
@@ -5549,7 +5553,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Equipo de testeo"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5564,7 +5568,7 @@ msgstr ""
 "\n"
 "Si te gustó el juego, cuéntale a tus amigos sobre nosotros."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "¡HAS PROSPERADO!"
@@ -5620,11 +5624,11 @@ msgstr "Este mod fue instalado localmente"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Este mod fue descargado desde el Workshop de Steam"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Hilos:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thrivepedia"
 
@@ -5780,7 +5784,7 @@ msgstr "Pausa"
 msgid "TOGGLE_UNBINDING"
 msgstr "Alternar separación"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Herramientas"
 
@@ -5845,7 +5849,7 @@ msgstr "Intenta tomar algunas capturas de pantalla!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "¡Intenta guardar una partida!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Intenta tomar algunas capturas de pantalla!"
 
@@ -6010,11 +6014,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Ver ahora"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr "Visita nuestra página de Twitter"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6039,7 +6043,7 @@ msgstr "Desunir todas"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Modo desunión"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr "Esta es una versión de prueba por lo que la información mostada debajo puede no estar a la actualizada"
 
@@ -6059,7 +6063,7 @@ msgstr "Deshacer la última acción"
 msgid "UNKNOWN"
 msgstr "Desconocido"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Desconocido"
 
@@ -6071,7 +6075,7 @@ msgstr "Botón desconocido del mouse"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Desconocido en Windows"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "Versión desconocida"
 
@@ -6079,7 +6083,7 @@ msgstr "Versión desconocida"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "ID de Workshop desconocido para el mod actual"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Tienes cambios sin guardar que serán descartados.\n"
@@ -6123,7 +6127,7 @@ msgstr "Guardado con éxito"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Licencias y Bibliotecas Usadas"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "Renderizardor en uso:"
 
@@ -6139,7 +6143,7 @@ msgstr "Usar carga Automática de Harmony"
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Automáticamente carga parches de Harmony desde Assembly (no requiere especificar la clase del mod)"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Usar un nombre personalizado"
 
@@ -6147,11 +6151,11 @@ msgstr "Usar un nombre personalizado"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "Especies creadas para aumentar biodiversidad toma parte su población de especies existente"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Ajustar manualmente el número de hilos en segundo plano"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr "Utilizar tamaño de ventana virtual"
 
@@ -6177,7 +6181,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Versión:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr "Vertical:"
 
@@ -6186,11 +6190,11 @@ msgstr "Vertical:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Vertical (Axis:{0})"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "Memoria de video en uso:"
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0} MiB"
 
@@ -6198,7 +6202,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Visualizador"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Ver código fuente"
 
@@ -6210,7 +6214,7 @@ msgstr "Colaboradores VIP"
 msgid "VISIBLE"
 msgstr "Visible"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Sugerir una característica"
 
@@ -6230,7 +6234,7 @@ msgstr "Silenciar volumen"
 msgid "VOLUMEUP"
 msgstr "Subir volumen"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "Sincronización Vertical"
 
@@ -6339,7 +6343,7 @@ msgstr ""
 "Incluir prototipos de etapas posteriores: {0}\n"
 "Incluir \"huevos de pascua\": {1}"
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "para incrementar la velocidad de movimiento"
@@ -6348,15 +6352,15 @@ msgstr "para incrementar la velocidad de movimiento"
 msgid "WORST_PATCH_COLON"
 msgstr "Peor bioma:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6368,7 +6372,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "años"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Visita nuestro canal de YouTube"
 

--- a/locale/es_AR.po
+++ b/locale/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-01-20 07:56+0000\n"
 "Last-Translator: Iván Sviser Lisiuk <lextromex@gmail.com>\n"
 "Language-Team: Spanish (Argentina) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/es_AR/>\n"
@@ -203,7 +203,7 @@ msgstr "\" {0} \" - {1}"
 msgid "ART_BY"
 msgstr "Arte creado por {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 #, fuzzy
 msgid "ART_GALLERY"
 msgstr "Fan Arts"
@@ -300,7 +300,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -344,8 +344,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -604,27 +604,27 @@ msgstr "Bloq Mayus"
 msgid "CARBON_DIOXIDE"
 msgstr "Dióxido de carbono"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -888,19 +888,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1100,7 +1100,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Créditos"
 
@@ -1262,11 +1262,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1274,11 +1274,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1392,7 +1392,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgstr "población:"
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "Normal"
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1666,15 +1666,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1727,6 +1727,15 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "Normal"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1776,7 +1785,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1828,7 +1837,7 @@ msgstr "populación en parches:"
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1836,7 +1845,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1863,6 +1872,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1947,7 +1972,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -2046,7 +2071,7 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -2054,12 +2079,12 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 #, fuzzy
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 advertencia de modo"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Estas abriendo Thrive mediante GLES2. Esto esta casi totalmente sin probar y seguro se te crashea o bugea. Intenta pibe actualizar tus controladores de video y/o fuerce el uso de gráficos AMD o Nvidia para ejecutar Thrive sin que se te trabe."
 
@@ -2343,7 +2368,7 @@ msgstr "Hierro"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2561,7 +2586,7 @@ msgstr "Este lenguaje todavía esta en progreso ({0}% completado)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Esta traducción esta bastante incompleta ({0}% hecha) porfis ayudanos a terminarla!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2720,7 +2745,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licencias"
 
@@ -2854,7 +2879,8 @@ msgstr ""
 msgid "LOADING"
 msgstr "Preparate por que los viern… Cargando"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Presiona cualquier tecla…"
@@ -2886,12 +2912,12 @@ msgstr "Presiona el botón de deshacer en el editor para corregir el error"
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Cargar Juego"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3172,7 +3198,7 @@ msgstr ""
 "\n"
 "Nitrogenasa: Convierte el nitrógeno atmosférico en amoníaco y consume ATP."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3407,11 +3433,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3497,11 +3523,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Error cargando tus mods"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Un error ha ocurrido mientras cargábamos uno o varios de tus mods. Los logs pueden que contengan información adicional del error."
 
@@ -3735,15 +3761,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Nuevo Juego"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3849,7 +3879,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3861,7 +3891,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Desactivado"
@@ -3892,7 +3922,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr "Núcleo"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3911,8 +3941,8 @@ msgstr "Bloq Num"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3925,15 +3955,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4005,11 +4035,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opciones"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4219,7 +4249,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4277,8 +4307,8 @@ msgstr "Rendimiento"
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4328,7 +4358,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4403,7 +4433,7 @@ msgstr "población:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "populación en parches:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4459,7 +4489,7 @@ msgstr "anterior:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4503,11 +4533,11 @@ msgstr "Carga rápida"
 msgid "QUICK_SAVE"
 msgstr "Guardado rapido"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Salida"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4548,7 +4578,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4685,7 +4715,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4775,12 +4805,12 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "Normal"
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -5156,7 +5186,7 @@ msgstr "Spawnear amoníaco"
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -5207,7 +5237,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5324,16 +5354,16 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "población:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5374,7 +5404,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Logeado como: {0}"
 
@@ -5489,7 +5519,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5497,7 +5527,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5558,7 +5588,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5711,7 +5741,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Desvincular"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Herramientas"
 
@@ -5881,7 +5911,7 @@ msgstr "Usá W, A, S y D y el mouse para moverte. E para disparar OxiToxi NT si 
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -6070,7 +6100,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -6082,7 +6112,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6235,7 +6265,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/es_AR.po
+++ b/locale/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-01-20 07:56+0000\n"
 "Last-Translator: Iván Sviser Lisiuk <lextromex@gmail.com>\n"
 "Language-Team: Spanish (Argentina) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/es_AR/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.9.1\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr "Habilitar el editor"
 msgid "3D_MOVEMENT"
 msgstr "Movimientos"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -141,7 +141,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Volumen del ambiente"
 
@@ -152,11 +152,11 @@ msgstr "Volumen del ambiente"
 msgid "AMMONIA"
 msgstr "Amoníaco"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -182,11 +182,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr "\" {0} \" - {1}"
 msgid "ART_BY"
 msgstr "Arte creado por {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 #, fuzzy
 msgid "ART_GALLERY"
 msgstr "Fan Arts"
@@ -216,7 +216,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Dispositivo de salida:"
 
@@ -264,8 +264,8 @@ msgstr "Dispositivo de salida:"
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Automática"
 
@@ -292,7 +292,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% ha hecho {1:n0}/{2:n0} pasos."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -300,7 +300,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -330,7 +330,7 @@ msgstr "anterior:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Moverse automáticamente"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 #, fuzzy
 msgid "AUTO_RESOLUTION"
 msgstr "Resolución:"
@@ -344,9 +344,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -485,7 +485,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr "Cámara"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -680,7 +680,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr "Chetos (de cmds)"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Aberración cromática:"
 
@@ -812,15 +812,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr "Cerrar"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -836,7 +836,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Correcciones para daltónicos:"
 
@@ -888,23 +888,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "población:"
@@ -931,7 +931,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Nubes de componentes"
 
@@ -1014,7 +1014,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1039,11 +1039,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanopia (Rojo-verde)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanopia (Azul-Amarillo)"
 
@@ -1100,7 +1100,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Créditos"
 
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1191,7 +1191,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Dispositivo de salida por defecto"
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1262,11 +1262,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1274,11 +1274,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1352,7 +1352,7 @@ msgstr "Izquierda"
 msgid "DIRECTIONR"
 msgstr "Derecha"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Desactivado"
 
@@ -1360,7 +1360,7 @@ msgstr "Desactivado"
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1392,33 +1392,33 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "población:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "Normal"
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Barrita de habilidades (recomendado)"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "Barrita de habilidades (recomendado)"
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1638,7 +1638,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "x8"
 
@@ -1654,7 +1654,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr "Habilitar el editor"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Permitir efectos de luz del GUI"
 
@@ -1711,7 +1711,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1723,16 +1723,16 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "Normal"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1764,12 +1764,12 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "población:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1785,7 +1785,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1837,7 +1837,7 @@ msgstr "populación en parches:"
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1845,7 +1845,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1874,19 +1874,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2011,7 +2011,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "x4"
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Pantalla completa"
 
@@ -2071,24 +2071,24 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 #, fuzzy
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 advertencia de modo"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Estas abriendo Thrive mediante GLES2. Esto esta casi totalmente sin probar y seguro se te crashea o bugea. Intenta pibe actualizar tus controladores de video y/o fuerce el uso de gráficos AMD o Nvidia para ejecutar Thrive sin que se te trabe."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2142,12 +2142,12 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "Nuevo Juego"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Gráficos"
 
@@ -2155,7 +2155,7 @@ msgstr "Gráficos"
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2167,7 +2167,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Volumen de la interfaz"
 
@@ -2189,11 +2189,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(mayor valor te queman la pc)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(mientras mas alto peor te iba ir tu pc bro)"
 
@@ -2218,7 +2218,7 @@ msgstr ""
 msgid "HOME"
 msgstr "tecla \"Home\""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "población:"
@@ -2294,7 +2294,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Controles"
 
@@ -2347,8 +2347,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2368,7 +2368,7 @@ msgstr "Hierro"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2376,19 +2376,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2570,19 +2570,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Idiomas bro:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Este lenguaje esta {0}% completado"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Este lenguaje todavía esta en progreso ({0}% completado)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Esta traducción esta bastante incompleta ({0}% hecha) porfis ayudanos a terminarla!"
 
@@ -2745,7 +2745,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licencias"
 
@@ -2814,7 +2814,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr "x8"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "Extras"
@@ -2829,32 +2829,32 @@ msgstr "Normal"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "Normal"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "Normal"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2879,7 +2879,7 @@ msgstr ""
 msgid "LOADING"
 msgstr "Preparate por que los viern… Cargando"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
@@ -2912,12 +2912,12 @@ msgstr "Presiona el botón de deshacer en el editor para corregir el error"
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Cargar Juego"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2986,7 +2986,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr "Nieve marina(?"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Volumen maestro"
 
@@ -2995,15 +2995,15 @@ msgstr "Volumen maestro"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "populación en parches:"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Máximos FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Poder ilimitado"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3198,7 +3198,7 @@ msgstr ""
 "\n"
 "Nitrogenasa: Convierte el nitrógeno atmosférico en amoníaco y consume ATP."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3368,7 +3368,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Otras cosas"
 
@@ -3433,11 +3433,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3523,11 +3523,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Error cargando tus mods"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Un error ha ocurrido mientras cargábamos uno o varios de tus mods. Los logs pueden que contengan información adicional del error."
 
@@ -3580,11 +3580,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3702,7 +3702,7 @@ msgstr "Poner organela"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Poner organela"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 #, fuzzy
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Multiejemplo anti-aliasing:"
@@ -3715,7 +3715,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Volumen de la música"
 
@@ -3735,9 +3735,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Mutear"
 
@@ -3769,11 +3769,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Nuevo Juego"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3842,7 +3842,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Ninguno (no activado)"
 
@@ -3891,7 +3891,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Desactivado"
@@ -3909,7 +3909,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3955,15 +3955,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -4010,7 +4010,7 @@ msgstr "Abrir menú de organelas"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -4018,7 +4018,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Ayudame a traducir el juego bro"
 
@@ -4035,11 +4035,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opciones"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4249,7 +4249,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4299,7 +4299,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Rendimiento"
 
@@ -4382,7 +4382,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4394,23 +4394,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4533,11 +4533,11 @@ msgstr "Carga rápida"
 msgid "QUICK_SAVE"
 msgstr "Guardado rapido"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Salida"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4578,7 +4578,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4634,7 +4634,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr "Núcleo"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "NOW ENGLISH"
 
@@ -4642,23 +4642,23 @@ msgstr "NOW ENGLISH"
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4667,7 +4667,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Resolución:"
 
@@ -4715,7 +4715,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr "población:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4805,20 +4805,20 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "Normal"
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4911,23 +4911,23 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr ""
 "Agente de \n"
 "vinculación"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5028,7 +5028,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Volumen de efectos"
 
@@ -5044,20 +5044,24 @@ msgstr "Mostrar mini-tutorial"
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -5116,7 +5120,7 @@ msgstr "Silicio"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "x16"
 
@@ -5158,7 +5162,7 @@ msgstr "población:"
 msgid "SMALL_IRON_CHUNK"
 msgstr "Pedacito de hierro"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Sonido"
 
@@ -5354,16 +5358,16 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "población:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Logeado como: {0}"
 
@@ -5519,7 +5523,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5527,7 +5531,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5741,7 +5745,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Desvincular"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Herramientas"
 
@@ -5808,7 +5812,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5911,11 +5915,11 @@ msgstr "Usá W, A, S y D y el mouse para moverte. E para disparar OxiToxi NT si 
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "x2"
 
@@ -5940,7 +5944,7 @@ msgstr "Desvincular a todos"
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5960,7 +5964,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Barrita de habilidades (recomendado)"
@@ -5973,7 +5977,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5981,7 +5985,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -6023,7 +6027,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6039,7 +6043,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -6047,11 +6051,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6077,7 +6081,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "población:"
@@ -6088,11 +6092,11 @@ msgstr "población:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Nuevo Juego"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6100,7 +6104,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -6112,7 +6116,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6132,7 +6136,7 @@ msgstr "Mutear volumen"
 msgid "VOLUMEUP"
 msgstr "Subir Volumen"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSync"
 
@@ -6237,7 +6241,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -6245,15 +6249,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6265,7 +6269,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/et.po
+++ b/locale/et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-04-07 21:08+0000\n"
 "Last-Translator: Anelle Lisetter Viktoria Rodin <lisete.rodin@gmail.com>\n"
 "Language-Team: Estonian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/et/>\n"
@@ -215,7 +215,7 @@ msgstr "\"{0}\" – {1}"
 msgid "ART_BY"
 msgstr "Kunst autorilt {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Kunstigalerii"
 
@@ -315,7 +315,7 @@ msgstr "Automaatne salvestamine mängu ajal"
 msgid "AUTO_EVO"
 msgstr "auto-evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "käitamise olek:"
@@ -360,8 +360,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -624,27 +624,27 @@ msgstr "caps lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Süsinikdioksiid"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "küllus"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "õiglane summa"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "pisut"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "üsna palju"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "mõni"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "väga vähe"
 
@@ -918,21 +918,21 @@ msgstr "Küllastusväärtus, halli hulk konkreetses värvitoonis"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Värvi väärtus (heledus), heledus või intensiivsus"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Lisage uus võtme sidumine"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "meie Viki"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "vabasurm"
@@ -1147,7 +1147,7 @@ msgstr "Loomine..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Objektide loomine salvestamisest"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Krediidid"
 
@@ -1323,12 +1323,12 @@ msgstr "Devbuildsi toetajad"
 msgid "DEVELOPERS"
 msgstr "Arendajad"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Arendust toetab Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Lisage uus võtme sidumine"
@@ -1337,12 +1337,12 @@ msgstr "Lisage uus võtme sidumine"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Arendust toetab Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Arendajad"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Abi"
@@ -1467,7 +1467,7 @@ msgstr ""
 "Seal on paigutatud organellid, mis ei ole ülejäänud osaga ühendatud.\n"
 "Ühendage kõik paigutatud organellid üksteisega või võtke muudatused tagasi."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Möödunud aeg: {0:#,#} aastat"
@@ -1485,7 +1485,7 @@ msgstr ""
 "ja võib olla tükkide osas palju ambitsioonikam.\n"
 "Reageerivad mikroobid lülituvad varem uutele sihtmärkidele."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Kahekihiline membraan kaitseb paremini kahjustuste eest ja võtab vähem energiat, et mitte deformeeruda. Siiski aeglustab see raku tööd ja aeglustab ressursside neelamise kiirust."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1722,15 +1722,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Energia: {0}, {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Energiaallikad:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "Kogutud energia on {0} individuaalse kuluga {1}, mille tulemuseks on korrigeerimata elanikkond {2}"
 
@@ -1786,6 +1786,20 @@ msgstr "Viga mod teabefaili loomisel"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Viga: uute sätete salvestamine konfiguratsioonifaili nurjus."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+"Kartlikud mikroobid põgenevad suuremate vahemaade taha\n"
+"ja üldiselt põgenevad nad suurema tõenäosusega röövloomade eest.\n"
+"Vapraid mikroobe ei hirmuta läheduses olevad kiskjad\n"
+"ja tõenäoliselt ründab tagasi."
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Viga mod teabefaili loomisel"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Viga laadimisel"
@@ -1838,7 +1852,7 @@ msgstr "Salvestusandmete laadimisel juhtus erand"
 msgid "EXIT"
 msgstr "Välju"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Käivitage E"
@@ -1892,7 +1906,7 @@ msgstr "Lapist välja surnud"
 msgid "EXTINCT_SPECIES"
 msgstr "Väljasurnud liigid"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Lisad"
 
@@ -1900,7 +1914,7 @@ msgstr "Lisad"
 msgid "EXTRA_OPTIONS"
 msgstr "Lisavalikud"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Peata mäng"
@@ -1934,6 +1948,23 @@ msgstr "Petuklahvid on lubatud"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "veebruar"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Steam kliendi teegi lähtestamine ebaõnnestus"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -2020,7 +2051,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Toiduahel"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0} energia: {1} (fitness: {2}) kogu saadaolev energia: {3} (kogu fitness: {4})"
 
@@ -2135,7 +2166,7 @@ msgstr "Põlvkond:"
 msgid "GENERATION_COLON"
 msgstr "Põlvkond:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "vabasurm"
@@ -2144,11 +2175,11 @@ msgstr "vabasurm"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 režiimi hoiatus"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Kasutate GLES2-ga Thrive'i. See on tõsiselt testimata ja põhjustab tõenäoliselt probleeme. Proovige värskendada oma videodraivereid ja/või sundida Thrive'i käitamiseks kasutama AMD või Nvidia graafikat."
 
@@ -2439,7 +2470,7 @@ msgstr "Raud"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Raua kemolitoautotroofia"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "vabasurm"
@@ -2658,7 +2689,7 @@ msgstr "See keel on veel pooleli ({0}% valmis)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "See tõlge on väga puudulik ({0}% valmis). Palun aidake meid sellega!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2822,7 +2853,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Vasak hiir"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Litsentsid"
 
@@ -2963,7 +2994,8 @@ msgstr "Laadige"
 msgid "LOADING"
 msgstr "Laadimine"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Laadimine..."
 
@@ -2995,12 +3027,12 @@ msgstr "Vea parandamiseks vajutage redaktoris tagasivõtmisnuppu"
 msgid "LOAD_FINISHED"
 msgstr "Laadimine lõpetatud"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Laadi mäng"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Pausi menüü"
@@ -3281,7 +3313,7 @@ msgstr "Igal põlvkonnal on teil kulutada 100 mutatsioonipunkti (MP) ja iga muud
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Iga kord, kui paljunete, sisenete mikroobide redaktorisse, kus saate oma liigis muudatusi teha (lisades, liigutades või eemaldades organelle), et oma liigi edu suurendada. Iga mikroobide staadiumis toimetaja külastus tähistab [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] miljonit aastat evolutsiooni."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Microbe Freebuildi redaktor"
 
@@ -3534,11 +3566,11 @@ msgstr "Muuda Organelle"
 msgid "MODIFY_TYPE"
 msgstr "Muuda tüüp"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Modifikatsioonid"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3627,11 +3659,11 @@ msgstr "Sisemine (kausta) nimi:"
 msgid "MOD_LICENSE"
 msgstr "Modifikatsiooni litsents:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Modifikaadi laadimise vead"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Ühe või mitme modifikatsiooni laadimisel ilmnesid vead. Logid võivad sisaldada lisateavet."
 
@@ -3885,15 +3917,19 @@ msgstr ""
 "See salvestamine pärineb Thrive'i uuemast versioonist ja tõenäoliselt ei ühildu.\n"
 "Kas soovite siiski proovida salvestust laadida?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Uus mäng"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Pausi menüü"
@@ -3995,7 +4031,7 @@ msgid "NO_AI"
 msgstr "AI puudub"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Kuvatavaid andmeid pole"
 
@@ -4008,7 +4044,7 @@ msgstr "Sündmusi pole salvestatud"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Salvestatud kataloogi ei leitud"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "töövõimetu"
@@ -4039,7 +4075,7 @@ msgstr "Modifikatsiooni pole valitud"
 msgid "NUCLEUS"
 msgstr "Tuum"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -4058,8 +4094,8 @@ msgstr "Numeratsioonilukk"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "ei ole kohaldatav"
@@ -4072,16 +4108,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr "oktoober"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "vabasurm"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4162,11 +4198,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunistlik"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Valikud"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Abi"
@@ -4387,7 +4423,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Peata mäng"
@@ -4448,8 +4484,8 @@ msgstr "Esitus"
 msgid "PERFORM_UNBINDING"
 msgstr "Tehke lahti sidumine"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/sekund"
 
@@ -4499,7 +4535,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Mängija rakk"
 
@@ -4576,7 +4612,7 @@ msgstr "elanikkond:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "populatsioon laikudena:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4630,7 +4666,7 @@ msgstr "eelmine:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Laaditud objektide töötlemine"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4674,11 +4710,11 @@ msgstr "Kiire laadimine"
 msgid "QUICK_SAVE"
 msgstr "Kiire salvestamine"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Lõpeta"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4724,7 +4760,7 @@ msgstr "Teemad:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Soovitatav Thrive:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Jätkake mängu"
@@ -4866,7 +4902,7 @@ msgstr ""
 "Kas soovite kindlasti peamenüüst väljuda?\n"
 "Kaotate kõik salvestamata edusammud."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Autor Revolutionary Games Studio"
@@ -4955,7 +4991,7 @@ msgstr "Rustitsüaniin on valk, mis on võimeline kasutama gaasilist süsinikdio
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Muudab [thrive:compound type=\"iron\"][/thrive:compound] tüübiks [thrive:compound type=\"atp\"][/thrive:compound]. Hindamisskaalad kontsentratsiooniga [thrive:compound type=\"süsinikdioksiid\"][/thrive:compound] ja [thrive:compound type=\"hapnik\"][/thrive:ühend]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4964,7 +5000,7 @@ msgstr ""
 "Vapraid mikroobe ei hirmuta läheduses olevad kiskjad\n"
 "ja tõenäoliselt ründab tagasi."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Eemaldage kohalikud andmed"
@@ -5339,7 +5375,7 @@ msgstr "Kudema ammoniaaki"
 msgid "SPAWN_ENEMY"
 msgstr "Kudema vaenlane"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Ei saa kasutada vaenlase pettust, kuna see plaaster ei sisalda ühtegi vaenlase liiki"
 
@@ -5392,7 +5428,7 @@ msgstr "Liigi nimi..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Liigi nimi..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5507,19 +5543,19 @@ msgstr "Steam pole praegu saadaval, proovige uuesti"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Ilmnes tundmatu Steami viga"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Steam kliendi teegi lähtestamine ebaõnnestus"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Määratud salvestuse täiendamine nurjus järgmise tõrke tõttu:\n"
 "{0}"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Peata mäng"
@@ -5562,7 +5598,7 @@ msgstr "Varud"
 msgid "STORAGE_COLON"
 msgstr "Varud"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Sisse logitud kui: {0}"
 
@@ -5679,7 +5715,7 @@ msgstr "temperatuur."
 msgid "TESTING_TEAM"
 msgstr "Testimismeeskond"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5694,7 +5730,7 @@ msgstr ""
 "\n"
 "Kui teile mäng meeldis, rääkige meist oma sõpradele."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "SA OLED ÕIDULIKUD!"
@@ -5758,7 +5794,7 @@ msgstr "See mod laaditakse alla Steami töökojast"
 msgid "THREADS"
 msgstr "Teemad:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5909,7 +5945,7 @@ msgstr "Paus"
 msgid "TOGGLE_UNBINDING"
 msgstr "Lülita lahti sidumine"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Tööriistad"
 
@@ -6129,7 +6165,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Vaata nüüd"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Möödunud aeg: {0:#,#} aastat"
@@ -6329,7 +6365,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Vaataja"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Vaadake lähtekoodi"
 
@@ -6341,7 +6377,7 @@ msgstr "VIP toetajad"
 msgid "VISIBLE"
 msgstr "Nähtav"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6497,7 +6533,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "aastat"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Peata mäng"

--- a/locale/et.po
+++ b/locale/et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-04-07 21:08+0000\n"
 "Last-Translator: Anelle Lisetter Viktoria Rodin <lisete.rodin@gmail.com>\n"
 "Language-Team: Estonian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/et/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.11.2\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr "Toimetaja"
 msgid "3D_MOVEMENT"
 msgstr "Liikumine"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -65,7 +65,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr "tegev"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Praegused lõimed:"
 
@@ -153,7 +153,7 @@ msgstr "Organismi statistika"
 msgid "ALT"
 msgstr "ALT"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Ambiance helitugevus"
 
@@ -164,11 +164,11 @@ msgstr "Ambiance helitugevus"
 msgid "AMMONIA"
 msgstr "Ammoniaak"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Säilitatavate automaatsete salvestamiste arv:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Säilitatavate kiirsäästude arv:"
 
@@ -194,11 +194,11 @@ msgstr "Rakenda muudatused"
 msgid "APRIL"
 msgstr "aprill"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Kas olete kindel, et soovite lähtestada KÕIK seaded normaalseks?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Kas olete kindel, et soovite lähtestada sisendseaded normaalseks?"
 
@@ -215,7 +215,7 @@ msgstr "\"{0}\" – {1}"
 msgid "ART_BY"
 msgstr "Kunst autorilt {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Kunstigalerii"
 
@@ -228,7 +228,7 @@ msgstr "Mod-monteerimisklass on nõutav, kui kokkupanek on täpsustatud"
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "Mod-monteerimisklass on nõutav, kui kokkupanek on täpsustatud"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Oletame, et CPU-l on hüperkeermestamine lubatud"
 
@@ -270,7 +270,7 @@ msgstr "Selle salvestusfaili kirjutamise katse ebaõnnestus. Salvestusnimi võib
 msgid "AT_CURSOR"
 msgstr "Kursori juures:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Heli väljundseade:"
 
@@ -278,8 +278,8 @@ msgstr "Heli väljundseade:"
 msgid "AUGUST"
 msgstr "august"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Automaatne"
 
@@ -307,7 +307,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% valmis. {1:n0}/{2:n0} sammu."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Automaatne salvestamine mängu ajal"
 
@@ -315,7 +315,7 @@ msgstr "Automaatne salvestamine mängu ajal"
 msgid "AUTO_EVO"
 msgstr "auto-evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "käitamise olek:"
@@ -346,7 +346,7 @@ msgstr "käitamise olek:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Automaatne edasiliikumine"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 #, fuzzy
 msgid "AUTO_RESOLUTION"
 msgstr "Resolutsioon:"
@@ -360,9 +360,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -506,7 +506,7 @@ msgstr "Võimaldab siduda teiste rakkudega. See on esimene samm mitmerakulisuse 
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Köitmisrežiimi sisse- ja väljalülitamiseks vajutage nuppu [thrive:input]g_lüliti_siduv[/thrive:input]. Sidumisrežiimis saate oma kolooniaga kinnitada teisi oma liigi rakke, liikudes nendesse. Kolooniast lahkumiseks vajutage [thrive:input]g_lahti_siduma_kõik[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -568,7 +568,7 @@ msgstr "Sellel membraanil on tugev kaltsiumkarbonaadist valmistatud kest. See ta
 msgid "CAMERA"
 msgstr "Kaamera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -698,7 +698,7 @@ msgstr "Muutke sümmeetriat"
 msgid "CHEATS"
 msgstr "Sohitegija"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Petuklahvid on lubatud"
 
@@ -790,7 +790,7 @@ msgstr "Toodab [thrive:compound type=\"glucose\"][/thrive:compound]. Hindamisska
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Valitud failinimi ({0}) on juba olemas. Kas kirjutada üle?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Kromaatiline aberratsioon:"
 
@@ -833,15 +833,15 @@ msgstr "Vanade salvestuste puhastamine"
 msgid "CLOSE"
 msgstr "Sulge"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Kas sulgeda valikud?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Pilve eraldusvõime jagaja:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Pilve simulatsiooni minimaalne intervall:"
 
@@ -857,7 +857,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr "Värv"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Värvipime korrigeerimine:"
 
@@ -918,26 +918,26 @@ msgstr "Küllastusväärtus, halli hulk konkreetses värvitoonis"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Värvi väärtus (heledus), heledus või intensiivsus"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Lisage uus võtme sidumine"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "meie Viki"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "vabasurm"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Ühendid:"
@@ -965,7 +965,7 @@ msgstr "Ühendid:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Liitsaldod"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Liitpilved"
 
@@ -1059,7 +1059,7 @@ msgstr "Kas jätkata prototüüpide lavastamist?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1073,11 +1073,11 @@ msgstr "See paneel näitab numbreid, millest automaatse evo ennustus töötab. L
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1085,11 +1085,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Kopeerimise viga lõikelauale"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanope (punane-roheline)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanope (sinine-kollane)"
 
@@ -1147,7 +1147,7 @@ msgstr "Loomine..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Objektide loomine salvestamisest"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Krediidid"
 
@@ -1173,7 +1173,7 @@ msgstr "Praegused arendajad"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Organismi statistika"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Kohandatud kasutajanimi:"
 
@@ -1246,7 +1246,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr "detsember"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Vaikimisi väljundseade"
 
@@ -1310,7 +1310,7 @@ msgstr "Kirjeldus on liiga pikk"
 msgid "DESPAWN_ENTITIES"
 msgstr "Kudema vaenlane"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Tuvastatud protsessorite arv:"
 
@@ -1323,12 +1323,12 @@ msgstr "Devbuildsi toetajad"
 msgid "DEVELOPERS"
 msgstr "Arendajad"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Arendust toetab Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Lisage uus võtme sidumine"
@@ -1337,12 +1337,12 @@ msgstr "Lisage uus võtme sidumine"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Arendust toetab Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Arendajad"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Abi"
@@ -1419,7 +1419,7 @@ msgstr "Vasakule"
 msgid "DIRECTIONR"
 msgstr "paremale"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "töövõimetu"
 
@@ -1427,7 +1427,7 @@ msgstr "töövõimetu"
 msgid "DISABLE_ALL"
 msgstr "Keela kõik"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Visake ära ja jätkake"
 
@@ -1467,17 +1467,17 @@ msgstr ""
 "Seal on paigutatud organellid, mis ei ole ülejäänud osaga ühendatud.\n"
 "Ühendage kõik paigutatud organellid üksteisega või võtke muudatused tagasi."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Möödunud aeg: {0:#,#} aastat"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Kiirus:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
@@ -1485,19 +1485,19 @@ msgstr ""
 "ja võib olla tükkide osas palju ambitsioonikam.\n"
 "Reageerivad mikroobid lülituvad varem uutele sihtmärkidele."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Kuvamisvõimaluste riba"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "Kuvamisvõimaluste riba"
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Kahekihiline membraan kaitseb paremini kahjustuste eest ja võtab vähem energiat, et mitte deformeeruda. Siiski aeglustab see raku tööd ja aeglustab ressursside neelamise kiirust."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1694,7 +1694,7 @@ msgstr ""
 "\n"
 "Kui olete valmis, vajutage jätkamiseks paremas alanurgas nuppu \"Järgmine\"."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1710,7 +1710,7 @@ msgstr "Luba kõik ühilduvad modifikatsioonid"
 msgid "ENABLE_EDITOR"
 msgstr "Luba redaktor"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Lubage GUI valgusefektid"
 
@@ -1770,7 +1770,7 @@ msgstr "Näita/peida keskkonda ja ühendeid"
 msgid "EPIPELAGIC"
 msgstr "Epipelaagiline"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Viga"
 
@@ -1782,11 +1782,11 @@ msgstr "Modifikaadi kausta loomisel tekkis viga"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Viga mod teabefaili loomisel"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Viga: uute sätete salvestamine konfiguratsioonifaili nurjus."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
@@ -1795,7 +1795,7 @@ msgstr ""
 "Vapraid mikroobe ei hirmuta läheduses olevad kiskjad\n"
 "ja tõenäoliselt ründab tagasi."
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Viga mod teabefaili loomisel"
@@ -1830,12 +1830,12 @@ msgstr "Autor Revolutionary Games Studio"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Autor Revolutionary Games Studio"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Versioon:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "vabasurm"
@@ -1852,7 +1852,7 @@ msgstr "Salvestusandmete laadimisel juhtus erand"
 msgid "EXIT"
 msgstr "Välju"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Käivitage E"
@@ -1906,7 +1906,7 @@ msgstr "Lapist välja surnud"
 msgid "EXTINCT_SPECIES"
 msgstr "Väljasurnud liigid"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Lisad"
 
@@ -1914,7 +1914,7 @@ msgstr "Lisad"
 msgid "EXTRA_OPTIONS"
 msgstr "Lisavalikud"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Peata mäng"
@@ -1949,20 +1949,20 @@ msgstr "Petuklahvid on lubatud"
 msgid "FEBRUARY"
 msgstr "veebruar"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Steam kliendi teegi lähtestamine ebaõnnestus"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr "istuv"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2136,7 +2136,7 @@ msgstr ""
 "ja võib olla tükkide osas palju ambitsioonikam.\n"
 "Reageerivad mikroobid lülituvad varem uutele sihtmärkidele."
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Täisekraan"
 
@@ -2166,24 +2166,24 @@ msgstr "Põlvkond:"
 msgid "GENERATION_COLON"
 msgstr "Põlvkond:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "vabasurm"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 režiimi hoiatus"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Kasutate GLES2-ga Thrive'i. See on tõsiselt testimata ja põhjustab tõenäoliselt probleeme. Proovige värskendada oma videodraivereid ja/või sundida Thrive'i käitamiseks kasutama AMD või Nvidia graafikat."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2237,12 +2237,12 @@ msgstr "Sain aru"
 msgid "GPL_LICENSE_HEADING"
 msgstr "GPL litsentsi tekst on järgmine:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Graafika"
 
@@ -2250,7 +2250,7 @@ msgstr "Graafika"
 msgid "GRAPHICS_TEAM"
 msgstr "Graafika meeskond"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2267,7 +2267,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0}K"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "GUI helitugevus"
 
@@ -2289,11 +2289,11 @@ msgstr "Abi"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Abi"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(kõrgemad väärtused suurendavad jõudlust)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(kõrgemad väärtused halvendavad jõudlust)"
 
@@ -2318,7 +2318,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Kodu"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Versioon:"
@@ -2393,7 +2393,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Möödunud aeg: {0:#,#} aastat"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Sisendid"
 
@@ -2447,8 +2447,8 @@ msgstr "Vale URL-i vorming"
 msgid "INVALID_URL_SCHEME"
 msgstr "Vigane URL-i skeem"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2470,7 +2470,7 @@ msgstr "Raud"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Raua kemolitoautotroofia"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "vabasurm"
@@ -2479,19 +2479,19 @@ msgstr "vabasurm"
 msgid "JANUARY"
 msgstr "jaanuaril"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "JSON-i silumisrežiim:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Alati"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automaatselt"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Mitte kunagi"
 
@@ -2673,19 +2673,19 @@ msgstr "number ."
 msgid "KPSUBTRACT"
 msgstr "number -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Keel:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "See keel on {0}% valmis"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "See keel on veel pooleli ({0}% valmis)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "See tõlge on väga puudulik ({0}% valmis). Palun aidake meid sellega!"
 
@@ -2853,7 +2853,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Vasak hiir"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Litsentsid"
 
@@ -2929,7 +2929,7 @@ msgstr "Ratas paremale"
 msgid "LIGHT_MAX"
 msgstr "Valgus"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "Lisad"
@@ -2944,32 +2944,32 @@ msgstr "KINNITA"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "See paneel näitab numbreid, millest automaatse evo ennustus töötab. Lõpliku populatsiooni määrab kogu energia, mida liik suudab püüda, ja kulu liigi isendi kohta. Auto-evo kasutab lihtsustatud tegelikkuse mudelit, et arvutada, kui hästi liigid toimivad, võttes aluseks energia, mida nad suudavad koguda. Iga toiduallika puhul näidatakse, et liik saab sellest palju energiat. Lisaks kuvatakse sellest allikast saadaolev koguenergia. See, kui suur osa liikide koguenergiast võidab, põhineb sellel, kui suur on sobivus võrreldes kogu sobivusega. Fitness on mõõdik selle kohta, kui hästi liik suudab seda toiduallikat kasutada."
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "KINNITA"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2994,7 +2994,7 @@ msgstr "Laadige"
 msgid "LOADING"
 msgstr "Laadimine"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Laadimine..."
@@ -3027,12 +3027,12 @@ msgstr "Vea parandamiseks vajutage redaktoris tagasivõtmisnuppu"
 msgid "LOAD_FINISHED"
 msgstr "Laadimine lõpetatud"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Laadi mäng"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Pausi menüü"
@@ -3113,7 +3113,7 @@ msgstr "märtsil"
 msgid "MARINE_SNOW"
 msgstr "Mere lumi"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Master helitugevus"
 
@@ -3122,15 +3122,15 @@ msgstr "Master helitugevus"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Lapist välja surnud"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "max FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Piiramatu"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3313,7 +3313,7 @@ msgstr "Igal põlvkonnal on teil kulutada 100 mutatsioonipunkti (MP) ja iga muud
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Iga kord, kui paljunete, sisenete mikroobide redaktorisse, kus saate oma liigis muudatusi teha (lisades, liigutades või eemaldades organelle), et oma liigi edu suurendada. Iga mikroobide staadiumis toimetaja külastus tähistab [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] miljonit aastat evolutsiooni."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Microbe Freebuildi redaktor"
 
@@ -3500,7 +3500,7 @@ msgstr "Minimaalne:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Ei ole lubatud kuvada vähem kui {0} andmestikku!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Muud"
 
@@ -3566,11 +3566,11 @@ msgstr "Muuda Organelle"
 msgid "MODIFY_TYPE"
 msgstr "Muuda tüüp"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Modifikatsioonid"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3659,11 +3659,11 @@ msgstr "Sisemine (kausta) nimi:"
 msgid "MOD_LICENSE"
 msgstr "Modifikatsiooni litsents:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Modifikaadi laadimise vead"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Ühe või mitme modifikatsiooni laadimisel ilmnesid vead. Logid võivad sisaldada lisateavet."
 
@@ -3716,11 +3716,11 @@ msgstr "Modifikatsiooni versioon:"
 msgid "MORE_INFO"
 msgstr "Näita rohkem teavet"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3851,7 +3851,7 @@ msgstr "Asetage organell"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Asetage organell"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Mitme proovi antialiasing:"
 
@@ -3863,7 +3863,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Muusika"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Muusika helitugevus"
 
@@ -3887,9 +3887,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr "Mutatsioonipunktid"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Vaigista"
 
@@ -3925,11 +3925,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Uus mäng"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Pausi menüü"
@@ -3995,7 +3995,7 @@ msgstr "Lämmastikku fikseeriv plastiid on valk, mis on võimeline kasutama gaas
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Muudab [thrive:compound type=\"atp\"][/thrive:compound] tüübiks [thrive:compound type=\"ammoniaak\"][/thrive:compound]. Hindamisskaalad [thrive:compound type=\"nitrogen\"][/thrive:compound] ja [thrive:compound type=\"oxygen\"][/thrive:compound] kontsentratsiooniga."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Mitte ühtegi"
 
@@ -4044,7 +4044,7 @@ msgstr "Sündmusi pole salvestatud"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Salvestatud kataloogi ei leitud"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "töövõimetu"
@@ -4062,7 +4062,7 @@ msgstr "Salvestusi ei leitud"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Salvestatud kataloogi ei leitud"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Ekraanitõmmiste kataloogi ei leitud"
 
@@ -4108,16 +4108,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr "oktoober"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "vabasurm"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4154,7 +4154,7 @@ msgstr "Avage abiekraan"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Vabaehitus"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Avage logide kaust"
 
@@ -4170,7 +4170,7 @@ msgstr "Ava Organelli menüü"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Avage Salvesta kataloog"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Avage ekraanipildi kaust"
 
@@ -4178,7 +4178,7 @@ msgstr "Avage ekraanipildi kaust"
 msgid "OPEN_THE_MENU"
 msgstr "Avage menüü"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Aidake mängu tõlkida"
 
@@ -4198,11 +4198,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunistlik"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Valikud"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Abi"
@@ -4423,7 +4423,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Peata mäng"
@@ -4476,7 +4476,7 @@ msgstr "Rahulik"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Esitus"
 
@@ -4560,7 +4560,7 @@ msgstr "Dubleeri pleier"
 msgid "PLAYER_EXTINCT"
 msgstr "Mängija on välja surnud"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Mängija on välja surnud"
@@ -4575,23 +4575,23 @@ msgstr ""
 "Mängija\n"
 "Kiirus"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Esita sissejuhatav video"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Mängige uues mängus mikroobide tutvustust"
 
@@ -4710,11 +4710,11 @@ msgstr "Kiire laadimine"
 msgid "QUICK_SAVE"
 msgstr "Kiire salvestamine"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Lõpeta"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4760,7 +4760,7 @@ msgstr "Teemad:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Soovitatav Thrive:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Jätkake mängu"
@@ -4816,7 +4816,7 @@ msgstr "Paljundamine:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Tuum"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "lähtestada"
 
@@ -4825,24 +4825,24 @@ msgstr "lähtestada"
 msgid "RESET_DEADZONES"
 msgstr "Kas lähtestada normaalseks?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Kas lähtestada sisendid normaalseks?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Lähtestage sisendid"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "normaalne"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Kas lähtestada normaalseks?"
 
@@ -4851,7 +4851,7 @@ msgstr "Kas lähtestada normaalseks?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Resolutsioon:"
 
@@ -4902,7 +4902,7 @@ msgstr ""
 "Kas soovite kindlasti peamenüüst väljuda?\n"
 "Kaotate kõik salvestamata edusammud."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Autor Revolutionary Games Studio"
@@ -4936,7 +4936,7 @@ msgstr "Pöörake paremale"
 msgid "ROTATION_COLON"
 msgstr "elanikkond:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Käivitage mängu ajal auto-evo"
 
@@ -4991,7 +4991,7 @@ msgstr "Rustitsüaniin on valk, mis on võimeline kasutama gaasilist süsinikdio
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Muudab [thrive:compound type=\"iron\"][/thrive:compound] tüübiks [thrive:compound type=\"atp\"][/thrive:compound]. Hindamisskaalad kontsentratsiooniga [thrive:compound type=\"süsinikdioksiid\"][/thrive:compound] ja [thrive:compound type=\"hapnik\"][/thrive:ühend]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -5000,16 +5000,16 @@ msgstr ""
 "Vapraid mikroobe ei hirmuta läheduses olevad kiskjad\n"
 "ja tõenäoliselt ründab tagasi."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Eemaldage kohalikud andmed"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Salvesta"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Salvestage ja jätkake"
 
@@ -5110,21 +5110,21 @@ msgstr "Salvestamine ei ole praegu võimalik järgmistel põhjustel:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Salvestamine õnnestus"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr "Signaaliagent"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5227,7 +5227,7 @@ msgstr "istuv"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "See väärtus kehtib ainult uutele mängudele, mis alustati pärast selle valiku muutmist"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "SFX helitugevus"
 
@@ -5243,21 +5243,25 @@ msgstr "Näita abi"
 msgid "SHOW_TUTORIALS"
 msgstr "Näita õpetusi"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Näita õpetusi (praeguses mängus)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Näita õpetusi (uutes mängudes)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Kuva salvestamata edenemise hoiatus"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Lubab/keelab salvestamata edenemise hoiatuse hüpikakna, kui mängija proovib mängust väljuda."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5305,7 +5309,7 @@ msgstr "Ränidioksiid"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Sellel membraanil on tugev ränidioksiidi sein. See talub hästi üldist kahju ja on väga vastupidav füüsilistele kahjustustele. Samuti nõuab see oma vormi säilitamiseks vähem energiat. Kuid see aeglustab raku tööd suure teguri võrra ja rakk neelab ressursse vähendatud kiirusega."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5347,7 +5351,7 @@ msgstr "Muudab [thrive:compound type=\"glucose\"][/thrive:compound] tüübiks [t
 msgid "SMALL_IRON_CHUNK"
 msgstr "Väike raua tükk"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Heli"
 
@@ -5543,19 +5547,19 @@ msgstr "Steam pole praegu saadaval, proovige uuesti"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Ilmnes tundmatu Steami viga"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Steam kliendi teegi lähtestamine ebaõnnestus"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Määratud salvestuse täiendamine nurjus järgmise tõrke tõttu:\n"
 "{0}"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Peata mäng"
@@ -5598,7 +5602,7 @@ msgstr "Varud"
 msgid "STORAGE_COLON"
 msgstr "Varud"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Sisse logitud kui: {0}"
 
@@ -5715,7 +5719,7 @@ msgstr "temperatuur."
 msgid "TESTING_TEAM"
 msgstr "Testimismeeskond"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5730,7 +5734,7 @@ msgstr ""
 "\n"
 "Kui teile mäng meeldis, rääkige meist oma sõpradele."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "SA OLED ÕIDULIKUD!"
@@ -5790,11 +5794,11 @@ msgstr "See on kohapeal installitud mod"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "See mod laaditakse alla Steami töökojast"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Teemad:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgstr "Paus"
 msgid "TOGGLE_UNBINDING"
 msgstr "Lülita lahti sidumine"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Tööriistad"
 
@@ -6011,7 +6015,7 @@ msgstr "Proovige teha ekraanipilte!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Proovige salvestada!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Proovige teha ekraanipilte!"
 
@@ -6165,12 +6169,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Vaata nüüd"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Möödunud aeg: {0:#,#} aastat"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6195,7 +6199,7 @@ msgstr "Vabastage kõik"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Vabasta sidumisrežiim"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6218,7 +6222,7 @@ msgstr "Võta viimane toiming tagasi"
 msgid "UNKNOWN"
 msgstr "Tundmatu"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Kuvamisvõimaluste riba"
@@ -6232,7 +6236,7 @@ msgstr "Tundmatu hiir"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Tundmatu töökoja ID selle modifikatsiooni jaoks"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Modifikatsiooni versioon:"
@@ -6241,7 +6245,7 @@ msgstr "Modifikatsiooni versioon:"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Tundmatu töökoja ID selle modifikatsiooni jaoks"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Teil on salvestamata muudatusi, mis tühistatakse.\n"
@@ -6286,7 +6290,7 @@ msgstr "Üleslaadimine õnnestus"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Litsentsid ja kasutatud raamatukogud"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "vabasurm"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Kasutage kohandatud kasutajanime"
 
@@ -6312,11 +6316,11 @@ msgstr "Kasutage kohandatud kasutajanime"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Taustalõimede arvu käsitsi määramine"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6342,7 +6346,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr "Versioon:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Versioon:"
@@ -6353,11 +6357,11 @@ msgstr "Versioon:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Uus nimi:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6365,7 +6369,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Vaataja"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Vaadake lähtekoodi"
 
@@ -6377,7 +6381,7 @@ msgstr "VIP toetajad"
 msgid "VISIBLE"
 msgstr "Nähtav"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6397,7 +6401,7 @@ msgstr "Heli vaigistamine"
 msgid "VOLUMEUP"
 msgstr "Helitugevuse suurendamine"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "vsync"
 
@@ -6504,7 +6508,7 @@ msgstr "Organismi statistika"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "Aluse liikumine"
@@ -6513,15 +6517,15 @@ msgstr "Aluse liikumine"
 msgid "WORST_PATCH_COLON"
 msgstr "Halvim plaaster:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6533,7 +6537,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "aastat"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Peata mäng"

--- a/locale/fi.po
+++ b/locale/fi.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
-"PO-Revision-Date: 2023-01-30 07:23+0000\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"PO-Revision-Date: 2023-02-02 14:27+0200\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Finnish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/fi/>\n"
 "Language: fi\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14\n"
+"X-Generator: Poedit 3.2.2\n"
 "Generated-By: Babel 2.8.0\n"
 
 #: ../src/general/OptionsMenu.tscn:1452
@@ -214,7 +214,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Taidetta, jonka tekijä on {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Taidegalleria"
 
@@ -314,7 +314,7 @@ msgstr "Tallenna automaattisesti"
 msgid "AUTO_EVO"
 msgstr "Auto-evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "suorituksen status:"
@@ -358,8 +358,8 @@ msgid "AWAKEN"
 msgstr "Herää"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -625,28 +625,28 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Hiilidioksidi"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 #, fuzzy
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "yltäkylläisyys"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "kohtuullisesti"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "vähän"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "jonkin verran"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "hieman"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "erittäin vähän"
 
@@ -927,21 +927,21 @@ msgstr "Lisää uusi syöte"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Lisää uusi syöte"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr "Yhteisöfoorumi"
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Lisää uusi syöte"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "Wikimme"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Kuole"
@@ -1153,7 +1153,7 @@ msgstr "Hae..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Luodaan objekteja tallennuksesta"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Tekijät"
 
@@ -1332,12 +1332,12 @@ msgstr "DevBuild-tukijat"
 msgid "DEVELOPERS"
 msgstr "Kehittäjät"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Kehitystä tukee Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Lisää uusi syöte"
@@ -1346,12 +1346,12 @@ msgstr "Lisää uusi syöte"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Kehitystä tukee Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Kehittäjät"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Help"
@@ -1479,7 +1479,7 @@ msgstr ""
 "Jotkin soluelimistä eivät ole yhtydessä muihin.\n"
 "Yhdistä kaikki soluelimet toisiinsa tai kumoa muutoksesi."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Lisää uusi syöte"
@@ -1497,7 +1497,7 @@ msgstr ""
 "ja voivat olla kunnianhimoisempia löytyvien palasten keruussa.\n"
 "Responssiiviset mikrobit vaihtavat kohdetta nopeammin, jos ei niitä heti saa kiinni."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1545,7 +1545,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1744,15 +1744,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Energiaa {0} jota käytetään {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Energianlähteet:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1810,6 +1810,20 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Virhe: Uusien asetusten tallentaminen tiedostoon epäonnistui."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+"Pelokkaat mikrobit pakenevat pidempiä matkoja, kuin urheat, ja\n"
+"todennäköisemmin pakenevat petoja.\n"
+"Rohkeat mikrobit eivät välitä pedoista lähellään ja hyökkäävät\n"
+"todennäköisimmin takaisin uhattuna."
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Virhe tallennettaessa"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Virhe ladattaessa"
@@ -1864,7 +1878,7 @@ msgstr "Poikkeus tapahtui ladattaessa tallennuksen tietoja"
 msgid "EXIT"
 msgstr "Poistu"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1919,7 +1933,7 @@ msgstr "sukupuuttoon planeetalta"
 msgid "EXTINCT_SPECIES"
 msgstr "Sukupuuttoon kuolleet lajit"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Ekstrat"
 
@@ -1927,7 +1941,7 @@ msgstr "Ekstrat"
 msgid "EXTRA_OPTIONS"
 msgstr "Lisäasetukset"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Laita peli tauolle"
@@ -1962,6 +1976,22 @@ msgstr "Huijauskoodit aktiivisia"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "helmikuu"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr "Julkaistu {0}"
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -2048,7 +2078,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Ruokaketju"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0} energiaa: {1} (sopivuus: {2}) kokonaisenergia: {3} (kokonaissopivuus: {4})"
 
@@ -2158,7 +2188,7 @@ msgstr "Sukupolvi:"
 msgid "GENERATION_COLON"
 msgstr "Sukupolvi:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Kuole"
@@ -2167,11 +2197,11 @@ msgstr "Kuole"
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2-moodi Varoitus"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2455,7 +2485,7 @@ msgstr "Rauta"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Rautakemolitoautotrofia"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Kuole"
@@ -2674,7 +2704,7 @@ msgstr "Tämä käännös on vielä kesken ({0}% valmis)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Tämä käännös on pahasti kesken ({0}% valmis) ole kiltti ja auta meitä sen kanssa!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2839,7 +2869,7 @@ msgstr "Hiiren vasen painike"
 msgid "LEFT_MOUSE"
 msgstr "Hiiren vasen painike"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Lisenssit"
 
@@ -2979,7 +3009,8 @@ msgstr "Lataa"
 msgid "LOADING"
 msgstr "Ladataan"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Ladataan..."
@@ -3012,12 +3043,12 @@ msgstr "Paina kumoamispainiketta editorissa korjataksesi tehdyn virheen"
 msgid "LOAD_FINISHED"
 msgstr "Lataus on valmistunut"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Lataa Peli"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Pysäytysmenu"
@@ -3289,7 +3320,7 @@ msgstr "Joka sukupolvi sinulla on käytössäsi 100 mutaatiopistettä (MP). Joka
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Joka kerta kun jatkat sukuasi, pääset mikrobieditoriin, jossa voit tehdä muutoksia lajiisi (lisäämällä, siirtämällä tai poistamalla soluelimiä) parantaaksesi sen menestystä. Jokainen vierailu editoriin mikrobitasolla edustaa evoluutiota, joka tapahtuu [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] miljoonan vuoden aikana."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Mikrobien vapaa rakentelu"
 
@@ -3542,11 +3573,11 @@ msgstr "Muokkaa soluelintä"
 msgid "MODIFY_TYPE"
 msgstr "Vaihda tyyppiä"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Modit"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3638,11 +3669,11 @@ msgstr "Sisäinen nimi (Kansio):"
 msgid "MOD_LICENSE"
 msgstr "Lisenssit"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Modien latausvirheet"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Yhden tai useamman modin latauksessa kohdattiin virheitä. Lokit voivat sisältää lisää tietoa."
 
@@ -3885,15 +3916,19 @@ msgstr ""
 "Tämä tallennus on uudemmasta Thriven versiosta ja erittäin todennäköisesti\n"
 "se ei ole yhteensopiva. Lataa kuitenkin?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr "UUTISET"
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Uusi Peli"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Pysäytysmenu"
@@ -3997,7 +4032,7 @@ msgid "NO_AI"
 msgstr "Ei tekoälyä"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Ei dataa näytettäväksi"
 
@@ -4010,7 +4045,7 @@ msgstr "Tapahtumia ei tallennettu"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Avaa tallennusten kansio"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Ei käytössä"
@@ -4043,7 +4078,7 @@ msgstr "Ei valittua Modia"
 msgid "NUCLEUS"
 msgstr "Tuma"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -4062,8 +4097,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -4076,16 +4111,16 @@ msgstr "- MP"
 msgid "OCTOBER"
 msgstr "Lokakuu"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr "Virallinen Nettisivu"
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Kuole"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4164,11 +4199,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunistinen"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Asetukset"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Help"
@@ -4389,7 +4424,7 @@ msgstr "Proseduraalinen"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Laita peli tauolle"
@@ -4450,8 +4485,8 @@ msgstr "Suorituskyky"
 msgid "PERFORM_UNBINDING"
 msgstr "Erkane"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/sekunti"
 
@@ -4502,7 +4537,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr "Planeetan satunnainen lähtöarvo"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Pelaajan solu"
 
@@ -4580,7 +4615,7 @@ msgstr "populaatio:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "populaatio alueilla:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4635,7 +4670,7 @@ msgstr "edellinen:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Prosessoidaan ladattuja objekteja"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4679,11 +4714,11 @@ msgstr "Lataa viimeisin tallennus"
 msgid "QUICK_SAVE"
 msgstr "Tee pika-tallennus"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Lopeta"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4729,7 +4764,7 @@ msgstr "Taustasuorittajia:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Thriven Suositeltu Versio:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Jatka"
@@ -4871,7 +4906,7 @@ msgstr ""
 "Haluatko varmasti palata päävalikkoon?\n"
 "Menetät tallentamattomat tiedot."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Tehnyt Revolutionary Games Studio"
@@ -4960,7 +4995,7 @@ msgstr "Rustisyaniini on proteiini, joka käyttää hiilidioksiidia ja happea mu
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Muuntaa [thrive:compound type=\"iron\"]raudan[/thrive:compound] [thrive:compound type=\"atp\"]ATP:ksi[/thrive:compound]. Muunnosnopeus vaihtelee ympäristön [thrive:compound type=\"carbondioxide\"][/thrive:compound]n ja [thrive:compound type=\"oxygen\"][/thrive:compound]n mukaan."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4969,7 +5004,7 @@ msgstr ""
 "Rohkeat mikrobit eivät välitä pedoista lähellään ja hyökkäävät\n"
 "todennäköisimmin takaisin uhattuna."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Poista Paikallinen Data"
@@ -5352,7 +5387,7 @@ msgstr "Luo ammoniakkia"
 msgid "SPAWN_ENEMY"
 msgstr "Luo vihollinen"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 #, fuzzy
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Luo vihollinen"
@@ -5406,7 +5441,7 @@ msgstr "Lajin nimi..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Lajin nimi..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5524,17 +5559,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Tuntematon Steam-virhe tapahtui"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Tallennus epäonnistui! Poikkeus tapahtui"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Pistä muita soluja tällä."
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Laita peli tauolle"
@@ -5576,7 +5611,7 @@ msgstr "Varastotila"
 msgid "STORAGE_COLON"
 msgstr "Varastotila:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Sisäänkirjauduttu käyttäjänä: {0}"
 
@@ -5693,7 +5728,7 @@ msgstr "Lämpö."
 msgid "TESTING_TEAM"
 msgstr "Testaustiimi"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5708,7 +5743,7 @@ msgstr ""
 "\n"
 "Jos tykkäsit pelistä, kerrothan kavereillesi meistä."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "OLET SELVIYTYNYT!"
@@ -5772,7 +5807,7 @@ msgstr ""
 msgid "THREADS"
 msgstr "Taustasuorittajia:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5922,7 +5957,7 @@ msgstr "Pysäytä"
 msgid "TOGGLE_UNBINDING"
 msgstr "Aloita/Lopeta erkanemistila"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Työkalut"
 
@@ -6140,7 +6175,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Katso nyt"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Help"
@@ -6345,7 +6380,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Tarkastelija"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Katsele lähdekoodia"
 
@@ -6357,7 +6392,7 @@ msgstr "VIP-tukijat"
 msgid "VISIBLE"
 msgstr "Näkyvä"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6517,7 +6552,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "vuotta"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Laita peli tauolle"

--- a/locale/fi.po
+++ b/locale/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2023-02-02 14:27+0200\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Finnish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/fi/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Poedit 3.2.2\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr "2D-liikkumisen tyyli:"
 
@@ -33,7 +33,7 @@ msgstr "Editori"
 msgid "3D_MOVEMENT"
 msgstr "Liikkuminen"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr "3D-liikkumisen tyyli:"
 
@@ -65,7 +65,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr "Aktiivinen"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Nykyinen suorittajien määrä:"
 
@@ -153,7 +153,7 @@ msgstr "Statistiikkaa organismista"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Tunnelmaäänet"
 
@@ -164,11 +164,11 @@ msgstr "Tunnelmaäänet"
 msgid "AMMONIA"
 msgstr "Ammoniakki"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Paikat automaattitallenuksille:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Paikat nopeille tallennuksille:"
 
@@ -193,11 +193,11 @@ msgstr "Hyväksy Muutokset"
 msgid "APRIL"
 msgstr "Huhtikuu"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Haluatko varmasti korvata KAIKKI asetukset oletusarvoilla?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Haluatko varmasti korvata syötteiden asetukset oletusarvoilla?"
 
@@ -214,7 +214,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Taidetta, jonka tekijä on {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Taidegalleria"
 
@@ -226,7 +226,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Oleta, että prosessorissa on hyperthreading käytössä"
 
@@ -269,7 +269,7 @@ msgstr "Auto-evon suorittaminen epäonnistui"
 msgid "AT_CURSOR"
 msgstr "Kursorin alla:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Äänen ulostulolaite:"
 
@@ -277,8 +277,8 @@ msgstr "Äänen ulostulolaite:"
 msgid "AUGUST"
 msgstr "Elokuu"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "automaattinen"
 
@@ -306,7 +306,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% valmis. {1:n0}/{2:n0} vaihetta."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Tallenna automaattisesti"
 
@@ -314,7 +314,7 @@ msgstr "Tallenna automaattisesti"
 msgid "AUTO_EVO"
 msgstr "Auto-evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "suorituksen status:"
@@ -345,7 +345,7 @@ msgstr "suorituksen status:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Liiku automaattisesti eteenpäin"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Automaattinen ({0}x{1})"
 
@@ -358,9 +358,9 @@ msgid "AWAKEN"
 msgstr "Herää"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -506,7 +506,7 @@ msgstr "Jäykempi solukalvo kestää enemmän vahinkoa, mutta vaikeuttaa solun l
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Vaihda liittymismoodia painamall [thrive:input]g_toggle_binding[/thrive:input]. Liittymismoodissa voit liittyä toisiin lajisi soluihin liikkumalla heitä kohti. Poistuaksesi ryppäästä paina [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -568,7 +568,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr "Kamera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -701,7 +701,7 @@ msgstr "Vaihda symmetriamoodia"
 msgid "CHEATS"
 msgstr "Huijauskoodit"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Huijauskoodit aktiivisia"
 
@@ -795,7 +795,7 @@ msgstr "Tuottaa [thrive:compound type=\"glucose\"]glukoosia[/thrive:compound]. T
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Valittu tiedostonimi ({0}) on jo olemassa. Kirjoitetaanko yli?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Kromaattinen vääristymä:"
 
@@ -839,15 +839,15 @@ msgstr "Siivoa vanhat tallennukset"
 msgid "CLOSE"
 msgstr "Sulje"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Sulje asetukset?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Pilvien resoluutioiden jakaja:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Pienin pilvien päivitys aikajakso:"
 
@@ -863,7 +863,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr "Väri"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Värisokeuden korjaus:"
 
@@ -927,26 +927,26 @@ msgstr "Lisää uusi syöte"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Lisää uusi syöte"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr "Yhteisöfoorumi"
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Lisää uusi syöte"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "Wikimme"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Kuole"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr "Käännetty ajanhetkellä:"
 
@@ -973,7 +973,7 @@ msgstr "Yhdisteet:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Yhdisteiden tasapainopisteet"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Yhdistepilvet"
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1076,11 +1076,11 @@ msgstr "Tämä paneeli kertoo mistä luvuista auto-evo simuloi ennusteensa. Laji
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr "Ohjaimen herkkyys"
 
@@ -1088,11 +1088,11 @@ msgstr "Ohjaimen herkkyys"
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Kopioi virhe leikepöydälle"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanopia (punavihersokeus)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanopia (sininen-keltainen)"
 
@@ -1153,7 +1153,7 @@ msgstr "Hae..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Luodaan objekteja tallennuksesta"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Tekijät"
 
@@ -1179,7 +1179,7 @@ msgstr "Nykyiset kehittäjät"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Statistiikkaa organismista"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Valittu käyttäjänimi:"
 
@@ -1252,7 +1252,7 @@ msgstr "Virheenkorjauspaneeli"
 msgid "DECEMBER"
 msgstr "Joulukuu"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Oletus ulostulolaite"
 
@@ -1319,7 +1319,7 @@ msgstr "Kuvaus on liian pitkä"
 msgid "DESPAWN_ENTITIES"
 msgstr "Luo vihollinen"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Tunnistettu prosessoriytimien määrä:"
 
@@ -1332,12 +1332,12 @@ msgstr "DevBuild-tukijat"
 msgid "DEVELOPERS"
 msgstr "Kehittäjät"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Kehitystä tukee Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Lisää uusi syöte"
@@ -1346,12 +1346,12 @@ msgstr "Lisää uusi syöte"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Kehitystä tukee Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Kehittäjät"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Help"
@@ -1428,7 +1428,7 @@ msgstr "Vasemmalle"
 msgid "DIRECTIONR"
 msgstr "Oikealle"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Ei käytössä"
 
@@ -1437,7 +1437,7 @@ msgstr "Ei käytössä"
 msgid "DISABLE_ALL"
 msgstr "Ei käytössä"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Hylkää ja jatka"
 
@@ -1479,17 +1479,17 @@ msgstr ""
 "Jotkin soluelimistä eivät ole yhtydessä muihin.\n"
 "Yhdistä kaikki soluelimet toisiinsa tai kumoa muutoksesi."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Lisää uusi syöte"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Nopeus:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
@@ -1497,19 +1497,19 @@ msgstr ""
 "ja voivat olla kunnianhimoisempia löytyvien palasten keruussa.\n"
 "Responssiiviset mikrobit vaihtavat kohdetta nopeammin, jos ei niitä heti saa kiinni."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Näytä kykypalkki"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Näytä taustahiukkasia"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "Näytä kykypalkki"
@@ -1545,7 +1545,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1714,7 +1714,7 @@ msgstr ""
 "\n"
 "Kun olet valmis jatkamaan, paina \"jatka\" painiketta alhaalla oikealla."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1732,7 +1732,7 @@ msgstr "Valittu tallennus ei ole yhteensopiva"
 msgid "ENABLE_EDITOR"
 msgstr "Avaa editorin lukitus"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Käytä käyttöliittymän valoefektejä"
 
@@ -1793,7 +1793,7 @@ msgstr "Näytä / piilota ympäristö ja yhdisteet"
 msgid "EPIPELAGIC"
 msgstr "Epipelaginen vyöhyke"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Virhe"
 
@@ -1806,11 +1806,11 @@ msgstr "Virhe tallennettaessa"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Virhe: Uusien asetusten tallentaminen tiedostoon epäonnistui."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
@@ -1819,7 +1819,7 @@ msgstr ""
 "Rohkeat mikrobit eivät välitä pedoista lähellään ja hyökkäävät\n"
 "todennäköisimmin takaisin uhattuna."
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Virhe tallennettaessa"
@@ -1854,12 +1854,12 @@ msgstr "Tehnyt Revolutionary Games Studio"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Tehnyt Revolutionary Games Studio"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Sukupolvi:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Lisää uusi syöte"
@@ -1878,7 +1878,7 @@ msgstr "Poikkeus tapahtui ladattaessa tallennuksen tietoja"
 msgid "EXIT"
 msgstr "Poistu"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1933,7 +1933,7 @@ msgstr "sukupuuttoon planeetalta"
 msgid "EXTINCT_SPECIES"
 msgstr "Sukupuuttoon kuolleet lajit"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Ekstrat"
 
@@ -1941,7 +1941,7 @@ msgstr "Ekstrat"
 msgid "EXTRA_OPTIONS"
 msgstr "Lisäasetukset"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Laita peli tauolle"
@@ -1977,19 +1977,19 @@ msgstr "Huijauskoodit aktiivisia"
 msgid "FEBRUARY"
 msgstr "helmikuu"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr "Julkaistu {0}"
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2124,7 +2124,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr "Sessiili"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2159,7 +2159,7 @@ msgstr ""
 "ja voivat olla kunnianhimoisempia löytyvien palasten keruussa.\n"
 "Responssiiviset mikrobit vaihtavat kohdetta nopeammin, jos ei niitä heti saa kiinni."
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Koko näyttö"
 
@@ -2188,24 +2188,24 @@ msgstr "Sukupolvi:"
 msgid "GENERATION_COLON"
 msgstr "Sukupolvi:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Kuole"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2-moodi Varoitus"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr "GLES3"
 
@@ -2259,12 +2259,12 @@ msgstr "Selvä"
 msgid "GPL_LICENSE_HEADING"
 msgstr "GPL-lisenssin teksti:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafiikat"
 
@@ -2272,7 +2272,7 @@ msgstr "Grafiikat"
 msgid "GRAPHICS_TEAM"
 msgstr "Grafiikkatiimi"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "Käyttöliittymä"
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} k"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Käyttöliittymä"
 
@@ -2307,11 +2307,11 @@ msgstr "Apua"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Help"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(suuremmat arvot lisäävät suorituskykyä)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(suuremmat arvot heikentävät suorituskykyä)"
 
@@ -2336,7 +2336,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Koti"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr "Horisontaalinen:"
 
@@ -2410,7 +2410,7 @@ msgstr "Nielty Aine"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Lisää uusi syöte"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Syötteet"
 
@@ -2465,8 +2465,8 @@ msgstr "Virheellinen URL muoto"
 msgid "INVALID_URL_SCHEME"
 msgstr "Virheellinen URL-osoitemalli"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr "Käänteinen"
 
@@ -2485,7 +2485,7 @@ msgstr "Rauta"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Rautakemolitoautotrofia"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Kuole"
@@ -2494,19 +2494,19 @@ msgstr "Kuole"
 msgid "JANUARY"
 msgstr "Tammikuu"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "JSON-virheenkäsittelymoodi:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Aina"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automaattisesti"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Ei koskaan"
 
@@ -2688,19 +2688,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Kieli:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Tämä kieli on {0}% käännetty"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Tämä käännös on vielä kesken ({0}% valmis)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Tämä käännös on pahasti kesken ({0}% valmis) ole kiltti ja auta meitä sen kanssa!"
 
@@ -2869,7 +2869,7 @@ msgstr "Hiiren vasen painike"
 msgid "LEFT_MOUSE"
 msgstr "Hiiren vasen painike"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Lisenssit"
 
@@ -2945,7 +2945,7 @@ msgstr "Hiiren rulla oikealle"
 msgid "LIGHT_MAX"
 msgstr "Valo"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Äärimmäinen"
 
@@ -2959,31 +2959,31 @@ msgstr "VAHVISTA"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "Tämä paneeli kertoo mistä luvuista auto-evo simuloi ennusteensa. Lajin selviytymiseen vaikuttaa sen onnistuminen energian haalimisessa ja muut tarpeet. Auto-evo käyttää yksinkertaistettua mallia laskeakseen lajin menestymisen perustaen sen lajin hankkimaan energiaan. Jokaisen ravintotyypin kohdalla voi nähdä kuinka paljon siitä saa energiaa. Lajin sopivuus kertoo kuinka hyvin lajin jäsenet pystyvät käyttämään kyseisiä ravinnon lähteitä."
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Valtava"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Suuri"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Normaali"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Pieni"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Hyvin pieni"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Erittäin suuri"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Erittäin pieni"
 
@@ -3009,7 +3009,7 @@ msgstr "Lataa"
 msgid "LOADING"
 msgstr "Ladataan"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
@@ -3043,12 +3043,12 @@ msgstr "Paina kumoamispainiketta editorissa korjataksesi tehdyn virheen"
 msgid "LOAD_FINISHED"
 msgstr "Lataus on valmistunut"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Lataa Peli"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Pysäytysmenu"
@@ -3122,7 +3122,7 @@ msgstr "Maaliskuu"
 msgid "MARINE_SNOW"
 msgstr "Leijuvat hiukkaset"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Pää äänitaso"
 
@@ -3131,15 +3131,15 @@ msgstr "Pää äänitaso"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "sukupuuttoon planeetalta"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Maksimi kuvia sekunnissa:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Rajoittamaton"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3320,7 +3320,7 @@ msgstr "Joka sukupolvi sinulla on käytössäsi 100 mutaatiopistettä (MP). Joka
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Joka kerta kun jatkat sukuasi, pääset mikrobieditoriin, jossa voit tehdä muutoksia lajiisi (lisäämällä, siirtämällä tai poistamalla soluelimiä) parantaaksesi sen menestystä. Jokainen vierailu editoriin mikrobitasolla edustaa evoluutiota, joka tapahtuu [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] miljoonan vuoden aikana."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Mikrobien vapaa rakentelu"
 
@@ -3508,7 +3508,7 @@ msgstr "Versio:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Ei ole lupaa näyttää vähempää kuin {0} datajoukko(a)!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Muut"
 
@@ -3573,11 +3573,11 @@ msgstr "Muokkaa soluelintä"
 msgid "MODIFY_TYPE"
 msgstr "Vaihda tyyppiä"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Modit"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3669,11 +3669,11 @@ msgstr "Sisäinen nimi (Kansio):"
 msgid "MOD_LICENSE"
 msgstr "Lisenssit"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Modien latausvirheet"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Yhden tai useamman modin latauksessa kohdattiin virheitä. Lokit voivat sisältää lisää tietoa."
 
@@ -3732,11 +3732,11 @@ msgstr "Versio:"
 msgid "MORE_INFO"
 msgstr "Näytä Lisää Tietoa"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr "Hiirellä näkymän kääntämisen herkkyys"
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3850,7 +3850,7 @@ msgstr "Lisää soluelin"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Useita elimiä"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Monen näytteen reunanpehmennys:"
 
@@ -3862,7 +3862,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Musiikki"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Musiikin voimakkuus"
 
@@ -3886,9 +3886,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr "Mutaatiopisteet"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Mykistä"
 
@@ -3924,11 +3924,11 @@ msgstr "UUTISET"
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Uusi Peli"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Pysäytysmenu"
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Muuntaa [thrive:compound type=\"atp\"][/thrive:compound]:tä [thrive:compound type=\"ammonia\"]ammoniakiksi[/thrive:compound]. Muunnosnopeus riippuu ympäristön [thrive:compound type=\"nitrogen\"]typpi-[/thrive:compound] ja [thrive:compound type=\"oxygen\"]happipitoisuudesta[/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Ei mitään"
 
@@ -4045,7 +4045,7 @@ msgstr "Tapahtumia ei tallennettu"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Avaa tallennusten kansio"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Ei käytössä"
@@ -4064,7 +4064,7 @@ msgstr "Tallennuksia ei löytynyt"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Avaa tallennusten kansio"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 #, fuzzy
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Avaa Näyttökuva kansio"
@@ -4111,16 +4111,16 @@ msgstr "- MP"
 msgid "OCTOBER"
 msgstr "Lokakuu"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr "Virallinen Nettisivu"
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Kuole"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4154,7 +4154,7 @@ msgstr "Avaa apuvalikko"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Vapaa rakentelu"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Avaa lokien kansio"
 
@@ -4171,7 +4171,7 @@ msgstr "Avaa soluelimen valikko"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Avaa tallennusten kansio"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Avaa Näyttökuva kansio"
 
@@ -4179,7 +4179,7 @@ msgstr "Avaa Näyttökuva kansio"
 msgid "OPEN_THE_MENU"
 msgstr "Avaa valikko"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Auta pelin kääntämisessä"
 
@@ -4199,11 +4199,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunistinen"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Asetukset"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Help"
@@ -4424,7 +4424,7 @@ msgstr "Proseduraalinen"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Laita peli tauolle"
@@ -4477,7 +4477,7 @@ msgstr "Rauhallinen"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Suorituskyky"
 
@@ -4564,7 +4564,7 @@ msgstr "pelaaja kuoli"
 msgid "PLAYER_EXTINCT"
 msgstr "pelaaja kuoli"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Suhteellinen pelaajaan"
 
@@ -4578,23 +4578,23 @@ msgstr ""
 "Pelaajan\n"
 "nopeus"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr "PlayStation 3"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr "PlayStation 4"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr "PlayStation 5"
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Näytä introvideo"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Näytä mikrobi-intro aloitettaessa uusi peli"
 
@@ -4714,11 +4714,11 @@ msgstr "Lataa viimeisin tallennus"
 msgid "QUICK_SAVE"
 msgstr "Tee pika-tallennus"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Lopeta"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4764,7 +4764,7 @@ msgstr "Taustasuorittajia:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Thriven Suositeltu Versio:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Jatka"
@@ -4820,7 +4820,7 @@ msgstr "Lisääntyminen:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Tuma"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Kumoa muutokset"
 
@@ -4829,23 +4829,23 @@ msgstr "Kumoa muutokset"
 msgid "RESET_DEADZONES"
 msgstr "Palauta oletukset?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Palauta näppäimien oletukset?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr "Palauta syötteet oletuksiksi"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Palauta oletukset"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Palauta oletukset?"
 
@@ -4854,7 +4854,7 @@ msgstr "Palauta oletukset?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Tarkkuus:"
 
@@ -4906,7 +4906,7 @@ msgstr ""
 "Haluatko varmasti palata päävalikkoon?\n"
 "Menetät tallentamattomat tiedot."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Tehnyt Revolutionary Games Studio"
@@ -4940,7 +4940,7 @@ msgstr "Käännä oikealle"
 msgid "ROTATION_COLON"
 msgstr "Pyöriminen:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Suorita auto-evo pelin aikana"
 
@@ -4995,7 +4995,7 @@ msgstr "Rustisyaniini on proteiini, joka käyttää hiilidioksiidia ja happea mu
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Muuntaa [thrive:compound type=\"iron\"]raudan[/thrive:compound] [thrive:compound type=\"atp\"]ATP:ksi[/thrive:compound]. Muunnosnopeus vaihtelee ympäristön [thrive:compound type=\"carbondioxide\"][/thrive:compound]n ja [thrive:compound type=\"oxygen\"][/thrive:compound]n mukaan."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -5004,16 +5004,16 @@ msgstr ""
 "Rohkeat mikrobit eivät välitä pedoista lähellään ja hyökkäävät\n"
 "todennäköisimmin takaisin uhattuna."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Poista Paikallinen Data"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Tallenna"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Tallenna ja jatka"
 
@@ -5113,20 +5113,20 @@ msgstr "Tallennus epäonnistui! Poikkeus tapahtui"
 msgid "SAVING_SUCCEEDED"
 msgstr "Tallennus onnistui"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr "Ei mitään"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr "Skaalattu"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr "Käänteisesti skaalattu"
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "Suhteellinen peli-ikkunaan"
 
@@ -5232,7 +5232,7 @@ msgstr "Sessiili"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Tämä arvo vaikuttaa vain uusiin peleihin, jotka on aloitettu tämän muuttamisen jälkeen"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Efektien voimakkuus"
 
@@ -5249,17 +5249,17 @@ msgstr "Näytä apu"
 msgid "SHOW_TUTORIALS"
 msgstr "Näytä tutoriaalit"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Näytä tutoriaalit (nykyisessä pelissä)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Näytä tutoriaalit (uusissa peleissä)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Näytä varoitus tallentamattomista muutoksista"
 
@@ -5269,6 +5269,10 @@ msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr ""
 "Sinulla on tallentamattomia muutoksia, jotka menetetään.\n"
 "Haluatko jatkaa?"
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5317,7 +5321,7 @@ msgstr "Piidioksidi"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5359,7 +5363,7 @@ msgstr "Muuntaa [thrive:compound type=\"glucose\"]a [/thrive:compound] [thrive:c
 msgid "SMALL_IRON_CHUNK"
 msgstr "Pieni rautalohkare"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Ääni"
 
@@ -5559,17 +5563,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Tuntematon Steam-virhe tapahtui"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Tallennus epäonnistui! Poikkeus tapahtui"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Pistä muita soluja tällä."
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Laita peli tauolle"
@@ -5611,7 +5615,7 @@ msgstr "Varastotila"
 msgid "STORAGE_COLON"
 msgstr "Varastotila:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Sisäänkirjauduttu käyttäjänä: {0}"
 
@@ -5728,7 +5732,7 @@ msgstr "Lämpö."
 msgid "TESTING_TEAM"
 msgstr "Testaustiimi"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5743,7 +5747,7 @@ msgstr ""
 "\n"
 "Jos tykkäsit pelistä, kerrothan kavereillesi meistä."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "OLET SELVIYTYNYT!"
@@ -5803,11 +5807,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Taustasuorittajia:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5957,7 +5961,7 @@ msgstr "Pysäytä"
 msgid "TOGGLE_UNBINDING"
 msgstr "Aloita/Lopeta erkanemistila"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Työkalut"
 
@@ -6022,7 +6026,7 @@ msgstr "Kokeile ottaa ruudunkaappauksia!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Kokeile tallennuksen tekemistä!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Kokeile ottaa ruudunkaappauksia!"
 
@@ -6175,12 +6179,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Katso nyt"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Help"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6207,7 +6211,7 @@ msgstr "Erkane kaikista"
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6230,7 +6234,7 @@ msgstr "Kumoa viimeisin toimenpide"
 msgid "UNKNOWN"
 msgstr "Tuntematon"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Näytä kykypalkki"
@@ -6244,7 +6248,7 @@ msgstr "Tuntematon hiiren painike"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Tuntematon hiiren painike"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Versio:"
@@ -6254,7 +6258,7 @@ msgstr "Versio:"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Tuntematon hiiren painike"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Sinulla on tallentamattomia muutoksia, jotka menetetään.\n"
@@ -6302,7 +6306,7 @@ msgstr "Tallennus onnistui"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Lisenssit ja käytetyt kirjastot"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "Käytetty renderöijä:"
 
@@ -6319,7 +6323,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Lisää uusi syöte"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Käytä annettua käyttäjänimeä"
 
@@ -6327,11 +6331,11 @@ msgstr "Käytä annettua käyttäjänimeä"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Määritä manuaalisesti taustalla pyörivien suorittajien määrä"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr "Käytä virtuaalista ikkunankokoa"
 
@@ -6357,7 +6361,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Versio:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Sukupolvi:"
@@ -6368,11 +6372,11 @@ msgstr "Sukupolvi:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Uusi nimi:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0} MiB"
 
@@ -6380,7 +6384,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Tarkastelija"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Katsele lähdekoodia"
 
@@ -6392,7 +6396,7 @@ msgstr "VIP-tukijat"
 msgid "VISIBLE"
 msgstr "Näkyvä"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6412,7 +6416,7 @@ msgstr "Hiljennä äänet"
 msgid "VOLUMEUP"
 msgstr "Äänenvoimakkuus isommalle"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "Pystysynkronointi"
 
@@ -6523,7 +6527,7 @@ msgstr "Statistiikkaa organismista"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "Suhteellinen maailmaan"
 
@@ -6532,15 +6536,15 @@ msgstr "Suhteellinen maailmaan"
 msgid "WORST_PATCH_COLON"
 msgstr "Lajit:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr "Xbox 360"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr "Xbox One"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6552,7 +6556,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "vuotta"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Laita peli tauolle"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-12-02 16:07+0000\n"
 "Last-Translator: cesco <lothindir@gmail.com>\n"
 "Language-Team: French <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/fr/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "Éditeur tridimensionnel"
 msgid "3D_MOVEMENT"
 msgstr "Mouvement tridimensionnel"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "Action bloquée pendant qu'une autre est en cours"
 msgid "ACTIVE"
 msgstr "Actif"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Threads actuels :"
 
@@ -145,7 +145,7 @@ msgstr "Statistiques de l'Organisme"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Volume d'ambiance"
 
@@ -156,11 +156,11 @@ msgstr "Volume d'ambiance"
 msgid "AMMONIA"
 msgstr "Ammoniaque"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Nombre de sauvegardes à conserver :"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Nombre de sauvegardes rapide à conserver :"
 
@@ -185,11 +185,11 @@ msgstr "appliquer les changements"
 msgid "APRIL"
 msgstr "Avril"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Êtes-vous sûr de vouloir restaurer tous les paramètres par défaut ?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Êtes-vous sur de vouloir restaurer les entrées à leurs valeurs par défauts ?"
 
@@ -205,7 +205,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Œuvre de {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Galerie d'art"
 
@@ -219,7 +219,7 @@ msgstr "La classe de l'assemblage des Mods est requise lorsque l'assemblage est 
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "La classe de l'assemblage des Mods est requise lorsque l'assemblage est spécifié"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Supposer que l'hyper-threading du CPU est activé"
 
@@ -262,7 +262,7 @@ msgstr "La tentative d'écriture de ce fichier de sauvegarde a échoué. Le nom 
 msgid "AT_CURSOR"
 msgstr "Au pointeur :"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Périphérique de sortie audio :"
 
@@ -270,8 +270,8 @@ msgstr "Périphérique de sortie audio :"
 msgid "AUGUST"
 msgstr "Août"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Automatique"
 
@@ -299,7 +299,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% terminé. {1:n0}/{2:n0} étapes."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Sauvegarde automatique en jeu"
 
@@ -307,7 +307,7 @@ msgstr "Sauvegarde automatique en jeu"
 msgid "AUTO_EVO"
 msgstr "Auto-Évo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Outil d'exploration Auto-Évo"
 
@@ -337,7 +337,7 @@ msgstr "état de lancement :"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Avance auto"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Automatique ({0}x{1})"
 
@@ -351,9 +351,9 @@ msgid "AWAKEN"
 msgstr "Conscient"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -491,7 +491,7 @@ msgstr "Appuyez sur [thrive:input]g_toggle_binding[/thrive:input] pour basculer 
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Appuyez sur [thrive:input]g_toggle_binding[/thrive:input] pour basculer en mode de liaison. En mode de liaison, vous pouvez attacher d’autres cellules de votre espèce à votre colonie en vous y déplaçant. Pour quitter une colonie, appuyez sur [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr "Lier les axes ensemble"
 
@@ -553,7 +553,7 @@ msgstr "Cette membrane a une coque résistante faite de carbonate de calcium. El
 msgid "CAMERA"
 msgstr "Caméra"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -687,7 +687,7 @@ msgstr "Modifier la symétrie"
 msgid "CHEATS"
 msgstr "Triches"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Codes de triche activés"
 
@@ -779,7 +779,7 @@ msgstr "Produit du [thrive:compound type=\"glucose\"][/thrive:compound]. Taux pr
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "La sauvegarde sélectionnée ({0}) existe déjà. Réécrire par dessus?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Aberration chromatique :"
 
@@ -820,15 +820,15 @@ msgstr "Suppression des Anciennes Sauvegardes"
 msgid "CLOSE"
 msgstr "Fermer"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Fermer les paramètres ?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Diviseur de résolution des nuages :"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Intervalle minimal de simulation des nuages :"
 
@@ -844,7 +844,7 @@ msgstr "Créer les entités avec les formes de collision"
 msgid "COLOUR"
 msgstr "Couleur"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Correction daltonienne :"
 
@@ -905,23 +905,23 @@ msgstr "Saturation de la couleur (proportion de gris)"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Luminosité ou intensité de la couleur"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr "Forum de la communauté"
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Rejoignez la communauté Thrive sur notre forum communautaire"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr "Wiki de la communauté"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Visitez le wiki de la communauté"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr "Compilé à :"
 
@@ -947,7 +947,7 @@ msgstr "Composés :"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Équilibre des composants"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Nuages de composés"
 
@@ -1033,7 +1033,7 @@ msgstr "Continuer vers les phases en prototype ?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr "Visualiseurs d'axes de contrôle :"
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr "Zones mortes du contrôleur"
 
@@ -1048,11 +1048,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr "Zone morte :"
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr "Sensibilité du contrôleur"
 
@@ -1060,11 +1060,11 @@ msgstr "Sensibilité du contrôleur"
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Copier l'Erreur"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanopie (Rouge-Vert)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanopie (Bleue-Jaune)"
 
@@ -1125,7 +1125,7 @@ msgstr "Rechercher..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Création des objets à partir de la sauvegarde"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Crédits"
 
@@ -1151,7 +1151,7 @@ msgstr "Développeurs actuels"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Statistiques de l'Organisme"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Pseudo personnalisé :"
 
@@ -1216,7 +1216,7 @@ msgstr "Débogueur"
 msgid "DECEMBER"
 msgstr "Décembre"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Périphérique de sortie par défaut"
 
@@ -1281,7 +1281,7 @@ msgstr "La description est trop longue"
 msgid "DESPAWN_ENTITIES"
 msgstr "Supprimer toutes les entités"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Nombre de CPU détectés :"
 
@@ -1296,11 +1296,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Développeurs"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr "Forum de développement"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Consultez les mises à jour du développement sur notre forum de développement"
 
@@ -1308,11 +1308,11 @@ msgstr "Consultez les mises à jour du développement sur notre forum de dévelo
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Développé avec le soutien de Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr "Wiki de développement"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Visitez notre wiki de développement"
 
@@ -1399,7 +1399,7 @@ msgstr "Vers la gauche"
 msgid "DIRECTIONR"
 msgstr "Vers la droite"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Désactivé"
 
@@ -1407,7 +1407,7 @@ msgstr "Désactivé"
 msgid "DISABLE_ALL"
 msgstr "Tout désactiver"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Annuler et continuer"
 
@@ -1448,33 +1448,33 @@ msgstr ""
 "Il y a des organites placées qui ne sont pas connectés au reste.\n"
 "Veuillez connecter toutes les organites placées avec les autres ou annulez vos changements."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr "Rejoint notre serveur Discord de la communauté"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Popups désactivées :"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 "Ceci indique le nombre de fenêtres contextuelles qui ont été définitivement désactivées par l'utilisateur.\n"
 "Si certaines fenêtres contextuelles, qui sont en fait souhaitées, ont été désactivées, le bouton situé à côté peut être utilisé pour faire réapparaître toutes les fenêtres contextuelles désactivées."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr "Ne plus montrer"
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Afficher la barre des capacités"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Afficher les particules en arrière-plan"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Afficher les noms des boutons de sélection des parties"
 
@@ -1509,7 +1509,7 @@ msgstr "Double-cliquer pour voir en plein écran"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Étant une membrane à double couche de phospholipides, elle offre une meilleure protection et demande peu d'énergie pour ne pas se déformer. Néanmoins, elle peut ralentir une cellule en terme de vitesse de locomotion et d'absorption de ressources."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Ne plus me prévenir"
 
@@ -1664,7 +1664,7 @@ msgstr ""
 "\n"
 "Lorsque vous êtes prêt, appuyez sur le bouton \"suivant\" en bas à droite pour continuer."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1682,7 +1682,7 @@ msgstr "La sauvegarde sélectionnée est incompatible"
 msgid "ENABLE_EDITOR"
 msgstr "Activer l'éditeur"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Activer les effets lumineux dans l'interface utilisateur"
 
@@ -1741,7 +1741,7 @@ msgstr "Afficher / cacher l'environnement et les composés"
 msgid "EPIPELAGIC"
 msgstr "Épipélagique"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Erreur"
 
@@ -1755,16 +1755,16 @@ msgstr "Erreur de création du dossier pour la modification"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Erreur de création du fichier d'information pour la modification"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Erreur : les nouveaux paramètres n'ont pas été sauvegardés dans le fichier de configuration."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(secrets apparaissant au hasard dans le jeu)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Erreur de création du fichier d'information pour la modification"
@@ -1800,11 +1800,11 @@ msgstr ""
 "\n"
 "Si aucun de ces cas ne s'applique, une erreur s'est produite. Veuillez en informer l'équipe de développement et fournir les logs de jeu."
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr "Version exacte de Thrive :"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Ceci est le code exact à partir duquel cette version de Thrive a été compilée"
 
@@ -1822,7 +1822,7 @@ msgstr "Une exception a eu lieu pendant le chargement des données de sauvegarde
 msgid "EXIT"
 msgstr "Quitter"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Revenir au lanceur"
 
@@ -1876,7 +1876,7 @@ msgstr "a disparu du secteur"
 msgid "EXTINCT_SPECIES"
 msgstr "Espèces disparues"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1884,7 +1884,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr "Autres Options"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Visitez notre page Facebook"
 
@@ -1916,12 +1916,12 @@ msgstr "Activé"
 msgid "FEBRUARY"
 msgstr "Février"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "L'initialisation de la bibliothèque du client Steam a échoué"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1943,11 +1943,11 @@ msgstr ""
 "Temps total du CPU :\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2077,7 +2077,7 @@ msgstr "Fossiliser cette espèce (déjà fossilisée)"
 msgid "FOSSILISE"
 msgstr "Fossiliser"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2107,7 +2107,7 @@ msgstr "Nuage de glucose à la sortie de l'éditeur"
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(commencer par un nuage de glucose à proximité de chaque génération)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Plein écran"
 
@@ -2136,23 +2136,23 @@ msgstr "Générations"
 msgid "GENERATION_COLON"
 msgstr "Génération :"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr "Visitez notre repository Github"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Alerte Mode GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Vous utilisez Thrive avec le GLES2. Cela demeure non testé et risque de causer des problèmes. Essayez de mettre à jour vos pilotes vidéos et/ou de forcer l'utilisation des graphiques AMD ou Nvidia pour lancer Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr "GLES3"
 
@@ -2206,11 +2206,11 @@ msgstr "Bien reçu"
 msgid "GPL_LICENSE_HEADING"
 msgstr "Texte de la licence GPL :"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "GPU :"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Graphismes"
 
@@ -2218,7 +2218,7 @@ msgstr "Graphismes"
 msgid "GRAPHICS_TEAM"
 msgstr "Équipe de graphisme"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "Interface utilisateur"
 
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} K"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Volume de l'interface"
 
@@ -2257,11 +2257,11 @@ msgstr "Aide"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Aide"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(des valeurs plus hautes améliorent les performances)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(des valeurs plus élevées demandent plus de performances)"
 
@@ -2286,7 +2286,7 @@ msgstr "Maintenez [thrive:input]g_free_cursor[/thrive:input] pour le curseur"
 msgid "HOME"
 msgstr "Menu principal"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr "Horizontal :"
 
@@ -2361,7 +2361,7 @@ msgstr "Matière ingérée"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Rejoint notre serveur Discord de la communauté"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Entrées"
 
@@ -2417,8 +2417,8 @@ msgstr "Format d'URL invalide"
 msgid "INVALID_URL_SCHEME"
 msgstr "Schéma d'URL invalide"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr "Inversé"
 
@@ -2441,7 +2441,7 @@ msgstr "Fer"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Chimiolithoautotrophe Ferrique"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr "Visitez notre page Itch.io"
 
@@ -2449,19 +2449,19 @@ msgstr "Visitez notre page Itch.io"
 msgid "JANUARY"
 msgstr "Janvier"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "Mode de débogage de JSON :"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Toujours"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automatiquement"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Jamais"
 
@@ -2643,19 +2643,19 @@ msgstr "nombre ."
 msgid "KPSUBTRACT"
 msgstr "nombre -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Langue :"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Aidez-nous à traduire le jeu (complet à {0}%)"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Cette langue est encore en cours de rédaction ({0}% effectué)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Cette traduction est très incomplète ({0}% effectué). Aidez-nous à la terminer !"
 
@@ -2819,7 +2819,7 @@ msgstr "Clic gauche"
 msgid "LEFT_MOUSE"
 msgstr "Clic gauche"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licences"
 
@@ -2889,7 +2889,7 @@ msgstr "Roulette droite"
 msgid "LIGHT_MAX"
 msgstr "Lumière"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Extrême"
 
@@ -2901,31 +2901,31 @@ msgstr "Limiter l'utilisation du composé de croissance"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(si elle est activée, la vitesse de croissance est plafonnée, si elle est désactivée, seuls les composés disponibles affectent la vitesse de croissance)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Énorme"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Grand"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Normal"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Petit"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Minuscule"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Très grand"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Très petit"
 
@@ -2950,7 +2950,7 @@ msgstr "Charger"
 msgid "LOADING"
 msgstr "Chargement"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
@@ -2983,12 +2983,12 @@ msgstr "Appuyez sur le bouton Revenir en Arrière dans l'éditeur pour corriger 
 msgid "LOAD_FINISHED"
 msgstr "Chargement terminé"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Charger une partie"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Charger les sauvegardes précédentes"
 
@@ -3065,7 +3065,7 @@ msgstr "Mars"
 msgid "MARINE_SNOW"
 msgstr "Neige marine"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Volume principal"
 
@@ -3073,15 +3073,15 @@ msgstr "Volume principal"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Nombre maximum d'espèces dans un secteur avant des extinctions forcées"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "FPS max. :"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Illimitées"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Nombre maximum d'entités :"
 
@@ -3269,7 +3269,7 @@ msgstr "À chaque génération, vous avez 100 points de mutation (PM) à dépens
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "À chaque fois que vous vous reproduisez, vous entrez dans l'Éditeur de Microbes, où vous pouvez modifier votre espèce (en ajoutant, pivotant ou retirant des organites) pour augmenter ses chances de réussite. Chaque passage dans l'éditeur du stade Microbe représente [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] millions d'années d'évolution."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Éditeur Libre de Microbe"
 
@@ -3454,7 +3454,7 @@ msgstr "Version :"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Il n'est pas permis d'afficher moins de {0} datasets !"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Divers"
 
@@ -3522,11 +3522,11 @@ msgstr "Déplacer organite"
 msgid "MODIFY_TYPE"
 msgstr "Modifier le type"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Des mods installés ont été détectés, mais aucun mod n'a été activé.\n"
@@ -3623,11 +3623,11 @@ msgstr "Nom de dossier interne :"
 msgid "MOD_LICENSE"
 msgstr "Licence :"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Erreurs liées au chargement de mods"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Des erreurs sont apparues lors du chargement d'un ou plusieurs mods. Les logs pourraient contenir des informations supplémentaires."
 
@@ -3685,11 +3685,11 @@ msgstr "Version :"
 msgid "MORE_INFO"
 msgstr "Plus d'informations"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr "Sensibilité de la souris"
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr "Sensibilité de la souris en fonction de la taille de la fenêtre"
 
@@ -3805,7 +3805,7 @@ msgstr "Placer organite"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Placer organite"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Anticrénelage plusieurs échantillons :"
 
@@ -3820,7 +3820,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Musique"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Volume de la musique"
 
@@ -3840,9 +3840,9 @@ msgstr "(coût des organites, membranes et autres éléments dans l'éditeur)"
 msgid "MUTATION_POINTS"
 msgstr "Points de mutation"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Silencieux"
 
@@ -3878,11 +3878,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Population initiale pour les espèces augmentant la biodiversité"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Nouvelle partie"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Commencer une nouvelle partie"
 
@@ -3947,7 +3947,7 @@ msgstr "Le plaste fixateur d'azote est une protéine capable d'utiliser l'[thriv
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Transforme l'[thrive:compound type=\"atp\"][/thrive:compound] en [thrive:compound type=\"ammonia\"][/thrive:compound]. Taux proportionnels à la concentration d'[thrive:compound type=\"nitrogen\"][/thrive:compound] et d'[thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Aucune"
 
@@ -3996,7 +3996,7 @@ msgstr "Aucun évènement enregistré"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Pas de dossier de sauvegarde trouvé"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr "Pas de mods activés"
 
@@ -4013,7 +4013,7 @@ msgstr "Aucune sauvegarde trouvée"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Pas de dossier de sauvegarde trouvé"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Pas de dossier de captures d'écrans trouvé"
 
@@ -4062,15 +4062,15 @@ msgstr "N/A PM"
 msgid "OCTOBER"
 msgstr "Octobre"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr "Site web officiel"
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Visitez le site officiel de Revolutionary Games"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4110,7 +4110,7 @@ msgstr "Ouvrir l'écran d'aide"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Construction Libre"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Ouvrir le dossier des Logs"
 
@@ -4127,7 +4127,7 @@ msgstr "Ouvrir le menu des organites"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Ouvrir le Dossier de Sauvegarde"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Ouvrir le dossier de captures d'écran"
 
@@ -4135,7 +4135,7 @@ msgstr "Ouvrir le dossier de captures d'écran"
 msgid "OPEN_THE_MENU"
 msgstr "Ouvrir le menu"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Aidez nous à traduire le jeu"
 
@@ -4154,11 +4154,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportuniste"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Options"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Modifier les paramètres"
 
@@ -4371,7 +4371,7 @@ msgstr "Procédural"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr "Visitez notre page Patreon"
 
@@ -4424,7 +4424,7 @@ msgstr "Pacifique"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Performance"
 
@@ -4513,7 +4513,7 @@ msgstr "joueur en double"
 msgid "PLAYER_EXTINCT"
 msgstr "Le joueur est éteint"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Le joueur est éteint"
@@ -4528,26 +4528,26 @@ msgstr ""
 "Vitesse\n"
 "du joueur"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 #, fuzzy
 msgid "PLAYSTATION_3"
 msgstr "population :"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 #, fuzzy
 msgid "PLAYSTATION_4"
 msgstr "population :"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 #, fuzzy
 msgid "PLAYSTATION_5"
 msgstr "population :"
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Jouer la vidéo d'intro"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Jouer l'introduction à chaque nouvelle partie"
 
@@ -4666,11 +4666,11 @@ msgstr "Chargement rapide"
 msgid "QUICK_SAVE"
 msgstr "Sauvegarde rapide"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Quitter"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Quitter le jeu"
@@ -4712,7 +4712,7 @@ msgstr "Prêt"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Version de Thrive recommandée :"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr "Visitez notre subreddit"
 
@@ -4767,7 +4767,7 @@ msgstr "Reproduction :"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Noyau"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Réinitialiser"
 
@@ -4775,23 +4775,23 @@ msgstr "Réinitialiser"
 msgid "RESET_DEADZONES"
 msgstr "Réinitialiser les zones mortes"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr "Réinitialiser les popups désactivées"
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Réinitialiser les entrées aux valeurs par défaut ?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr "Réinitialiser les raccourcis clavier"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Par Défaut"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Restaurer par défaut ?"
 
@@ -4800,7 +4800,7 @@ msgstr "Restaurer par défaut ?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr "Résistant à l'engloutissement de base"
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Résolution :"
 
@@ -4852,7 +4852,7 @@ msgstr ""
 "Voulez-vous vraiment retourner au menu principal ?\n"
 "Vous perdrez toute progression non sauvegardée."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Visitez les sites officiels de Revolutionary Games"
 
@@ -4886,7 +4886,7 @@ msgstr "Tourner à droite"
 msgid "ROTATION_COLON"
 msgstr "population :"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Activer l'Auto-Évo en jeu"
 
@@ -4941,7 +4941,7 @@ msgstr "La rusticyanine est une protéine capable d'utiliser le [thrive:compound
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Transforme le [thrive:compound type=\"iron\"][/thrive:compound] en [thrive:compound type=\"atp\"][/thrive:compound]. Taux proportionnels à la concentration de [thrive:compound type=\"carbondioxide\"][/thrive:compound] et d'[thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive a démarré en mode sans échec en raison d'un échec de démarrage antérieur.\n"
@@ -4953,15 +4953,15 @@ msgstr ""
 "\n"
 "Si vous ne résolvez pas le problème à l'origine de l'échec du démarrage, vous devrez redémarrer et faire planter Thrive plusieurs fois pour revenir en mode sans échec."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive a démarré en mode sans échec"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Sauvegarder"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Sauvegarder et continuer"
 
@@ -5062,20 +5062,20 @@ msgstr "Sauvegarde actuellement impossible à cause de :"
 msgid "SAVING_SUCCEEDED"
 msgstr "Sauvegarde réussi"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr "Aucun"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr "Proportionel"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr "Inversement proportionnel"
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "pour augmenter la mobilité"
@@ -5181,7 +5181,7 @@ msgstr "Sessile"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Cette valeur ne s'applique qu'aux nouvelles parties après avoir changé cette option"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Volume des effets spéciaux"
 
@@ -5198,15 +5198,15 @@ msgstr "Montrer l'aide"
 msgid "SHOW_TUTORIALS"
 msgstr "Montrer les tutoriels"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Afficher les tutoriels (dans la partie actuelle)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Afficher les tutoriels (dans les nouvelles parties)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Avertissement lorsque la progression n'a pas été sauvegardée"
 
@@ -5214,6 +5214,10 @@ msgstr "Avertissement lorsque la progression n'a pas été sauvegardée"
 #, fuzzy
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Active / désactive les popup d'avertissement de progrès non sauvegardés lorsque le joueur essayer de quitter le jeu."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5267,7 +5271,7 @@ msgstr "Silice"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Cette membrane possède une paroi solide de silice. Elle résiste bien aux dommages globaux et très bien aux dommages physiques. Elle requiert aussi moins d'énergie pour maintenir sa forme. Cependant, elle ralentit sensiblement la cellue et celle-ci absorbe les ressources à un taux réduit."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5307,7 +5311,7 @@ msgstr "Transforme le [thrive:compound type=\"glucose\"][/thrive:compound] en [t
 msgid "SMALL_IRON_CHUNK"
 msgstr "Petit morceau de fer"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Son"
 
@@ -5517,17 +5521,17 @@ msgstr "Steam est indisponible pour le moment, veuillez réessayer ultérieureme
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Une erreur Steam inconnue vient de se produire"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "L'initialisation de la bibliothèque du client Steam a échoué"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "La mise à jour de la sauvegarde a échouée à cause de cette erreur :"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr "Visitez notre page Steam"
 
@@ -5567,7 +5571,7 @@ msgstr "Stockage"
 msgid "STORAGE_COLON"
 msgstr "Stockage :"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Connecté sous le nom de : {0}"
 
@@ -5686,7 +5690,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Équipe de test"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Merci de soutenir le développement de Thrive en achetant cette copie de Thrive !\n"
@@ -5702,7 +5706,7 @@ msgstr ""
 "\n"
 "Si vous avez aimé le jeu, n'hésitez pas à en parler à vos amis."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr "Merci"
 
@@ -5757,11 +5761,11 @@ msgstr "Cette modification est installée localement"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Cette modification a été téléchargée depuis l'atelier Steam"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Threads :"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thriveopédia"
 
@@ -5919,7 +5923,7 @@ msgstr "Pause"
 msgid "TOGGLE_UNBINDING"
 msgstr "Activer/désactiver la liaison"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Outils"
 
@@ -5984,7 +5988,7 @@ msgstr "Essayez de prendre une capture d'écran !"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Essayez de sauvegarder !"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Essayez de prendre une capture d'écran !"
 
@@ -6150,11 +6154,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Tutoriel"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr "Visite notre flux Twitter"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6181,7 +6185,7 @@ msgstr "Dissocier tout"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Mode de Délier"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr "Il s'agit d'une version de debug où les informations ci-dessous ne sont probablement pas à jour"
 
@@ -6201,7 +6205,7 @@ msgstr "Annuler la dernière action"
 msgid "UNKNOWN"
 msgstr "Entrée inconnue"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Inconnu"
 
@@ -6213,7 +6217,7 @@ msgstr "Souris inconnue"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Inconnu sur Windows"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "Version inconnue"
 
@@ -6222,7 +6226,7 @@ msgstr "Version inconnue"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Souris inconnue"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Des changements non sauvegardés vont être abandonnés.\n"
@@ -6269,7 +6273,7 @@ msgstr "Sauvegarde réussi"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Licences et bibliothèques utilisés"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "Moteur de rendu utilisé :"
 
@@ -6287,7 +6291,7 @@ msgstr "Utiliser le chargement auto-harmonie"
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Chargement automatique des patchs Harmony à partir de l'Assembleur (ne nécessite pas de spécifier la classe de mod)"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Utiliser un nom d'utilisateur personnalisé"
 
@@ -6295,11 +6299,11 @@ msgstr "Utiliser un nom d'utilisateur personnalisé"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "La création d'espèces pour augmenter la biodiversité vole de la population aux espèces existantes"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Saisie manuelle du nombre de thread en arrière-plan"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr "Utiliser la taille de la fenêtre virtuelle"
 
@@ -6326,7 +6330,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Génération :"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr "Vertical :"
 
@@ -6335,11 +6339,11 @@ msgstr "Vertical :"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Vertical (Axe : {0})"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "Mémoire vidéo actuellement utilisée :"
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0} MiO"
 
@@ -6347,7 +6351,7 @@ msgstr "{0} MiO"
 msgid "VIEWER"
 msgstr "Visionneur"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Voir le code source"
 
@@ -6359,7 +6363,7 @@ msgstr "Soutiens VIP"
 msgid "VISIBLE"
 msgstr "Visible"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Proposer une fonctionnalité"
 
@@ -6379,7 +6383,7 @@ msgstr "Taire le volume sonore"
 msgid "VOLUMEUP"
 msgstr "Augmenter le volume sonore"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "Sync V"
 
@@ -6492,7 +6496,7 @@ msgstr ""
 "Inclure les prototypes des stades avancés : {0}\n"
 "Inclure les Easter eggs : {1}"
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "pour augmenter la mobilité"
@@ -6501,15 +6505,15 @@ msgstr "pour augmenter la mobilité"
 msgid "WORST_PATCH_COLON"
 msgstr "Pire secteur :"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6521,7 +6525,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "années"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Visitez notre chaîne YouTube"
 

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-12-02 16:07+0000\n"
 "Last-Translator: cesco <lothindir@gmail.com>\n"
 "Language-Team: French <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/fr/>\n"
@@ -205,7 +205,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Œuvre de {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Galerie d'art"
 
@@ -307,7 +307,7 @@ msgstr "Sauvegarde automatique en jeu"
 msgid "AUTO_EVO"
 msgstr "Auto-Évo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Outil d'exploration Auto-Évo"
 
@@ -351,8 +351,8 @@ msgid "AWAKEN"
 msgstr "Conscient"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -611,27 +611,27 @@ msgstr "Lettre en majuscules"
 msgid "CARBON_DIOXIDE"
 msgstr "Gaz carbonique"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "en abondance"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "une quantité raisonnable"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "peu"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "en certaine quantité"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "quelque"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "tres peu"
 
@@ -905,19 +905,19 @@ msgstr "Saturation de la couleur (proportion de gris)"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Luminosité ou intensité de la couleur"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr "Forum de la communauté"
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Rejoignez la communauté Thrive sur notre forum communautaire"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr "Wiki de la communauté"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Visitez le wiki de la communauté"
 
@@ -1125,7 +1125,7 @@ msgstr "Rechercher..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Création des objets à partir de la sauvegarde"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Crédits"
 
@@ -1296,11 +1296,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Développeurs"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr "Forum de développement"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Consultez les mises à jour du développement sur notre forum de développement"
 
@@ -1308,11 +1308,11 @@ msgstr "Consultez les mises à jour du développement sur notre forum de dévelo
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Développé avec le soutien de Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr "Wiki de développement"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Visitez notre wiki de développement"
 
@@ -1448,7 +1448,7 @@ msgstr ""
 "Il y a des organites placées qui ne sont pas connectés au reste.\n"
 "Veuillez connecter toutes les organites placées avec les autres ou annulez vos changements."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr "Rejoint notre serveur Discord de la communauté"
 
@@ -1462,7 +1462,7 @@ msgstr ""
 "Ceci indique le nombre de fenêtres contextuelles qui ont été définitivement désactivées par l'utilisateur.\n"
 "Si certaines fenêtres contextuelles, qui sont en fait souhaitées, ont été désactivées, le bouton situé à côté peut être utilisé pour faire réapparaître toutes les fenêtres contextuelles désactivées."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr "Ne plus montrer"
 
@@ -1509,7 +1509,7 @@ msgstr "Double-cliquer pour voir en plein écran"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Étant une membrane à double couche de phospholipides, elle offre une meilleure protection et demande peu d'énergie pour ne pas se déformer. Néanmoins, elle peut ralentir une cellule en terme de vitesse de locomotion et d'absorption de ressources."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Ne plus me prévenir"
 
@@ -1694,15 +1694,15 @@ msgstr "{0} : -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0} : +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Énergie dans le secteur {0} pour la source : {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Sources d'énergie :"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "{0} unités d'énergie ont été récoltées au total, avec un coût de {1} par individu, résultant en une population non-ajustée de {2}"
 
@@ -1759,6 +1759,16 @@ msgstr "Erreur de création du fichier d'information pour la modification"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Erreur : les nouveaux paramètres n'ont pas été sauvegardés dans le fichier de configuration."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(secrets apparaissant au hasard dans le jeu)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Erreur de création du fichier d'information pour la modification"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Erreur de Chargement"
@@ -1812,7 +1822,7 @@ msgstr "Une exception a eu lieu pendant le chargement des données de sauvegarde
 msgid "EXIT"
 msgstr "Quitter"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Revenir au lanceur"
 
@@ -1866,7 +1876,7 @@ msgstr "a disparu du secteur"
 msgid "EXTINCT_SPECIES"
 msgstr "Espèces disparues"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1874,7 +1884,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr "Autres Options"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Visitez notre page Facebook"
 
@@ -1905,6 +1915,41 @@ msgstr "Activé"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Février"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "L'initialisation de la bibliothèque du client Steam a échoué"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Temps de traitement : {0} s\n"
+"Temps de calculs physiques : {1} s\n"
+"Entités : {2} Autres : {3}\n"
+"Apparition : {4} Désapparitions : {5}\n"
+"Nœuds utilisés : {6}\n"
+"Mémoire utilisée : {7}\n"
+"Mémoire GPU : {8}\n"
+"Objets rendus : {9}\n"
+"Appels de dessin : {10} 2D : {11}\n"
+"Sommets rendus : {12}\n"
+"Modifications de matériaux : {13}\n"
+"Modifications de shaders : {14}\n"
+"Nœuds rendus orphelins : {15}\n"
+"Latence audio : {16} ms\n"
+"Nombre total de threads : {17}\n"
+"Temps total du CPU :\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1988,7 +2033,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Chaîne Alimentaire"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "Unités d'énergie pour la source « {0} » : {1} (valeur sélective : {2}) énergie totale disponible : {3} (valeur totale : {4})"
 
@@ -2091,7 +2136,7 @@ msgstr "Générations"
 msgid "GENERATION_COLON"
 msgstr "Génération :"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr "Visitez notre repository Github"
 
@@ -2099,11 +2144,11 @@ msgstr "Visitez notre repository Github"
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Alerte Mode GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Vous utilisez Thrive avec le GLES2. Cela demeure non testé et risque de causer des problèmes. Essayez de mettre à jour vos pilotes vidéos et/ou de forcer l'utilisation des graphiques AMD ou Nvidia pour lancer Thrive."
 
@@ -2396,7 +2441,7 @@ msgstr "Fer"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Chimiolithoautotrophe Ferrique"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr "Visitez notre page Itch.io"
 
@@ -2614,7 +2659,7 @@ msgstr "Cette langue est encore en cours de rédaction ({0}% effectué)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Cette traduction est très incomplète ({0}% effectué). Aidez-nous à la terminer !"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 #, fuzzy
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "Impossible de supprimer la dernière organelle"
@@ -2774,7 +2819,7 @@ msgstr "Clic gauche"
 msgid "LEFT_MOUSE"
 msgstr "Clic gauche"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licences"
 
@@ -2905,7 +2950,8 @@ msgstr "Charger"
 msgid "LOADING"
 msgstr "Chargement"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Chargement..."
@@ -2937,12 +2983,12 @@ msgstr "Appuyez sur le bouton Revenir en Arrière dans l'éditeur pour corriger 
 msgid "LOAD_FINISHED"
 msgstr "Chargement terminé"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Charger une partie"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Charger les sauvegardes précédentes"
 
@@ -3223,7 +3269,7 @@ msgstr "À chaque génération, vous avez 100 points de mutation (PM) à dépens
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "À chaque fois que vous vous reproduisez, vous entrez dans l'Éditeur de Microbes, où vous pouvez modifier votre espèce (en ajoutant, pivotant ou retirant des organites) pour augmenter ses chances de réussite. Chaque passage dans l'éditeur du stade Microbe représente [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] millions d'années d'évolution."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Éditeur Libre de Microbe"
 
@@ -3476,11 +3522,11 @@ msgstr "Déplacer organite"
 msgid "MODIFY_TYPE"
 msgstr "Modifier le type"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Des mods installés ont été détectés, mais aucun mod n'a été activé.\n"
@@ -3577,11 +3623,11 @@ msgstr "Nom de dossier interne :"
 msgid "MOD_LICENSE"
 msgstr "Licence :"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Erreurs liées au chargement de mods"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Des erreurs sont apparues lors du chargement d'un ou plusieurs mods. Les logs pourraient contenir des informations supplémentaires."
 
@@ -3824,15 +3870,19 @@ msgstr ""
 "Cette sauvegarde vient dune version postérieure de Thrive et a beaucoup de chances d'être incompatible.\n"
 "Voulez-vous tout de même tenter de charger la sauvegarde?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Population initiale pour les espèces augmentant la biodiversité"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Nouvelle partie"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Commencer une nouvelle partie"
 
@@ -3932,7 +3982,7 @@ msgid "NO_AI"
 msgstr "Pas d'IA"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Aucune donnée à afficher"
 
@@ -3946,7 +3996,7 @@ msgstr "Aucun évènement enregistré"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Pas de dossier de sauvegarde trouvé"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr "Pas de mods activés"
 
@@ -3976,7 +4026,7 @@ msgstr "Aucune modification sélectionnée"
 msgid "NUCLEUS"
 msgstr "Noyau"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 #, fuzzy
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
@@ -3998,8 +4048,8 @@ msgstr "Verr Num"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "Aucun"
@@ -4012,15 +4062,15 @@ msgstr "N/A PM"
 msgid "OCTOBER"
 msgstr "Octobre"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr "Site web officiel"
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Visitez le site officiel de Revolutionary Games"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4104,11 +4154,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportuniste"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Options"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Modifier les paramètres"
 
@@ -4321,7 +4371,7 @@ msgstr "Procédural"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr "Visitez notre page Patreon"
 
@@ -4382,8 +4432,8 @@ msgstr "Performance"
 msgid "PERFORM_UNBINDING"
 msgstr "Supprimer le relieur"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/second"
 
@@ -4439,7 +4489,7 @@ msgstr "La génération de planète arrive bientôt !"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Graine planétaire aléatoire"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Cellule du joueur"
 
@@ -4518,7 +4568,7 @@ msgstr "population :"
 msgid "POPULATION_IN_PATCHES"
 msgstr "population dans les secteurs :"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4572,7 +4622,7 @@ msgstr "précédente :"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Compréhension des objets chargés"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4616,11 +4666,11 @@ msgstr "Chargement rapide"
 msgid "QUICK_SAVE"
 msgstr "Sauvegarde rapide"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Quitter"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Quitter le jeu"
@@ -4662,7 +4712,7 @@ msgstr "Prêt"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Version de Thrive recommandée :"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr "Visitez notre subreddit"
 
@@ -4802,7 +4852,7 @@ msgstr ""
 "Voulez-vous vraiment retourner au menu principal ?\n"
 "Vous perdrez toute progression non sauvegardée."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Visitez les sites officiels de Revolutionary Games"
 
@@ -4891,7 +4941,7 @@ msgstr "La rusticyanine est une protéine capable d'utiliser le [thrive:compound
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Transforme le [thrive:compound type=\"iron\"][/thrive:compound] en [thrive:compound type=\"atp\"][/thrive:compound]. Taux proportionnels à la concentration de [thrive:compound type=\"carbondioxide\"][/thrive:compound] et d'[thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive a démarré en mode sans échec en raison d'un échec de démarrage antérieur.\n"
@@ -4903,7 +4953,7 @@ msgstr ""
 "\n"
 "Si vous ne résolvez pas le problème à l'origine de l'échec du démarrage, vous devrez redémarrer et faire planter Thrive plusieurs fois pour revenir en mode sans échec."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive a démarré en mode sans échec"
 
@@ -5285,7 +5335,7 @@ msgstr "Créer de l'ammoniaque"
 msgid "SPAWN_ENEMY"
 msgstr "Invoquer un ennemi"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Impossible d'invoquer une espèce ennemie, car ce secteur ne contient pas d'espèces ennemies"
 
@@ -5345,7 +5395,7 @@ msgstr "Nom de l’espèce..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Le nom de l’espèce est trop long !"
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5467,17 +5517,17 @@ msgstr "Steam est indisponible pour le moment, veuillez réessayer ultérieureme
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Une erreur Steam inconnue vient de se produire"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "L'initialisation de la bibliothèque du client Steam a échoué"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "La mise à jour de la sauvegarde a échouée à cause de cette erreur :"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr "Visitez notre page Steam"
 
@@ -5517,7 +5567,7 @@ msgstr "Stockage"
 msgid "STORAGE_COLON"
 msgstr "Stockage :"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Connecté sous le nom de : {0}"
 
@@ -5636,7 +5686,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Équipe de test"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Merci de soutenir le développement de Thrive en achetant cette copie de Thrive !\n"
@@ -5652,7 +5702,7 @@ msgstr ""
 "\n"
 "Si vous avez aimé le jeu, n'hésitez pas à en parler à vos amis."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr "Merci"
 
@@ -5711,7 +5761,7 @@ msgstr "Cette modification a été téléchargée depuis l'atelier Steam"
 msgid "THREADS"
 msgstr "Threads :"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thriveopédia"
 
@@ -5869,7 +5919,7 @@ msgstr "Pause"
 msgid "TOGGLE_UNBINDING"
 msgstr "Activer/désactiver la liaison"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Outils"
 
@@ -6100,7 +6150,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Tutoriel"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr "Visite notre flux Twitter"
 
@@ -6297,7 +6347,7 @@ msgstr "{0} MiO"
 msgid "VIEWER"
 msgstr "Visionneur"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Voir le code source"
 
@@ -6309,7 +6359,7 @@ msgstr "Soutiens VIP"
 msgid "VISIBLE"
 msgstr "Visible"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Proposer une fonctionnalité"
 
@@ -6471,7 +6521,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "années"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Visitez notre chaîne YouTube"
 

--- a/locale/frm.po
+++ b/locale/frm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -194,7 +194,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -330,8 +330,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -586,27 +586,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -865,19 +865,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1230,11 +1230,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1242,11 +1242,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1417,7 +1417,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1591,15 +1591,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1652,6 +1652,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1700,7 +1708,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1750,7 +1758,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1758,7 +1766,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1784,6 +1792,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1865,7 +1889,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1961,7 +1985,7 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1969,11 +1993,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2249,7 +2273,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2465,7 +2489,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2623,7 +2647,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2751,7 +2775,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2781,12 +2806,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2986,7 +3011,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3183,11 +3208,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3273,11 +3298,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3501,15 +3526,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3609,7 +3638,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3621,7 +3650,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3651,7 +3680,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3670,8 +3699,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3684,15 +3713,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3763,11 +3792,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3972,7 +4001,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4030,8 +4059,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4081,7 +4110,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4154,7 +4183,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4208,7 +4237,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4252,11 +4281,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4296,7 +4325,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4430,7 +4459,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4516,11 +4545,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4876,7 +4905,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4926,7 +4955,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5041,15 +5070,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5089,7 +5118,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5204,7 +5233,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5212,7 +5241,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5271,7 +5300,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5418,7 +5447,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5561,7 +5590,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5745,7 +5774,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5757,7 +5786,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5910,7 +5939,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/frm.po
+++ b/locale/frm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -29,7 +29,7 @@ msgstr ""
 msgid "3D_MOVEMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -60,7 +60,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -145,11 +145,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -174,11 +174,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -246,7 +246,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -254,8 +254,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -280,7 +280,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -317,7 +317,7 @@ msgstr ""
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -330,9 +330,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -468,7 +468,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -658,7 +658,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -748,7 +748,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -789,15 +789,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -865,23 +865,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr ""
 
@@ -907,7 +907,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -986,7 +986,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -999,11 +999,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1011,11 +1011,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1095,7 +1095,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1218,7 +1218,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1230,11 +1230,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1242,11 +1242,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1318,7 +1318,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1358,31 +1358,31 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1417,7 +1417,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1648,15 +1648,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1688,11 +1688,11 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1708,7 +1708,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1758,7 +1758,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1766,7 +1766,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1794,19 +1794,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1927,7 +1927,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1957,7 +1957,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -1985,23 +1985,23 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2054,11 +2054,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2066,7 +2066,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2078,7 +2078,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2100,11 +2100,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2128,7 +2128,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr ""
 
@@ -2200,7 +2200,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2253,8 +2253,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2273,7 +2273,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2281,19 +2281,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2473,19 +2473,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2647,7 +2647,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2715,7 +2715,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2727,31 +2727,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2775,7 +2775,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2806,12 +2806,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2884,15 +2884,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3011,7 +3011,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3145,7 +3145,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3208,11 +3208,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3298,11 +3298,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3355,11 +3355,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3468,7 +3468,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3480,7 +3480,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3500,9 +3500,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3534,11 +3534,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3603,7 +3603,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3650,7 +3650,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3667,7 +3667,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3713,15 +3713,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3752,7 +3752,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3776,7 +3776,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3792,11 +3792,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4001,7 +4001,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4134,7 +4134,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4146,23 +4146,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4325,7 +4325,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4378,7 +4378,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4386,23 +4386,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4459,7 +4459,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4491,7 +4491,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4545,19 +4545,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4649,20 +4649,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4775,20 +4775,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4837,7 +4841,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4877,7 +4881,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5070,15 +5074,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5118,7 +5122,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5233,7 +5237,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5241,7 +5245,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5296,11 +5300,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5447,7 +5451,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5509,7 +5513,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5590,11 +5594,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5619,7 +5623,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5639,7 +5643,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5651,7 +5655,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5659,7 +5663,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5699,7 +5703,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5715,7 +5719,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5723,11 +5727,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5753,7 +5757,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr ""
 
@@ -5762,11 +5766,11 @@ msgstr ""
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5774,7 +5778,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5786,7 +5790,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5806,7 +5810,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5911,7 +5915,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5919,15 +5923,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/he.po
+++ b/locale/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-11-17 16:00+0000\n"
 "Last-Translator: doomlightning <tamirt500@gmail.com>\n"
 "Language-Team: Hebrew <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/he/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "עורך תלת-מימדי"
 msgid "3D_MOVEMENT"
 msgstr "תנועה תלת-מימדית"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "פעולה זו חסומה בזמן שפעולה אחרת בתהליך"
 msgid "ACTIVE"
 msgstr "פעיל"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "נושאים נוכחים:"
 
@@ -144,7 +144,7 @@ msgstr "סטטיסטיקת האורגניזם"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "עוצמת אווירה"
 
@@ -155,11 +155,11 @@ msgstr "עוצמת אווירה"
 msgid "AMMONIA"
 msgstr "אמוניה"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "כמות שמירה אוטומטית שניתן לשמור:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "כמות שמירה מהירה שניתן לשמור:"
 
@@ -184,11 +184,11 @@ msgstr "החל שינויים"
 msgid "APRIL"
 msgstr "אפריל"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "האם אתה בטוח שברצונך לאפס את כל הגדרות לברירת מחדל?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "האם אתה בטוח שברצונך לאפס את כל הגדרות הקלטים לברירת מחדל?"
 
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "ציור מאת {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "גלרית אומנות"
 
@@ -216,7 +216,7 @@ msgstr "נדרשת מחלקת פריקת מוד בזמן שפריקה היא ס�
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "נדרשת מחלקת פריקת מוד בזמן שפריקה Harmony מוד נבחרה"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "נניח שלמעבד יכול להפעיל מרבה-נושאים"
 
@@ -258,7 +258,7 @@ msgstr "הניסיון לשכתב מחדש קובץ שמירה נכשלה. שם 
 msgid "AT_CURSOR"
 msgstr "בסמן העכבר:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "פלט מכשיר שמע:"
 
@@ -266,8 +266,8 @@ msgstr "פלט מכשיר שמע:"
 msgid "AUGUST"
 msgstr "אוגוסט"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "אוטומטי"
 
@@ -294,7 +294,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% הסתיים. {1:n0}/{2:n0} שלבים."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "שמירה אוטומטית במהלך המשחק"
 
@@ -302,7 +302,7 @@ msgstr "שמירה אוטומטית במהלך המשחק"
 msgid "AUTO_EVO"
 msgstr "מפתח - אוטומטי"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "כלים חקר של מפתח-אוטומטי"
 
@@ -332,7 +332,7 @@ msgstr "מריץ סטטוס:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "התקדמות אוטומטית"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "אוטומטי ({0}X{1})"
 
@@ -345,9 +345,9 @@ msgid "AWAKEN"
 msgstr "מודע"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -483,7 +483,7 @@ msgstr "מאפשר להתחבר לתאים אחרים. זהו הצד הראשו�
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "לחץ על [thrive:input]g_toggle_binding[/thrive:input] על מנת להחליף למצב קישור. בזמן מצב קישור אתה יכול להיצמד לתאים אחרים מאותו בני מינך על מנת ליצור מושבות על ידי תזוזה אליהם. על מנת לעזוב את המושבה לחץ [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr "קשר צירים יחד"
 
@@ -545,7 +545,7 @@ msgstr "לממברנה זו יש קליפה חזקה העשויה מסידן פ�
 msgid "CAMERA"
 msgstr "מצלמה"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -673,7 +673,7 @@ msgstr "שנה סימטריה"
 msgid "CHEATS"
 msgstr "קודים"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "מקשי קודים מופעלים"
 
@@ -763,7 +763,7 @@ msgstr "מייצר[thrive:compound type=\"glucose\"][/thrive:compound]. בהתא
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "שם הקובץ הנבחר ({0}) כבר קיים. לשכתב מחדש?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "סטייה כרומטית:"
 
@@ -804,15 +804,15 @@ msgstr "נקה שמירות ישנות"
 msgid "CLOSE"
 msgstr "סגור"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "לסגור אפשרויות?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "מחליק רזולוציית ענן:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "מרווח מינימלי של הדמיית ענן:"
 
@@ -828,7 +828,7 @@ msgstr "זמן ישויות עם צורות התנגשות"
 msgid "COLOUR"
 msgstr "צבע"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "תיקון לעיוורון צבעים:"
 
@@ -889,23 +889,23 @@ msgstr "ערך הרוויה, הכמות צבע האפור בצבע מסוים"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "ערך הבהירות, עוצמת הצבע"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr "פורום קהילתי"
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "הצטרף לקהילת Thrive בפורום הקהילתי שלנו"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr "ויקי קהילתי"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "ראו את ויקי הקהילתי שלנו"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr "נבנה ב:"
 
@@ -931,7 +931,7 @@ msgstr "תרכובות:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "מאזן תרכובות"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "ענני תרכובות"
 
@@ -1016,7 +1016,7 @@ msgstr "להמשיך לשלב האבטיפוס?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr "מצג ציר בקר :"
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr "שטחי מת של הבקר"
 
@@ -1031,11 +1031,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr "שטח מת:"
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr "רגישות הבקר"
 
@@ -1043,11 +1043,11 @@ msgstr "רגישות הבקר"
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "מעתיק שגיאה ללוח העתקה"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "פרוטנופ (אדום-ירוק)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "טריטנופ (כחול - צהוב)"
 
@@ -1103,7 +1103,7 @@ msgstr "יוצר..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "יוצר אובייקטים משמירה"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "קרדיט"
 
@@ -1129,7 +1129,7 @@ msgstr "מפתחים נוכחים"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "סטטיסטיקת האורגניזם"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "שם משתמש מותאם אישית:"
 
@@ -1195,7 +1195,7 @@ msgstr "חלונית דיבאג"
 msgid "DECEMBER"
 msgstr "דצמבר"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "פלט ברירת מחדל"
 
@@ -1257,7 +1257,7 @@ msgstr "התיאור ארוך מידי"
 msgid "DESPAWN_ENTITIES"
 msgstr "הסר כל הישויות"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "זוהה ספירת מעבד:"
 
@@ -1272,11 +1272,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "מפתחים"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr "פורום מפתחים"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "ראו עדכוני פיתוח בפורום המפתחים שלנו"
 
@@ -1284,11 +1284,11 @@ msgstr "ראו עדכוני פיתוח בפורום המפתחים שלנו"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "פיתוח נתמך על ידי Revolutionary Games Studio"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr "ויקי מפתחים"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "בקרו בויקי מפתחים שלנו"
 
@@ -1361,7 +1361,7 @@ msgstr "שמאלה"
 msgid "DIRECTIONR"
 msgstr "ימינה"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "כבוי"
 
@@ -1369,7 +1369,7 @@ msgstr "כבוי"
 msgid "DISABLE_ALL"
 msgstr "השבת הכל"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "מחק והמשך"
 
@@ -1407,16 +1407,16 @@ msgstr ""
 "ישנם אברונים שאינם מחוברים לשאר.\n"
 "בבקשה חבר את כל האברונים אחד עם השני או בטל את הפעולה."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr "היצטרפו לשרת הדיסטורט הקהילתי שלנו"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "מהירות עיכול:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
@@ -1424,19 +1424,19 @@ msgstr ""
 "ולרוב הוא ישאף לגושים.\n"
 "מיקורבים מגיבים ישנו למטרה חדשה באופן כפוף יותר."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "תצוגת רשימת יכולות"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "הצג חלקיקי רקע"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "הצג שמות כפתורי בחירת חלקים"
 
@@ -1471,7 +1471,7 @@ msgstr "לחץ פעמיים בשביל להציג במסך מלא"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "קרום עם שתי שכבות, יש לו הגנה טובה יותר מפני נזק ולוקח פחות אנרגיה על מנת שלא להתעוות. יחד עם זאת, זה מאט את התא במעט ומוריד את הקצב שבו הוא ספוג משאבים מהסביבה."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "אל תזהיר אותי שוב"
 
@@ -1625,7 +1625,7 @@ msgstr ""
 "\n"
 "בשביל לעבור ללשונית הבאה, לחץ על הבא שבפינה הימנית התחתונה."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1641,7 +1641,7 @@ msgstr "הפעל את כל המודים התואמים"
 msgid "ENABLE_EDITOR"
 msgstr "הפעל את העורך"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "אפשר תצוגת אור בממשק משתמש"
 
@@ -1698,7 +1698,7 @@ msgstr "הראה/החבא סביבה"
 msgid "EPIPELAGIC"
 msgstr "אפיפלגית"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "שגיאה"
 
@@ -1710,16 +1710,16 @@ msgstr "תקלה ביצירת תיקייה בשביל המוד"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "תקלה ביצירת מידע על המוד"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "שגיאה: נכשל הניסיון לשמור ההגדרות החדשות לקובץ התצורה."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(באקראי מייצר סודות במשחק)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "תקלה ביצירת מידע על המוד"
@@ -1753,11 +1753,11 @@ msgstr "עץ אבולוציוני"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "עץ אבולוציוני"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr "גרסת Thrive מדויקת:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "זוהי מחויבת הקוד המדויקת שממנה הורכבה הגרסה הזו של Thrive"
 
@@ -1773,7 +1773,7 @@ msgstr "חריג אירע בעת טעינת נתוני שמירה"
 msgid "EXIT"
 msgstr "יציאה"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "מקש E"
@@ -1826,7 +1826,7 @@ msgstr "נכחד מהאזור"
 msgid "EXTINCT_SPECIES"
 msgstr "מינים נכחדים"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "תוספות"
 
@@ -1834,7 +1834,7 @@ msgstr "תוספות"
 msgid "EXTRA_OPTIONS"
 msgstr "אפשרויות נוספות"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr "בקרו באתר הפייסבוק שלנו"
 
@@ -1868,12 +1868,12 @@ msgstr "מקשי קודים מופעלים"
 msgid "FEBRUARY"
 msgstr "פברואר"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "אתחול ספריית Steam נכשל"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1895,11 +1895,11 @@ msgstr ""
 "זמן מעבד כולל:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2030,7 +2030,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr "נייח"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2060,7 +2060,7 @@ msgstr "ענני גלוקוז חופשיים בזמן שיוצאים מהעור�
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(מתחיל עם ענן גלוקוז חופשי קרוב בכל דור)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "מסך מלא"
 
@@ -2088,23 +2088,23 @@ msgstr "דורות"
 msgid "GENERATION_COLON"
 msgstr "דור:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr "צפו בספריית GitHub שלנו"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "אזהרת GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "אתה מריץ את Thrive על GLES2. אופציה זו עדין לא נבדקה ועלולה לגרום לבעיות. אנא נסה לעדכן את מנהל התקן ו / או להשתמש במקום בכרטיס גרפיקה של AMD או Nvidia על מנת להפעלת את Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr "GLES3"
 
@@ -2157,11 +2157,11 @@ msgstr "הבנתי"
 msgid "GPL_LICENSE_HEADING"
 msgstr "להלן טקסט רישיון GPL:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "מעבד גרפי:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "גרפיקה"
 
@@ -2169,7 +2169,7 @@ msgstr "גרפיקה"
 msgid "GRAPHICS_TEAM"
 msgstr "צוות גרפיקה"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "ממשק משתמש"
 
@@ -2186,7 +2186,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} אלפים"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "עוצמת ממשק עזרים"
 
@@ -2208,11 +2208,11 @@ msgstr "עזרה"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "עזרה"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(ערכים גבוהים יותר מגדילים ביצועים)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(ערכים גבוהים מדרדר ביצועים)"
 
@@ -2237,7 +2237,7 @@ msgstr "החזק [thrive:input]g_free_cursor[/thrive:input] עבור סמן הע
 msgid "HOME"
 msgstr "מקש Home"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr "אופקי:"
 
@@ -2310,7 +2310,7 @@ msgstr "חומר שנבלע"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "היצטרפו לשרת הדיסטורט הקהילתי שלנו"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "קלטים"
 
@@ -2363,8 +2363,8 @@ msgstr "פורמט של כתובת אתר אינו חוקי"
 msgid "INVALID_URL_SCHEME"
 msgstr "סכימת כתובת URL לא חוקית"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr "הפוך"
 
@@ -2387,7 +2387,7 @@ msgstr "ברזל"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "כימוליתו-אוטוטרופי מברזל"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr "ראו את דף Itch.io שלנו"
 
@@ -2395,19 +2395,19 @@ msgstr "ראו את דף Itch.io שלנו"
 msgid "JANUARY"
 msgstr "ינואר"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "מצב ניפוי JSON:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "תמיד"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "באופן אוטומטי"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "לעולם לא"
 
@@ -2589,19 +2589,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "שפה:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "שפה זו היינו {0}% הושלם"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "תרגום זה עדין בשלבי הכנה ({0}% הושלם)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "תרגום זה מאוד לא מוכן ({0}% מושלם), בבקשה תעזרו לנו עם זה!"
 
@@ -2764,7 +2764,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "לחצן עכבר השמאלי"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "רישיונות"
 
@@ -2834,7 +2834,7 @@ msgstr "גלגל ימינה"
 msgid "LIGHT_MAX"
 msgstr "אור"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "מפלצתי"
 
@@ -2846,31 +2846,31 @@ msgstr "הגבל שימוש בתרכובות לצורך גידול"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(כאשר מופעל מגביל מהירות הצמיחה, ואם מושבת רק תרכובות הזמינות משפיעות על מהירות הצמיחה)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "ענק"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "גדול"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "רגיל"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "קטן"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "זעיר"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "מאוד גדול"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "מאוד קטן"
 
@@ -2894,7 +2894,7 @@ msgstr "טען"
 msgid "LOADING"
 msgstr "טוען"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "טוען..."
@@ -2925,12 +2925,12 @@ msgstr "לחץ על הכפתור \"בטל\" בעורך בשביל לתקן טע�
 msgid "LOAD_FINISHED"
 msgstr "טעינה הסתיימה"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "טען שמירה"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "טען שמירות שנשמרו"
 
@@ -3004,7 +3004,7 @@ msgstr "מרץ"
 msgid "MARINE_SNOW"
 msgstr "שלג ימי"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "עוצמה כללית"
 
@@ -3012,15 +3012,15 @@ msgstr "עוצמה כללית"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "מספר מינים מרבי באזור לפני הכחדות מכוונות"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "מקסימום FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "ללא הגבלה"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "מספר מרבי של ישויות:"
 
@@ -3206,7 +3206,7 @@ msgstr "בכל דור, נוצרים 100 נקודות מוטציה (נקמ\"ו) �
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "בכל פעם שאתה מתרבה, אתה נכנס לעורך המיקרובי. שם תוכל לבצע שינוי במין שלך (על ידי הוספה, העברה או הסרה של אברונים) בכדי להגדיל את הצלחת המין שלך. כל ביקור בעורך בשלב המיקרובי מייצג [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] מיליון שנות אבולוציה."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "עורך ארגז חול המיקרובי"
 
@@ -3390,7 +3390,7 @@ msgstr "מינימום:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "לא ניתן להציג פחות מ{0} נתונים!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "שונות"
 
@@ -3454,11 +3454,11 @@ msgstr "שנה תפקוד אברון"
 msgid "MODIFY_TYPE"
 msgstr "שנה סוג"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "מודים"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "זוהה מודים מותקנים, אך אין מודים מופעלים.\n"
@@ -3547,11 +3547,11 @@ msgstr "שם (תיקייה) פנימי:"
 msgid "MOD_LICENSE"
 msgstr "רישיון המוד:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "שגיאה בעליית המוד"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "שגיאה קרתה בזמן שטען אחד או יותר מודים. תיעודם עשויים להכיל מידע נוסף."
 
@@ -3604,11 +3604,11 @@ msgstr "גרסת המוד:"
 msgid "MORE_INFO"
 msgstr "הראה עוד מידע"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr "רגישות מראה עכבר"
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr "רגישות העכבר בקנה מידה עם גודל החלון"
 
@@ -3722,7 +3722,7 @@ msgstr "שכפל כדורי-בשר"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "שכפל אברונים"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "החלקת גרפיקה:"
 
@@ -3734,7 +3734,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "מוזיקה"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "עוצמת מוזיקה"
 
@@ -3754,9 +3754,9 @@ msgstr "(העלות של אברונים, ממברנה וחפצים אחרים ב
 msgid "MUTATION_POINTS"
 msgstr "נקודות מוטציה"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "השתק"
 
@@ -3792,11 +3792,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "אוכלוסיה ראשונית למינים הגדלים במגוון הביולוגי"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "משחק חדש"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "התחל משחק חדש"
 
@@ -3861,7 +3861,7 @@ msgstr "פלסטיד מקבע חנקן הוא חלבון המסוגל להשתמ
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "הופך [thrive:compound type=\"atp\"][/thrive:compound] ל[thrive:compound type=\"ammonia\"][/thrive:compound]. בהתאם לריכוזם של ה[thrive:compound type=\"nitrogen\"][/thrive:compound] וה[thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "ריק"
 
@@ -3909,7 +3909,7 @@ msgstr "לא תעדו אירועים"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "לא נמצאה ספריית שמירות"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr "אין מודים מופעלים"
 
@@ -3926,7 +3926,7 @@ msgstr "לא נמצאה שמירה"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "לא נמצאה ספריית שמירות"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "לא נמצאה ספריית צילומי מסך"
 
@@ -3974,15 +3974,15 @@ msgstr "אין נקמ\"ו"
 msgid "OCTOBER"
 msgstr "אוקטובר"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr "אתר רשמי"
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "להיכנס לאתר הרשמי של Revolutionary Games"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4019,7 +4019,7 @@ msgstr "פתח את מסך העזרה"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "ארגז חול"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "פתח תקיית קבצי לוג"
 
@@ -4035,7 +4035,7 @@ msgstr "פתח תפריט האברון"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "פתח ספריית שמירות"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "פתח תיקיית צילומי מסך"
 
@@ -4043,7 +4043,7 @@ msgstr "פתח תיקיית צילומי מסך"
 msgid "OPEN_THE_MENU"
 msgstr "פתח את התפריט"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "עזור לתרגם את המשחק"
 
@@ -4062,11 +4062,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "אופורטוניסטי"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "אפשרויות"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "שנה את ההגדרות שלך"
 
@@ -4277,7 +4277,7 @@ msgstr "פרוצדורלי"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr "ראו את דף הפטריון שלנו"
 
@@ -4327,7 +4327,7 @@ msgstr "שלוו"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "ביצועים"
 
@@ -4411,7 +4411,7 @@ msgstr "שכפל שחקן"
 msgid "PLAYER_EXTINCT"
 msgstr "השחקן נכחד"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "השחקן נכחד"
@@ -4426,23 +4426,23 @@ msgstr ""
 "מהירות\n"
 "שחקן"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "הפעל סרטון פתיחה"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "הפעל פתיח שלב המיקרוב במשחק חדש"
 
@@ -4561,11 +4561,11 @@ msgstr "טעינה מהירה"
 msgid "QUICK_SAVE"
 msgstr "שמירה מהירה"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "יציאה"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "צא מהמשחק"
@@ -4607,7 +4607,7 @@ msgstr "מוכן"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "המלצת Thrive:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr "ראו בתת-נושא הרדייט שלנו"
 
@@ -4660,7 +4660,7 @@ msgstr "סוגי רבייה:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "נדרש גרעין התא"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "איפוס"
 
@@ -4668,23 +4668,23 @@ msgstr "איפוס"
 msgid "RESET_DEADZONES"
 msgstr "אפס שטחים מתים"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "איפוס קלטים לברירת מחדל?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr "איפוס חיבורי מקשים"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "ברירת מחדל"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "איפוס לברירת מחדל?"
 
@@ -4693,7 +4693,7 @@ msgstr "איפוס לברירת מחדל?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr "עמידות לבליעה בסיסית"
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "רזולוציה:"
 
@@ -4743,7 +4743,7 @@ msgstr ""
 "האם אתה בטוח שאתה רוצה לצאת לתפריט הראשי?\n"
 "אתה עלול לאבד כל פעולה לא שמורה."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "בקרו באתר הרשמי של Revolutionary Games"
 
@@ -4775,7 +4775,7 @@ msgstr "סובב ימינה"
 msgid "ROTATION_COLON"
 msgstr "רוטציה:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "הפעל התפתחות אוטומטית במהלך המשחק"
 
@@ -4830,7 +4830,7 @@ msgstr "רוסטיצינין הוא חלבון המסוגל להשתמש ב[thri
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "הופך [thrive:compound type=\"iron\"][/thrive:compound] ל[thrive:compound type=\"atp\"][/thrive:compound]. בהתאם לריכוזם של [thrive:compound type=\"carbondioxide\"][/thrive:compound] ו[thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4839,15 +4839,15 @@ msgstr ""
 "מיקרובים אמיצים לא יפחדו מטורפים לידם\n"
 "והם נוטים לתקוף חזרה."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive הופעל במצב בטוח"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "שמור"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "שמור והמשך"
 
@@ -4945,20 +4945,20 @@ msgstr "שמירה אינה אפשרית כרגע בשל:"
 msgid "SAVING_SUCCEEDED"
 msgstr "נשמר בהצלחה"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr "שום דבר"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr "בקנה מידה"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr "בקנה מידה הפוך"
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "להגדלת התנועה"
@@ -5056,7 +5056,7 @@ msgstr "נייח"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "ערך זה חל רק על שמירות חדשות לאחר שינויו"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "עוצמת אפקטים"
 
@@ -5072,21 +5072,25 @@ msgstr "הצג עזרה"
 msgid "SHOW_TUTORIALS"
 msgstr "הצג מדריכים"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "הצג מדריכים (בשמירה נוכחית)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "הצג מדריכים (בשמירות חדשות)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "הראה אזהרת התקדמות ללא שמירה"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "הפעל / השבת את חלון אזהרת התקדמות הלא שמורה בזמן שהשחק מנסה לצאת מהמשחק."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5134,7 +5138,7 @@ msgstr "צורן"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "לקרום זה יש קיר חזק העשוי מצורן. מה שמאפשר לו לעמוד היטב עם הנזק הכללי ועמיד מאוד בפני נזקים פיזיים. זהו גם דורש פחות אנרגיה כדי לשמור על צורתו. עם זאת, הוא מאט את התא בצורה רצינית והתא סופג משאבים בקצב מופחת."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5174,7 +5178,7 @@ msgstr "הופך [thrive:compound type=\"glucose\"][/thrive:compound] ל[thrive:
 msgid "SMALL_IRON_CHUNK"
 msgstr "גוש ברזל קטן"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "קול"
 
@@ -5377,17 +5381,17 @@ msgstr "Steam לא זמין כרגע, בבקשה נסה שוב"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "שגיאת Steam לא ידועה קרתה"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "אתחול ספריית Steam נכשל"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "שדרוג שמירה שצוינה נכשלה בעקבות השגיאה הבאה:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr "ראו את הדף הSteam שלנו"
 
@@ -5427,7 +5431,7 @@ msgstr "אחסון"
 msgid "STORAGE_COLON"
 msgstr "אחסון:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "התחבר כ:{0}"
 
@@ -5544,7 +5548,7 @@ msgstr "טמפ'."
 msgid "TESTING_TEAM"
 msgstr "צוות בודקים"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5559,7 +5563,7 @@ msgstr ""
 "\n"
 "אם נהנתה מהמשחק, ספר לחבריך עלינו."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "אתה שגשגת!"
@@ -5615,11 +5619,11 @@ msgstr "זהו מוד מותקן באופן מקומי"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "מוד זה הורד מSteam Workshop"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "נושאים:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "טראיבופדיה"
 
@@ -5766,7 +5770,7 @@ msgstr "עצור"
 msgid "TOGGLE_UNBINDING"
 msgstr "בטל מצב קישור"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "כלים"
 
@@ -5831,7 +5835,7 @@ msgstr "נסה לצלם כמה צילומי מסך!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "נסה ליצור שמירה!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "נסה לצלם כמה צילומי מסך!"
 
@@ -5993,11 +5997,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "הראה עכשיו"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr "בקרו בעמוד בטוייטר שלנו"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6022,7 +6026,7 @@ msgstr "שחרר הכל"
 msgid "UNBIND_HELP_TEXT"
 msgstr "מצב שחרר"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr "זהו בניית די-באג כאשר שהמידע מתחת ככל הנראה לא מעודכן"
 
@@ -6042,7 +6046,7 @@ msgstr "בטל פעולה אחרונה"
 msgid "UNKNOWN"
 msgstr "לא יודע"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "לא ידוע"
 
@@ -6054,7 +6058,7 @@ msgstr "לחצן עכבר לא יודע"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "לא מוכר לWindows"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "גרסה לא יודעה"
 
@@ -6062,7 +6066,7 @@ msgstr "גרסה לא יודעה"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Workshop ID לא יודע בשביל מוד זה"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "ישנם שינויים שלא נשמרו שיימחקו.\n"
@@ -6106,7 +6110,7 @@ msgstr "העלאה הצליחה"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "רישיונות וספריות שימוש"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "מעבד בשימוש:"
 
@@ -6122,7 +6126,7 @@ msgstr "השתמש במעלה אוטו-Harmony"
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "מעלה אוטומטי את Harmony מהמפרק (לא דורש מחלקת מוד מסויימת)"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "השתמש בשם משתמש מותאמת אישית"
 
@@ -6130,11 +6134,11 @@ msgstr "השתמש בשם משתמש מותאמת אישית"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "יצירת מינים שמגדילה את המגוון הביולוגי גונבת מספרי אוכלוסיה ממינים קיימים"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "הגדר ידנית את מספר נושאי הרקע"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr "השתמש בגודל חלון וירטואלי"
 
@@ -6160,7 +6164,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "גרסה:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr "אנכי:"
 
@@ -6169,11 +6173,11 @@ msgstr "אנכי:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "אנכי (ציר: {0})"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "שימוש נוכחי בזיכרון וידיאו:"
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0} MiB"
 
@@ -6181,7 +6185,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "צופה"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "צפה בקוד מקור"
 
@@ -6193,7 +6197,7 @@ msgstr "תומכי VIP"
 msgid "VISIBLE"
 msgstr "גלוי"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "הצע רעיון"
 
@@ -6213,7 +6217,7 @@ msgstr "מקש השתק"
 msgid "VOLUMEUP"
 msgstr "מקש הגבר קול"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "סנכרון אנכי"
 
@@ -6320,7 +6324,7 @@ msgstr "סטטיסטיקת האורגניזם"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "להגדלת התנועה"
@@ -6329,15 +6333,15 @@ msgstr "להגדלת התנועה"
 msgid "WORST_PATCH_COLON"
 msgstr "האזור הגרוע ביותר:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6349,7 +6353,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "שנים"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr "צפו באתר היוטיוב שלנו"
 

--- a/locale/he.po
+++ b/locale/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-11-17 16:00+0000\n"
 "Last-Translator: doomlightning <tamirt500@gmail.com>\n"
 "Language-Team: Hebrew <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/he/>\n"
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "ציור מאת {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "גלרית אומנות"
 
@@ -302,7 +302,7 @@ msgstr "שמירה אוטומטית במהלך המשחק"
 msgid "AUTO_EVO"
 msgstr "מפתח - אוטומטי"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "כלים חקר של מפתח-אוטומטי"
 
@@ -345,8 +345,8 @@ msgid "AWAKEN"
 msgstr "מודע"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -601,27 +601,27 @@ msgstr "מקש Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "פחמן דו חמצני"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "שפע"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "כמות נכבדת"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "קטן"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "לא מעט"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "כמה"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "קטן מאוד"
 
@@ -889,19 +889,19 @@ msgstr "ערך הרוויה, הכמות צבע האפור בצבע מסוים"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "ערך הבהירות, עוצמת הצבע"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr "פורום קהילתי"
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "הצטרף לקהילת Thrive בפורום הקהילתי שלנו"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr "ויקי קהילתי"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "ראו את ויקי הקהילתי שלנו"
 
@@ -1103,7 +1103,7 @@ msgstr "יוצר..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "יוצר אובייקטים משמירה"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "קרדיט"
 
@@ -1272,11 +1272,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "מפתחים"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr "פורום מפתחים"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "ראו עדכוני פיתוח בפורום המפתחים שלנו"
 
@@ -1284,11 +1284,11 @@ msgstr "ראו עדכוני פיתוח בפורום המפתחים שלנו"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "פיתוח נתמך על ידי Revolutionary Games Studio"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr "ויקי מפתחים"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "בקרו בויקי מפתחים שלנו"
 
@@ -1407,7 +1407,7 @@ msgstr ""
 "ישנם אברונים שאינם מחוברים לשאר.\n"
 "בבקשה חבר את כל האברונים אחד עם השני או בטל את הפעולה."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr "היצטרפו לשרת הדיסטורט הקהילתי שלנו"
 
@@ -1424,7 +1424,7 @@ msgstr ""
 "ולרוב הוא ישאף לגושים.\n"
 "מיקורבים מגיבים ישנו למטרה חדשה באופן כפוף יותר."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1471,7 +1471,7 @@ msgstr "לחץ פעמיים בשביל להציג במסך מלא"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "קרום עם שתי שכבות, יש לו הגנה טובה יותר מפני נזק ולוקח פחות אנרגיה על מנת שלא להתעוות. יחד עם זאת, זה מאט את התא במעט ומוריד את הקצב שבו הוא ספוג משאבים מהסביבה."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "אל תזהיר אותי שוב"
 
@@ -1653,15 +1653,15 @@ msgstr "{0}: {1}- ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: {1}+ ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "אנרגיה מ{0} ל{1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "מקורות אנרגיה:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "סך האנרגיה שנאספה הוא {0} עם עלות בודדת של {1} וכתוצאה מכך אוכלוסייה בלתי מותאמת של {2}"
 
@@ -1714,6 +1714,16 @@ msgstr "תקלה ביצירת מידע על המוד"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "שגיאה: נכשל הניסיון לשמור ההגדרות החדשות לקובץ התצורה."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(באקראי מייצר סודות במשחק)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "תקלה ביצירת מידע על המוד"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "טוען שגיאה"
@@ -1763,7 +1773,7 @@ msgstr "חריג אירע בעת טעינת נתוני שמירה"
 msgid "EXIT"
 msgstr "יציאה"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "מקש E"
@@ -1816,7 +1826,7 @@ msgstr "נכחד מהאזור"
 msgid "EXTINCT_SPECIES"
 msgstr "מינים נכחדים"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "תוספות"
 
@@ -1824,7 +1834,7 @@ msgstr "תוספות"
 msgid "EXTRA_OPTIONS"
 msgstr "אפשרויות נוספות"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr "בקרו באתר הפייסבוק שלנו"
 
@@ -1857,6 +1867,41 @@ msgstr "מקשי קודים מופעלים"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "פברואר"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "אתחול ספריית Steam נכשל"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"זמן עיבוד: {0} שניות\n"
+"זמן ממשי: {1} שניות\n"
+"ישויות: {2} אחר: {3}\n"
+"נוצרו: {4} נמחקו: {5}\n"
+"צמתים בשימוש: {6}\n"
+"זיכרון בשימוש: {7}\n"
+"זכרון מעבד גרפי: {8}\n"
+"אובייקטים עובדו: {9}\n"
+"תאים צוירו: {10} 2D: {11}\n"
+"פסגות שעובדו: {12}\n"
+"שינויי חומרים: {13}\n"
+"שינויי הצללה: {14}\n"
+"צמתים מופרדים: {15}\n"
+"וידאו שנעצר: {16} ms\n"
+"סך הכול: {17}\n"
+"זמן מעבד כולל:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1940,7 +1985,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "שרשרת המזון"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0} אנרגיה: {1} (כשירות: {2}) כמות אנרגיה זמינה: {3} (כשירות כללית: {4})"
 
@@ -2043,7 +2088,7 @@ msgstr "דורות"
 msgid "GENERATION_COLON"
 msgstr "דור:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr "צפו בספריית GitHub שלנו"
 
@@ -2051,11 +2096,11 @@ msgstr "צפו בספריית GitHub שלנו"
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "אזהרת GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "אתה מריץ את Thrive על GLES2. אופציה זו עדין לא נבדקה ועלולה לגרום לבעיות. אנא נסה לעדכן את מנהל התקן ו / או להשתמש במקום בכרטיס גרפיקה של AMD או Nvidia על מנת להפעלת את Thrive."
 
@@ -2342,7 +2387,7 @@ msgstr "ברזל"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "כימוליתו-אוטוטרופי מברזל"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr "ראו את דף Itch.io שלנו"
 
@@ -2560,7 +2605,7 @@ msgstr "תרגום זה עדין בשלבי הכנה ({0}% הושלם)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "תרגום זה מאוד לא מוכן ({0}% מושלם), בבקשה תעזרו לנו עם זה!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "לא ניתן להסיר את האברון האחרון"
 
@@ -2719,7 +2764,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "לחצן עכבר השמאלי"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "רישיונות"
 
@@ -2849,7 +2894,8 @@ msgstr "טען"
 msgid "LOADING"
 msgstr "טוען"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "טוען..."
 
@@ -2879,12 +2925,12 @@ msgstr "לחץ על הכפתור \"בטל\" בעורך בשביל לתקן טע�
 msgid "LOAD_FINISHED"
 msgstr "טעינה הסתיימה"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "טען שמירה"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "טען שמירות שנשמרו"
 
@@ -3160,7 +3206,7 @@ msgstr "בכל דור, נוצרים 100 נקודות מוטציה (נקמ\"ו) �
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "בכל פעם שאתה מתרבה, אתה נכנס לעורך המיקרובי. שם תוכל לבצע שינוי במין שלך (על ידי הוספה, העברה או הסרה של אברונים) בכדי להגדיל את הצלחת המין שלך. כל ביקור בעורך בשלב המיקרובי מייצג [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] מיליון שנות אבולוציה."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "עורך ארגז חול המיקרובי"
 
@@ -3408,11 +3454,11 @@ msgstr "שנה תפקוד אברון"
 msgid "MODIFY_TYPE"
 msgstr "שנה סוג"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "מודים"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "זוהה מודים מותקנים, אך אין מודים מופעלים.\n"
@@ -3501,11 +3547,11 @@ msgstr "שם (תיקייה) פנימי:"
 msgid "MOD_LICENSE"
 msgstr "רישיון המוד:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "שגיאה בעליית המוד"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "שגיאה קרתה בזמן שטען אחד או יותר מודים. תיעודם עשויים להכיל מידע נוסף."
 
@@ -3738,15 +3784,19 @@ msgstr ""
 "השמירה זו נוצרה בגרסאות החדשות יותר של Thrive ויכולה שלא תפקד כראוי.\n"
 "האם ברצונך להמשיך לפתוח בכל זאת?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "אוכלוסיה ראשונית למינים הגדלים במגוון הביולוגי"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "משחק חדש"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "התחל משחק חדש"
 
@@ -3846,7 +3896,7 @@ msgid "NO_AI"
 msgstr "מצב בודד"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "אין מידע להציג"
 
@@ -3859,7 +3909,7 @@ msgstr "לא תעדו אירועים"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "לא נמצאה ספריית שמירות"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr "אין מודים מופעלים"
 
@@ -3889,7 +3939,7 @@ msgstr "לא נבחר מוד"
 msgid "NUCLEUS"
 msgstr "גרעין התא"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 "לא ניתן להסיר גרעין שכן זהו התפתחות בלתי-ניתנת להפיכה.\n"
@@ -3910,8 +3960,8 @@ msgstr "מקש Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "לא זמין"
@@ -3924,15 +3974,15 @@ msgstr "אין נקמ\"ו"
 msgid "OCTOBER"
 msgstr "אוקטובר"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr "אתר רשמי"
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "להיכנס לאתר הרשמי של Revolutionary Games"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4012,11 +4062,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "אופורטוניסטי"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "אפשרויות"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "שנה את ההגדרות שלך"
 
@@ -4227,7 +4277,7 @@ msgstr "פרוצדורלי"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr "ראו את דף הפטריון שלנו"
 
@@ -4285,8 +4335,8 @@ msgstr "ביצועים"
 msgid "PERFORM_UNBINDING"
 msgstr "בצע שחרור"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "\\לשנייה"
 
@@ -4337,7 +4387,7 @@ msgstr "מייצר כוכבי לכת בקרוב!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "כוכב סייד אקראי"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "תא השחקן"
 
@@ -4413,7 +4463,7 @@ msgstr "אוכלוסיה:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "אכלוסיה באזורים:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4467,7 +4517,7 @@ msgstr "קודם:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "מעלה אובייקטים"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4511,11 +4561,11 @@ msgstr "טעינה מהירה"
 msgid "QUICK_SAVE"
 msgstr "שמירה מהירה"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "יציאה"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "צא מהמשחק"
@@ -4557,7 +4607,7 @@ msgstr "מוכן"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "המלצת Thrive:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr "ראו בתת-נושא הרדייט שלנו"
 
@@ -4693,7 +4743,7 @@ msgstr ""
 "האם אתה בטוח שאתה רוצה לצאת לתפריט הראשי?\n"
 "אתה עלול לאבד כל פעולה לא שמורה."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "בקרו באתר הרשמי של Revolutionary Games"
 
@@ -4780,7 +4830,7 @@ msgstr "רוסטיצינין הוא חלבון המסוגל להשתמש ב[thri
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "הופך [thrive:compound type=\"iron\"][/thrive:compound] ל[thrive:compound type=\"atp\"][/thrive:compound]. בהתאם לריכוזם של [thrive:compound type=\"carbondioxide\"][/thrive:compound] ו[thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4789,7 +4839,7 @@ msgstr ""
 "מיקרובים אמיצים לא יפחדו מטורפים לידם\n"
 "והם נוטים לתקוף חזרה."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive הופעל במצב בטוח"
 
@@ -5152,7 +5202,7 @@ msgstr "זמן אמוניה"
 msgid "SPAWN_ENEMY"
 msgstr "זמן אויב"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "אינך יכול לזמן אוייבים צ'יטים בגלל שאזור זה אינו מכיל שום מינים אויבים"
 
@@ -5212,7 +5262,7 @@ msgstr "שם המין..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "שם המין ארוך מדי!"
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5327,17 +5377,17 @@ msgstr "Steam לא זמין כרגע, בבקשה נסה שוב"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "שגיאת Steam לא ידועה קרתה"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "אתחול ספריית Steam נכשל"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "שדרוג שמירה שצוינה נכשלה בעקבות השגיאה הבאה:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr "ראו את הדף הSteam שלנו"
 
@@ -5377,7 +5427,7 @@ msgstr "אחסון"
 msgid "STORAGE_COLON"
 msgstr "אחסון:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "התחבר כ:{0}"
 
@@ -5494,7 +5544,7 @@ msgstr "טמפ'."
 msgid "TESTING_TEAM"
 msgstr "צוות בודקים"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5509,7 +5559,7 @@ msgstr ""
 "\n"
 "אם נהנתה מהמשחק, ספר לחבריך עלינו."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "אתה שגשגת!"
@@ -5569,7 +5619,7 @@ msgstr "מוד זה הורד מSteam Workshop"
 msgid "THREADS"
 msgstr "נושאים:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "טראיבופדיה"
 
@@ -5716,7 +5766,7 @@ msgstr "עצור"
 msgid "TOGGLE_UNBINDING"
 msgstr "בטל מצב קישור"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "כלים"
 
@@ -5943,7 +5993,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "הראה עכשיו"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr "בקרו בעמוד בטוייטר שלנו"
 
@@ -6131,7 +6181,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "צופה"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "צפה בקוד מקור"
 
@@ -6143,7 +6193,7 @@ msgstr "תומכי VIP"
 msgid "VISIBLE"
 msgstr "גלוי"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "הצע רעיון"
 
@@ -6299,7 +6349,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "שנים"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr "צפו באתר היוטיוב שלנו"
 

--- a/locale/hr.po
+++ b/locale/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-09-22 10:31+0000\n"
 "Last-Translator: Ivan Bratović <ivanbratovic4@gmail.com>\n"
 "Language-Team: Croatian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/hr/>\n"
@@ -196,7 +196,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -332,8 +332,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -588,27 +588,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -867,19 +867,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1232,11 +1232,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1244,11 +1244,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1595,15 +1595,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1656,6 +1656,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1704,7 +1712,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1754,7 +1762,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1762,7 +1770,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1788,6 +1796,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1869,7 +1893,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1965,7 +1989,7 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1973,11 +1997,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2253,7 +2277,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2469,7 +2493,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2628,7 +2652,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2756,7 +2780,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2786,12 +2811,12 @@ msgstr "Pritisnite gumb za poništavanje u uređivaču kako biste ispravili pogr
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3041,7 +3066,7 @@ msgstr "Za svaku generaciju imate 100 mutacijskih bodova (MP) koje možete potro
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Prilikom svakog razmnožavanja, ući ćete u Uređivač Mikroba, gdje možete mijenjati svoju vrstu (dodavanjem, premještanjem ili uklanjanjem organela) kako biste povećali uspjeh svoje vrste. Svaki posjet uređivaču tijekom Stadija Mikroba predstavlja [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milijuna godina evolucije."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3273,11 +3298,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3363,11 +3388,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3591,15 +3616,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3699,7 +3728,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3711,7 +3740,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3741,7 +3770,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3760,8 +3789,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3774,15 +3803,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3853,11 +3882,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4062,7 +4091,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4120,8 +4149,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4171,7 +4200,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4244,7 +4273,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4298,7 +4327,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4342,11 +4371,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4386,7 +4415,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4520,7 +4549,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4606,11 +4635,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4966,7 +4995,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -5016,7 +5045,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5131,15 +5160,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5179,7 +5208,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5294,7 +5323,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5302,7 +5331,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5361,7 +5390,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5508,7 +5537,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5661,7 +5690,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5845,7 +5874,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5857,7 +5886,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6010,7 +6039,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/hr.po
+++ b/locale/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-09-22 10:31+0000\n"
 "Last-Translator: Ivan Bratović <ivanbratovic4@gmail.com>\n"
 "Language-Team: Croatian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/hr/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.10.3\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr ""
 msgid "3D_MOVEMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -147,11 +147,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -176,11 +176,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -196,7 +196,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -256,8 +256,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -282,7 +282,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -319,7 +319,7 @@ msgstr ""
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -332,9 +332,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -470,7 +470,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -660,7 +660,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -791,15 +791,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -815,7 +815,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -867,23 +867,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr ""
 
@@ -909,7 +909,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1001,11 +1001,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1013,11 +1013,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1162,7 +1162,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1220,7 +1220,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1232,11 +1232,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1244,11 +1244,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1361,31 +1361,31 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1567,7 +1567,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1583,7 +1583,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1652,15 +1652,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1692,11 +1692,11 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1712,7 +1712,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1762,7 +1762,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1770,7 +1770,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1798,19 +1798,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1931,7 +1931,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -1989,23 +1989,23 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2058,11 +2058,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2070,7 +2070,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2082,7 +2082,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2104,11 +2104,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2132,7 +2132,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr ""
 
@@ -2204,7 +2204,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2257,8 +2257,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2277,7 +2277,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2285,19 +2285,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2477,19 +2477,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2652,7 +2652,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2720,7 +2720,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2732,31 +2732,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2780,7 +2780,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2811,12 +2811,12 @@ msgstr "Pritisnite gumb za poništavanje u uređivaču kako biste ispravili pogr
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2881,7 +2881,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2889,15 +2889,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3066,7 +3066,7 @@ msgstr "Za svaku generaciju imate 100 mutacijskih bodova (MP) koje možete potro
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Prilikom svakog razmnožavanja, ući ćete u Uređivač Mikroba, gdje možete mijenjati svoju vrstu (dodavanjem, premještanjem ili uklanjanjem organela) kako biste povećali uspjeh svoje vrste. Svaki posjet uređivaču tijekom Stadija Mikroba predstavlja [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milijuna godina evolucije."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3234,7 +3234,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3298,11 +3298,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3388,11 +3388,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3445,11 +3445,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3558,7 +3558,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3570,7 +3570,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Glazba"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3590,9 +3590,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3624,11 +3624,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3693,7 +3693,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3740,7 +3740,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3757,7 +3757,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3803,15 +3803,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3842,7 +3842,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3858,7 +3858,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3866,7 +3866,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3882,11 +3882,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4091,7 +4091,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4141,7 +4141,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4224,7 +4224,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4236,23 +4236,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4371,11 +4371,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4415,7 +4415,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4468,7 +4468,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4476,23 +4476,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4501,7 +4501,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4549,7 +4549,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4581,7 +4581,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4635,19 +4635,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4739,20 +4739,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4849,7 +4849,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4865,20 +4865,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4927,7 +4931,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4967,7 +4971,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5160,15 +5164,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5208,7 +5212,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5323,7 +5327,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5331,7 +5335,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5386,11 +5390,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5537,7 +5541,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5599,7 +5603,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5690,11 +5694,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5719,7 +5723,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5739,7 +5743,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5751,7 +5755,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5759,7 +5763,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5799,7 +5803,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5815,7 +5819,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5823,11 +5827,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5853,7 +5857,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr ""
 
@@ -5862,11 +5866,11 @@ msgstr ""
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5874,7 +5878,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5886,7 +5890,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5906,7 +5910,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -6011,7 +6015,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -6019,15 +6023,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6039,7 +6043,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-11-11 17:58+0000\n"
 "Last-Translator: Undibundi <andras9334@citromail.hu>\n"
 "Language-Team: Hungarian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/hu/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "3D Szerkesztő"
 msgid "3D_MOVEMENT"
 msgstr "3D Mozgás"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -63,7 +63,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr "Aktív"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Észlelhető szálak:"
 
@@ -146,7 +146,7 @@ msgstr "Organizmus statisztikái"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Környezeti hangerő"
 
@@ -157,11 +157,11 @@ msgstr "Környezeti hangerő"
 msgid "AMMONIA"
 msgstr "Ammónia"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Megtartható automentések mennyisége:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Megtartható gyorsmentések mennyisége:"
 
@@ -187,11 +187,11 @@ msgstr "Változtatások elfogadása"
 msgid "APRIL"
 msgstr "Április"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Biztos MINDEN beállítást vissza akarsz állítani alap értékekre?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Biztos vissza akarod állítani a bemeneti beállításokat az alapokra?"
 
@@ -207,7 +207,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "A rajzot {0} készítette"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Rajz galéria"
 
@@ -219,7 +219,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "A CPU hyperthread engedélyezésének feltételezése"
 
@@ -260,7 +260,7 @@ msgstr "Auto-evo futtatása sikertelen"
 msgid "AT_CURSOR"
 msgstr "A kurzornál:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Audio eszköz:"
 
@@ -268,8 +268,8 @@ msgstr "Audio eszköz:"
 msgid "AUGUST"
 msgstr "Augusztus"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Auto"
 
@@ -298,7 +298,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% kész. {1:n0}/{2:n0} lépés."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Automata mentés a játék során"
 
@@ -306,7 +306,7 @@ msgstr "Automata mentés a játék során"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "futtatási státusz:"
@@ -337,7 +337,7 @@ msgstr "futtatási státusz:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Automata mozgás előre"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Auto ({0}x{1})"
 
@@ -350,9 +350,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -494,7 +494,7 @@ msgstr "Több sejthez való kapcsolódást teszi lehetővé. Ez a legelső lép�
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr "Ez a membrán egy erős kalcium-karbonát páncéllal rendelkezik. Képe
 msgid "CAMERA"
 msgstr "Kamera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -689,7 +689,7 @@ msgstr "Szimmetria változtatása"
 msgid "CHEATS"
 msgstr "Csalások"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Csalások engedélyezve"
 
@@ -780,7 +780,7 @@ msgstr "[thrive:compound type=\"glucose\"][/thrive:compound]-t állít elő. Hat
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "A kiválasztott fájl neve ({0}) már létezik. Lecseréled?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Kromatikus aberráció:"
 
@@ -823,15 +823,15 @@ msgstr "Régi mentések törlése"
 msgid "CLOSE"
 msgstr "Bezár"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Bezárod a beállítás panelt?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Felhő felbontásának osztója:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Felhőszimuláció minimum intervalluma:"
 
@@ -847,7 +847,7 @@ msgstr "Entitások lerakása ütközési alakzatokkal"
 msgid "COLOUR"
 msgstr "Szín"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Színvakság javító:"
 
@@ -908,26 +908,26 @@ msgstr "Telítettségi érték, a szürke mennyisége egy adott színben"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Érték (fényerősség) értéke, a szín fényerőssége vagy intenzitása"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Segítség"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "Wikipédiánk"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Kilépés a játékból"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Vegyületek:"
@@ -955,7 +955,7 @@ msgstr "Vegyületek:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Vegyületfelhők"
 
@@ -1041,7 +1041,7 @@ msgstr "Folytatod a fázis prototípusokkal?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1055,11 +1055,11 @@ msgstr "A {0} populációjának egyedszáma megváltozott {1}-értékkel, emiatt
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1067,11 +1067,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Hiba másolása vágólapra"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanóp (Piros-Zöld)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanóp (Kék-Citrom)"
 
@@ -1129,7 +1129,7 @@ msgstr "Létrehozás..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Objektumok létrehozása a mentésből"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Stáblista"
 
@@ -1155,7 +1155,7 @@ msgstr "Jelenlegi fejlesztők"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Organizmus statisztikái"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Saját felhasználónév:"
 
@@ -1224,7 +1224,7 @@ msgstr "Debug panel"
 msgid "DECEMBER"
 msgstr "December"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Alap kimeneti eszköz"
 
@@ -1287,7 +1287,7 @@ msgstr "A leírás túl hosszú"
 msgid "DESPAWN_ENTITIES"
 msgstr "Entitások maximális száma:"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Észlelt processzorszám:"
 
@@ -1300,12 +1300,12 @@ msgstr "Devbuild támogatók"
 msgid "DEVELOPERS"
 msgstr "Fejlesztők"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "A játékot a Revolutionary Games Studio ry fejleszti"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Segítség"
@@ -1314,12 +1314,12 @@ msgstr "Segítség"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "A játékot a Revolutionary Games Studio ry fejleszti"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Fejlesztők"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Segítség"
@@ -1396,7 +1396,7 @@ msgstr "Bal"
 msgid "DIRECTIONR"
 msgstr "Jobb"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Kikapcsolva"
 
@@ -1404,7 +1404,7 @@ msgstr "Kikapcsolva"
 msgid "DISABLE_ALL"
 msgstr "Az összes tiltása"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Elvet és folytatás"
 
@@ -1444,36 +1444,36 @@ msgstr ""
 "Vannak olyan sejtszervecskék, melyek nem kötődnek egymáshoz.\n"
 "Kérlek kapcsold össze a sejtszervecskéket egymással, vagy vond vissza eddigi változtatásaidat."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Segítség"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Sebesség:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 "A fókuszált sejtek nagyobb távolságokat tesznek meg táplálék reményében.\n"
 "A reszponzív sejtek hamar új célpontokat keresnek."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Képesség sáv megjelenítése"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Háttérrészecskék megjelenítése"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "Képesség sáv megjelenítése"
@@ -1509,7 +1509,7 @@ msgstr "Dupla kattintás a teljes képernyő nézetért"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Egy membrán, ami két rétegből áll. Jobb védelmet nyújt sérülések ellen, és kevesebb energia szükséges ahhoz, hogy ne deformálódjon el. Hátránya viszont, hogy lassítja a sejt bekebelező képességét."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1664,7 +1664,7 @@ msgstr ""
 "\n"
 "A következő szerkesztő ablakba való lépéshez nyomd meg jobb lenti gombot."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1680,7 +1680,7 @@ msgstr "Az összes kompatibilis mod engedélyezése"
 msgid "ENABLE_EDITOR"
 msgstr "Szerkesztő engedélyezése"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "GUI fényeffektjeinek engedélyezése"
 
@@ -1739,7 +1739,7 @@ msgstr "A környezet és a vegyületek mutatása / elrejtése"
 msgid "EPIPELAGIC"
 msgstr "Epipelagikus"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Hiba"
 
@@ -1751,16 +1751,16 @@ msgstr "Hiba a mod-hoz való mappa létrehozása közben"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Hiba a mod fájllá való átalakítása közben"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Hiba: A beállításokat nem sikerült menteni."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(random megidézett titkok a játékban)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Hiba a mod fájllá való átalakítása közben"
@@ -1795,12 +1795,12 @@ msgstr "A Revolutionary Games Studio-tól"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "A Revolutionary Games Studio-tól"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Verzió:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Öngyilkosság"
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "EXIT"
 msgstr "Kilépés"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Indítás E"
@@ -1873,7 +1873,7 @@ msgstr "kihalt a bolygón"
 msgid "EXTINCT_SPECIES"
 msgstr "Kihalt fajok"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extrák"
 
@@ -1881,7 +1881,7 @@ msgstr "Extrák"
 msgid "EXTRA_OPTIONS"
 msgstr "Extra opciók"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Játék szüneteltetése"
@@ -1916,11 +1916,11 @@ msgstr "Csalások engedélyezve"
 msgid "FEBRUARY"
 msgstr "Február"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1942,11 +1942,11 @@ msgstr ""
 "Teljes CPU idő:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2079,7 +2079,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr "Rögzült"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2109,7 +2109,7 @@ msgstr "Ingyenes glükóz felhő a szerkesztő elhagyásakor"
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(a szerkesztő elhagyása után egy közeli glükózfelhő mellett lesz a sejted)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Teljes képernyő"
 
@@ -2138,24 +2138,24 @@ msgstr "Generáció:"
 msgid "GENERATION_COLON"
 msgstr "Generáció:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Kilépés a játékból"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 mód figyelmeztetés"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "A Thrive-ot GLES2 módban futtatod. Ennek a módnak a használata nincs letesztelve, és nagy eséllyel hibákat okozhat. Próbáld meg frissíteni a videókártyád driverét vagy/és kényszerítsd az AMD vagy Nvidia grafikai szoftverét a Thrive futtatására."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2208,12 +2208,12 @@ msgstr "Rendben"
 msgid "GPL_LICENSE_HEADING"
 msgstr "A GLP licenc szövege a következő:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafika"
 
@@ -2221,7 +2221,7 @@ msgstr "Grafika"
 msgid "GRAPHICS_TEAM"
 msgstr "Grafikus csapat"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2234,7 +2234,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} K"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "GUI hangerő"
 
@@ -2256,11 +2256,11 @@ msgstr "Segítség"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Segítség"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(a nagyobb értékek javíthatják a teljesítményt)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(a nagyobb értékek ronthatják a teljesítményt)"
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Home"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Verzió:"
@@ -2359,7 +2359,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Segítség"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Bemenet"
 
@@ -2415,8 +2415,8 @@ msgstr "Érvénytelen URL formátum"
 msgid "INVALID_URL_SCHEME"
 msgstr "Érvénytelen URL séma"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2436,7 +2436,7 @@ msgstr "Vas"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Vas oxidálása"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Kilépés a játékból"
@@ -2445,19 +2445,19 @@ msgstr "Kilépés a játékból"
 msgid "JANUARY"
 msgstr "Január"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "JSON debug mód:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Mindig"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automatikusan"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Soha"
 
@@ -2639,19 +2639,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Nyelv:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Erre a nyelvre való fordítás {0}%-a van elkészülve"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "A játéknak erre a nyelvre való lefordítása még mindig készülőben van ({0}% kész)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "A játék erre a nyelvre még nincs teljesen lefordítva ({0}% kész). Kérünk, hogy segíts nekünk ez ügyben te is!"
 
@@ -2814,7 +2814,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Bal egérgomb"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licenszek"
 
@@ -2884,7 +2884,7 @@ msgstr "Görgetés jobbra"
 msgid "LIGHT_MAX"
 msgstr "Fény"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "Extrém"
@@ -2899,35 +2899,35 @@ msgstr "Elfogad"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(a sebesség, mely alatt az MI fajok mutálódnak)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_LARGE"
 msgstr "Nagy"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "Elfogad"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_SMALL"
 msgstr "Kicsi"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_VERY_LARGE"
 msgstr "Nagyon nagy"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_VERY_SMALL"
 msgstr "Elég kicsi"
@@ -2953,7 +2953,7 @@ msgstr "Töltés"
 msgid "LOADING"
 msgstr "Betöltés"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Betöltés..."
@@ -2985,12 +2985,12 @@ msgstr "A szerkesztőben a visszavonás gomb lenyomásával kíjavíthatsz egy v
 msgid "LOAD_FINISHED"
 msgstr "Betöltés befejezve"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Játék betöltése"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Korábbi mentett játékok betöltése"
 
@@ -3062,7 +3062,7 @@ msgstr "Március"
 msgid "MARINE_SNOW"
 msgstr "Tengeri hó"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Fő hangerő"
 
@@ -3071,15 +3071,15 @@ msgstr "Fő hangerő"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "kihalt a bolygón"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Maximum FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Végtelen"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Entitások maximális száma:"
 
@@ -3253,7 +3253,7 @@ msgstr "Minden egyes generációban 100 mutáció pont (MP) áll rendelkezésedr
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Minden egyes alkalommal, amikor osztódsz, a sejtszerkesztőbe fogsz belépni, ahol változtatásokat végezhetsz a fajod setjein (úgy, hogy hozzáadsz, áthelyezel, vagy eltörölsz sejtszervecskéket), hogy növeld túlélési esélyüket. Minden egyes látogatás a szerkesztőben [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] millió évnyi fejlődést jelent a fajod számára."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Sejtszerkesztő"
 
@@ -3435,7 +3435,7 @@ msgstr "Minimum:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Nem engedélyezett {0}-nál/nél kevesebb adathalmaz mutatása!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Egyéb"
 
@@ -3500,11 +3500,11 @@ msgstr "Sejtalkotó szerkesztése"
 msgid "MODIFY_TYPE"
 msgstr "Típus módosítása"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Modok"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3595,11 +3595,11 @@ msgstr "Mappa neve:"
 msgid "MOD_LICENSE"
 msgstr "Mod licensze:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Mod betöltési hibák"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Hiba történt a mod/modok betöltése közben. A hibáról több információt találhatsz a logok között."
 
@@ -3653,11 +3653,11 @@ msgstr "Mod verzió:"
 msgid "MORE_INFO"
 msgstr "Több infó mutatása"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3784,7 +3784,7 @@ msgstr "Több sejt"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Sejtszervecske elhelyezése"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Többszörös élsimítás:"
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Zene"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Zene hangereje"
 
@@ -3817,9 +3817,9 @@ msgstr "(a szervek, membránok, és egyéb dolgok költsége a szerkesztőben)"
 msgid "MUTATION_POINTS"
 msgstr "Mutáció pont"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Némítás"
 
@@ -3855,11 +3855,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Új játék"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Új játék indítása"
 
@@ -3924,7 +3924,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "[thrive:compound type=\"atp\"][/thrive:compound]-t alakít át [thrive:compound type=\"ammonia\"][/thrive:compound]-vá. Hatékonysága függ a [thrive:compound type=\"nitrogen\"][/thrive:compound] és az [thrive:compound type=\"oxygen\"][/thrive:compound] koncentrációjától."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Semmi"
 
@@ -3973,7 +3973,7 @@ msgstr "Nincs feljegyzett esemény"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "A mentések mappa nem található"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Kikapcsolva"
@@ -3991,7 +3991,7 @@ msgstr "Nincs mentés"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "A mentések mappa nem található"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "A képernyőképmappa nem található"
 
@@ -4038,16 +4038,16 @@ msgstr ""
 msgid "OCTOBER"
 msgstr "Október"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Öngyilkosság"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4084,7 +4084,7 @@ msgstr "Nyisd meg a segítség ablakot"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Szabad szerkesztés"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Feljegyzés mappa megnyitása"
 
@@ -4100,7 +4100,7 @@ msgstr "Sejtszervecske menü megnyitása"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Mentések mappájának megnyitása"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Képernyőkép mappa megnyitása"
 
@@ -4108,7 +4108,7 @@ msgstr "Képernyőkép mappa megnyitása"
 msgid "OPEN_THE_MENU"
 msgstr "Nyisd meg a menüt"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Segíts a játék fordításában"
 
@@ -4128,11 +4128,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunista"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Beállítások"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Változtasd meg beállításaidat"
 
@@ -4347,7 +4347,7 @@ msgstr "Procedurális"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Játék szüneteltetése"
@@ -4399,7 +4399,7 @@ msgstr "Békés"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Teljesítmény"
 
@@ -4483,7 +4483,7 @@ msgstr "A játékos megkettőzése"
 msgid "PLAYER_EXTINCT"
 msgstr "A játékos faja kihalt"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "A játékos faja kihalt"
@@ -4498,23 +4498,23 @@ msgstr ""
 "Játékos\n"
 "Sebesség"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Intró videó lejátszása"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Új játék esetén az intró lejátszása"
 
@@ -4634,11 +4634,11 @@ msgstr "Gyorstöltés"
 msgid "QUICK_SAVE"
 msgstr "Gyorsmentés"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Kilépés"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Kilépés a játékból"
@@ -4682,7 +4682,7 @@ msgstr "Szálak:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Ajánlott Thrive verzió:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Játék folytatása"
@@ -4738,7 +4738,7 @@ msgstr "Reprodukció:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Sejtmag"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Visszaállít"
 
@@ -4747,24 +4747,24 @@ msgstr "Visszaállít"
 msgid "RESET_DEADZONES"
 msgstr "Visszaállítja-e az alap dolgokat?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Vissza akarod állítani a bemeneteket az alapokra?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Bemeneti eszközök visszaállítása"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Alapok"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Visszaállítja-e az alap dolgokat?"
 
@@ -4773,7 +4773,7 @@ msgstr "Visszaállítja-e az alap dolgokat?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Felbontás:"
 
@@ -4823,7 +4823,7 @@ msgstr ""
 "Biztos vissza akarsz lépni a főmenübe?\n"
 "Az eddigi teljesítményeid el fognak veszni (hacsak nem mentettél)."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "A Revolutionary Games Studio-tól"
@@ -4856,7 +4856,7 @@ msgstr "Forgatás jobbra"
 msgid "ROTATION_COLON"
 msgstr "Fordulás:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Auto-evo futtatása játék alatt"
 
@@ -4911,7 +4911,7 @@ msgstr "A rusticyanin egy fehérje, ami szén-dioxid, és oxigén segítségéve
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "[thrive:compound type=\"iron\"][/thrive:compound]-at alakít át [thrive:compound type=\"atp\"][/thrive:compound]-vé. Hatékonysága függ az [thrive:compound type=\"carbondioxide\"][/thrive:compound] és az [thrive:compound type=\"oxygen\"][/thrive:compound] koncentrációjától."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4920,16 +4920,16 @@ msgstr ""
 "A bátor sejtek nem ijednek meg a ragadozó sejtektől,\n"
 "így nagy eséllyel védekezésképp vissza is támadnak."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Helyi adatok törlése"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Mentés"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Mentés és folytatás"
 
@@ -5029,21 +5029,21 @@ msgstr "A mentés nem sikerült a következő ok(ok)miatt:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Sikeres mentés"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr "Jelző szövet"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5146,7 +5146,7 @@ msgstr "Rögzült"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "SFX hangerő"
 
@@ -5163,20 +5163,24 @@ msgstr "Segítség mutatása"
 msgid "SHOW_TUTORIALS"
 msgstr "Tutorial-ok mutatása"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Tutoriálok mutatása (jelenlegi játékban)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Tutoriálok mutatása (új játék esetén)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "\"Mentetlen játék\" figyelmeztetés mutatása"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -5227,7 +5231,7 @@ msgstr "Kovasav"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5269,7 +5273,7 @@ msgstr "[thrive:compound type=\"glucose\"][/thrive:compound]-t alakít át [thri
 msgid "SMALL_IRON_CHUNK"
 msgstr "Kis vasdarab"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Hang"
 
@@ -5478,19 +5482,19 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Ismeretlen Steam hiba történt"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "A mentés sikertelen! Hiba történt"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Ezen mentés frissítése nem sikerült a következő hiba miatt:\n"
 "{0}"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Játék szüneteltetése"
@@ -5531,7 +5535,7 @@ msgstr "Tárhely"
 msgid "STORAGE_COLON"
 msgstr "Tárhely:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Belépve mint: {0}"
 
@@ -5648,7 +5652,7 @@ msgstr "Hőm."
 msgid "TESTING_TEAM"
 msgstr "Tesztelő csapat"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5663,7 +5667,7 @@ msgstr ""
 "\n"
 "Ha élvezted a játékot, akkor beszélj a barátaidnak is rólunk."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "TÚLÉLTÉL!"
@@ -5721,11 +5725,11 @@ msgstr "Ez egy lokálisan letöltött mod"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Ez a mod a Steam Műhelyből lett letöltve"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Szálak:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5872,7 +5876,7 @@ msgstr "Szünet"
 msgid "TOGGLE_UNBINDING"
 msgstr "Szétválás be/ki"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Eszközök"
 
@@ -5937,7 +5941,7 @@ msgstr "Próbálj pár képernyőképet készíteni!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Próbálj egy mentést létrehozni!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Próbálj pár képernyőképet készíteni!"
 
@@ -6081,12 +6085,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Tutorial"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Változtasd meg beállításaidat"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6111,7 +6115,7 @@ msgstr "Összes szétválasztása"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Szétkapcsolás mód"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6134,7 +6138,7 @@ msgstr "Utolsó akció visszavonása"
 msgid "UNKNOWN"
 msgstr "Ismeretlen"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Képesség sáv megjelenítése"
@@ -6147,7 +6151,7 @@ msgstr "Ismeretlen egér"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Ismeretlen a Windows-on"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Mod verzió:"
@@ -6156,7 +6160,7 @@ msgstr "Mod verzió:"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Mod műhely ID-je ismeretlen"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Mentetlen változtatásaid vannak, melyek el fognak veszni.\n"
@@ -6201,7 +6205,7 @@ msgstr "Sikeres feltöltés"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Licenszek"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6218,7 +6222,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Öngyilkosság"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Adj meg egy saját felhasználónevet"
 
@@ -6226,11 +6230,11 @@ msgstr "Adj meg egy saját felhasználónevet"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "A háttérben futó szálak számának manuális beállítása"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6256,7 +6260,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Verzió:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Verzió:"
@@ -6267,11 +6271,11 @@ msgstr "Verzió:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Új név:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6280,7 +6284,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Galéria nézet"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "A forráskód megtekintése"
 
@@ -6292,7 +6296,7 @@ msgstr "VIP támogatók"
 msgid "VISIBLE"
 msgstr "Látható"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6312,7 +6316,7 @@ msgstr "Némítás"
 msgid "VOLUMEUP"
 msgstr "Hangerő növelése"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSync"
 
@@ -6420,7 +6424,7 @@ msgstr "Organizmus statisztikái"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "Alap mozgás"
@@ -6429,15 +6433,15 @@ msgstr "Alap mozgás"
 msgid "WORST_PATCH_COLON"
 msgstr "Legrosszabb patch:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6449,7 +6453,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "évek"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Játék szüneteltetése"

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-11-11 17:58+0000\n"
 "Last-Translator: Undibundi <andras9334@citromail.hu>\n"
 "Language-Team: Hungarian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/hu/>\n"
@@ -207,7 +207,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "A rajzot {0} készítette"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Rajz galéria"
 
@@ -306,7 +306,7 @@ msgstr "Automata mentés a játék során"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "futtatási státusz:"
@@ -350,8 +350,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -613,28 +613,28 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Szén-dioxid"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "bőséges mennyiség"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "elég sok"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 #, fuzzy
 msgid "CATEGORY_LITTLE"
 msgstr "Elméleti csapat"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "kis mennyiség"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "közepes mennyiség"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "nagyon kicsi mennyiség"
 
@@ -908,21 +908,21 @@ msgstr "Telítettségi érték, a szürke mennyisége egy adott színben"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Érték (fényerősség) értéke, a szín fényerőssége vagy intenzitása"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Segítség"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "Wikipédiánk"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Kilépés a játékból"
@@ -1129,7 +1129,7 @@ msgstr "Létrehozás..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Objektumok létrehozása a mentésből"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Stáblista"
 
@@ -1300,12 +1300,12 @@ msgstr "Devbuild támogatók"
 msgid "DEVELOPERS"
 msgstr "Fejlesztők"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "A játékot a Revolutionary Games Studio ry fejleszti"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Segítség"
@@ -1314,12 +1314,12 @@ msgstr "Segítség"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "A játékot a Revolutionary Games Studio ry fejleszti"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Fejlesztők"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Segítség"
@@ -1444,7 +1444,7 @@ msgstr ""
 "Vannak olyan sejtszervecskék, melyek nem kötődnek egymáshoz.\n"
 "Kérlek kapcsold össze a sejtszervecskéket egymással, vagy vond vissza eddigi változtatásaidat."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Segítség"
@@ -1461,7 +1461,7 @@ msgstr ""
 "A fókuszált sejtek nagyobb távolságokat tesznek meg táplálék reményében.\n"
 "A reszponzív sejtek hamar új célpontokat keresnek."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1509,7 +1509,7 @@ msgstr "Dupla kattintás a teljes képernyő nézetért"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Egy membrán, ami két rétegből áll. Jobb védelmet nyújt sérülések ellen, és kevesebb energia szükséges ahhoz, hogy ne deformálódjon el. Hátránya viszont, hogy lassítja a sejt bekebelező képességét."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1692,15 +1692,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Energia forrásai:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1755,6 +1755,16 @@ msgstr "Hiba a mod fájllá való átalakítása közben"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Hiba: A beállításokat nem sikerült menteni."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(random megidézett titkok a játékban)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Hiba a mod fájllá való átalakítása közben"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Betöltési hiba"
@@ -1807,7 +1817,7 @@ msgstr ""
 msgid "EXIT"
 msgstr "Kilépés"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Indítás E"
@@ -1863,7 +1873,7 @@ msgstr "kihalt a bolygón"
 msgid "EXTINCT_SPECIES"
 msgstr "Kihalt fajok"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extrák"
 
@@ -1871,7 +1881,7 @@ msgstr "Extrák"
 msgid "EXTRA_OPTIONS"
 msgstr "Extra opciók"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Játék szüneteltetése"
@@ -1905,6 +1915,40 @@ msgstr "Csalások engedélyezve"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Február"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Feldolgozási idő: {0} s\n"
+"Fizika ideje: {1} s\n"
+"Entitások: {2} Egyéb: {3}\n"
+"Spawnolt: {4} Despawnolt: {5}\n"
+"Használatban lévő node-ok: {6}\n"
+"Használatban lévő memória: {7} MiB\n"
+"GPU memória: {8} MiB\n"
+"Renderelt objektumok: {9}\n"
+"Draw hívások: {10} 2D: {11}\n"
+"Renderelt csúcsok: {12}\n"
+"Anyag változások: {13}\n"
+"Shader változások: {14}\n"
+"Árva node-ok: {15}\n"
+"Audió késése: {16} ms\n"
+"Összes szál: {17}\n"
+"Teljes CPU idő:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1989,7 +2033,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Tápláléklánc"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -2094,7 +2138,7 @@ msgstr "Generáció:"
 msgid "GENERATION_COLON"
 msgstr "Generáció:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Kilépés a játékból"
@@ -2103,11 +2147,11 @@ msgstr "Kilépés a játékból"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 mód figyelmeztetés"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "A Thrive-ot GLES2 módban futtatod. Ennek a módnak a használata nincs letesztelve, és nagy eséllyel hibákat okozhat. Próbáld meg frissíteni a videókártyád driverét vagy/és kényszerítsd az AMD vagy Nvidia grafikai szoftverét a Thrive futtatására."
 
@@ -2392,7 +2436,7 @@ msgstr "Vas"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Vas oxidálása"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Kilépés a játékból"
@@ -2611,7 +2655,7 @@ msgstr "A játéknak erre a nyelvre való lefordítása még mindig készülőbe
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "A játék erre a nyelvre még nincs teljesen lefordítva ({0}% kész). Kérünk, hogy segíts nekünk ez ügyben te is!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2770,7 +2814,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Bal egérgomb"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licenszek"
 
@@ -2909,7 +2953,8 @@ msgstr "Töltés"
 msgid "LOADING"
 msgstr "Betöltés"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Betöltés..."
 
@@ -2940,12 +2985,12 @@ msgstr "A szerkesztőben a visszavonás gomb lenyomásával kíjavíthatsz egy v
 msgid "LOAD_FINISHED"
 msgstr "Betöltés befejezve"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Játék betöltése"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Korábbi mentett játékok betöltése"
 
@@ -3208,7 +3253,7 @@ msgstr "Minden egyes generációban 100 mutáció pont (MP) áll rendelkezésedr
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Minden egyes alkalommal, amikor osztódsz, a sejtszerkesztőbe fogsz belépni, ahol változtatásokat végezhetsz a fajod setjein (úgy, hogy hozzáadsz, áthelyezel, vagy eltörölsz sejtszervecskéket), hogy növeld túlélési esélyüket. Minden egyes látogatás a szerkesztőben [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] millió évnyi fejlődést jelent a fajod számára."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Sejtszerkesztő"
 
@@ -3455,11 +3500,11 @@ msgstr "Sejtalkotó szerkesztése"
 msgid "MODIFY_TYPE"
 msgstr "Típus módosítása"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Modok"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3550,11 +3595,11 @@ msgstr "Mappa neve:"
 msgid "MOD_LICENSE"
 msgstr "Mod licensze:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Mod betöltési hibák"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Hiba történt a mod/modok betöltése közben. A hibáról több információt találhatsz a logok között."
 
@@ -3802,15 +3847,19 @@ msgstr ""
 "Ez a mentés a Thrive egyik frissebb verziójából származik, és nagy eséllyel nem kompatibilis.\n"
 "Így is be akarod tölteni a mentést?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Új játék"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Új játék indítása"
 
@@ -3911,7 +3960,7 @@ msgid "NO_AI"
 msgstr "Nincs MI"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Nincs adat"
 
@@ -3924,7 +3973,7 @@ msgstr "Nincs feljegyzett esemény"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "A mentések mappa nem található"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Kikapcsolva"
@@ -3955,7 +4004,7 @@ msgstr "Egy mod sincs kijelölve"
 msgid "NUCLEUS"
 msgstr "Sejtmag"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3975,8 +4024,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -3989,16 +4038,16 @@ msgstr ""
 msgid "OCTOBER"
 msgstr "Október"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Öngyilkosság"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4079,11 +4128,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunista"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Beállítások"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Változtasd meg beállításaidat"
 
@@ -4298,7 +4347,7 @@ msgstr "Procedurális"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Játék szüneteltetése"
@@ -4358,8 +4407,8 @@ msgstr "Teljesítmény"
 msgid "PERFORM_UNBINDING"
 msgstr "Szétválasztás végrehajtása"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/másodperc"
 
@@ -4410,7 +4459,7 @@ msgstr "Bolygó generálás hamarosan!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Véletlen bolygó seed"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Játékos sejtje"
 
@@ -4486,7 +4535,7 @@ msgstr "Populáció:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "Populáció a patch-ekben:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4541,7 +4590,7 @@ msgstr "Előző:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Betöltött objektumok feldolgozása"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4585,11 +4634,11 @@ msgstr "Gyorstöltés"
 msgid "QUICK_SAVE"
 msgstr "Gyorsmentés"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Kilépés"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Kilépés a játékból"
@@ -4633,7 +4682,7 @@ msgstr "Szálak:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Ajánlott Thrive verzió:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Játék folytatása"
@@ -4774,7 +4823,7 @@ msgstr ""
 "Biztos vissza akarsz lépni a főmenübe?\n"
 "Az eddigi teljesítményeid el fognak veszni (hacsak nem mentettél)."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "A Revolutionary Games Studio-tól"
@@ -4862,7 +4911,7 @@ msgstr "A rusticyanin egy fehérje, ami szén-dioxid, és oxigén segítségéve
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "[thrive:compound type=\"iron\"][/thrive:compound]-at alakít át [thrive:compound type=\"atp\"][/thrive:compound]-vé. Hatékonysága függ az [thrive:compound type=\"carbondioxide\"][/thrive:compound] és az [thrive:compound type=\"oxygen\"][/thrive:compound] koncentrációjától."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4871,7 +4920,7 @@ msgstr ""
 "A bátor sejtek nem ijednek meg a ragadozó sejtektől,\n"
 "így nagy eséllyel védekezésképp vissza is támadnak."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Helyi adatok törlése"
@@ -5248,7 +5297,7 @@ msgstr "Ammónia létrehozása"
 msgid "SPAWN_ENEMY"
 msgstr "Ellenség spawnolása"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 #, fuzzy
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Ellenség spawnolása"
@@ -5311,7 +5360,7 @@ msgstr "Faj neve..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Faj neve..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5429,19 +5478,19 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Ismeretlen Steam hiba történt"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "A mentés sikertelen! Hiba történt"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Ezen mentés frissítése nem sikerült a következő hiba miatt:\n"
 "{0}"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Játék szüneteltetése"
@@ -5482,7 +5531,7 @@ msgstr "Tárhely"
 msgid "STORAGE_COLON"
 msgstr "Tárhely:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Belépve mint: {0}"
 
@@ -5599,7 +5648,7 @@ msgstr "Hőm."
 msgid "TESTING_TEAM"
 msgstr "Tesztelő csapat"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5614,7 +5663,7 @@ msgstr ""
 "\n"
 "Ha élvezted a játékot, akkor beszélj a barátaidnak is rólunk."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "TÚLÉLTÉL!"
@@ -5676,7 +5725,7 @@ msgstr "Ez a mod a Steam Műhelyből lett letöltve"
 msgid "THREADS"
 msgstr "Szálak:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5823,7 +5872,7 @@ msgstr "Szünet"
 msgid "TOGGLE_UNBINDING"
 msgstr "Szétválás be/ki"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Eszközök"
 
@@ -6032,7 +6081,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Tutorial"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Változtasd meg beállításaidat"
@@ -6231,7 +6280,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Galéria nézet"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "A forráskód megtekintése"
 
@@ -6243,7 +6292,7 @@ msgstr "VIP támogatók"
 msgid "VISIBLE"
 msgstr "Látható"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6400,7 +6449,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "évek"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Játék szüneteltetése"

--- a/locale/id.po
+++ b/locale/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-08-18 10:33+0000\n"
 "Last-Translator: Kasterisk <microscube@gmail.com>\n"
 "Language-Team: Indonesian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/id/>\n"
@@ -205,7 +205,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Seni oleh {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Galeri Seni"
 
@@ -305,7 +305,7 @@ msgstr "Save otomatis ketika bermain"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Alat Penjelajah Auto-Evo"
 
@@ -349,8 +349,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -615,27 +615,27 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Karbon Dioksida"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -911,20 +911,20 @@ msgstr "Nilai saturasi, jumlah abu-abu dari sebuah warna"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Nilai kecerahan, kecerahan atau intensitas dari warna"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Tambah keybind baru"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Keluar dari permainan"
@@ -1135,7 +1135,7 @@ msgstr "Cari..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Membuat obyek dari save"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Kredit"
 
@@ -1311,12 +1311,12 @@ msgstr "Pendukung Devbuilds"
 msgid "DEVELOPERS"
 msgstr "Pengembang"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Pengembangan didukung oleh Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Tambah keybind baru"
@@ -1325,12 +1325,12 @@ msgstr "Tambah keybind baru"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Pengembangan didukung oleh Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Pengembang"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Tambah keybind baru"
@@ -1456,7 +1456,7 @@ msgstr ""
 "Ada organel yang tidak tersambung dengan yang lainnya.\n"
 "Mohon sambungkan semua organel atau batalkan perubahanmu."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Tambah keybind baru"
@@ -1471,7 +1471,7 @@ msgstr "Kecepatan:"
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "{0} populasi berubah {1} karena: {2}"
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1520,7 +1520,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Membran dengan dua lapis, memiliki perlindungan yang lebih baik terhadap kerusakan dan memerlukan lebih sedikit energi agar tak berubah bentuk. Namun, memperlambat sel dan mengurangi laju kemampuannya menyerap sumber daya."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1707,15 +1707,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1772,6 +1772,16 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Error: Gagal menyimpan pengaturan baru ke file konfigurasi."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "{0} populasi berubah {1} karena: {2}"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Error Menyimpan"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Error Memuat"
@@ -1825,7 +1835,7 @@ msgstr "Sebuah eksepsi terjadi saat sedang memuat data save"
 msgid "EXIT"
 msgstr "Keluar"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Launch E"
@@ -1882,7 +1892,7 @@ msgstr "telah punah dari planet"
 msgid "EXTINCT_SPECIES"
 msgstr "KEPUNAHAN"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Lainnya"
 
@@ -1890,7 +1900,7 @@ msgstr "Lainnya"
 msgid "EXTRA_OPTIONS"
 msgstr "Pilihan Ekstra"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Tambah keybind baru"
@@ -1921,6 +1931,40 @@ msgstr "Aktifkan tombol cheat"
 #, fuzzy
 msgid "FEBRUARY"
 msgstr "Muara"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Waktu Proses: {0} s\n"
+"Waktu Fisik: {1} s\n"
+"Entitas: {2} Lainnya: {3}\n"
+"Dimunculkan: {4} Dihapus: {5}\n"
+"Simpul Terpakai: {6}\n"
+"Memori Terpakai: {7}\n"
+"Memori GPU: {8}\n"
+"Obyek Tertampil: {9}\n"
+"Jumlah Panggilan Gambar: {10} 2D: {11}\n"
+"Vertex Tertampil: {12}\n"
+"Perubahan Material: {13}\n"
+"Perubahan Shader: {14}\n"
+"Simpul Lepas: {15}\n"
+"Latensi Suara: {16} ms\n"
+"Thread Total: {17}\n"
+"Waktu CPU Total:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -2002,7 +2046,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Rantai Makanan"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -2103,7 +2147,7 @@ msgstr "Generasi"
 msgid "GENERATION_COLON"
 msgstr "Generasi:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Keluar dari permainan"
@@ -2112,11 +2156,11 @@ msgstr "Keluar dari permainan"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Peringatan Mode GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Kamu menjalankan Thrive dengan GLES2. Ini belum teruji secara penuh dan mungkin akan menyebabkan masalah. Coba perbarui driver dan/atau paksa grafik AMD atau Nvidia anda untuk digunakan menjalankan Thrive."
 
@@ -2408,7 +2452,7 @@ msgstr "Besi"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Kemolitoautotrofi Besi"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Keluar dari permainan"
@@ -2628,7 +2672,7 @@ msgstr "Terjemahan ini masih dalam tahap pengerjaan ({0}% selesai)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Terjemahan ini sangat belum lengkap ({0}% selesai) tolong bantu kami menerjemahkannya!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2788,7 +2832,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2924,7 +2968,8 @@ msgstr "Muat"
 msgid "LOADING"
 msgstr "Memuat"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Memuat..."
@@ -2956,12 +3001,12 @@ msgstr "Tekan tombol undo di editor untuk membatalkan kesalahan"
 msgid "LOAD_FINISHED"
 msgstr "Selesai memuat"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Muat Permainan"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Muat permainan yang sudah disimpan"
 
@@ -3229,7 +3274,7 @@ msgstr "Setiap generasi, kamu mendapat 100 mutation points/poin mutasi (MP) untu
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Setiap kali kamu reproduksi, kamu akan memasuki Editor Mikroba, tempat untuk membuat perubahan pada spesiesmu (Dengan cara menambahkan, memindahkan, atau melepaskan organel) agar meningkatkan keberhasilan spesiesmu. Setiap masuk ke editor di Tahap Mikroba mewakili [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] juta tahun evolusi."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor Mikroba Bangun-bebas"
 
@@ -3480,11 +3525,11 @@ msgstr "Hapus organel"
 msgid "MODIFY_TYPE"
 msgstr "Ubah Tipe"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mod"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3580,11 +3625,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr "Lisensi dan Libraries yang Digunakan"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3822,15 +3867,19 @@ msgstr ""
 "Save ini berasal dari versi Thrive yang lebih baru dan kemungkinan besar tidak lagi kompatibel.\n"
 "Apakah kamu ingin tetap memuat save ini?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Populasi awal untuk spesies peningkat biodiversitas"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Permainan Baru"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Mulai permainan baru"
 
@@ -3933,7 +3982,7 @@ msgid "NO_AI"
 msgstr "Nonaktifkan AI (kecerdasan buatan)"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Tidak Ada Data Untuk Ditampilkan"
 
@@ -3946,7 +3995,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Buka Direktori Save"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Aktifkan tombol cheat"
@@ -3980,7 +4029,7 @@ msgstr "Terpilih:"
 msgid "NUCLEUS"
 msgstr "Nukleus"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3999,8 +4048,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 #, fuzzy
 msgid "N_A"
@@ -4014,16 +4063,16 @@ msgstr "N/A PM"
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Tambah keybind baru"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4102,11 +4151,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opsi"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Ubah setelan"
 
@@ -4326,7 +4375,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Gua"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Tambah keybind baru"
@@ -4388,8 +4437,8 @@ msgstr "Performa"
 msgid "PERFORM_UNBINDING"
 msgstr "Lakukan pelepasan"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/detik"
 
@@ -4440,7 +4489,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Sel Pemain"
 
@@ -4518,7 +4567,7 @@ msgstr "populasi:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "populasi di daerah-daerah:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 #, fuzzy
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "POPULASI:"
@@ -4575,7 +4624,7 @@ msgstr "sebelumnya:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Memproses obyek yang termuat"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4620,11 +4669,11 @@ msgstr "Muat cepat"
 msgid "QUICK_SAVE"
 msgstr "Simpan cepat"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Keluar"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Keluar dari permainan"
@@ -4667,7 +4716,7 @@ msgstr "Siap"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Lanjutkan"
@@ -4810,7 +4859,7 @@ msgstr ""
 "Apakah kamu yakin ingin keluar ke menu utama?\n"
 "Progress yang tidak disave akan hilang."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Oleh Revolutionary Games Studio"
@@ -4899,12 +4948,12 @@ msgstr "Rustisianin adalah protein yang dapat menggunakan gas karbon dioksida da
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Mengubah [thrive:compound type=\"iron\"][/thrive:compound] menjadi [thrive:compound type=\"atp\"][/thrive:compound]. Laju berbanding lurus dengan konsentrasi [thrive:compound type=\"carbondioxide\"][/thrive:compound] dan [thrive:compound type=\"oxygen\"][/thrive:compound]"
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "{0} populasi berubah {1} karena: {2}"
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -5299,7 +5348,7 @@ msgstr "Munculkan amonia"
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -5360,7 +5409,7 @@ msgstr "Nama spesies..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Nama spesies..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 #, fuzzy
 msgid "SPECIES_N_TIMES"
 msgstr "Daftar Spesies"
@@ -5481,19 +5530,19 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Gagal menyimpan! Terjadi eksepsi"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Gagal memperbarui save karena error berikut:\n"
 "{0}"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Lanjutkan"
@@ -5536,7 +5585,7 @@ msgstr "Penyimpanan"
 msgid "STORAGE_COLON"
 msgstr "Penyimpanan"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Masuk sebagai {0}"
 
@@ -5654,7 +5703,7 @@ msgstr "Suhu"
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5669,7 +5718,7 @@ msgstr ""
 "\n"
 "Jika kamu menikmati game ini, tolong beritahu teman anda tentang kami."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "KAMU TELAH BERKEMBANG!"
@@ -5731,7 +5780,7 @@ msgstr ""
 msgid "THREADS"
 msgstr "Threads:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5880,7 +5929,7 @@ msgstr "Jeda"
 msgid "TOGGLE_UNBINDING"
 msgstr "Nyala/matikan pelepasan"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Alat"
 
@@ -6115,7 +6164,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Tutorial"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Ubah setelan"
@@ -6320,7 +6369,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Tampilan"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Lihat Kode Sumber"
 
@@ -6332,7 +6381,7 @@ msgstr "Pendukung VIP"
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6493,7 +6542,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "tahun"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Lanjutkan"

--- a/locale/id.po
+++ b/locale/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-08-18 10:33+0000\n"
 "Last-Translator: Kasterisk <microscube@gmail.com>\n"
 "Language-Team: Indonesian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/id/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.13.1\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "Editor 3D"
 msgid "3D_MOVEMENT"
 msgstr "Gerakan 3D"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "Tindakan diblokir saat yang lain sedang berlangsung"
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 #, fuzzy
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Simpan dan lanjut"
@@ -143,7 +143,7 @@ msgstr "Statistika Organisme"
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Volume lingkungan"
 
@@ -154,11 +154,11 @@ msgstr "Volume lingkungan"
 msgid "AMMONIA"
 msgstr "Amonia"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Jumlah save otomatis tersimpan:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Jumlah save cepat tersimpan:"
 
@@ -184,11 +184,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Apakah kamu yakin ingin menyetel ulang SEMUA pengaturan ke nilai semula?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Apakah kamu yakin ingin menyetel ulang pengaturan input ke nilai semula?"
 
@@ -205,7 +205,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Seni oleh {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Galeri Seni"
 
@@ -217,7 +217,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Asumsikan hyperthreading diaktifkan pada CPU"
 
@@ -260,7 +260,7 @@ msgstr "Auto-evo gagal bekerja"
 msgid "AT_CURSOR"
 msgstr "Pada Kursor:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Perangkat output audio:"
 
@@ -268,8 +268,8 @@ msgstr "Perangkat output audio:"
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "otomatis"
 
@@ -297,7 +297,7 @@ msgstr "Pembangkit listrik sel. Mitokondria adalah struktur membran ganda yang t
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% selesai. {1:n0}/{2:n0} tahap."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Save otomatis ketika bermain"
 
@@ -305,7 +305,7 @@ msgstr "Save otomatis ketika bermain"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Alat Penjelajah Auto-Evo"
 
@@ -335,7 +335,7 @@ msgstr "status auto-evo:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Gerak otomatis depan"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 #, fuzzy
 msgid "AUTO_RESOLUTION"
 msgstr "Resolusi:"
@@ -349,9 +349,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -496,7 +496,7 @@ msgstr "Memungkinkan pelekatan antar sel. Ini merupakan tahap pertama menuju mul
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Tekan [thrive:input]g_toggle_binding[/thrive:input] untuk menyalakan/matikan mode lekat. Ketika di mode lekat kamu bisa melekatkan sel lain yang satu spesies dengamu dengan cara bergerak mendekati mereka. Untuk keluar dari koloni tekan tombol [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -558,7 +558,7 @@ msgstr "Membran ini memiliki kulit kuat yang terbuat dari kalsium karbonat. Sang
 msgid "CAMERA"
 msgstr "Kamera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -690,7 +690,7 @@ msgstr "Ubah simetri"
 msgid "CHEATS"
 msgstr "Cheat"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Aktifkan tombol cheat"
 
@@ -785,7 +785,7 @@ msgstr "Memproduksi [thrive:compound type=\"glucose\"][/thrive:compound]. Laju b
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Nama file yang dipilih {0} sudah ada. Timpa?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Aberasi Kromatik:"
 
@@ -828,15 +828,15 @@ msgstr "Bersihkan Save Lama"
 msgid "CLOSE"
 msgstr "Tutup"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Tutup pilihan?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Pembagi Resolusi Awan:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 "Interval Minimum Simulasi\n"
@@ -854,7 +854,7 @@ msgstr "Munculkan entitas dengan bentukan pendeteksi benturan"
 msgid "COLOUR"
 msgstr "Warna"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Koreksi Buta Warna:"
 
@@ -911,25 +911,25 @@ msgstr "Nilai saturasi, jumlah abu-abu dari sebuah warna"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Nilai kecerahan, kecerahan atau intensitas dari warna"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Tambah keybind baru"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Keluar dari permainan"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Senyawa:"
@@ -957,7 +957,7 @@ msgstr "Senyawa:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Keseimbangan Senyawa"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Awan senyawa"
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr "{0} populasi berubah {1} karena: {2}"
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1069,11 +1069,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Salin Error ke Clipboard"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1135,7 +1135,7 @@ msgstr "Cari..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Membuat obyek dari save"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Kredit"
 
@@ -1161,7 +1161,7 @@ msgstr "Pengembang Masa Ini"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Statistika Organisme"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Nama Pengguna Kustom:"
 
@@ -1230,7 +1230,7 @@ msgstr "Panel Debug"
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Perangkat output bawaan"
 
@@ -1297,7 +1297,7 @@ msgstr "Deskripsi:"
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 #, fuzzy
 msgid "DETECTED_CPU_COUNT"
 msgstr "Terpilih:"
@@ -1311,12 +1311,12 @@ msgstr "Pendukung Devbuilds"
 msgid "DEVELOPERS"
 msgstr "Pengembang"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Pengembangan didukung oleh Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Tambah keybind baru"
@@ -1325,12 +1325,12 @@ msgstr "Tambah keybind baru"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Pengembangan didukung oleh Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Pengembang"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Tambah keybind baru"
@@ -1407,7 +1407,7 @@ msgstr "Left"
 msgid "DIRECTIONR"
 msgstr "Right"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1415,7 +1415,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Buang dan lanjut"
 
@@ -1456,34 +1456,34 @@ msgstr ""
 "Ada organel yang tidak tersambung dengan yang lainnya.\n"
 "Mohon sambungkan semua organel atau batalkan perubahanmu."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Tambah keybind baru"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Kecepatan:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "{0} populasi berubah {1} karena: {2}"
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Tampilkan Bilah Kemampuan Sel"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "Tampilkan Bilah Kemampuan Sel"
@@ -1520,7 +1520,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Membran dengan dua lapis, memiliki perlindungan yang lebih baik terhadap kerusakan dan memerlukan lebih sedikit energi agar tak berubah bentuk. Namun, memperlambat sel dan mengurangi laju kemampuannya menyerap sumber daya."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1677,7 +1677,7 @@ msgstr ""
 "\n"
 "Untuk pindah ke tab editor selanjutnya, tekan tombol lanjut di sebelah kanan bawah."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1695,7 +1695,7 @@ msgstr "Save terpilih tidak kompatibel"
 msgid "ENABLE_EDITOR"
 msgstr "Aktifkan editor"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Aktifkan Efek Cahaya GUI"
 
@@ -1755,7 +1755,7 @@ msgstr "Tambah keybind baru"
 msgid "EPIPELAGIC"
 msgstr "Epipelagik"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Error"
 
@@ -1768,16 +1768,16 @@ msgstr "Error Menyimpan"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Error: Gagal menyimpan pengaturan baru ke file konfigurasi."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "{0} populasi berubah {1} karena: {2}"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Error Menyimpan"
@@ -1811,12 +1811,12 @@ msgstr "Pohon Evolusi"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Pohon Evolusi"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Generasi:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Tambah keybind baru"
@@ -1835,7 +1835,7 @@ msgstr "Sebuah eksepsi terjadi saat sedang memuat data save"
 msgid "EXIT"
 msgstr "Keluar"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Launch E"
@@ -1892,7 +1892,7 @@ msgstr "telah punah dari planet"
 msgid "EXTINCT_SPECIES"
 msgstr "KEPUNAHAN"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Lainnya"
 
@@ -1900,7 +1900,7 @@ msgstr "Lainnya"
 msgid "EXTRA_OPTIONS"
 msgstr "Pilihan Ekstra"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Tambah keybind baru"
@@ -1932,11 +1932,11 @@ msgstr "Aktifkan tombol cheat"
 msgid "FEBRUARY"
 msgstr "Muara"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1958,11 +1958,11 @@ msgstr ""
 "Waktu CPU Total:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2088,7 +2088,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Layar penuh"
 
@@ -2147,24 +2147,24 @@ msgstr "Generasi"
 msgid "GENERATION_COLON"
 msgstr "Generasi:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Keluar dari permainan"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Peringatan Mode GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Kamu menjalankan Thrive dengan GLES2. Ini belum teruji secara penuh dan mungkin akan menyebabkan masalah. Coba perbarui driver dan/atau paksa grafik AMD atau Nvidia anda untuk digunakan menjalankan Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2217,12 +2217,12 @@ msgstr "Baiklah"
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "Gua"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafik"
 
@@ -2231,7 +2231,7 @@ msgstr "Grafik"
 msgid "GRAPHICS_TEAM"
 msgstr "Grafik"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2248,7 +2248,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} rb"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Volume GUI"
 
@@ -2271,11 +2271,11 @@ msgstr "Bantuan"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Tambah keybind baru"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(Nilai tinggi menambah performa)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(Nilai tinggi memperburuk performa)"
 
@@ -2300,7 +2300,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Home"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Generasi:"
@@ -2375,7 +2375,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Tambah keybind baru"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Input"
 
@@ -2432,8 +2432,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2452,7 +2452,7 @@ msgstr "Besi"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Kemolitoautotrofi Besi"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Keluar dari permainan"
@@ -2461,19 +2461,19 @@ msgstr "Keluar dari permainan"
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2655,20 +2655,20 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Bahasa:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 #, fuzzy
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Bantu Alih Bahasa Permainan"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Terjemahan ini masih dalam tahap pengerjaan ({0}% selesai)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Terjemahan ini sangat belum lengkap ({0}% selesai) tolong bantu kami menerjemahkannya!"
 
@@ -2832,7 +2832,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2902,7 +2902,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr "Cahaya"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "Lainnya"
@@ -2917,32 +2917,32 @@ msgstr "KONFIRMASI"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "{0} populasi berubah {1} karena: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "KONFIRMASI"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2968,7 +2968,7 @@ msgstr "Muat"
 msgid "LOADING"
 msgstr "Memuat"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
@@ -3001,12 +3001,12 @@ msgstr "Tekan tombol undo di editor untuk membatalkan kesalahan"
 msgid "LOAD_FINISHED"
 msgstr "Selesai memuat"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Muat Permainan"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Muat permainan yang sudah disimpan"
 
@@ -3087,7 +3087,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr "Salju laut"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Volume master"
 
@@ -3095,16 +3095,16 @@ msgstr "Volume master"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Ambang batas jumlah spesies di suatu daerah untuk terjadinya kepunahan paksa"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "FPS Maks:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 #, fuzzy
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "FPS Maks:"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3274,7 +3274,7 @@ msgstr "Setiap generasi, kamu mendapat 100 mutation points/poin mutasi (MP) untu
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Setiap kali kamu reproduksi, kamu akan memasuki Editor Mikroba, tempat untuk membuat perubahan pada spesiesmu (Dengan cara menambahkan, memindahkan, atau melepaskan organel) agar meningkatkan keberhasilan spesiesmu. Setiap masuk ke editor di Tahap Mikroba mewakili [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] juta tahun evolusi."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor Mikroba Bangun-bebas"
 
@@ -3457,7 +3457,7 @@ msgstr "Versi:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Tidak diperbolehkan menampilkan kurang dari {0} dataset!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Ragam"
 
@@ -3525,11 +3525,11 @@ msgstr "Hapus organel"
 msgid "MODIFY_TYPE"
 msgstr "Ubah Tipe"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mod"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3625,11 +3625,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr "Lisensi dan Libraries yang Digunakan"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3687,11 +3687,11 @@ msgstr "Versi:"
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3805,7 +3805,7 @@ msgstr "Letakkan organel"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Letakkan organel"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Anti-aliasing multisampel:"
 
@@ -3817,7 +3817,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Musik"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Volume musik"
 
@@ -3837,9 +3837,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr "Poin Mutasi"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Bisu"
 
@@ -3875,11 +3875,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Populasi awal untuk spesies peningkat biodiversitas"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Permainan Baru"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Mulai permainan baru"
 
@@ -3946,7 +3946,7 @@ msgstr "Plastida Pengikat Nitrogen adalah protein yang dapat menggunakan gas nit
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Mengubah [thrive:compound type=\"atp\"][/thrive:compound] menjadi [thrive:compound type=\"ammonia\"][/thrive:compound]. Laju berbanding lurus dengan konsentrasi [thrive:compound type=\"nitrogen\"][/thrive:compound] dan [thrive:compound type=\"oxygen\"][/thrive:compound]"
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3995,7 +3995,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Buka Direktori Save"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Aktifkan tombol cheat"
@@ -4014,7 +4014,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Buka Direktori Save"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 #, fuzzy
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Buka Folder Tangkapan Layar"
@@ -4063,16 +4063,16 @@ msgstr "N/A PM"
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Tambah keybind baru"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4110,7 +4110,7 @@ msgstr "Buka tampilan bantuan"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Bangun-bebas"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Buka Folder Catatan"
 
@@ -4127,7 +4127,7 @@ msgstr "Buka menu organel"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Buka Direktori Save"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Buka Folder Tangkapan Layar"
 
@@ -4135,7 +4135,7 @@ msgstr "Buka Folder Tangkapan Layar"
 msgid "OPEN_THE_MENU"
 msgstr "Buka Menu"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Bantu Alih Bahasa Permainan"
 
@@ -4151,11 +4151,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opsi"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Ubah setelan"
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Gua"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Tambah keybind baru"
@@ -4429,7 +4429,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Performa"
 
@@ -4515,7 +4515,7 @@ msgstr "Gandakan Pemain"
 msgid "PLAYER_EXTINCT"
 msgstr "Gandakan Pemain"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Gandakan Pemain"
@@ -4530,23 +4530,23 @@ msgstr ""
 "Kecepatan\n"
 "Pemain"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Putar video pengantar"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Putar Video Pengantar Mikroba saat Permainan Baru"
 
@@ -4669,11 +4669,11 @@ msgstr "Muat cepat"
 msgid "QUICK_SAVE"
 msgstr "Simpan cepat"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Keluar"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Keluar dari permainan"
@@ -4716,7 +4716,7 @@ msgstr "Siap"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Lanjutkan"
@@ -4772,7 +4772,7 @@ msgstr "Reproduksi:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Nukleus"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Setel ulang"
 
@@ -4781,24 +4781,24 @@ msgstr "Setel ulang"
 msgid "RESET_DEADZONES"
 msgstr "Setel ulang ke semula?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Setel ulang input ke semula?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Setel Ulang Input"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Semula"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Setel ulang ke semula?"
 
@@ -4807,7 +4807,7 @@ msgstr "Setel ulang ke semula?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Resolusi:"
 
@@ -4859,7 +4859,7 @@ msgstr ""
 "Apakah kamu yakin ingin keluar ke menu utama?\n"
 "Progress yang tidak disave akan hilang."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Oleh Revolutionary Games Studio"
@@ -4893,7 +4893,7 @@ msgstr "Putar kanan"
 msgid "ROTATION_COLON"
 msgstr "{0} populasi berubah {1} karena: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Jalankan auto-evo selama berlangsungnya permainan"
 
@@ -4948,20 +4948,20 @@ msgstr "Rustisianin adalah protein yang dapat menggunakan gas karbon dioksida da
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Mengubah [thrive:compound type=\"iron\"][/thrive:compound] menjadi [thrive:compound type=\"atp\"][/thrive:compound]. Laju berbanding lurus dengan konsentrasi [thrive:compound type=\"carbondioxide\"][/thrive:compound] dan [thrive:compound type=\"oxygen\"][/thrive:compound]"
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "{0} populasi berubah {1} karena: {2}"
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Simpan"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Simpan dan lanjut"
 
@@ -5068,21 +5068,21 @@ msgstr "Gagal menyimpan! Terjadi eksepsi"
 msgid "SAVING_SUCCEEDED"
 msgstr "Sukses menyimpan"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr "Agen Persinyalan"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5186,7 +5186,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Nilai ini hanya berlaku untuk permainan baru setelah mengubah opsi ini"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Volume SFX"
 
@@ -5203,17 +5203,17 @@ msgstr "Tampilkan bantuan"
 msgid "SHOW_TUTORIALS"
 msgstr "Tampilkan tutorial"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Tampilkan tutorial (di permainan saat ini)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Tampilkan tutorial (di permainan baru)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 #, fuzzy
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
@@ -5226,6 +5226,10 @@ msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr ""
 "Kamu memiliki perubahan yang belum tersimpan yang akan dibuang.\n"
 "Apakah kamu ingin lanjut?"
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5277,7 +5281,7 @@ msgstr "Silika"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Membran ini memiliki dinding kuat terbuat dari silika. Dapat menahan kerusakan secara keseluruhan dengan baik dan sangat kebal terhadap kerusakan fisik. Juga memerlukan lebih sedikit energi untuk mempertahankan bentuk. Namun, sangat memperlambat sel dan juga memperlambat laju kemampuan sel menyerap sumber daya."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -5319,7 +5323,7 @@ msgstr "Mengubah [thrive:compound type=\"glucose\"][/thrive:compound] menjadi [t
 msgid "SMALL_IRON_CHUNK"
 msgstr "Potongan Besi Kecil"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Suara"
 
@@ -5530,19 +5534,19 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Gagal menyimpan! Terjadi eksepsi"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Gagal memperbarui save karena error berikut:\n"
 "{0}"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Lanjutkan"
@@ -5585,7 +5589,7 @@ msgstr "Penyimpanan"
 msgid "STORAGE_COLON"
 msgstr "Penyimpanan"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Masuk sebagai {0}"
 
@@ -5703,7 +5707,7 @@ msgstr "Suhu"
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5718,7 +5722,7 @@ msgstr ""
 "\n"
 "Jika kamu menikmati game ini, tolong beritahu teman anda tentang kami."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "KAMU TELAH BERKEMBANG!"
@@ -5776,11 +5780,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Threads:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5929,7 +5933,7 @@ msgstr "Jeda"
 msgid "TOGGLE_UNBINDING"
 msgstr "Nyala/matikan pelepasan"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Alat"
 
@@ -5996,7 +6000,7 @@ msgstr "Ambil tangkapan layar"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Coba buat save!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 #, fuzzy
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Ambil tangkapan layar"
@@ -6164,12 +6168,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Tutorial"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Ubah setelan"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -6196,7 +6200,7 @@ msgstr "Lepas semua"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Mode Lepas"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6219,7 +6223,7 @@ msgstr "Batalkan tindakan terakhir"
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Tampilkan Bilah Kemampuan Sel"
@@ -6232,7 +6236,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Tidak diketahui di Windows"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Versi:"
@@ -6241,7 +6245,7 @@ msgstr "Versi:"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Kamu memiliki perubahan yang belum tersimpan yang akan dibuang.\n"
@@ -6289,7 +6293,7 @@ msgstr "Sukses menyimpan"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Lisensi dan Libraries yang Digunakan"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6307,7 +6311,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Tambah keybind baru"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Gunakan nama pengguna kustom"
 
@@ -6315,11 +6319,11 @@ msgstr "Gunakan nama pengguna kustom"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "Penciptaan spesies peningkat biodiversitas mengurangi populasi dari spesies yang sudah ada"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Atur jumlah background thread secara manual"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6346,7 +6350,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr "Generasi:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Generasi:"
@@ -6357,11 +6361,11 @@ msgstr "Generasi:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Nama Baru:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6369,7 +6373,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Tampilan"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Lihat Kode Sumber"
 
@@ -6381,7 +6385,7 @@ msgstr "Pendukung VIP"
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6401,7 +6405,7 @@ msgstr "Volume Mute"
 msgid "VOLUMEUP"
 msgstr "Volume Up"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSync"
 
@@ -6512,7 +6516,7 @@ msgstr "Statistika Organisme"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "Pergerakan Dasar"
@@ -6522,15 +6526,15 @@ msgstr "Pergerakan Dasar"
 msgid "WORST_PATCH_COLON"
 msgstr "Spesies:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6542,7 +6546,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "tahun"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Lanjutkan"

--- a/locale/it.po
+++ b/locale/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-10-17 19:00+0000\n"
 "Last-Translator: Simone Nobili <simonenobili@yandex.com>\n"
 "Language-Team: Italian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/it/>\n"
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Autore: {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Galleria"
 
@@ -302,7 +302,7 @@ msgstr "Salvataggio automatico durante il gioco"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Strumento di esplorazione Auto-Evo"
 
@@ -345,8 +345,8 @@ msgid "AWAKEN"
 msgstr "Risvegliati"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -604,27 +604,27 @@ msgstr "Bloc Maiusc [Caps Lock]"
 msgid "CARBON_DIOXIDE"
 msgstr "Diossido di carbonio"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "un sacco"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "un po'"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "un pizzico"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "un bel po'"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "una manciata"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "una traccia"
 
@@ -892,21 +892,21 @@ msgstr "S: saturation (saturazione): è la quantità di grigio nel colore"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "V: value (valore): è la luminosità/intensità del colore"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Apri l'editor e modifica la tua specie"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "nostra Wiki"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Esci dal gioco"
@@ -1109,7 +1109,7 @@ msgstr "Creazione..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Creazione oggetti da salvataggio"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Ringraziamenti"
 
@@ -1279,12 +1279,12 @@ msgstr "Sostenitori Devbuilds"
 msgid "DEVELOPERS"
 msgstr "Sviluppatori"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Sviluppo sostenuto da Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Apri l'editor e modifica la tua specie"
@@ -1293,12 +1293,12 @@ msgstr "Apri l'editor e modifica la tua specie"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Sviluppo sostenuto da Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Sviluppatori"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Come giocare"
@@ -1418,7 +1418,7 @@ msgstr ""
 "Ci sono organuli non connessi al resto della cellula.\n"
 "Connetti tutti gli organuli alla cellula o annulla i cambiamenti effettuati."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Tempo trascorso: {0:#,#} anni"
@@ -1436,7 +1436,7 @@ msgstr ""
 "e potrebbero essere più ambiziosi per questi ultimi.\n"
 "I microbi reattivi cambiano più facilmente bersaglio."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr "Fai doppio click per visualizzare a schermo pieno"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Una membrana a due strati. Offre una migliore protezione ai danni e richiede meno energia per non deformarsi. Tuttavia, rallenta un po' la cellula e la sua capacità di assorbire i nutrienti."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1665,15 +1665,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Energia in {0} per {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Fonti di energia:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "L'energia totale accumulata è {0}, con un costo individuale di {1}, risultante in una popolazione (non calibrata) di {2}"
 
@@ -1726,6 +1726,16 @@ msgstr "Si è verificato un errore nella creazione del file di info"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Errore: è stato impossibile salvare nuove impostazioni su file di configurazione."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(segreti che possono apparire casualmente nel gioco)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Si è verificato un errore nella creazione del file di info"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Errore di caricamento"
@@ -1777,7 +1787,7 @@ msgstr "Si è verificata un'eccezione nel caricamento dei dati di salvataggio"
 msgid "EXIT"
 msgstr "Esci"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Launch E"
@@ -1830,7 +1840,7 @@ msgstr "estinto nella zona"
 msgid "EXTINCT_SPECIES"
 msgstr "Specie estinte"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extra"
 
@@ -1838,7 +1848,7 @@ msgstr "Extra"
 msgid "EXTRA_OPTIONS"
 msgstr "Opzioni Extra"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Metti in pausa il gioco"
@@ -1872,6 +1882,41 @@ msgstr "Abilita i trucchi"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Febbraio"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Inizializzazione della libreria client Steam fallita"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Tempo processi [process time]: {0} s\n"
+"Tempo fisica [physics time]: {1} s\n"
+"Entità: {2} Altro: {3}\n"
+"Generate [spawned]: {4} Distrutte [despawned]: {5}\n"
+"Nodi usati: {6}\n"
+"Memoria usata: {7} MiB\n"
+"Memoria GPU: {8} Mib\n"
+"Oggetti renderizzati: {9}\n"
+"Chiamate di disegno [draw calls]: {10} 2D: {11}\n"
+"Vertici renderizzati: {12}\n"
+"Cambi di materiale [material changes]: {13}\n"
+"Cambi di ombreggiatura [shader changes]: {14}\n"
+"Nodi orfani [orphaned nodes]: {15}\n"
+"Latenza audio: {16} ms\n"
+"Thread totali: {17}\n"
+"Tempo totale CPU:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1955,7 +2000,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Catena alimentare"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0} -> energia: {1} (idoneità: {2}) energia totale disponibile: {3} (idoneità totale: {4})"
 
@@ -2058,7 +2103,7 @@ msgstr "Generazioni"
 msgid "GENERATION_COLON"
 msgstr "Generazione:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Esci dal gioco"
@@ -2067,11 +2112,11 @@ msgstr "Esci dal gioco"
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Avvertimento Modalità GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Stai eseguendo Thrive con GLES2. Ciò non è collaudato a dovere, ed è probabile che causi problemi. Prova ad aggiornare i tuoi driver video e/o a forzare la grafica AMD o Nvidia a eseguire Thrive."
 
@@ -2359,7 +2404,7 @@ msgstr "Ferro"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Chemiolitoautotrofia del ferro"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Esci dal gioco"
@@ -2578,7 +2623,7 @@ msgstr "Questa traduzione è ancora in corso ({0}% fatto)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Questa traduzione è molto incompleta ({0}% fatto). Perfavore, aiutaci!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "Impossibile eliminare l'ultimo organulo"
 
@@ -2737,7 +2782,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Clic sinistro"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licenze"
 
@@ -2868,7 +2913,8 @@ msgstr "Carica"
 msgid "LOADING"
 msgstr "Caricamento"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Caricamento..."
 
@@ -2898,12 +2944,12 @@ msgstr "Nell'editor, premi il tasto \"Annulla l'ultima azione\" per correggere e
 msgid "LOAD_FINISHED"
 msgstr "Caricamento completato"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Carica partita"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Carica partite salvate precedentemente"
 
@@ -3179,7 +3225,7 @@ msgstr "Ogni generazione possiedi 100 punti mutazione (PM) da spendere, e ogni m
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Ogni volta che ti riproduci farai ingresso nell'Editor Microbico, dove potrai fare modifiche alla tua specie (aggiungere, spostare o rimuovere organuli) per aumentarne il successo. Ogni visita all'editor nella Fase Microbica rappresenta [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milioni di anni di evoluzione."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor Microbico Libero"
 
@@ -3428,11 +3474,11 @@ msgstr "Modifica organulo"
 msgid "MODIFY_TYPE"
 msgstr "Modifica tipo"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mod"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3518,11 +3564,11 @@ msgstr "Nome interno (della cartella):"
 msgid "MOD_LICENSE"
 msgstr "Licenza:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Errori di caricamento mod"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Si sono verificati degli errori nel caricamento di una o più mod. I log potrebbero contenere informazioni ulteriori."
 
@@ -3765,15 +3811,19 @@ msgstr ""
 "Questo salvataggio viene da una versione più recente di Thrive. Probabilmente è incompatibile.\n"
 "Vuoi provare a caricarlo lo stesso?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Popolazione iniziale delle specie aumenta-biodiversità"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Nuova partita"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Avvia una nuova partita"
 
@@ -3873,7 +3923,7 @@ msgid "NO_AI"
 msgstr "Disattiva AI"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Nessun dato da mostrare"
 
@@ -3886,7 +3936,7 @@ msgstr "Nessun evento registrato"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Nessuna cartella dei salvataggi trovata"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Disattivato"
@@ -3917,7 +3967,7 @@ msgstr "Nessuna mod selezionata"
 msgid "NUCLEUS"
 msgstr "Nucleo"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 "Impossibile eliminare il nucleo: si tratta di un'evoluzione irreversibile.\n"
@@ -3938,8 +3988,8 @@ msgstr "Bloc Num [Num Lock]"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -3952,16 +4002,16 @@ msgstr "N/A PM"
 msgid "OCTOBER"
 msgstr "Ottobre"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Autodistruzione"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4041,11 +4091,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunista"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opzioni"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Modifica le impostazioni di gioco"
 
@@ -4257,7 +4307,7 @@ msgstr "Procedurale"
 msgid "PATCH_NAME"
 msgstr "{1} {0}o/a"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Metti in pausa il gioco"
@@ -4316,8 +4366,8 @@ msgstr "Prestazioni"
 msgid "PERFORM_UNBINDING"
 msgstr "Slega una"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "al secondo"
 
@@ -4368,7 +4418,7 @@ msgstr "Generazione planetaria in arrivo!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Seme casuale del pianeta"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Cellula del giocatore"
 
@@ -4444,7 +4494,7 @@ msgstr "popolazione:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "popolazione nelle zone:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4498,7 +4548,7 @@ msgstr "precedente:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Elaborazione degli oggetti caricati"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4542,11 +4592,11 @@ msgstr "Caricamento rapido"
 msgid "QUICK_SAVE"
 msgstr "Salvataggio rapido"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Chiudi"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Esci dal gioco"
@@ -4589,7 +4639,7 @@ msgstr "Pronto"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Versione consigliata di Thrive:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Riprendi il gioco"
@@ -4729,7 +4779,7 @@ msgstr ""
 "Sicuro di voler chiudere e andare al menù principale?\n"
 "Perderai tutti i progressi non salvati."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Di Revolutionary Games Studio"
@@ -4817,7 +4867,7 @@ msgstr "La rusticianina è una proteina che usa il [thrive:compound type=\"carbo
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Trasforma il [thrive:compound type=\"iron\"][/thrive:compound] in [thrive:compound type=\"atp\"][/thrive:compound]. Il tasso aumenta con la concentrazione di [thrive:compound type=\"carbondioxide\"][/thrive:compound] e di [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4826,7 +4876,7 @@ msgstr ""
 "I microbi coraggiosi non sono spaventati dai predatori vicini\n"
 "e sono più disposti a contrattaccare."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Rimuovi Dati Locali"
@@ -5193,7 +5243,7 @@ msgstr "Genera ammoniaca"
 msgid "SPAWN_ENEMY"
 msgstr "Genera nemico"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Non puoi usare il trucco genera-nemici, perché questa zona non contiene alcuna specie nemica"
 
@@ -5253,7 +5303,7 @@ msgstr "Nome della specie..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Questo nome è troppo lungo!"
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5368,17 +5418,17 @@ msgstr "Steam è momentaneamente non disponibile, riprova"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Steam: si è verificato un errore sconosciuto"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Inizializzazione della libreria client Steam fallita"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "L'aggiornamento del salvataggio specificato non è riuscito a causa del seguente errore:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Metti in pausa il gioco"
@@ -5419,7 +5469,7 @@ msgstr "Spazio di stoccaggio"
 msgid "STORAGE_COLON"
 msgstr "Spazio di stoccaggio:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Hai effettuato l'accesso come: {0}"
 
@@ -5536,7 +5586,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Squadra Collaudatori"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5551,7 +5601,7 @@ msgstr ""
 "\n"
 "Se il gioco ti è piaciuto, parlane anche ai tuoi amici."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "HAI PROSPERATO!"
@@ -5611,7 +5661,7 @@ msgstr "Questa mod è stata scaricata dal Workshop di Steam"
 msgid "THREADS"
 msgstr "Thread:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5758,7 +5808,7 @@ msgstr "Metti in pausa"
 msgid "TOGGLE_UNBINDING"
 msgstr "Attiva la modalità di slegatura"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Strumenti"
 
@@ -5978,7 +6028,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Vedi ora"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Tempo trascorso: {0:#,#} anni"
@@ -6174,7 +6224,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Visualizzatore"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Vedi codice sorgente"
 
@@ -6186,7 +6236,7 @@ msgstr "Sostenitori VIP"
 msgid "VISIBLE"
 msgstr "Visibile"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6342,7 +6392,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "anni"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Metti in pausa il gioco"

--- a/locale/it.po
+++ b/locale/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-10-17 19:00+0000\n"
 "Last-Translator: Simone Nobili <simonenobili@yandex.com>\n"
 "Language-Team: Italian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/it/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "Editor 3D"
 msgid "3D_MOVEMENT"
 msgstr "Movimento 3D"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "Azione bloccata mentre un'altra è in corso"
 msgid "ACTIVE"
 msgstr "Attivo"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Thread attuali:"
 
@@ -144,7 +144,7 @@ msgstr "Statistiche dell'organismo"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Volume dell'ambiente"
 
@@ -155,11 +155,11 @@ msgstr "Volume dell'ambiente"
 msgid "AMMONIA"
 msgstr "Ammoniaca"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Numero di salvataggi automatici da conservare:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Numero di salvataggi rapidi da conservare:"
 
@@ -184,11 +184,11 @@ msgstr "Applica modifiche"
 msgid "APRIL"
 msgstr "Aprile"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Sicuro di voler ripristinare TUTTE le impostazioni ai valori predefiniti?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Sei sicuro di voler ripristinare i comandi ai valori iniziali?"
 
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Autore: {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Galleria"
 
@@ -216,7 +216,7 @@ msgstr "La classe dell'assembly è richiesta quando l'assembly è specificato"
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "La classe dell'assembly è richiesta quando la modalità Auto Harmony è selezionata"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Supponi che la CPU abbia attivato l'hyperthreading"
 
@@ -258,7 +258,7 @@ msgstr "Il tentativo di scrittura di questo file di salvataggio è fallito. È p
 msgid "AT_CURSOR"
 msgstr "Sotto il cursore:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Dispositivo di output audio:"
 
@@ -266,8 +266,8 @@ msgstr "Dispositivo di output audio:"
 msgid "AUGUST"
 msgstr "Agosto"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Automatica"
 
@@ -294,7 +294,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% fatto. Passo {1:n0}/{2:n0}."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Salvataggio automatico durante il gioco"
 
@@ -302,7 +302,7 @@ msgstr "Salvataggio automatico durante il gioco"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Strumento di esplorazione Auto-Evo"
 
@@ -332,7 +332,7 @@ msgstr "stato d'esecuzione:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Muoviti automaticamente avanti"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Automatica ({0}x{1})"
 
@@ -345,9 +345,9 @@ msgid "AWAKEN"
 msgstr "Risvegliati"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -486,7 +486,7 @@ msgstr "Permette di legarsi ad altre cellule: è il primo passo verso la multice
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Premi [thrive:input]g_toggle_binding[/thrive:input] per attivare la modalità di legatura. In essa, puoi attaccarti ad altre cellule della tua specie per formare una colonia. Per abbandonare la colonia premi [thrive:input]g_unbind_all[/thrive:input]. Non puoi accedere all'editor quando sei legato ad altre cellule."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr "Questa membrana possiede un forte involucro in carbonato di calcio. Resi
 msgid "CAMERA"
 msgstr "Telecamera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -676,7 +676,7 @@ msgstr "Cambia la simmetria"
 msgid "CHEATS"
 msgstr "Trucchi"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Abilita i trucchi"
 
@@ -766,7 +766,7 @@ msgstr "Produce [thrive:compound type=\"glucose\"][/thrive:compound]. Il tasso a
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Esiste già un file con lo stesso nome ({0}). Vuoi sovrascriverlo?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Aberrazione cromatica:"
 
@@ -807,15 +807,15 @@ msgstr "Pulisci i vecchi salvataggi"
 msgid "CLOSE"
 msgstr "Chiudi"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Chiudere le opzioni?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Divisore risoluzione nuvole:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Intervallo minimo simulazione nuvole:"
 
@@ -831,7 +831,7 @@ msgstr "Genera entità con forme di collisione"
 msgid "COLOUR"
 msgstr "Colore"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Correzione colore (per daltonismo):"
 
@@ -892,26 +892,26 @@ msgstr "S: saturation (saturazione): è la quantità di grigio nel colore"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "V: value (valore): è la luminosità/intensità del colore"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Apri l'editor e modifica la tua specie"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "nostra Wiki"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Esci dal gioco"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Composti:"
@@ -938,7 +938,7 @@ msgstr "Composti:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Bilancio dei composti"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Nuvole di composti"
 
@@ -1023,7 +1023,7 @@ msgstr "Continuare ai prototipi?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1037,11 +1037,11 @@ msgstr "Questo pannello mostra i numeri in base ai quali l'Auto-Evo fa la sua pr
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1049,11 +1049,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Copia Errore negli Appunti"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanopica (Rosso-Verde)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanopica (Blu-Giallo)"
 
@@ -1109,7 +1109,7 @@ msgstr "Creazione..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Creazione oggetti da salvataggio"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Ringraziamenti"
 
@@ -1135,7 +1135,7 @@ msgstr "Sviluppatori attuali"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Statistiche dell'organismo"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Nome utente personalizzato:"
 
@@ -1204,7 +1204,7 @@ msgstr "Pannello di debug"
 msgid "DECEMBER"
 msgstr "Dicembre"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Dispositivo di output audio di default"
 
@@ -1266,7 +1266,7 @@ msgstr "La descrizione è troppo lunga"
 msgid "DESPAWN_ENTITIES"
 msgstr "Elimina ogni entità"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Numero di CPU rilevate:"
 
@@ -1279,12 +1279,12 @@ msgstr "Sostenitori Devbuilds"
 msgid "DEVELOPERS"
 msgstr "Sviluppatori"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Sviluppo sostenuto da Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Apri l'editor e modifica la tua specie"
@@ -1293,12 +1293,12 @@ msgstr "Apri l'editor e modifica la tua specie"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Sviluppo sostenuto da Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Sviluppatori"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Come giocare"
@@ -1372,7 +1372,7 @@ msgstr "Sinistra (tasto direzionale)"
 msgid "DIRECTIONR"
 msgstr "Destra (tasto direzionale)"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Disattivato"
 
@@ -1380,7 +1380,7 @@ msgstr "Disattivato"
 msgid "DISABLE_ALL"
 msgstr "Disattiva tutte"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Continua senza salvare"
 
@@ -1418,17 +1418,17 @@ msgstr ""
 "Ci sono organuli non connessi al resto della cellula.\n"
 "Connetti tutti gli organuli alla cellula o annulla i cambiamenti effettuati."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Tempo trascorso: {0:#,#} anni"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Velocità di digestione:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
@@ -1436,19 +1436,19 @@ msgstr ""
 "e potrebbero essere più ambiziosi per questi ultimi.\n"
 "I microbi reattivi cambiano più facilmente bersaglio."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Mostra la barra delle abilità"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Mostra particelle di sfondo"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Mostra i nomi dei pulsanti di selezione delle parti"
 
@@ -1483,7 +1483,7 @@ msgstr "Fai doppio click per visualizzare a schermo pieno"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Una membrana a due strati. Offre una migliore protezione ai danni e richiede meno energia per non deformarsi. Tuttavia, rallenta un po' la cellula e la sua capacità di assorbire i nutrienti."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1637,7 +1637,7 @@ msgstr ""
 "\n"
 "Quando ti ritieni pronto, premi il pulsante \"AVANTI\" in basso a destra per continuare."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1653,7 +1653,7 @@ msgstr "Attiva tutte le mod compatibili"
 msgid "ENABLE_EDITOR"
 msgstr "Editor istantaneo"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Abilita gli effetti di luce della GUI"
 
@@ -1710,7 +1710,7 @@ msgstr "Mostra/nascondi l'ambiente"
 msgid "EPIPELAGIC"
 msgstr "Epipelagico"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Errore"
 
@@ -1722,16 +1722,16 @@ msgstr "Errore nella creazione della cartella per la mod"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Si è verificato un errore nella creazione del file di info"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Errore: è stato impossibile salvare nuove impostazioni su file di configurazione."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(segreti che possono apparire casualmente nel gioco)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Si è verificato un errore nella creazione del file di info"
@@ -1765,12 +1765,12 @@ msgstr "Albero evolutivo"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Albero evolutivo"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Versione:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Carica automaticamente patch Harmony dall'Assembly (non richiede di specificare la classe della mod)"
@@ -1787,7 +1787,7 @@ msgstr "Si è verificata un'eccezione nel caricamento dei dati di salvataggio"
 msgid "EXIT"
 msgstr "Esci"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Launch E"
@@ -1840,7 +1840,7 @@ msgstr "estinto nella zona"
 msgid "EXTINCT_SPECIES"
 msgstr "Specie estinte"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extra"
 
@@ -1848,7 +1848,7 @@ msgstr "Extra"
 msgid "EXTRA_OPTIONS"
 msgstr "Opzioni Extra"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Metti in pausa il gioco"
@@ -1883,12 +1883,12 @@ msgstr "Abilita i trucchi"
 msgid "FEBRUARY"
 msgstr "Febbraio"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Inizializzazione della libreria client Steam fallita"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1910,11 +1910,11 @@ msgstr ""
 "Tempo totale CPU:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2045,7 +2045,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr "Sessile"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2075,7 +2075,7 @@ msgstr "Nuvola bonus di glucosio all'uscita dall'editor"
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(comincia ogni generazione vicino a una nuvola di glucosio)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Schermo intero"
 
@@ -2103,24 +2103,24 @@ msgstr "Generazioni"
 msgid "GENERATION_COLON"
 msgstr "Generazione:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Esci dal gioco"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Avvertimento Modalità GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Stai eseguendo Thrive con GLES2. Ciò non è collaudato a dovere, ed è probabile che causi problemi. Prova ad aggiornare i tuoi driver video e/o a forzare la grafica AMD o Nvidia a eseguire Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr "GLES3"
 
@@ -2173,11 +2173,11 @@ msgstr "Ho capito"
 msgid "GPL_LICENSE_HEADING"
 msgstr "Di seguito il testo della licenza GPL:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "GPU:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafica"
 
@@ -2185,7 +2185,7 @@ msgstr "Grafica"
 msgid "GRAPHICS_TEAM"
 msgstr "Squadra Grafici"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "GUI"
 
@@ -2202,7 +2202,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0}mila"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Volume della GUI"
 
@@ -2224,11 +2224,11 @@ msgstr "Aiuto"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Come giocare"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(valori più elevati migliorano le prestazioni)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(valori più elevati compromettono le prestazioni)"
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Home"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Versione:"
@@ -2327,7 +2327,7 @@ msgstr "Materia ingerita"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Tempo trascorso: {0:#,#} anni"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Controlli"
 
@@ -2380,8 +2380,8 @@ msgstr "Formato URL non valido"
 msgid "INVALID_URL_SCHEME"
 msgstr "Schema URL non valido"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2404,7 +2404,7 @@ msgstr "Ferro"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Chemiolitoautotrofia del ferro"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Esci dal gioco"
@@ -2413,19 +2413,19 @@ msgstr "Esci dal gioco"
 msgid "JANUARY"
 msgstr "Gennaio"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "Modalità di debug JSON:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Sempre"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automaticamente"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Mai"
 
@@ -2607,19 +2607,19 @@ msgstr ". (tastierino numerico)"
 msgid "KPSUBTRACT"
 msgstr "- (tastierino numerico)"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Lingua:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Percentuale di completamento di questa traduzione: {0}%"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Questa traduzione è ancora in corso ({0}% fatto)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Questa traduzione è molto incompleta ({0}% fatto). Perfavore, aiutaci!"
 
@@ -2782,7 +2782,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Clic sinistro"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licenze"
 
@@ -2851,7 +2851,7 @@ msgstr "Notte"
 msgid "LIGHT_MAX"
 msgstr "Luce"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Estremo"
 
@@ -2865,31 +2865,31 @@ msgstr "Normale"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(velocità di mutazione delle specie controllate dall'intelligenza artificiale)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Enorme"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Alto"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Normale"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Basso"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Minuscolo"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Ingente"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Esiguo"
 
@@ -2913,7 +2913,7 @@ msgstr "Carica"
 msgid "LOADING"
 msgstr "Caricamento"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Caricamento..."
@@ -2944,12 +2944,12 @@ msgstr "Nell'editor, premi il tasto \"Annulla l'ultima azione\" per correggere e
 msgid "LOAD_FINISHED"
 msgstr "Caricamento completato"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Carica partita"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Carica partite salvate precedentemente"
 
@@ -3023,7 +3023,7 @@ msgstr "Marzo"
 msgid "MARINE_SNOW"
 msgstr "Neve marina"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Volume principale"
 
@@ -3031,15 +3031,15 @@ msgstr "Volume principale"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Numero massimo di specie per zona prima che vengano effettuate estinzioni forzate"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "FPS massimi:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Illimitati"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Numero massimo di entità:"
 
@@ -3225,7 +3225,7 @@ msgstr "Ogni generazione possiedi 100 punti mutazione (PM) da spendere, e ogni m
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Ogni volta che ti riproduci farai ingresso nell'Editor Microbico, dove potrai fare modifiche alla tua specie (aggiungere, spostare o rimuovere organuli) per aumentarne il successo. Ogni visita all'editor nella Fase Microbica rappresenta [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milioni di anni di evoluzione."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor Microbico Libero"
 
@@ -3409,7 +3409,7 @@ msgstr "Minima:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Impossibile mostrare meno di {0} set di dati!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Altro"
 
@@ -3474,11 +3474,11 @@ msgstr "Modifica organulo"
 msgid "MODIFY_TYPE"
 msgstr "Modifica tipo"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mod"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3564,11 +3564,11 @@ msgstr "Nome interno (della cartella):"
 msgid "MOD_LICENSE"
 msgstr "Licenza:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Errori di caricamento mod"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Si sono verificati degli errori nel caricamento di una o più mod. I log potrebbero contenere informazioni ulteriori."
 
@@ -3621,11 +3621,11 @@ msgstr "Versione:"
 msgid "MORE_INFO"
 msgstr "Mostra più info"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3749,7 +3749,7 @@ msgstr "Metasfere multiple"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Organuli multipli"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Anti-aliasing multicampionamento [MSAA]:"
 
@@ -3761,7 +3761,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Musica"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Volume della musica"
 
@@ -3781,9 +3781,9 @@ msgstr "(costo di organuli, membrane e altri oggetti nell'editor)"
 msgid "MUTATION_POINTS"
 msgstr "Punti Mutazione"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Muto"
 
@@ -3819,11 +3819,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Popolazione iniziale delle specie aumenta-biodiversità"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Nuova partita"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Avvia una nuova partita"
 
@@ -3888,7 +3888,7 @@ msgstr "Il plastidio azotofissante è una proteina che converte l'[thrive:compou
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Trasforma l'[thrive:compound type=\"atp\"][/thrive:compound] in [thrive:compound type=\"ammonia\"][/thrive:compound]. Il tasso aumenta con la concentrazione di [thrive:compound type=\"nitrogen\"][/thrive:compound] e di [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Nessuna"
 
@@ -3936,7 +3936,7 @@ msgstr "Nessun evento registrato"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Nessuna cartella dei salvataggi trovata"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Disattivato"
@@ -3954,7 +3954,7 @@ msgstr "Nessun Salvataggio Trovato"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Nessuna cartella dei salvataggi trovata"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Cartella degli screenshot non trovata"
 
@@ -4002,16 +4002,16 @@ msgstr "N/A PM"
 msgid "OCTOBER"
 msgstr "Ottobre"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Autodistruzione"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4048,7 +4048,7 @@ msgstr "Apri la finestra di aiuto"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Modifica Libera"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Apri la cartella dei log"
 
@@ -4064,7 +4064,7 @@ msgstr "Apri il menù dell'organulo"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Apri la cartella dei salvataggi"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Apri la cartella degli screenshot"
 
@@ -4072,7 +4072,7 @@ msgstr "Apri la cartella degli screenshot"
 msgid "OPEN_THE_MENU"
 msgstr "Apri il menù"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Aiutaci a tradurre il gioco"
 
@@ -4091,11 +4091,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunista"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opzioni"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Modifica le impostazioni di gioco"
 
@@ -4307,7 +4307,7 @@ msgstr "Procedurale"
 msgid "PATCH_NAME"
 msgstr "{1} {0}o/a"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Metti in pausa il gioco"
@@ -4358,7 +4358,7 @@ msgstr "Pacifico"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Prestazioni"
 
@@ -4442,7 +4442,7 @@ msgstr "Duplica giocatore"
 msgid "PLAYER_EXTINCT"
 msgstr "Il giocatore si è estinto"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Il giocatore si è estinto"
@@ -4457,23 +4457,23 @@ msgstr ""
 "Velocità\n"
 "giocatore"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Riproduci video introduttivo"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Riproduci filmato iniziale microbico in nuove partite"
 
@@ -4592,11 +4592,11 @@ msgstr "Caricamento rapido"
 msgid "QUICK_SAVE"
 msgstr "Salvataggio rapido"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Chiudi"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Esci dal gioco"
@@ -4639,7 +4639,7 @@ msgstr "Pronto"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Versione consigliata di Thrive:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Riprendi il gioco"
@@ -4694,7 +4694,7 @@ msgstr "Riproduzione:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Richiede nucleo"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Ripristina"
 
@@ -4703,24 +4703,24 @@ msgstr "Ripristina"
 msgid "RESET_DEADZONES"
 msgstr "Ripristinare le impostazioni predefinite?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Ripristinare i comandi?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Ripristina i comandi"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Predefinite"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Ripristinare le impostazioni predefinite?"
 
@@ -4729,7 +4729,7 @@ msgstr "Ripristinare le impostazioni predefinite?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr "Resistente alla fagocitosi di base"
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Risoluzione:"
 
@@ -4779,7 +4779,7 @@ msgstr ""
 "Sicuro di voler chiudere e andare al menù principale?\n"
 "Perderai tutti i progressi non salvati."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Di Revolutionary Games Studio"
@@ -4812,7 +4812,7 @@ msgstr "Ruota a destra"
 msgid "ROTATION_COLON"
 msgstr "Rotazione:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Esegui Auto-Evo in gioco"
 
@@ -4867,7 +4867,7 @@ msgstr "La rusticianina è una proteina che usa il [thrive:compound type=\"carbo
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Trasforma il [thrive:compound type=\"iron\"][/thrive:compound] in [thrive:compound type=\"atp\"][/thrive:compound]. Il tasso aumenta con la concentrazione di [thrive:compound type=\"carbondioxide\"][/thrive:compound] e di [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4876,16 +4876,16 @@ msgstr ""
 "I microbi coraggiosi non sono spaventati dai predatori vicini\n"
 "e sono più disposti a contrattaccare."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Rimuovi Dati Locali"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Salva"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Salva e continua"
 
@@ -4983,21 +4983,21 @@ msgstr "Impossibile salvare, al momento, per questo motivo:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Salvataggio riuscito"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr "Agente di Segnalazione"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "per aumentare la"
@@ -5095,7 +5095,7 @@ msgstr "Sessile"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Se modifichi questo valore, l'effetto si applica solo alle nuove partite"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Volume degli effetti sonori"
 
@@ -5111,21 +5111,25 @@ msgstr "Mostra la finestra di aiuto"
 msgid "SHOW_TUTORIALS"
 msgstr "Mostra i tutorial"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Mostra i tutorial (nella partita attuale)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Mostra i tutorial (in nuove partite)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Mostra avvertimeto relativo ai progressi non salvati"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Abilita/disabilita la finestra di avvertimento sui progressi non salvati quando il giocatore tenta di chiudere il gioco."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5173,7 +5177,7 @@ msgstr "Silice"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Questa membrana ha una forte parete di silice. Resiste al danno molto bene, in particolare a quello fisico. Inoltre, consuma meno energia per mantenere la forma. Tuttavia, rallenta di molto la cellula e il tasso con cui assorbe le risorse."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5215,7 +5219,7 @@ msgstr "Aumentano la velocità di viraggio. Utili per cellule molto grandi."
 msgid "SMALL_IRON_CHUNK"
 msgstr "Frammento di ferro piccolo"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Suono"
 
@@ -5418,17 +5422,17 @@ msgstr "Steam è momentaneamente non disponibile, riprova"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Steam: si è verificato un errore sconosciuto"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Inizializzazione della libreria client Steam fallita"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "L'aggiornamento del salvataggio specificato non è riuscito a causa del seguente errore:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Metti in pausa il gioco"
@@ -5469,7 +5473,7 @@ msgstr "Spazio di stoccaggio"
 msgid "STORAGE_COLON"
 msgstr "Spazio di stoccaggio:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Hai effettuato l'accesso come: {0}"
 
@@ -5586,7 +5590,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Squadra Collaudatori"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5601,7 +5605,7 @@ msgstr ""
 "\n"
 "Se il gioco ti è piaciuto, parlane anche ai tuoi amici."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "HAI PROSPERATO!"
@@ -5657,11 +5661,11 @@ msgstr "Questa mod è stata installata localmente"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Questa mod è stata scaricata dal Workshop di Steam"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Thread:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5808,7 +5812,7 @@ msgstr "Metti in pausa"
 msgid "TOGGLE_UNBINDING"
 msgstr "Attiva la modalità di slegatura"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Strumenti"
 
@@ -5873,7 +5877,7 @@ msgstr "Prova a scattare qualche screenshot!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Prova a creare un salvataggio!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Prova a scattare qualche screenshot!"
 
@@ -6028,12 +6032,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Vedi ora"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Tempo trascorso: {0:#,#} anni"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6058,7 +6062,7 @@ msgstr "Slega tutte"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Modalità di slegatura"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6081,7 +6085,7 @@ msgstr "Annulla l'ultima azione"
 msgid "UNKNOWN"
 msgstr "Tasto sconosciuto"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Sconosciuto"
 
@@ -6093,7 +6097,7 @@ msgstr "Tasto sconosciuto del mouse"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Sconosciuto su Windows"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Versione:"
@@ -6102,7 +6106,7 @@ msgstr "Versione:"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Workshop ID sconosciuto per questa mod"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Hai modifiche non salvate. Saranno eliminate.\n"
@@ -6146,7 +6150,7 @@ msgstr "Caricamento riuscito"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Licenze e librerie usate"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "Renderer utilizzato:"
 
@@ -6162,7 +6166,7 @@ msgstr "Usa modalità Auto Harmony"
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Carica automaticamente patch Harmony dall'Assembly (non richiede di specificare la classe della mod)"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Utilizza un nome utente personalizzato"
 
@@ -6171,11 +6175,11 @@ msgstr "Utilizza un nome utente personalizzato"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "Usa separazione forzata biodiversità"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Imposta manualmente il numero di thread in background"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6201,7 +6205,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Versione:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Versione:"
@@ -6212,11 +6216,11 @@ msgstr "Versione:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Nuovo nome:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "Memoria video utilizzata al momento:"
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0} MiB"
 
@@ -6224,7 +6228,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Visualizzatore"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Vedi codice sorgente"
 
@@ -6236,7 +6240,7 @@ msgstr "Sostenitori VIP"
 msgid "VISIBLE"
 msgstr "Visibile"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6256,7 +6260,7 @@ msgstr "Volume muto (tasto audio)"
 msgid "VOLUMEUP"
 msgstr "Alza volume (tasto audio)"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSync"
 
@@ -6363,7 +6367,7 @@ msgstr "Statistiche dell'organismo"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "per aumentare la"
@@ -6372,15 +6376,15 @@ msgstr "per aumentare la"
 msgid "WORST_PATCH_COLON"
 msgstr "Peggior zona:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6392,7 +6396,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "anni"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Metti in pausa il gioco"

--- a/locale/ka.po
+++ b/locale/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-03-14 21:22+0000\n"
 "Last-Translator: Lazare Chikhradze <lazaresali@gmail.com>\n"
 "Language-Team: Georgian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ka/>\n"
@@ -197,7 +197,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -333,8 +333,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -589,27 +589,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -868,19 +868,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1233,11 +1233,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1245,11 +1245,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1594,15 +1594,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1655,6 +1655,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1703,7 +1711,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1753,7 +1761,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1761,7 +1769,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1787,6 +1795,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1868,7 +1892,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1964,7 +1988,7 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1972,11 +1996,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2252,7 +2276,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2468,7 +2492,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2626,7 +2650,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2754,7 +2778,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2784,12 +2809,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2993,7 +3018,7 @@ msgstr "ყოველი გენერაცია, შენ გექნ�
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3192,11 +3217,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3282,11 +3307,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3510,15 +3535,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3618,7 +3647,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3630,7 +3659,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3660,7 +3689,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3679,8 +3708,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3693,15 +3722,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3772,11 +3801,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3981,7 +4010,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4039,8 +4068,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4090,7 +4119,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4163,7 +4192,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4217,7 +4246,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4261,11 +4290,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4305,7 +4334,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4439,7 +4468,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4525,11 +4554,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4885,7 +4914,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4935,7 +4964,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5050,15 +5079,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5098,7 +5127,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5213,7 +5242,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5221,7 +5250,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5280,7 +5309,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5427,7 +5456,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5570,7 +5599,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5754,7 +5783,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5766,7 +5795,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5919,7 +5948,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/ka.po
+++ b/locale/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-03-14 21:22+0000\n"
 "Last-Translator: Lazare Chikhradze <lazaresali@gmail.com>\n"
 "Language-Team: Georgian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ka/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.10.1\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -32,7 +32,7 @@ msgstr "ყოველი გენერაცია, შენ გექნ�
 msgid "3D_MOVEMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -63,7 +63,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -137,7 +137,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -177,11 +177,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -197,7 +197,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -209,7 +209,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -249,7 +249,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -257,8 +257,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -283,7 +283,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -320,7 +320,7 @@ msgstr ""
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -333,9 +333,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -471,7 +471,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -533,7 +533,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -661,7 +661,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -792,15 +792,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -816,7 +816,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -868,23 +868,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr ""
 
@@ -910,7 +910,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -989,7 +989,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1002,11 +1002,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1014,11 +1014,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1098,7 +1098,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1233,11 +1233,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1245,11 +1245,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1361,31 +1361,31 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1639,7 +1639,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1651,15 +1651,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1691,11 +1691,11 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1711,7 +1711,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1761,7 +1761,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1769,7 +1769,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1797,19 +1797,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1960,7 +1960,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -1988,23 +1988,23 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2069,7 +2069,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2081,7 +2081,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2103,11 +2103,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2131,7 +2131,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2256,8 +2256,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2276,7 +2276,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2284,19 +2284,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2476,19 +2476,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2650,7 +2650,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2718,7 +2718,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2730,31 +2730,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2778,7 +2778,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2809,12 +2809,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2879,7 +2879,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2887,15 +2887,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3018,7 +3018,7 @@ msgstr "ყოველი გენერაცია, შენ გექნ�
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3154,7 +3154,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3217,11 +3217,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3307,11 +3307,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3364,11 +3364,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3477,7 +3477,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3509,9 +3509,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3543,11 +3543,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3612,7 +3612,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3659,7 +3659,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3676,7 +3676,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3722,15 +3722,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3761,7 +3761,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3777,7 +3777,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3785,7 +3785,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3801,11 +3801,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4010,7 +4010,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4060,7 +4060,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4155,23 +4155,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4290,11 +4290,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4334,7 +4334,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4395,23 +4395,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4420,7 +4420,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4468,7 +4468,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4500,7 +4500,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4554,19 +4554,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4658,20 +4658,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4784,20 +4784,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4846,7 +4850,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4886,7 +4890,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5079,15 +5083,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5127,7 +5131,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5242,7 +5246,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5250,7 +5254,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5305,11 +5309,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5456,7 +5460,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5518,7 +5522,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5599,11 +5603,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5628,7 +5632,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5648,7 +5652,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5660,7 +5664,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5668,7 +5672,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5708,7 +5712,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5724,7 +5728,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5732,11 +5736,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5762,7 +5766,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr ""
 
@@ -5771,11 +5775,11 @@ msgstr ""
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5783,7 +5787,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5795,7 +5799,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5815,7 +5819,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5920,7 +5924,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5928,15 +5932,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -5948,7 +5952,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-03-22 16:25+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Korean <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ko/>\n"
@@ -204,7 +204,7 @@ msgstr "번영했습니다!"
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -301,7 +301,7 @@ msgstr "진행 중 자동 저장"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "실행 상태:"
@@ -346,8 +346,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -618,27 +618,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr "이산화탄소"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -925,20 +925,20 @@ msgstr "새로운 키 배치 추가"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -1154,7 +1154,7 @@ msgstr "검색..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "저장된 객체 생성 중"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "크레딧"
 
@@ -1327,11 +1327,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -1340,11 +1340,11 @@ msgstr "새로운 키 배치 추가"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -1473,7 +1473,7 @@ msgstr ""
 "연결되지 않은 세포 기관이 배치되어 있습니다.\n"
 "배치된 모든 세포 기관을 서로 연결하거나 변경을 취소하세요."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -1488,7 +1488,7 @@ msgstr "속도:"
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "다음으로 인하여 개체 수가 {0} 에서 {1} 로 변화됨: {2}"
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1538,7 +1538,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "두 개의 층이있는 막으로써 피해로부터 더 잘 보호되고 무너지지 않는데 더 적은 에너지를 사용합니다. 그러나 세포의 속도와 자원 흡수 또한 더욱 느려집니다 ."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1727,15 +1727,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1792,6 +1792,16 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "오류: 새로운 설정을 설정 파일에 저장하는 데 실패하였습니다."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(게임 안에서 무작위로 생성되는 비밀)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "저장 오류"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "불러오기 오류"
@@ -1845,7 +1855,7 @@ msgstr "저장된 데이터를 불러오는 중 예기치 못한 일이 발생�
 msgid "EXIT"
 msgstr "종료"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1898,7 +1908,7 @@ msgstr "지역에서 멸종"
 msgid "EXTINCT_SPECIES"
 msgstr "멸종"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "추가요소"
 
@@ -1906,7 +1916,7 @@ msgstr "추가요소"
 msgid "EXTRA_OPTIONS"
 msgstr "추가 설정"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -1937,6 +1947,22 @@ msgstr "치트 키 활성화"
 #, fuzzy
 msgid "FEBRUARY"
 msgstr "어귀"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -2018,7 +2044,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "먹이 사슬"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -2120,7 +2146,7 @@ msgstr "세대"
 msgid "GENERATION_COLON"
 msgstr "세대:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -2129,11 +2155,11 @@ msgstr "새로운 키 배치 추가"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 모드 경고"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "GLES2를 사용하여 실행중입니다. 이는 실험되지 않았으며 이로 인해 문제가 발생할 수 있습니다. 비디오 카드 드라이버를 업데이트 하거나 AMD 혹은 Nvidia 그래픽을 사용하여 Thrive를 실행해주시기 바랍니다."
 
@@ -2422,7 +2448,7 @@ msgstr "철"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "철 화학합성독립영양"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -2649,7 +2675,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2809,7 +2835,7 @@ msgstr "마우스 왼쪽 버튼"
 msgid "LEFT_MOUSE"
 msgstr "마우스 왼쪽 버튼"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2945,7 +2971,8 @@ msgstr "불러오기"
 msgid "LOADING"
 msgstr "불러오는 중"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "불러오는 중..."
@@ -2978,12 +3005,12 @@ msgstr "편집기에서 취소 버튼을 눌러 실수를 정정 할 수 있습�
 msgid "LOAD_FINISHED"
 msgstr "불러오기 완료"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "불러오기"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -3252,7 +3279,7 @@ msgstr "각 세대마다, 100 변이 점수(MP)를 사용할 수 있으며, 각�
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "당신이 번식할 때마다, 미생물 편집기에 입장하며, 당신의 종을 변화하여(세포 기관의 추가, 이동, 제거를 통해) 성공적인 종의 종속을 이어갈 수 있습니다. 미생물 단계에서의 편집기 입장은 수백만년 분의 진화에 해당 됩니다."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "미생물 자유 편집기"
 
@@ -3497,11 +3524,11 @@ msgstr "세포 기관 제거"
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3592,11 +3619,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3833,15 +3860,19 @@ msgstr ""
 "이 저장은 이후 버전 Thrive의 것이며 호환되지 않을 수도 있습니다.\n"
 "그래도 불러오시겠습니까?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "생물 다양성을 증진하는 종의 최초 개체수"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "새 게임"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -3950,7 +3981,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3963,7 +3994,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "저장 폴더 열기"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "치트 키 활성화"
@@ -3998,7 +4029,7 @@ msgstr "선택됨:"
 msgid "NUCLEUS"
 msgstr "핵"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -4020,8 +4051,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 #, fuzzy
 msgid "N_A"
@@ -4035,16 +4066,16 @@ msgstr "N/A 변이 점수"
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4122,11 +4153,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "설정"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -4345,7 +4376,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "동굴"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -4407,8 +4438,8 @@ msgstr "성능"
 msgid "PERFORM_UNBINDING"
 msgstr "결합 해제 수행하기"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/초"
 
@@ -4459,7 +4490,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "플레이어 세포"
 
@@ -4536,7 +4567,7 @@ msgstr "개체수:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "지역 내 개체수:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 #, fuzzy
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "개체수:"
@@ -4594,7 +4625,7 @@ msgstr "이전:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "불러온 객체 처리 중"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4638,11 +4669,11 @@ msgstr "빠른 불러오기"
 msgid "QUICK_SAVE"
 msgstr "빠른 저장"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "종료"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4686,7 +4717,7 @@ msgstr "준비"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "재개"
@@ -4833,7 +4864,7 @@ msgstr ""
 "정말 주 메뉴로 나가시겠어요?\n"
 "저장되지 않은 진행 상황을 모두 잃게 됩니다."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -4924,7 +4955,7 @@ msgstr "루스티시아닌은 가스 상태의 이산화탄소와 산소를 사�
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "루스티시아닌은 가스 상태의 이산화탄소와 산소를 사용하여 산화철을 화학적 상태에서 다른 화학적 상태로 산화시킬 수 있는 단백질입니다. 철 호흡이라고하는 이 과정은 세포가 수확 할 수 있는 에너지를 방출합니다."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "이전의 실행 실패로 인해 Thrive가 안전 모드로 시작되었습니다.\n"
@@ -4936,7 +4967,7 @@ msgstr ""
 "\n"
 "시작 문제를 일으키는 원인을 해결하지 않으면 다시 안전 모드에 들어오기 위해 Thrive를 여러 번 재시작하고 오류를 겪어야 할 수도 있습니다."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr "암모니아 배치"
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -5386,7 +5417,7 @@ msgstr "종 명칭..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "종 명칭..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 #, fuzzy
 msgid "SPECIES_N_TIMES"
 msgstr "존재하는 종"
@@ -5508,17 +5539,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "저장 실패! 예외 발생"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "액포는 세포 내부 공간 저장에 사용되는 내부 막질 소기관입니다. 그들은 여러 개의 소낭, 저장을 위해 세포에서 널리 사용되는 작은 막 구조로 구성되어 합쳐졌습니다. 이 물질은 분자, 효소, 고체 및 기타 물질을 포함하는 데 사용되는 물로 채워져 있습니다. 액포의 모양은 유동적이며 세포마다 다를 수 있습니다."
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "재개"
@@ -5561,7 +5592,7 @@ msgstr "저장소"
 msgid "STORAGE_COLON"
 msgstr "저장소"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5679,7 +5710,7 @@ msgstr "온도."
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5687,7 +5718,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "번영했습니다!"
@@ -5750,7 +5781,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5900,7 +5931,7 @@ msgstr "일시 정지"
 msgid "TOGGLE_UNBINDING"
 msgstr "결합 해제 켜고 끄기"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "도구"
 
@@ -6136,7 +6167,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "튜토리얼"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -6345,7 +6376,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "뷰어"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "소스 코드 보기"
 
@@ -6357,7 +6388,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6521,7 +6552,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "년"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "재개"

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-03-22 16:25+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Korean <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ko/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.11.2\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "3차원 편집기"
 msgid "3D_MOVEMENT"
 msgstr "3차원 이동"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 #, fuzzy
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "저장 및 계속"
@@ -142,7 +142,7 @@ msgstr "생체 상태창"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "배경 음량"
 
@@ -153,11 +153,11 @@ msgstr "배경 음량"
 msgid "AMMONIA"
 msgstr "암모니아"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "저장할 수 있는 자동저장 갯수:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "저장할 수 있는 빠른저장 갯수:"
 
@@ -182,11 +182,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "모든 설정을 기본값으로 초기화하시겠습니까?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "키 입력을 기본값으로 초기화하시겠습니까?"
 
@@ -204,7 +204,7 @@ msgstr "번영했습니다!"
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -216,7 +216,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -257,7 +257,7 @@ msgstr "자동 진화 실행 실패"
 msgid "AT_CURSOR"
 msgstr "커서 위치에서:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -265,8 +265,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "자동"
 
@@ -293,7 +293,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% 완료됨. {1:n0}/{2:n0} 단계."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "진행 중 자동 저장"
 
@@ -301,7 +301,7 @@ msgstr "진행 중 자동 저장"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "실행 상태:"
@@ -332,7 +332,7 @@ msgstr "실행 상태:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "자동 앞으로 이동"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 #, fuzzy
 msgid "AUTO_RESOLUTION"
 msgstr "해상도:"
@@ -346,9 +346,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -498,7 +498,7 @@ msgstr "니트로게나아제는 ATP 형태의 기체 질소와 세포 에너지
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "니트로게나아제는 ATP 형태의 기체 질소와 세포 에너지를 사용하여 세포의 핵심 성장 영양소 인 암모니아를 생성 할 수있는 단백질입니다. 이것은 혐기성 질소 고정이라고하는 과정입니다. 질소 분해 효소가 세포질에 의해 직접 둘러싸이면 주변 유체가 일부 발효를 수행합니다."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr "이 세포막은 탄산 칼슘으로 만든 강한 껍질을 가지고 �
 msgid "CAMERA"
 msgstr "카메라"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -694,7 +694,7 @@ msgstr "연대 변경"
 msgid "CHEATS"
 msgstr "치트"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "치트 키 활성화"
 
@@ -792,7 +792,7 @@ msgstr "엽록체는 감광성 안료가 막낭에 쌓여있는 이중 막 구�
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "선택한 파일명 ({0}) 은 이미 존재합니다. 덮어쓰겠습니까?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "색수차:"
 
@@ -837,15 +837,15 @@ msgstr "이전 저장 정리"
 msgid "CLOSE"
 msgstr "닫기"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "설정을 종료합니까?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "구름 해상도 인자:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 "최소 구름 시뮬레이션\n"
@@ -863,7 +863,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr "색"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "색맹 교정:"
 
@@ -925,25 +925,25 @@ msgstr "새로운 키 배치 추가"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "화합물:"
@@ -972,7 +972,7 @@ msgstr "화합물:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "성분 비율"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "화합물 구름"
 
@@ -1059,7 +1059,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1074,11 +1074,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1086,11 +1086,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "클립보드에 오류 복사"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1154,7 +1154,7 @@ msgstr "검색..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "저장된 객체 생성 중"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "크레딧"
 
@@ -1179,7 +1179,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "생체 상태창"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "임의 사용자 이름:"
 
@@ -1247,7 +1247,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1314,7 +1314,7 @@ msgstr "설명:"
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 #, fuzzy
 msgid "DETECTED_CPU_COUNT"
 msgstr "선택됨:"
@@ -1327,11 +1327,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -1340,11 +1340,11 @@ msgstr "새로운 키 배치 추가"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -1422,7 +1422,7 @@ msgstr "설명:"
 msgid "DIRECTIONR"
 msgstr "설명:"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1430,7 +1430,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "취소 및 계속"
 
@@ -1473,35 +1473,35 @@ msgstr ""
 "연결되지 않은 세포 기관이 배치되어 있습니다.\n"
 "배치된 모든 세포 기관을 서로 연결하거나 변경을 취소하세요."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "속도:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "다음으로 인하여 개체 수가 {0} 에서 {1} 로 변화됨: {2}"
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 #, fuzzy
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "능력"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "능력"
@@ -1538,7 +1538,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "두 개의 층이있는 막으로써 피해로부터 더 잘 보호되고 무너지지 않는데 더 적은 에너지를 사용합니다. 그러나 세포의 속도와 자원 흡수 또한 더욱 느려집니다 ."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1695,7 +1695,7 @@ msgstr ""
 "\n"
 "다음 편집기 탭으로 이동하기 위해, 오른쪽 아래의 다음 버튼을 누르세요."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 #, fuzzy
 msgid "EIGHT_TIMES"
 msgstr "마우스 오른쪽 버튼"
@@ -1714,7 +1714,7 @@ msgstr "선택된 저장은 호환되지 않습니다"
 msgid "ENABLE_EDITOR"
 msgstr "편집기 활성화"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 #, fuzzy
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "외부 효과:"
@@ -1775,7 +1775,7 @@ msgstr "새로운 키 배치 추가"
 msgid "EPIPELAGIC"
 msgstr "표해수층"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "오류"
 
@@ -1788,16 +1788,16 @@ msgstr "저장 오류"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "오류: 새로운 설정을 설정 파일에 저장하는 데 실패하였습니다."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(게임 안에서 무작위로 생성되는 비밀)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "저장 오류"
@@ -1831,12 +1831,12 @@ msgstr "진화 계보"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "세대:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -1855,7 +1855,7 @@ msgstr "저장된 데이터를 불러오는 중 예기치 못한 일이 발생�
 msgid "EXIT"
 msgstr "종료"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr "지역에서 멸종"
 msgid "EXTINCT_SPECIES"
 msgstr "멸종"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "추가요소"
 
@@ -1916,7 +1916,7 @@ msgstr "추가요소"
 msgid "EXTRA_OPTIONS"
 msgstr "추가 설정"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -1948,19 +1948,19 @@ msgstr "치트 키 활성화"
 msgid "FEBRUARY"
 msgstr "어귀"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2086,7 +2086,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "전체화면"
 
@@ -2146,24 +2146,24 @@ msgstr "세대"
 msgid "GENERATION_COLON"
 msgstr "세대:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 모드 경고"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "GLES2를 사용하여 실행중입니다. 이는 실험되지 않았으며 이로 인해 문제가 발생할 수 있습니다. 비디오 카드 드라이버를 업데이트 하거나 AMD 혹은 Nvidia 그래픽을 사용하여 Thrive를 실행해주시기 바랍니다."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2216,12 +2216,12 @@ msgstr "알겠습니다"
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "동굴"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "그래픽"
 
@@ -2230,7 +2230,7 @@ msgstr "그래픽"
 msgid "GRAPHICS_TEAM"
 msgstr "그래픽"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2244,7 +2244,7 @@ msgstr "세포의 핵심. 미토콘드리온(복수형: 미토콘드리아)는 �
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} 천"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "GUI 음량"
 
@@ -2267,11 +2267,11 @@ msgstr "도움말"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(높은 값일수록 더 나은 성능)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(값이 커질수록 성능이 저하됩니다)"
 
@@ -2295,7 +2295,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "세대:"
@@ -2371,7 +2371,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "입력"
 
@@ -2428,8 +2428,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2448,7 +2448,7 @@ msgstr "철"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "철 화학합성독립영양"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -2457,19 +2457,19 @@ msgstr "새로운 키 배치 추가"
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2658,20 +2658,20 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "언어:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 #, fuzzy
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "게임을 번역하는 것을 도와주세요"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2835,7 +2835,7 @@ msgstr "마우스 왼쪽 버튼"
 msgid "LEFT_MOUSE"
 msgstr "마우스 왼쪽 버튼"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2906,7 +2906,7 @@ msgstr "휠 오른쪽으로"
 msgid "LIGHT_MAX"
 msgstr "빛"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "추가요소"
@@ -2920,32 +2920,32 @@ msgstr "확인"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(활성화하면 성장 속도를 제한하며, 비활성화하면 성장 속도가 오직 사용할 수 있는 화합물의 양에 영향을 받음)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "확인"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2971,7 +2971,7 @@ msgstr "불러오기"
 msgid "LOADING"
 msgstr "불러오는 중"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
@@ -3005,12 +3005,12 @@ msgstr "편집기에서 취소 버튼을 눌러 실수를 정정 할 수 있습�
 msgid "LOAD_FINISHED"
 msgstr "불러오기 완료"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "불러오기"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr "바다눈"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "주 음량"
 
@@ -3097,16 +3097,16 @@ msgstr "주 음량"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "강제 멸종이 일어나기 전에 지역에 존재할 수 있는 최대 종 수"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "최대 FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 #, fuzzy
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "최대 FPS:"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3279,7 +3279,7 @@ msgstr "각 세대마다, 100 변이 점수(MP)를 사용할 수 있으며, 각�
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "당신이 번식할 때마다, 미생물 편집기에 입장하며, 당신의 종을 변화하여(세포 기관의 추가, 이동, 제거를 통해) 성공적인 종의 종속을 이어갈 수 있습니다. 미생물 단계에서의 편집기 입장은 수백만년 분의 진화에 해당 됩니다."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "미생물 자유 편집기"
 
@@ -3456,7 +3456,7 @@ msgstr "버전:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "이 저장을 삭제하는 것은 취소할 수 없습니다, 영구적으로 {0} 을 삭제하시겠습니까?"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "기타"
 
@@ -3524,11 +3524,11 @@ msgstr "세포 기관 제거"
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3619,11 +3619,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3681,11 +3681,11 @@ msgstr "버전:"
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3798,7 +3798,7 @@ msgstr "세포 기관 배치"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "세포 기관 배치"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "멀티샘플 안티-앨리어싱:"
 
@@ -3810,7 +3810,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "음악"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "음악 음량"
 
@@ -3830,9 +3830,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr "변이 점수"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "음소거"
 
@@ -3868,11 +3868,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "생물 다양성을 증진하는 종의 최초 개체수"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "새 게임"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -3944,7 +3944,7 @@ msgstr "질소 고정 색소체는 ATP 형태의 기체 질소와 산소 및 세
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "질소 고정 색소체는 ATP 형태의 기체 질소와 산소 및 세포 에너지를 사용하여 세포의 핵심 성장 영양소인 암모니아를 생성 할 수 있는 단백질입니다. 이 과정은 호기성 질소 고정 이라고 불립니다."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "저장 폴더 열기"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "치트 키 활성화"
@@ -4014,7 +4014,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr "저장 폴더 열기"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 #, fuzzy
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "스크린샷 폴더 열기"
@@ -4066,16 +4066,16 @@ msgstr "N/A 변이 점수"
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4113,7 +4113,7 @@ msgstr "도움말 열기"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "자유 구성"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "로그 폴더 열기"
 
@@ -4129,7 +4129,7 @@ msgstr "세포 소기관 메뉴 열기"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "저장 폴더 열기"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "스크린샷 폴더 열기"
 
@@ -4137,7 +4137,7 @@ msgstr "스크린샷 폴더 열기"
 msgid "OPEN_THE_MENU"
 msgstr "메뉴 열기"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "게임을 번역하는 것을 도와주세요"
 
@@ -4153,11 +4153,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "설정"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -4376,7 +4376,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "동굴"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -4430,7 +4430,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "성능"
 
@@ -4516,7 +4516,7 @@ msgstr "플레이어 사망함"
 msgid "PLAYER_EXTINCT"
 msgstr "플레이어 사망함"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "플레이어 사망함"
@@ -4530,23 +4530,23 @@ msgstr "플레이어 복제됨"
 msgid "PLAYER_SPEED"
 msgstr "플레이어 사망함"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "인트로 영상 재생"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "새 게임 시 미생물 인트로 재생"
 
@@ -4669,11 +4669,11 @@ msgstr "빠른 불러오기"
 msgid "QUICK_SAVE"
 msgstr "빠른 저장"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "종료"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4717,7 +4717,7 @@ msgstr "준비"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "재개"
@@ -4777,7 +4777,7 @@ msgstr "생산"
 msgid "REQUIRES_NUCLEUS"
 msgstr "핵"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "초기화"
 
@@ -4786,24 +4786,24 @@ msgstr "초기화"
 msgid "RESET_DEADZONES"
 msgstr "기본값으로 초기화하시겠습니까?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "키 입력을 기본값으로 초기화하시겠습니까?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "키 설정 초기화"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "기본값"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "기본값으로 초기화하시겠습니까?"
 
@@ -4812,7 +4812,7 @@ msgstr "기본값으로 초기화하시겠습니까?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "해상도:"
 
@@ -4864,7 +4864,7 @@ msgstr ""
 "정말 주 메뉴로 나가시겠어요?\n"
 "저장되지 않은 진행 상황을 모두 잃게 됩니다."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "새로운 키 배치 추가"
@@ -4899,7 +4899,7 @@ msgstr "오른쪽으로 회전"
 msgid "ROTATION_COLON"
 msgstr "다음으로 인하여 개체 수가 {0} 에서 {1} 로 변화됨: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "게임 플레이 중 Auto-Evo 자동 진화 실행"
 
@@ -4955,7 +4955,7 @@ msgstr "루스티시아닌은 가스 상태의 이산화탄소와 산소를 사�
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "루스티시아닌은 가스 상태의 이산화탄소와 산소를 사용하여 산화철을 화학적 상태에서 다른 화학적 상태로 산화시킬 수 있는 단백질입니다. 철 호흡이라고하는 이 과정은 세포가 수확 할 수 있는 에너지를 방출합니다."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "이전의 실행 실패로 인해 Thrive가 안전 모드로 시작되었습니다.\n"
@@ -4967,15 +4967,15 @@ msgstr ""
 "\n"
 "시작 문제를 일으키는 원인을 해결하지 않으면 다시 안전 모드에 들어오기 위해 Thrive를 여러 번 재시작하고 오류를 겪어야 할 수도 있습니다."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "저장"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "저장 및 계속"
 
@@ -5077,23 +5077,23 @@ msgstr "저장 실패! 예외 발생"
 msgid "SAVING_SUCCEEDED"
 msgstr "저장 성공"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr ""
 "{0}에서 충돌이 있습니다.\n"
 "{1}에서 입력을 제거하시겠습니까?"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "이동 속도 향상"
@@ -5198,7 +5198,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "효과음 음량"
 
@@ -5215,17 +5215,17 @@ msgstr "도움말 보기"
 msgid "SHOW_TUTORIALS"
 msgstr "튜토리얼 보기"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "튜토리얼 보기(현재 진행중인 게임)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "튜토리얼 보기(새 게임 시작 시)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 #, fuzzy
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
@@ -5238,6 +5238,10 @@ msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr ""
 "저장하지 않은 변경점은 적용되지 않습니다.\n"
 "계속하시겠습니까?"
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5293,7 +5297,7 @@ msgstr "이산화규소"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "이 세포막은 이산화규소로 이루어진 강력한 벽 입니다. 전반적인 손상에 잘 견딜 수 있으며 물리적 손상에 매우 강합니다. 또한 형태를 유지하는 데 더 적은 에너지가 필요합니다. 그러나 이는 세포 속도를 크게 낮추고 자원을 느리게 흡수합니다."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -5335,7 +5339,7 @@ msgstr "끈적끈적한 세포 내부. 세포질은 이온, 단백질 및 세포
 msgid "SMALL_IRON_CHUNK"
 msgstr "작은 철 덩어리"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "소리"
 
@@ -5539,17 +5543,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "저장 실패! 예외 발생"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "액포는 세포 내부 공간 저장에 사용되는 내부 막질 소기관입니다. 그들은 여러 개의 소낭, 저장을 위해 세포에서 널리 사용되는 작은 막 구조로 구성되어 합쳐졌습니다. 이 물질은 분자, 효소, 고체 및 기타 물질을 포함하는 데 사용되는 물로 채워져 있습니다. 액포의 모양은 유동적이며 세포마다 다를 수 있습니다."
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "재개"
@@ -5592,7 +5596,7 @@ msgstr "저장소"
 msgid "STORAGE_COLON"
 msgstr "저장소"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5710,7 +5714,7 @@ msgstr "온도."
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5718,7 +5722,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "번영했습니다!"
@@ -5777,11 +5781,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5931,7 +5935,7 @@ msgstr "일시 정지"
 msgid "TOGGLE_UNBINDING"
 msgstr "결합 해제 켜고 끄기"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "도구"
 
@@ -6000,7 +6004,7 @@ msgstr "스크린샷 촬영"
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 #, fuzzy
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "스크린샷 촬영"
@@ -6167,12 +6171,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "튜토리얼"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -6199,7 +6203,7 @@ msgstr "모두 결합 해제하기"
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6223,7 +6227,7 @@ msgstr "마지막 활동 취소"
 msgid "UNKNOWN"
 msgstr "마우스 미확인 키"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "능력"
@@ -6237,7 +6241,7 @@ msgstr "마우스 미확인 키"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "마우스 미확인 키"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "버전:"
@@ -6247,7 +6251,7 @@ msgstr "버전:"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "마우스 미확인 키"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "저장하지 않은 변경점은 적용되지 않습니다.\n"
@@ -6295,7 +6299,7 @@ msgstr "저장 성공"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6313,7 +6317,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "새로운 키 배치 추가"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "임의 사용자 이름 사용"
 
@@ -6321,11 +6325,11 @@ msgstr "임의 사용자 이름 사용"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "생물 다양성을 증진하는 종의 생성 시 기존 종의 개체수를 빼앗음"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6353,7 +6357,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr "세대:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "세대:"
@@ -6364,11 +6368,11 @@ msgstr "세대:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "속도:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6376,7 +6380,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "뷰어"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "소스 코드 보기"
 
@@ -6388,7 +6392,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6411,7 +6415,7 @@ msgstr "효과음 음량"
 msgid "VOLUMEUP"
 msgstr "효과음 음량"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "수직동기화"
 
@@ -6522,7 +6526,7 @@ msgstr "생체 상태창"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "이동 속도 향상"
@@ -6532,15 +6536,15 @@ msgstr "이동 속도 향상"
 msgid "WORST_PATCH_COLON"
 msgstr "종:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6552,7 +6556,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "년"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "재개"

--- a/locale/la.po
+++ b/locale/la.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2021-01-03 09:13+0000\n"
 "Last-Translator: Azuriem <darkpitthe@hotmail.fr>\n"
 "Language-Team: Latin <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/la/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.3.2\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -32,7 +32,7 @@ msgstr "W,A,S,D et mus computatrum ut mŏvĕor. E ut iacio telum OxyToxy NT si v
 msgid "3D_MOVEMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -63,7 +63,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -137,7 +137,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -177,11 +177,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -197,7 +197,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -209,7 +209,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -249,7 +249,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -257,8 +257,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -283,7 +283,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -320,7 +320,7 @@ msgstr ""
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -333,9 +333,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -471,7 +471,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -533,7 +533,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -661,7 +661,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -792,15 +792,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -816,7 +816,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -868,23 +868,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr ""
 
@@ -910,7 +910,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -989,7 +989,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1002,11 +1002,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1014,11 +1014,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1098,7 +1098,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1233,11 +1233,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1245,11 +1245,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1361,31 +1361,31 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1598,7 +1598,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1655,7 +1655,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1667,15 +1667,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1707,11 +1707,11 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1727,7 +1727,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1777,7 +1777,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1785,7 +1785,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1813,19 +1813,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1946,7 +1946,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1976,7 +1976,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -2004,23 +2004,23 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2073,11 +2073,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2085,7 +2085,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2097,7 +2097,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2119,11 +2119,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2147,7 +2147,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2272,8 +2272,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2300,19 +2300,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2492,19 +2492,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2666,7 +2666,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2734,7 +2734,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2746,31 +2746,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2794,7 +2794,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2825,12 +2825,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2903,15 +2903,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr "W,A,S,D et mus computatrum ut mŏvĕor. E ut iacio telum OxyToxy NT si v
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "W,A,S,D et mus computatrum ut mŏvĕor. E ut iacio telum OxyToxy NT si vos have toxicum vacuole. G ut devorare habilito."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3190,7 +3190,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3253,11 +3253,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3343,11 +3343,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3400,11 +3400,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3513,7 +3513,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3525,7 +3525,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3545,9 +3545,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3579,11 +3579,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3648,7 +3648,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3695,7 +3695,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3712,7 +3712,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3758,15 +3758,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3797,7 +3797,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3813,7 +3813,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3821,7 +3821,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3837,11 +3837,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4046,7 +4046,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4096,7 +4096,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4179,7 +4179,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4191,23 +4191,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4326,11 +4326,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4370,7 +4370,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4423,7 +4423,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4431,23 +4431,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4456,7 +4456,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4504,7 +4504,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4536,7 +4536,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4590,19 +4590,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4694,20 +4694,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4804,7 +4804,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4820,20 +4820,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4882,7 +4886,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4922,7 +4926,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5115,15 +5119,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5163,7 +5167,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5278,7 +5282,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5286,7 +5290,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5341,11 +5345,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5492,7 +5496,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5646,11 +5650,11 @@ msgstr "W,A,S,D et mus computatrum ut mŏvĕor. E ut iacio telum OxyToxy NT si v
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5675,7 +5679,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5695,7 +5699,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5707,7 +5711,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5715,7 +5719,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5755,7 +5759,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5771,7 +5775,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5779,11 +5783,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr ""
 
@@ -5818,11 +5822,11 @@ msgstr ""
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5830,7 +5834,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5842,7 +5846,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5862,7 +5866,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5967,7 +5971,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5975,15 +5979,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -5995,7 +5999,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/la.po
+++ b/locale/la.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2021-01-03 09:13+0000\n"
 "Last-Translator: Azuriem <darkpitthe@hotmail.fr>\n"
 "Language-Team: Latin <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/la/>\n"
@@ -197,7 +197,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -333,8 +333,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -589,27 +589,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -868,19 +868,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1233,11 +1233,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1245,11 +1245,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1610,15 +1610,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1671,6 +1671,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1719,7 +1727,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1769,7 +1777,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1777,7 +1785,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1803,6 +1811,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1884,7 +1908,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1980,7 +2004,7 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1988,11 +2012,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2268,7 +2292,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2484,7 +2508,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2642,7 +2666,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2770,7 +2794,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2800,12 +2825,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3013,7 +3038,7 @@ msgstr "W,A,S,D et mus computatrum ut mŏvĕor. E ut iacio telum OxyToxy NT si v
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "W,A,S,D et mus computatrum ut mŏvĕor. E ut iacio telum OxyToxy NT si vos have toxicum vacuole. G ut devorare habilito."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3228,11 +3253,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3318,11 +3343,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3546,15 +3571,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3654,7 +3683,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3666,7 +3695,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3696,7 +3725,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3715,8 +3744,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3729,15 +3758,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3808,11 +3837,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4017,7 +4046,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4075,8 +4104,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4126,7 +4155,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4199,7 +4228,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4253,7 +4282,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4297,11 +4326,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4341,7 +4370,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4475,7 +4504,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4561,11 +4590,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4921,7 +4950,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4971,7 +5000,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5086,15 +5115,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5134,7 +5163,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5249,7 +5278,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5257,7 +5286,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5316,7 +5345,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5463,7 +5492,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5617,7 +5646,7 @@ msgstr "W,A,S,D et mus computatrum ut mŏvĕor. E ut iacio telum OxyToxy NT si v
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5801,7 +5830,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5813,7 +5842,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5966,7 +5995,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/lb_LU.po
+++ b/locale/lb_LU.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -194,7 +194,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -330,8 +330,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -586,27 +586,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -865,19 +865,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1230,11 +1230,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1242,11 +1242,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1417,7 +1417,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1591,15 +1591,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1652,6 +1652,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1700,7 +1708,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1750,7 +1758,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1758,7 +1766,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1784,6 +1792,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1865,7 +1889,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1961,7 +1985,7 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1969,11 +1993,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2249,7 +2273,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2465,7 +2489,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2623,7 +2647,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2751,7 +2775,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2781,12 +2806,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2986,7 +3011,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3183,11 +3208,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3273,11 +3298,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3501,15 +3526,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3609,7 +3638,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3621,7 +3650,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3651,7 +3680,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3670,8 +3699,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3684,15 +3713,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3763,11 +3792,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3972,7 +4001,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4030,8 +4059,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4081,7 +4110,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4154,7 +4183,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4208,7 +4237,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4252,11 +4281,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4296,7 +4325,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4430,7 +4459,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4516,11 +4545,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4876,7 +4905,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4926,7 +4955,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5041,15 +5070,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5089,7 +5118,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5204,7 +5233,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5212,7 +5241,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5271,7 +5300,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5418,7 +5447,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5561,7 +5590,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5745,7 +5774,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5757,7 +5786,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5910,7 +5939,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/lb_LU.po
+++ b/locale/lb_LU.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -29,7 +29,7 @@ msgstr ""
 msgid "3D_MOVEMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -60,7 +60,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -145,11 +145,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -174,11 +174,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -246,7 +246,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -254,8 +254,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -280,7 +280,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -317,7 +317,7 @@ msgstr ""
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -330,9 +330,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -468,7 +468,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -658,7 +658,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -748,7 +748,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -789,15 +789,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -865,23 +865,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr ""
 
@@ -907,7 +907,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -986,7 +986,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -999,11 +999,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1011,11 +1011,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1095,7 +1095,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1218,7 +1218,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1230,11 +1230,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1242,11 +1242,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1318,7 +1318,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1358,31 +1358,31 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1417,7 +1417,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1648,15 +1648,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1688,11 +1688,11 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1708,7 +1708,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1758,7 +1758,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1766,7 +1766,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1794,19 +1794,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1927,7 +1927,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1957,7 +1957,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -1985,23 +1985,23 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2054,11 +2054,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2066,7 +2066,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2078,7 +2078,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2100,11 +2100,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2128,7 +2128,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr ""
 
@@ -2200,7 +2200,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2253,8 +2253,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2273,7 +2273,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2281,19 +2281,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2473,19 +2473,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2647,7 +2647,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2715,7 +2715,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2727,31 +2727,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2775,7 +2775,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2806,12 +2806,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2884,15 +2884,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3011,7 +3011,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3145,7 +3145,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3208,11 +3208,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3298,11 +3298,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3355,11 +3355,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3468,7 +3468,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3480,7 +3480,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3500,9 +3500,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3534,11 +3534,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3603,7 +3603,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3650,7 +3650,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3667,7 +3667,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3713,15 +3713,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3752,7 +3752,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3776,7 +3776,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3792,11 +3792,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4001,7 +4001,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4134,7 +4134,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4146,23 +4146,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4325,7 +4325,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4378,7 +4378,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4386,23 +4386,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4459,7 +4459,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4491,7 +4491,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4545,19 +4545,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4649,20 +4649,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4775,20 +4775,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4837,7 +4841,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4877,7 +4881,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5070,15 +5074,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5118,7 +5122,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5233,7 +5237,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5241,7 +5245,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5296,11 +5300,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5447,7 +5451,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5509,7 +5513,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5590,11 +5594,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5619,7 +5623,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5639,7 +5643,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5651,7 +5655,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5659,7 +5663,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5699,7 +5703,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5715,7 +5719,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5723,11 +5727,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5753,7 +5757,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr ""
 
@@ -5762,11 +5766,11 @@ msgstr ""
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5774,7 +5778,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5786,7 +5790,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5806,7 +5810,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5911,7 +5915,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5919,15 +5923,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -29,7 +29,7 @@ msgstr ""
 msgid "3D_MOVEMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -60,7 +60,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -145,11 +145,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -174,11 +174,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Meno galerija"
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -246,7 +246,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -254,8 +254,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr "Rugpjūtis"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -280,7 +280,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -318,7 +318,7 @@ msgstr "Dailininkas:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -331,9 +331,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -474,7 +474,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -536,7 +536,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -664,7 +664,7 @@ msgstr "Pakeisti simetriją"
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -754,7 +754,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Failas nurodytu pavadinimu {0} jau yra. Perrašyti?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -795,15 +795,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -819,7 +819,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -874,25 +874,25 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Baigti žaidimą"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Baigti žaidimą"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Pavadinimas:"
@@ -920,7 +920,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -999,7 +999,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1012,11 +1012,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1024,11 +1024,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Nukopijuoti klaidą į iškarpinę"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1084,7 +1084,7 @@ msgstr "Kuriama..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1108,7 +1108,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1174,7 +1174,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr "Gruodis"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1232,7 +1232,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1244,12 +1244,12 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Kūrėjai"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Kūrėjai"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Pakeisti nustatymus"
@@ -1258,12 +1258,12 @@ msgstr "Pakeisti nustatymus"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Kūrėjai"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Pakeisti nustatymus"
@@ -1337,7 +1337,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1345,7 +1345,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1377,33 +1377,33 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Reikšmė, naudojama generuojant pasaulį, kuri turi būti teigiamas sveikas skaičius"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "(pradžios vieta)"
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1438,7 +1438,7 @@ msgstr "Spustelėkite du kartus peržiūrai pilname ekrane"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1585,7 +1585,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1601,7 +1601,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1659,7 +1659,7 @@ msgstr "Pradėti žaidimą tokiais nustatymais"
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1671,16 +1671,16 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(pradžios vieta)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1713,12 +1713,12 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Įkelti anksčiau išsaugotus žaidimus"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Aprašymas:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Baigti žaidimą"
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1786,7 +1786,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Priedai"
 
@@ -1794,7 +1794,7 @@ msgstr "Priedai"
 msgid "EXTRA_OPTIONS"
 msgstr "Papildomi nustatymai"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Baigti žaidimą"
@@ -1823,19 +1823,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1958,7 +1958,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1988,7 +1988,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -2017,24 +2017,24 @@ msgstr "Bendra"
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Baigti žaidimą"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2087,12 +2087,12 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr "GPL licenzijos tekstas nurodo:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "Pavadinimas:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2100,7 +2100,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2112,7 +2112,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2134,11 +2134,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Pavadinimas:"
@@ -2236,7 +2236,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Reikšmė, naudojama generuojant pasaulį, kuri turi būti teigiamas sveikas skaičius"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2289,8 +2289,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2309,7 +2309,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Baigti žaidimą"
@@ -2318,19 +2318,19 @@ msgstr "Baigti žaidimą"
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2510,19 +2510,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2685,7 +2685,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licencijos"
 
@@ -2754,7 +2754,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr "Lengvas"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2768,31 +2768,31 @@ msgstr "(greitis, kuriuo DI rūšys mutuoja)"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(greitis, kuriuo DI rūšys mutuoja)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2816,7 +2816,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Įkeliama..."
@@ -2847,12 +2847,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr "Įkrovimas baigtas"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Įkelti žaidimą"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Įkelti anksčiau išsaugotus žaidimus"
 
@@ -2917,7 +2917,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2925,15 +2925,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3053,7 +3053,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3189,7 +3189,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Įvairūs"
 
@@ -3253,11 +3253,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Modifikacijos"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3343,11 +3343,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Įvyko klaida įkeliant vieną ar daugiau modifikatorių. Žurnalai gali turėti papildomos informacijos."
 
@@ -3400,11 +3400,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3513,7 +3513,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3525,7 +3525,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Muzika"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3545,9 +3545,9 @@ msgstr "(organelių sąnaudos, membranos ir kiti elementai redaktoriuje)"
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3579,11 +3579,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Naujas žaidimas"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Pradėti naują žaidimą"
 
@@ -3648,7 +3648,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3713,7 +3713,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3759,16 +3759,16 @@ msgstr ""
 msgid "OCTOBER"
 msgstr "Spalis"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Įkelti anksčiau išsaugotus žaidimus"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3799,7 +3799,7 @@ msgstr "Atidaryti pagalbos langą"
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3815,7 +3815,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3823,7 +3823,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr "Atidaryti meniu"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3839,11 +3839,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Nustatymai"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Pakeisti nustatymus"
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Baigti žaidimą"
@@ -4102,7 +4102,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4185,7 +4185,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4197,23 +4197,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4332,11 +4332,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Išeiti"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Baigti žaidimą"
@@ -4378,7 +4378,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Reikšmė, naudojama generuojant pasaulį, kuri turi būti teigiamas sveikas skaičius"
@@ -4432,7 +4432,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4440,23 +4440,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4465,7 +4465,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4513,7 +4513,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Įkelti anksčiau išsaugotus žaidimus"
@@ -4546,7 +4546,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4601,20 +4601,20 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "(pradžios vieta)"
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4706,20 +4706,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4816,7 +4816,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4832,20 +4832,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4894,7 +4898,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4935,7 +4939,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5128,17 +5132,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Išsaugojimas nepavyko"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Elemento aprašymas:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Reikšmė, naudojama generuojant pasaulį, kuri turi būti teigiamas sveikas skaičius"
@@ -5179,7 +5183,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Prisijungęs kaip: {0}"
 
@@ -5294,7 +5298,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5302,7 +5306,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5357,11 +5361,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Įrankiai"
 
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5651,12 +5655,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Pakeisti nustatymus"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5681,7 +5685,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5701,7 +5705,7 @@ msgstr "Atšaukti paskutinį veiksmą"
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5713,7 +5717,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5721,7 +5725,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5763,7 +5767,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5779,7 +5783,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5787,11 +5791,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5817,7 +5821,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Pavadinimas:"
@@ -5827,11 +5831,11 @@ msgstr "Pavadinimas:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5840,7 +5844,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Galerijos žiūryklė"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Peržiūrėti išeities kodą"
 
@@ -5852,7 +5856,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr "Matomas"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5872,7 +5876,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5978,7 +5982,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5986,15 +5990,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6006,7 +6010,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Baigti žaidimą"

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -194,7 +194,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Meno galerija"
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -331,8 +331,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -592,27 +592,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -874,20 +874,20 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Baigti žaidimą"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Baigti žaidimą"
@@ -1084,7 +1084,7 @@ msgstr "Kuriama..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1244,12 +1244,12 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Kūrėjai"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Kūrėjai"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Pakeisti nustatymus"
@@ -1258,12 +1258,12 @@ msgstr "Pakeisti nustatymus"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Kūrėjai"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Pakeisti nustatymus"
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Reikšmė, naudojama generuojant pasaulį, kuri turi būti teigiamas sveikas skaičius"
@@ -1391,7 +1391,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "(pradžios vieta)"
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1438,7 +1438,7 @@ msgstr "Spustelėkite du kartus peržiūrai pilname ekrane"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1613,15 +1613,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1675,6 +1675,15 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(pradžios vieta)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1726,7 +1735,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1777,7 +1786,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Priedai"
 
@@ -1785,7 +1794,7 @@ msgstr "Priedai"
 msgid "EXTRA_OPTIONS"
 msgstr "Papildomi nustatymai"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Baigti žaidimą"
@@ -1812,6 +1821,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1894,7 +1919,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1992,7 +2017,7 @@ msgstr "Bendra"
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Baigti žaidimą"
@@ -2001,11 +2026,11 @@ msgstr "Baigti žaidimą"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2284,7 +2309,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Baigti žaidimą"
@@ -2501,7 +2526,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2660,7 +2685,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licencijos"
 
@@ -2791,7 +2816,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Įkeliama..."
 
@@ -2821,12 +2847,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr "Įkrovimas baigtas"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Įkelti žaidimą"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Įkelti anksčiau išsaugotus žaidimus"
 
@@ -3027,7 +3053,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3227,11 +3253,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Modifikacijos"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3317,11 +3343,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Įvyko klaida įkeliant vieną ar daugiau modifikatorių. Žurnalai gali turėti papildomos informacijos."
 
@@ -3545,15 +3571,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Naujas žaidimas"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Pradėti naują žaidimą"
 
@@ -3653,7 +3683,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 #, fuzzy
 msgid "NO_DATA_TO_SHOW"
 msgstr "Nėra duomenų rodymui"
@@ -3666,7 +3696,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3696,7 +3726,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3715,8 +3745,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -3729,16 +3759,16 @@ msgstr ""
 msgid "OCTOBER"
 msgstr "Spalis"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Įkelti anksčiau išsaugotus žaidimus"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3809,11 +3839,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Nustatymai"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Pakeisti nustatymus"
 
@@ -4021,7 +4051,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Baigti žaidimą"
@@ -4080,8 +4110,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4131,7 +4161,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4204,7 +4234,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4258,7 +4288,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Apdorojami įkrauti objektai"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4302,11 +4332,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Išeiti"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Baigti žaidimą"
@@ -4348,7 +4378,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Reikšmė, naudojama generuojant pasaulį, kuri turi būti teigiamas sveikas skaičius"
@@ -4483,7 +4513,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Įkelti anksčiau išsaugotus žaidimus"
@@ -4571,12 +4601,12 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "(pradžios vieta)"
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4933,7 +4963,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4983,7 +5013,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5098,17 +5128,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Išsaugojimas nepavyko"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Elemento aprašymas:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Reikšmė, naudojama generuojant pasaulį, kuri turi būti teigiamas sveikas skaičius"
@@ -5149,7 +5179,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Prisijungęs kaip: {0}"
 
@@ -5264,7 +5294,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5272,7 +5302,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5331,7 +5361,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5478,7 +5508,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Įrankiai"
 
@@ -5621,7 +5651,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Pakeisti nustatymus"
@@ -5810,7 +5840,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Galerijos žiūryklė"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Peržiūrėti išeities kodą"
 
@@ -5822,7 +5852,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr "Matomas"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5976,7 +6006,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Baigti žaidimą"

--- a/locale/lv.po
+++ b/locale/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-03-21 19:55+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Latvian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/lv/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.11.2\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr "Redaktors"
 msgid "3D_MOVEMENT"
 msgstr "Kustība"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Esošie pavedieni:"
 
@@ -155,7 +155,7 @@ msgstr "Organisma statistika"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -166,11 +166,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr "Amonjaks"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Automātisko saglabāšanas failu daudzums:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Ātru saglabāšanas failu daudzums:"
 
@@ -195,11 +195,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -216,7 +216,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -228,7 +228,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -268,7 +268,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -276,8 +276,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Automātiski"
 
@@ -303,7 +303,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% pabeigts. {1:n0}/{2:n0} pakāpieni."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Automātiski saglabāt progresu spēles laikā"
 
@@ -311,7 +311,7 @@ msgstr "Automātiski saglabāt progresu spēles laikā"
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Automātiska-Evo Pareģošana"
@@ -342,7 +342,7 @@ msgstr "Suga:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Automātiski pārvietoties uz priekšu"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 #, fuzzy
 msgid "AUTO_RESOLUTION"
 msgstr "Izšķirtspēja:"
@@ -356,9 +356,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -501,7 +501,7 @@ msgstr "Ļauj saistīties ar citām šūnām. Šis ir pirmais solis uz daudzšū
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Spiediet [thrive:input]g_toggle_binding[/thrive:input] , lai pārslēgtu saistīšanas režīmu. Kad esiet saistīšanas režīmā, jūs varat pievienot citas šūnas no jūsu sugas, virzoties tām pretī, jūsu kolonijai. Lai pamestu koloniju, spiediet [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -563,7 +563,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr "Kamera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -696,7 +696,7 @@ msgstr "Izmainīt simetriju"
 msgid "CHEATS"
 msgstr "Čīti"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Izvelētais faila nosaukums ({0}) jau eksistē. Pārrakstīt?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Hromatiskā aberācija:"
 
@@ -835,15 +835,15 @@ msgstr "Dzēst vecos saglabāšanas failus"
 msgid "CLOSE"
 msgstr "Aizvērt"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Mākoņa izšķirtspējas dalītājs:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Mākoņa simulācijas minimālais intervāls:"
 
@@ -859,7 +859,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr "Krāsa"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Krāsu korekcija krāsu aklumam:"
 
@@ -911,25 +911,25 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Savienojumi:"
@@ -957,7 +957,7 @@ msgstr "Savienojumi:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Savienojumu mākonis"
 
@@ -1044,7 +1044,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1069,11 +1069,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Kopēt kļūdu starpliktuvē"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr "Veido..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Notiek objektu izveidošana no saglabāšanas faila"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Organisma statistika"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Pielāgots lietotājvards:"
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1292,7 +1292,7 @@ msgstr "Apraksts ir pārāk garš"
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Atklātais CPU skaits:"
 
@@ -1304,11 +1304,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -1317,11 +1317,11 @@ msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -1397,7 +1397,7 @@ msgstr "Kreisi"
 msgid "DIRECTIONR"
 msgstr "Labi"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Atlaist un turpināt"
 
@@ -1437,17 +1437,17 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Ātrums:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
@@ -1455,19 +1455,19 @@ msgstr ""
 "un visticamāk būs ambiciozāki par gabaliem.\n"
 "Atsaucīgi mikrobi ātrāk pāries uz jauniem mērķiem."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1657,7 +1657,7 @@ msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr "Ieslēgt redaktoru"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Ieslēgt GUI gaismas efektus"
 
@@ -1731,7 +1731,7 @@ msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 msgid "EPIPELAGIC"
 msgstr "Epipelaģiāle"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Kļūda"
 
@@ -1743,11 +1743,11 @@ msgstr "Kļūme veidojot mapi modifikācijai"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
@@ -1756,7 +1756,7 @@ msgstr ""
 "Drosmīgos mikrobus neiebiedēs apkārtējie plēsēji\n"
 "un visbiežāk uzbruks pretī."
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Kļūme veidojot mapi modifikācijai"
@@ -1789,12 +1789,12 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Ģenerācija:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -1811,7 +1811,7 @@ msgstr ""
 msgid "EXIT"
 msgstr "Iziet"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1864,7 +1864,7 @@ msgstr "Izmira no plankuma"
 msgid "EXTINCT_SPECIES"
 msgstr "Izmirusi suga"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Papildinājumi"
 
@@ -1872,7 +1872,7 @@ msgstr "Papildinājumi"
 msgid "EXTRA_OPTIONS"
 msgstr "Papildu opcijas"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -1905,19 +1905,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr "Februāris"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2051,7 +2051,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -2087,7 +2087,7 @@ msgstr ""
 "un visticamāk būs ambiciozāki par gabaliem.\n"
 "Atsaucīgi mikrobi ātrāk pāries uz jauniem mērķiem."
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Pilnekrāns"
 
@@ -2117,24 +2117,24 @@ msgstr "Ģenerācija:"
 msgid "GENERATION_COLON"
 msgstr "Ģenerācija:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Atsākt spēli"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr "GPL licences teksts seko:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "Ala"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafika"
 
@@ -2201,7 +2201,7 @@ msgstr "Grafika"
 msgid "GRAPHICS_TEAM"
 msgstr "Grafikas Komanda"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2213,7 +2213,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Interfeisa skaļums"
 
@@ -2235,11 +2235,11 @@ msgstr "Palīdzība"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2264,7 +2264,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Mājas"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Ģenerācija:"
@@ -2339,7 +2339,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Ievade"
 
@@ -2392,8 +2392,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2412,7 +2412,7 @@ msgstr "Dzelzs"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Dzelža Ķīmolitoautotrofija"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Atsākt spēli"
@@ -2421,19 +2421,19 @@ msgstr "Atsākt spēli"
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2615,19 +2615,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Valoda:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Šī valoda ir {0}% pabeigta"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2795,7 +2795,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Peles kreisā poga"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2871,7 +2871,7 @@ msgstr "Rullīte pa labi"
 msgid "LIGHT_MAX"
 msgstr "Gaisma"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "Papildinājumi"
@@ -2888,32 +2888,32 @@ msgstr ""
 "Aktīvi mikrobi skraidīs apkārt un gāzīsies, kad nekas interesants nenotiek.\n"
 "Sēdošie mikrobi būs nekustīgi un gaidīs, kad vide mainīsies, pirms tie kaut ko dara."
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "APSTIPRINĀT"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2939,7 +2939,7 @@ msgstr ""
 msgid "LOADING"
 msgstr "Lādējas"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
@@ -2972,12 +2972,12 @@ msgstr "Lai labotu kļūdu redaktorā, nospied \"atsaukt\""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3055,7 +3055,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr "Jūras sniegs"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Skaļums"
 
@@ -3064,15 +3064,15 @@ msgstr "Skaļums"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Izmira no plankuma"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Augstākais FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Bezgalīgi"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3244,7 +3244,7 @@ msgstr "Katru paaudzi, jums ir 100 mutācijas punkti (MP), ko drīkstiet patēr�
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Katru reizi, kad jūs pavairojaties, jūs ieejat Mikrobu Redaktorā, kur jūs varat veikt izmaiņas jūsu sugai (Pievenojot, pārvietojot vai noņemot organoīdus), lai palielinātu jūsu sugas panākumus. Katrs apmeklējums redaktorā mikroba posmā pārstāv [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] miljonus evolucijas gadus."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3419,7 +3419,7 @@ msgstr "Minimums:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Nav atļauts rādīt mazāk nekā {0} datu kopu(as)!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3486,11 +3486,11 @@ msgstr "Pārvietot organoīdu"
 msgid "MODIFY_TYPE"
 msgstr "Modificēt"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3576,11 +3576,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3633,11 +3633,11 @@ msgstr "Modifikācijas Versija:"
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3753,7 +3753,7 @@ msgstr "Novietot organoīdu"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Novietot organoīdu"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Vairāku paraugu kropļojumnovērse:"
 
@@ -3765,7 +3765,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Mūzikas skaļums"
 
@@ -3789,9 +3789,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr "Mutācijas punkti"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Izslēgt skaņu"
 
@@ -3825,11 +3825,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Jauna spēle"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3897,7 +3897,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3947,7 +3947,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Nav atrasta saglabāšanas faila direktorija"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3964,7 +3964,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Nav atrasta saglabāšanas faila direktorija"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Nav atrasta ekrānuzņēmuma direktorija"
 
@@ -4010,16 +4010,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4051,7 +4051,7 @@ msgstr "Atvērt palīdzības ekrānu"
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Atvērt logu mapi"
 
@@ -4067,7 +4067,7 @@ msgstr "Atvērt oganoīdu izvēlni"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Atvērt saglabāšanas failu direktoriju"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Atvērt ekrānuzņēmumu mapi"
 
@@ -4075,7 +4075,7 @@ msgstr "Atvērt ekrānuzņēmumu mapi"
 msgid "OPEN_THE_MENU"
 msgstr "Atvērt izvēlni"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Palīdziet tulkot spēli"
 
@@ -4095,11 +4095,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opcijas"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -4325,7 +4325,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Ala"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -4378,7 +4378,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4462,7 +4462,7 @@ msgstr "Dublēt Spēlētāju"
 msgid "PLAYER_EXTINCT"
 msgstr "Spēlētājs ir izmiris"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Spēlētājs ir izmiris"
@@ -4477,23 +4477,23 @@ msgstr ""
 "Spēlētājs\n"
 "Ātrums"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4616,11 +4616,11 @@ msgstr "Ātrā ielāde"
 msgid "QUICK_SAVE"
 msgstr "Ātra saglabāšana"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Iziet"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Atsākt spēli"
@@ -4720,7 +4720,7 @@ msgstr "ATP RAŽOŠANA IR PĀRĀK ZEMA!"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Kodols"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4728,23 +4728,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4753,7 +4753,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Izšķirtspēja:"
 
@@ -4804,7 +4804,7 @@ msgstr ""
 "Vai patiešām vēlaties iziet uz galveno izvēlni?\n"
 "Jūs zaudēsiet nesaglabāto progresu."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4837,7 +4837,7 @@ msgstr "Pagriezt pa labi"
 msgid "ROTATION_COLON"
 msgstr "Kopējā Populācija:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4892,7 +4892,7 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Pārveido [thrive:compound type=\"iron\"][/thrive:compound] par [thrive:compound type=\"atp\"][/thrive:compound]. Likme mainās ar [thrive:compound type=\"carbondioxide\"][/thrive:compound] un[thrive:compound type=\"oxygen\"][/thrive:compound] koncentrāciju."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4901,15 +4901,15 @@ msgstr ""
 "Drosmīgos mikrobus neiebiedēs apkārtējie plēsēji\n"
 "un visbiežāk uzbruks pretī."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Saglabāt"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Saglabāt un turpināt"
 
@@ -5002,21 +5002,21 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr "Saglabāšana izdevās"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr "Saistviela"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5120,7 +5120,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "SFX skaļums"
 
@@ -5137,22 +5137,26 @@ msgstr "Rādīt palīdzību"
 msgid "SHOW_TUTORIALS"
 msgstr "Rādīt tutoriālus"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Rādīt tutoriālus (pašreizējā spēlē)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Rādīt tutoriālus (jaunās spēlēs)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -5206,7 +5210,7 @@ msgstr "Silīcija dioksīds"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -5248,7 +5252,7 @@ msgstr "Pārveido [thrive:compound type=\"glucose\"][/thrive:compound] par [thri
 msgid "SMALL_IRON_CHUNK"
 msgstr "Mazs dzelzs gabals"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Audio"
 
@@ -5447,17 +5451,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Nezināma Steam kļūme notika"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Saglabāšana neizdevās"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Apraksts:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Atsākt spēli"
@@ -5501,7 +5505,7 @@ msgstr "Uzglabāšana"
 msgid "STORAGE_COLON"
 msgstr "Uzglabāšana"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5618,7 +5622,7 @@ msgstr "Temperatūra."
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr "Licences aizsedzošās daļas no Thrive ir parādītas šeit"
@@ -5627,7 +5631,7 @@ msgstr "Licences aizsedzošās daļas no Thrive ir parādītas šeit"
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5686,11 +5690,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5844,7 +5848,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Atslēgt absorbēšanas režīmu"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Instrumenti"
 
@@ -5909,7 +5913,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -6046,12 +6050,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Tutoriāls"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -6077,7 +6081,7 @@ msgstr "Atsaistīt visu"
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -6097,7 +6101,7 @@ msgstr "Atsaukt pēdējo darbību"
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Automātiski saglabāt progresu spēles laikā"
@@ -6110,7 +6114,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Modifikācijas Versija:"
@@ -6119,7 +6123,7 @@ msgstr "Modifikācijas Versija:"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -6161,7 +6165,7 @@ msgstr "Augšuplāde Veiksmīga"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6178,7 +6182,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Izmantot pielāgotu lietotājvārdu"
 
@@ -6186,11 +6190,11 @@ msgstr "Izmantot pielāgotu lietotājvārdu"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6217,7 +6221,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr "Ģenerācija:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Ģenerācija:"
@@ -6228,11 +6232,11 @@ msgstr "Ģenerācija:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Ātrums:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6240,7 +6244,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Apskatīt pirmkodu"
 
@@ -6252,7 +6256,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6272,7 +6276,7 @@ msgstr "Skaļuma izslēgšana"
 msgid "VOLUMEUP"
 msgstr "Skaļums uz augšu"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "Vertikālā sinhronizācija"
 
@@ -6378,7 +6382,7 @@ msgstr "Organisma statistika"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -6386,15 +6390,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr "Sliktākais Plankums:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6406,7 +6410,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Atsākt spēli"

--- a/locale/lv.po
+++ b/locale/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-03-21 19:55+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Latvian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/lv/>\n"
@@ -216,7 +216,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -311,7 +311,7 @@ msgstr "Automātiski saglabāt progresu spēles laikā"
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Automātiska-Evo Pareģošana"
@@ -356,8 +356,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -620,27 +620,27 @@ msgstr "Caps Lock (taustiņš)"
 msgid "CARBON_DIOXIDE"
 msgstr "Ogļskābā gāze"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -911,20 +911,20 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -1133,7 +1133,7 @@ msgstr "Veido..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Notiek objektu izveidošana no saglabāšanas faila"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1304,11 +1304,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -1317,11 +1317,11 @@ msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -1455,7 +1455,7 @@ msgstr ""
 "un visticamāk būs ambiciozāki par gabaliem.\n"
 "Atsaucīgi mikrobi ātrāk pāries uz jauniem mērķiem."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1685,15 +1685,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1747,6 +1747,20 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+"Bailīgie mikrobi muks tālas distances\n"
+"un visbiežāk muks no plēsējiem kopumā.\n"
+"Drosmīgos mikrobus neiebiedēs apkārtējie plēsēji\n"
+"un visbiežāk uzbruks pretī."
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Kļūme veidojot mapi modifikācijai"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1797,7 +1811,7 @@ msgstr ""
 msgid "EXIT"
 msgstr "Iziet"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1850,7 +1864,7 @@ msgstr "Izmira no plankuma"
 msgid "EXTINCT_SPECIES"
 msgstr "Izmirusi suga"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Papildinājumi"
 
@@ -1858,7 +1872,7 @@ msgstr "Papildinājumi"
 msgid "EXTRA_OPTIONS"
 msgstr "Papildu opcijas"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -1890,6 +1904,22 @@ msgstr ""
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Februāris"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1977,7 +2007,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Barības ķēde"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -2087,7 +2117,7 @@ msgstr "Ģenerācija:"
 msgid "GENERATION_COLON"
 msgstr "Ģenerācija:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Atsākt spēli"
@@ -2096,11 +2126,11 @@ msgstr "Atsākt spēli"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2382,7 +2412,7 @@ msgstr "Dzelzs"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Dzelža Ķīmolitoautotrofija"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Atsākt spēli"
@@ -2601,7 +2631,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2765,7 +2795,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Peles kreisā poga"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2909,7 +2939,8 @@ msgstr ""
 msgid "LOADING"
 msgstr "Lādējas"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Augšuplādē..."
@@ -2941,12 +2972,12 @@ msgstr "Lai labotu kļūdu redaktorā, nospied \"atsaukt\""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3213,7 +3244,7 @@ msgstr "Katru paaudzi, jums ir 100 mutācijas punkti (MP), ko drīkstiet patēr�
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Katru reizi, kad jūs pavairojaties, jūs ieejat Mikrobu Redaktorā, kur jūs varat veikt izmaiņas jūsu sugai (Pievenojot, pārvietojot vai noņemot organoīdus), lai palielinātu jūsu sugas panākumus. Katrs apmeklējums redaktorā mikroba posmā pārstāv [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] miljonus evolucijas gadus."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3455,11 +3486,11 @@ msgstr "Pārvietot organoīdu"
 msgid "MODIFY_TYPE"
 msgstr "Modificēt"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3545,11 +3576,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3786,15 +3817,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Jauna spēle"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3899,7 +3934,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Nav datu, ko parādīt"
 
@@ -3912,7 +3947,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Nav atrasta saglabāšanas faila direktorija"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3942,7 +3977,7 @@ msgstr "Nav atlasīto modifikāciju"
 msgid "NUCLEUS"
 msgstr "Kodols"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3961,8 +3996,8 @@ msgstr "Num Lock (taustiņš)"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -3975,16 +4010,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4060,11 +4095,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opcijas"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -4290,7 +4325,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Ala"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -4351,8 +4386,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr "Veikt atsaistīšanu"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4403,7 +4438,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Spēlētāja šūna"
 
@@ -4481,7 +4516,7 @@ msgstr "Kopējā Populācija:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "{0} ({1})"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4537,7 +4572,7 @@ msgstr "Suga:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4581,11 +4616,11 @@ msgstr "Ātrā ielāde"
 msgid "QUICK_SAVE"
 msgstr "Ātra saglabāšana"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Iziet"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4627,7 +4662,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Atsākt spēli"
@@ -4769,7 +4804,7 @@ msgstr ""
 "Vai patiešām vēlaties iziet uz galveno izvēlni?\n"
 "Jūs zaudēsiet nesaglabāto progresu."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4857,7 +4892,7 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Pārveido [thrive:compound type=\"iron\"][/thrive:compound] par [thrive:compound type=\"atp\"][/thrive:compound]. Likme mainās ar [thrive:compound type=\"carbondioxide\"][/thrive:compound] un[thrive:compound type=\"oxygen\"][/thrive:compound] koncentrāciju."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4866,7 +4901,7 @@ msgstr ""
 "Drosmīgos mikrobus neiebiedēs apkārtējie plēsēji\n"
 "un visbiežāk uzbruks pretī."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -5241,7 +5276,7 @@ msgstr "Iespavnot amonjaku"
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -5295,7 +5330,7 @@ msgstr "Sugas nosaukums..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Sugas nosaukums..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5412,17 +5447,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Nezināma Steam kļūme notika"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Saglabāšana neizdevās"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Apraksts:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Atsākt spēli"
@@ -5466,7 +5501,7 @@ msgstr "Uzglabāšana"
 msgid "STORAGE_COLON"
 msgstr "Uzglabāšana"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5583,7 +5618,7 @@ msgstr "Temperatūra."
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr "Licences aizsedzošās daļas no Thrive ir parādītas šeit"
@@ -5592,7 +5627,7 @@ msgstr "Licences aizsedzošās daļas no Thrive ir parādītas šeit"
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5655,7 +5690,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5809,7 +5844,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Atslēgt absorbēšanas režīmu"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Instrumenti"
 
@@ -6011,7 +6046,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Tutoriāls"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
@@ -6205,7 +6240,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Apskatīt pirmkodu"
 
@@ -6217,7 +6252,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6371,7 +6406,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Atsākt spēli"

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -194,7 +194,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -330,8 +330,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -586,27 +586,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -864,19 +864,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1070,7 +1070,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1229,11 +1229,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1241,11 +1241,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1357,7 +1357,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1369,7 +1369,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1590,15 +1590,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1651,6 +1651,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1699,7 +1707,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1749,7 +1757,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1757,7 +1765,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1783,6 +1791,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1864,7 +1888,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1960,7 +1984,7 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1968,11 +1992,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2248,7 +2272,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2464,7 +2488,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2622,7 +2646,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2750,7 +2774,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2780,12 +2805,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2985,7 +3010,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3182,11 +3207,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3272,11 +3297,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3500,15 +3525,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3608,7 +3637,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3620,7 +3649,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3650,7 +3679,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3669,8 +3698,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3683,15 +3712,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3762,11 +3791,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3971,7 +4000,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4029,8 +4058,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4080,7 +4109,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4153,7 +4182,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4207,7 +4236,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4251,11 +4280,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4295,7 +4324,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4429,7 +4458,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4515,11 +4544,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4875,7 +4904,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4925,7 +4954,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5040,15 +5069,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5088,7 +5117,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5203,7 +5232,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5211,7 +5240,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5270,7 +5299,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5417,7 +5446,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5560,7 +5589,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5744,7 +5773,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5756,7 +5785,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5909,7 +5938,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Thrive.Scripts 1.1.0.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -29,7 +29,7 @@ msgstr ""
 msgid "3D_MOVEMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -60,7 +60,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -145,11 +145,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -174,11 +174,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -246,7 +246,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -254,8 +254,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -280,7 +280,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -317,7 +317,7 @@ msgstr ""
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -330,9 +330,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -468,7 +468,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -658,7 +658,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -748,7 +748,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -788,15 +788,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -812,7 +812,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -864,23 +864,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -998,11 +998,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1010,11 +1010,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1070,7 +1070,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1094,7 +1094,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1217,7 +1217,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1229,11 +1229,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1241,11 +1241,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1317,7 +1317,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1325,7 +1325,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1357,31 +1357,31 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1562,7 +1562,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1578,7 +1578,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1635,7 +1635,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1647,15 +1647,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1687,11 +1687,11 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1707,7 +1707,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1757,7 +1757,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1765,7 +1765,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1793,19 +1793,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1926,7 +1926,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1956,7 +1956,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -1984,23 +1984,23 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2053,11 +2053,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2065,7 +2065,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2077,7 +2077,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2099,11 +2099,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2127,7 +2127,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr ""
 
@@ -2199,7 +2199,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2252,8 +2252,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2272,7 +2272,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2280,19 +2280,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2472,19 +2472,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2646,7 +2646,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2714,7 +2714,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2726,31 +2726,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2774,7 +2774,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2805,12 +2805,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2875,7 +2875,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2883,15 +2883,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3010,7 +3010,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3207,11 +3207,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3354,11 +3354,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3467,7 +3467,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3479,7 +3479,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3499,9 +3499,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3533,11 +3533,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3602,7 +3602,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3649,7 +3649,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3712,15 +3712,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3751,7 +3751,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3767,7 +3767,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3775,7 +3775,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3791,11 +3791,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4000,7 +4000,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4050,7 +4050,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4133,7 +4133,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4145,23 +4145,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4280,11 +4280,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4377,7 +4377,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4385,23 +4385,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4410,7 +4410,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4458,7 +4458,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4490,7 +4490,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4544,19 +4544,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4648,20 +4648,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4758,7 +4758,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4774,20 +4774,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4836,7 +4840,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4876,7 +4880,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5069,15 +5073,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5117,7 +5121,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5232,7 +5236,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5240,7 +5244,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5295,11 +5299,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5446,7 +5450,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5589,11 +5593,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5618,7 +5622,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5658,7 +5662,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5698,7 +5702,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5714,7 +5718,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5722,11 +5726,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5752,7 +5756,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr ""
 
@@ -5761,11 +5765,11 @@ msgstr ""
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5773,7 +5777,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5785,7 +5789,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5805,7 +5809,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5910,7 +5914,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5918,15 +5922,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -5938,7 +5942,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/nb_NO.po
+++ b/locale/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-07-26 10:07+0000\n"
 "Last-Translator: Jonas Lindberg <eksno@pm.me>\n"
 "Language-Team: Norwegian Bokmål <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/nb_NO/>\n"
@@ -196,7 +196,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -332,8 +332,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -588,27 +588,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -867,19 +867,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1232,11 +1232,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1244,11 +1244,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1595,15 +1595,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1656,6 +1656,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1704,7 +1712,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1754,7 +1762,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1762,7 +1770,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1788,6 +1796,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1870,7 +1894,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1967,7 +1991,7 @@ msgstr "Generelt"
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1975,11 +1999,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2255,7 +2279,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2471,7 +2495,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2630,7 +2654,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2758,7 +2782,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2788,12 +2813,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2994,7 +3019,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3194,11 +3219,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3284,11 +3309,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3512,15 +3537,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3620,7 +3649,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3632,7 +3661,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3662,7 +3691,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3681,8 +3710,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3695,15 +3724,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3774,11 +3803,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3983,7 +4012,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4041,8 +4070,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4092,7 +4121,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4165,7 +4194,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4219,7 +4248,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4263,11 +4292,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4307,7 +4336,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4441,7 +4470,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4527,11 +4556,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4887,7 +4916,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4937,7 +4966,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5052,15 +5081,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5100,7 +5129,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5215,7 +5244,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5223,7 +5252,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5282,7 +5311,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5429,7 +5458,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5573,7 +5602,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5757,7 +5786,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5769,7 +5798,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5922,7 +5951,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/nb_NO.po
+++ b/locale/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-07-26 10:07+0000\n"
 "Last-Translator: Jonas Lindberg <eksno@pm.me>\n"
 "Language-Team: Norwegian Bokmål <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/nb_NO/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.13.1\n"
 "Generated-By: Babel 2.10.3\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr ""
 msgid "3D_MOVEMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -147,11 +147,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -176,11 +176,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -196,7 +196,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -256,8 +256,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -282,7 +282,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -319,7 +319,7 @@ msgstr ""
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -332,9 +332,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -470,7 +470,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -660,7 +660,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -791,15 +791,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -815,7 +815,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -867,23 +867,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr ""
 
@@ -909,7 +909,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1001,11 +1001,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1013,11 +1013,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1162,7 +1162,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1220,7 +1220,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1232,11 +1232,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1244,11 +1244,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1361,31 +1361,31 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1567,7 +1567,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1583,7 +1583,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1652,15 +1652,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1692,11 +1692,11 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1712,7 +1712,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1762,7 +1762,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1770,7 +1770,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1798,19 +1798,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1932,7 +1932,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1962,7 +1962,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -1991,23 +1991,23 @@ msgstr "Generelt"
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2060,11 +2060,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2072,7 +2072,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2084,7 +2084,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2106,11 +2106,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2134,7 +2134,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr ""
 
@@ -2206,7 +2206,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2259,8 +2259,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2279,7 +2279,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2287,19 +2287,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2479,19 +2479,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2654,7 +2654,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2722,7 +2722,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2734,31 +2734,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2782,7 +2782,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2813,12 +2813,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2883,7 +2883,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2891,15 +2891,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3019,7 +3019,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3155,7 +3155,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3219,11 +3219,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3309,11 +3309,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3366,11 +3366,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3479,7 +3479,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3491,7 +3491,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Musikk"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3511,9 +3511,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3545,11 +3545,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3614,7 +3614,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3661,7 +3661,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3678,7 +3678,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3724,15 +3724,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3763,7 +3763,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3779,7 +3779,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3787,7 +3787,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3803,11 +3803,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4012,7 +4012,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4062,7 +4062,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4157,23 +4157,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4292,11 +4292,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4336,7 +4336,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4389,7 +4389,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4397,23 +4397,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4422,7 +4422,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4470,7 +4470,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4502,7 +4502,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4556,19 +4556,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4660,20 +4660,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4770,7 +4770,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4786,20 +4786,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4888,7 +4892,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5081,15 +5085,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5129,7 +5133,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5244,7 +5248,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5252,7 +5256,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5307,11 +5311,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5458,7 +5462,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5520,7 +5524,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5602,11 +5606,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5631,7 +5635,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5651,7 +5655,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5663,7 +5667,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5671,7 +5675,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5711,7 +5715,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5727,7 +5731,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5735,11 +5739,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5765,7 +5769,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr ""
 
@@ -5774,11 +5778,11 @@ msgstr ""
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5786,7 +5790,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5798,7 +5802,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5923,7 +5927,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5931,15 +5935,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -5951,7 +5955,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-09-22 10:31+0000\n"
 "Last-Translator: Xradiation <tamimzain@hotmail.com>\n"
 "Language-Team: Dutch <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/nl/>\n"
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Kunst van {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Kunstgalerie"
 
@@ -302,7 +302,7 @@ msgstr "Sla automatisch op tijdens het spelen"
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "uitvoeringsstatus:"
@@ -347,8 +347,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -616,27 +616,27 @@ msgstr "Capslock"
 msgid "CARBON_DIOXIDE"
 msgstr "Kooldioxide"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -909,20 +909,20 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Hervat"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Verlaat het spel"
@@ -1129,7 +1129,7 @@ msgstr "Zoeken..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Credits"
 
@@ -1299,11 +1299,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Hervat"
@@ -1312,12 +1312,12 @@ msgstr "Hervat"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Hoofd Ontwikkelaars"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Pas je instellingen aan"
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Hervat"
@@ -1452,7 +1452,7 @@ msgstr "Snelheid:"
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "(startlocatie)"
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1681,15 +1681,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Energy Bronnen:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1744,6 +1744,16 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "ERROR: Het opslaan van nieuwe instellingen is mislukt."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "{0} populatie veranderd met {1} vanwege: {2}"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Open screenshots"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1796,7 +1806,7 @@ msgstr ""
 msgid "EXIT"
 msgstr "Sluit"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Lanceren E"
@@ -1852,7 +1862,7 @@ msgstr "stierf uit op de planeet"
 msgid "EXTINCT_SPECIES"
 msgstr "Uitgestorven Soorten"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extra's"
 
@@ -1860,7 +1870,7 @@ msgstr "Extra's"
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Hervat"
@@ -1890,6 +1900,40 @@ msgstr "Cheat-toetsen ingeschakeld"
 #, fuzzy
 msgid "FEBRUARY"
 msgstr "Estuarium"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Procestijd: {0} s\n"
+"Fysicatijd: {1} s\n"
+"Entiteiten: {2}, andere: {3}\n"
+"Gespawned: {4}, Ongespawned: {5}\n"
+"Gebruikte nodes: {6}\n"
+"Gebruikt geheugen: {7}\n"
+"GPU-geheugen: {8}\n"
+"Gerenderde objecten: {9}\n"
+"Draw calls: {10}, waarvan 2D: {11}\n"
+"Gerenderde vertexen: {12}\n"
+"Materiaalveranderingen: {13}\n"
+"Shaderveranderingen: {14}\n"
+"Verweesde nodes: {15}\n"
+"Audiovertraging: {16} ms\n"
+"Totaal aantal threads: {17}\n"
+"Totale CPU-tijd:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1972,7 +2016,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -2071,7 +2115,7 @@ msgstr "Generatie"
 msgid "GENERATION_COLON"
 msgstr "Generatie:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Verlaat het spel"
@@ -2080,11 +2124,11 @@ msgstr "Verlaat het spel"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 moduswaarschuwing"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Je gebruikt Thrive met GLES2. Dit is niet getest en zal hoogstwaarschijnlijk voor problemen veroorzaken. Update je drivers en/of forceer je AMD of Nvidia graphics om Thrive te laten runnen."
 
@@ -2369,7 +2413,7 @@ msgstr "Ijzer"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Ijzer-chemolithoautotrofie"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Verlaat het spel"
@@ -2588,7 +2632,7 @@ msgstr "De vertaling van deze taal is nog niet compleet ({0}% compleet)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Deze vertaling is nog niet compleet ({0}% klaar) help ons hier alstublieft mee!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2749,7 +2793,7 @@ msgstr "Linkermuisknop"
 msgid "LEFT_MOUSE"
 msgstr "Linkermuisknop"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licenties"
 
@@ -2885,7 +2929,8 @@ msgstr ""
 msgid "LOADING"
 msgstr "Laden"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Laden..."
@@ -2917,12 +2962,12 @@ msgstr "Klik de undo-knop in de editor om een fout te corrigeren"
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Laad spel"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Laad eerder opgeslagen spellen"
 
@@ -3189,7 +3234,7 @@ msgstr "Bij elke generatie heb je 100 mutatiepunten (MP) om te gebruiken. Elke v
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Telkens als je jezelf voortplant, open je de microbe editor waar je veranderingen aan je cel kan maken om je succes te verhogen. Elk bezoek aan de editor telt als 100 miljoen jaar."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Microbe vrij bouwen bewerker"
 
@@ -3402,11 +3447,11 @@ msgstr "Verplaats organellen"
 msgid "MODIFY_TYPE"
 msgstr "Pas het type aan"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3497,11 +3542,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Foutmeldingen bij het laden van de mod"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Er is een fout opgetreden bij het laden van een of meerdere mods. Logs kunnen bijkomende informatie bevatten."
 
@@ -3734,15 +3779,19 @@ msgstr ""
 "Dit opgeslagen bestand is van een nieuwere versie van Thrive en is waarschijnlijk niet-compatibel.\n"
 "Wil je toch proberen het opgeslagen bestand te laden?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Start populatie voor biodiversiteit vergrotende soorten"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Nieuw spel"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Start een nieuw spel"
 
@@ -3846,7 +3895,7 @@ msgid "NO_AI"
 msgstr "Geen AI"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3859,7 +3908,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Geen screenshot directory gevonden"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Cheat-toetsen ingeschakeld"
@@ -3891,7 +3940,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr "Kern"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3910,8 +3959,8 @@ msgstr "Numlock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 #, fuzzy
 msgid "N_A"
@@ -3925,16 +3974,16 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Hervat"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4012,11 +4061,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opties"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Pas je instellingen aan"
 
@@ -4234,7 +4283,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Grot"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Hervat"
@@ -4296,8 +4345,8 @@ msgstr "Prestatie"
 msgid "PERFORM_UNBINDING"
 msgstr "Ontbinden uitvoeren"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/seconde"
 
@@ -4347,7 +4396,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr "Willekeurige seed voor de planeet"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Spelercel"
 
@@ -4424,7 +4473,7 @@ msgstr "populatie:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "bevolking in gebieden:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 #, fuzzy
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "POPULATIE:"
@@ -4481,7 +4530,7 @@ msgstr "vorige:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4525,11 +4574,11 @@ msgstr "Snel laden"
 msgid "QUICK_SAVE"
 msgstr "Snel opslaan"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Stop"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Verlaat het spel"
@@ -4571,7 +4620,7 @@ msgstr "Klaar"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Hervat"
@@ -4714,7 +4763,7 @@ msgstr ""
 "Weet je zeker dat je terug wilt gaan naar het hoofmenu?\n"
 "Je verlies al je niet opgeslagen vooruitgang."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Laad eerder opgeslagen spellen"
@@ -4804,12 +4853,12 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "(startlocatie)"
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -5192,7 +5241,7 @@ msgstr "Spawn ammoniak"
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -5244,7 +5293,7 @@ msgstr "Soortnaam..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Soortnaam..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 #, fuzzy
 msgid "SPECIES_N_TIMES"
 msgstr "Soorten:"
@@ -5362,17 +5411,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Auto-evo mislukt"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Het upgraden van de geselecteerde save is gefaald door de volgende error:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Hervat"
@@ -5415,7 +5464,7 @@ msgstr "Opslag"
 msgid "STORAGE_COLON"
 msgstr "Opslag"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Ingelogd als: {0}"
 
@@ -5532,7 +5581,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5540,7 +5589,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5602,7 +5651,7 @@ msgstr ""
 msgid "THREADS"
 msgstr "Threads:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5750,7 +5799,7 @@ msgstr "Pauzeren"
 msgid "TOGGLE_UNBINDING"
 msgstr "Ontbinden aan/uit"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Tools"
 
@@ -5912,7 +5961,7 @@ msgstr "Microbe vrij bouwen"
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Pas je instellingen aan"
@@ -6115,7 +6164,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Kijker"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Ga naar broncode"
 
@@ -6127,7 +6176,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6286,7 +6335,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Hervat"

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-09-22 10:31+0000\n"
 "Last-Translator: Xradiation <tamimzain@hotmail.com>\n"
 "Language-Team: Dutch <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/nl/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "3D-editor"
 msgid "3D_MOVEMENT"
 msgstr "3D-beweging"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "Actie geblokkeerd tijdens een andere actie"
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Huidige threads:"
 
@@ -142,7 +142,7 @@ msgstr "Organismestatistieken"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Volume omgeving"
 
@@ -153,11 +153,11 @@ msgstr "Volume omgeving"
 msgid "AMMONIA"
 msgstr "Ammoniak"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Aantal automatische savegames om te bewaren:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Aantal savegames om te bewaren:"
 
@@ -183,11 +183,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Weet je zeker dat je ALLE instellingen wilt resetten?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Weet je zeker dat je de invoer wilt resetten?"
 
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Kunst van {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Kunstgalerie"
 
@@ -216,7 +216,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Veronderstel dat de CPU hyperthreading aan heeft staan"
 
@@ -257,7 +257,7 @@ msgstr "Auto-evo mislukt"
 msgid "AT_CURSOR"
 msgstr "Bij Cursor:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Audio uitvoer apparaat:"
 
@@ -265,8 +265,8 @@ msgstr "Audio uitvoer apparaat:"
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Automatisch"
 
@@ -294,7 +294,7 @@ msgstr "De gel-achtige binnenkant van een cel. Het cytoplasma is een mengsel van
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% klaar. {1:n0}/{2:n0} stappen."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Sla automatisch op tijdens het spelen"
 
@@ -302,7 +302,7 @@ msgstr "Sla automatisch op tijdens het spelen"
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "uitvoeringsstatus:"
@@ -333,7 +333,7 @@ msgstr "uitvoeringsstatus:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Beweeg automatisch naar voren"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 #, fuzzy
 msgid "AUTO_RESOLUTION"
 msgstr "Resolutie:"
@@ -347,9 +347,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -495,7 +495,7 @@ msgstr "Een stijver membraan geeft meer bescherming, maar maakt het lastiger om 
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Stikstofbindende plastide"
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -558,7 +558,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr "Camera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -691,7 +691,7 @@ msgstr "Verander symmetrie"
 msgid "CHEATS"
 msgstr "Cheats"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Cheat-toetsen ingeschakeld"
 
@@ -787,7 +787,7 @@ msgstr "De gel-achtige binnenkant van een cel. Het cytoplasma is een mengsel van
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Chromatische Aberratie:"
 
@@ -831,15 +831,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr "Sluiten"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Opties sluiten?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Wolk resolutiedeler:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 "Wolksimulatie minimum\n"
@@ -857,7 +857,7 @@ msgstr "Spawn entiteit met botsingsvorm"
 msgid "COLOUR"
 msgstr "Kleur"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Kleurenblindheid-correctie:"
 
@@ -909,25 +909,25 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Hervat"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Verlaat het spel"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Chemicaliën:"
@@ -956,7 +956,7 @@ msgstr "Chemicaliën:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Samenstellings-wolken"
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1052,11 +1052,11 @@ msgstr "{0} populatie veranderd met {1} vanwege: {2}"
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1064,11 +1064,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1129,7 +1129,7 @@ msgstr "Zoeken..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Credits"
 
@@ -1154,7 +1154,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Organismestatistieken"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Gebruikersnaam:"
 
@@ -1223,7 +1223,7 @@ msgstr "Debugpaneel"
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Standaard uitvoer apparaat"
 
@@ -1287,7 +1287,7 @@ msgstr "Generatie:"
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Gedetecteerde CPU count:"
 
@@ -1299,11 +1299,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Hervat"
@@ -1312,12 +1312,12 @@ msgstr "Hervat"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Hoofd Ontwikkelaars"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Pas je instellingen aan"
@@ -1394,7 +1394,7 @@ msgstr "Links"
 msgid "DIRECTIONR"
 msgstr "Rechts"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Annuleren en doorgaan"
 
@@ -1437,34 +1437,34 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Hervat"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Snelheid:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "(startlocatie)"
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Toon Capaciteiten Balk"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "Toon Capaciteiten Balk"
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr "Hervat"
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 #, fuzzy
 msgid "EIGHT_TIMES"
 msgstr "Rechtermuisknop"
@@ -1669,7 +1669,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr "Schakel de editor in"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Zet GUI Licht Effecten Aan"
 
@@ -1727,7 +1727,7 @@ msgstr "Hervat"
 msgid "EPIPELAGIC"
 msgstr "Epipelechisch"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -1740,16 +1740,16 @@ msgstr "Open screenshots"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "ERROR: Het opslaan van nieuwe instellingen is mislukt."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "{0} populatie veranderd met {1} vanwege: {2}"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Open screenshots"
@@ -1784,12 +1784,12 @@ msgstr "Stamboom"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Stamboom"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Generatie:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Hervat"
@@ -1806,7 +1806,7 @@ msgstr ""
 msgid "EXIT"
 msgstr "Sluit"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Lanceren E"
@@ -1862,7 +1862,7 @@ msgstr "stierf uit op de planeet"
 msgid "EXTINCT_SPECIES"
 msgstr "Uitgestorven Soorten"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extra's"
 
@@ -1870,7 +1870,7 @@ msgstr "Extra's"
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Hervat"
@@ -1901,11 +1901,11 @@ msgstr "Cheat-toetsen ingeschakeld"
 msgid "FEBRUARY"
 msgstr "Estuarium"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1927,11 +1927,11 @@ msgstr ""
 "Totale CPU-tijd:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2057,7 +2057,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -2087,7 +2087,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Volledig Scherm"
 
@@ -2115,24 +2115,24 @@ msgstr "Generatie"
 msgid "GENERATION_COLON"
 msgstr "Generatie:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Verlaat het spel"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 moduswaarschuwing"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Je gebruikt Thrive met GLES2. Dit is niet getest en zal hoogstwaarschijnlijk voor problemen veroorzaken. Update je drivers en/of forceer je AMD of Nvidia graphics om Thrive te laten runnen."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2185,12 +2185,12 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "Grot"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafische Kwaliteit"
 
@@ -2199,7 +2199,7 @@ msgstr "Grafische Kwaliteit"
 msgid "GRAPHICS_TEAM"
 msgstr "Grafische Kwaliteit"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2212,7 +2212,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} Kg"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Volume GUI"
 
@@ -2234,11 +2234,11 @@ msgstr "Hulp"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(hogere waarden verbeteren prestatie)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(hogere waarden verlagen de prestatie)"
 
@@ -2264,7 +2264,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Home"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Generatie:"
@@ -2339,7 +2339,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Hervat"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Invoer"
 
@@ -2393,8 +2393,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr "Ijzer"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Ijzer-chemolithoautotrofie"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Verlaat het spel"
@@ -2422,19 +2422,19 @@ msgstr "Verlaat het spel"
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2616,19 +2616,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Taal:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Deze taal is {0}% compleet"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "De vertaling van deze taal is nog niet compleet ({0}% compleet)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Deze vertaling is nog niet compleet ({0}% klaar) help ons hier alstublieft mee!"
 
@@ -2793,7 +2793,7 @@ msgstr "Linkermuisknop"
 msgid "LEFT_MOUSE"
 msgstr "Linkermuisknop"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licenties"
 
@@ -2863,7 +2863,7 @@ msgstr "Scroll naar rechts"
 msgid "LIGHT_MAX"
 msgstr "Licht"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "Extra's"
@@ -2878,32 +2878,32 @@ msgstr "BEVESTIGEN"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(snelheid waarmee AI-soorten muteren)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "BEVESTIGEN"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2929,7 +2929,7 @@ msgstr ""
 msgid "LOADING"
 msgstr "Laden"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
@@ -2962,12 +2962,12 @@ msgstr "Klik de undo-knop in de editor om een fout te corrigeren"
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Laad spel"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Laad eerder opgeslagen spellen"
 
@@ -3043,7 +3043,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr "Mariene sneeuw"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Master Volume"
 
@@ -3052,16 +3052,16 @@ msgstr "Master Volume"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "stierf uit op de planeet"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Maximale FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 #, fuzzy
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Maximale FPS:"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3234,7 +3234,7 @@ msgstr "Bij elke generatie heb je 100 mutatiepunten (MP) om te gebruiken. Elke v
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Telkens als je jezelf voortplant, open je de microbe editor waar je veranderingen aan je cel kan maken om je succes te verhogen. Elk bezoek aan de editor telt als 100 miljoen jaar."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Microbe vrij bouwen bewerker"
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Overig"
 
@@ -3447,11 +3447,11 @@ msgstr "Verplaats organellen"
 msgid "MODIFY_TYPE"
 msgstr "Pas het type aan"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3542,11 +3542,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Foutmeldingen bij het laden van de mod"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Er is een fout opgetreden bij het laden van een of meerdere mods. Logs kunnen bijkomende informatie bevatten."
 
@@ -3599,11 +3599,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3716,7 +3716,7 @@ msgstr "Plaats organellen"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Meerdere Organellen"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Anti-Aliasing:"
 
@@ -3728,7 +3728,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Muziek"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Volume muziek"
 
@@ -3749,9 +3749,9 @@ msgstr "(kost van organellen, membranen en andere items in de editor)"
 msgid "MUTATION_POINTS"
 msgstr "Mutatiepunten"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Demp"
 
@@ -3787,11 +3787,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Start populatie voor biodiversiteit vergrotende soorten"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Nieuw spel"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Start een nieuw spel"
 
@@ -3859,7 +3859,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Stikstofbindende plastide"
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3908,7 +3908,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Geen screenshot directory gevonden"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Cheat-toetsen ingeschakeld"
@@ -3927,7 +3927,7 @@ msgstr "Geen Opslagen Bestanden Gevonden"
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Geen screenshot directory gevonden"
 
@@ -3974,16 +3974,16 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Hervat"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4020,7 +4020,7 @@ msgstr "Open het hulpscherm"
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Open logs Folder"
 
@@ -4037,7 +4037,7 @@ msgstr "Open organel menu"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Open screenshots"
 
@@ -4045,7 +4045,7 @@ msgstr "Open screenshots"
 msgid "OPEN_THE_MENU"
 msgstr "Open het menu"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Help met vertalen"
 
@@ -4061,11 +4061,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opties"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Pas je instellingen aan"
 
@@ -4283,7 +4283,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Grot"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Hervat"
@@ -4337,7 +4337,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Prestatie"
 
@@ -4421,7 +4421,7 @@ msgstr "Dupliceer Speler"
 msgid "PLAYER_EXTINCT"
 msgstr "Spelercel"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Spelercel"
@@ -4436,23 +4436,23 @@ msgstr ""
 "Speler\n"
 "Snelheid"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Speel intro video"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Speel intro bij nieuw spel"
 
@@ -4574,11 +4574,11 @@ msgstr "Snel laden"
 msgid "QUICK_SAVE"
 msgstr "Snel opslaan"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Stop"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Verlaat het spel"
@@ -4620,7 +4620,7 @@ msgstr "Klaar"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Hervat"
@@ -4676,7 +4676,7 @@ msgstr "Reproductiemethode:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Kern"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Reset"
 
@@ -4685,24 +4685,24 @@ msgstr "Reset"
 msgid "RESET_DEADZONES"
 msgstr "Resetten naar standaard?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Invoer resetten?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Reset invoer"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Standaard"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Resetten naar standaard?"
 
@@ -4711,7 +4711,7 @@ msgstr "Resetten naar standaard?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Resolutie:"
 
@@ -4763,7 +4763,7 @@ msgstr ""
 "Weet je zeker dat je terug wilt gaan naar het hoofmenu?\n"
 "Je verlies al je niet opgeslagen vooruitgang."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Laad eerder opgeslagen spellen"
@@ -4798,7 +4798,7 @@ msgstr "Draai naar rechts"
 msgid "ROTATION_COLON"
 msgstr "{0} populatie veranderd met {1} vanwege: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Voer auto-evo uit tijdens het spelen"
 
@@ -4853,20 +4853,20 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "(startlocatie)"
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Sla op"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Opslaan en doorgaan"
 
@@ -4967,21 +4967,21 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr "Signaalstof"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Volume SFX"
 
@@ -5096,17 +5096,17 @@ msgstr "Open hulp"
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Laat tutorial zien in huidig spel"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Laat tutorial zien bij nieuw spel"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 #, fuzzy
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
@@ -5119,6 +5119,10 @@ msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr ""
 "Je hebt niet-opgeslagen instellingen.\n"
 "Doorgaan?"
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5170,7 +5174,7 @@ msgstr "Siliciumdioxide"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgstr "De gel-achtige binnenkant van een cel. Het cytoplasma is een mengsel van
 msgid "SMALL_IRON_CHUNK"
 msgstr "Klein stuk ijzer"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Geluid"
 
@@ -5411,17 +5415,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Auto-evo mislukt"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Het upgraden van de geselecteerde save is gefaald door de volgende error:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Hervat"
@@ -5464,7 +5468,7 @@ msgstr "Opslag"
 msgid "STORAGE_COLON"
 msgstr "Opslag"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Ingelogd als: {0}"
 
@@ -5581,7 +5585,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5589,7 +5593,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5647,11 +5651,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Threads:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5799,7 +5803,7 @@ msgstr "Pauzeren"
 msgid "TOGGLE_UNBINDING"
 msgstr "Ontbinden aan/uit"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Tools"
 
@@ -5866,7 +5870,7 @@ msgstr "Maak een screenshot!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Maak een screenshot!"
 
@@ -5961,12 +5965,12 @@ msgstr "Microbe vrij bouwen"
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Pas je instellingen aan"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5993,7 +5997,7 @@ msgstr "Ontbind al"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Loskoppelmodus"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6016,7 +6020,7 @@ msgstr "Herstel de laatste actie"
 msgid "UNKNOWN"
 msgstr "Onbekende knop"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Toon Capaciteiten Balk"
@@ -6029,7 +6033,7 @@ msgstr "Onbekende muisknop"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Onbekend op Windows"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Onbekende muisknop"
@@ -6039,7 +6043,7 @@ msgstr "Onbekende muisknop"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Onbekende muisknop"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Je hebt niet-opgeslagen instellingen.\n"
@@ -6085,7 +6089,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6101,7 +6105,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Gebruik een eigen naam"
 
@@ -6109,11 +6113,11 @@ msgstr "Gebruik een eigen naam"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Stel handmatig de nummers van achtergrond threads in"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6141,7 +6145,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr "Generatie:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Generatie:"
@@ -6152,11 +6156,11 @@ msgstr "Generatie:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Nieuwe naam:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6164,7 +6168,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Kijker"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Ga naar broncode"
 
@@ -6176,7 +6180,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6196,7 +6200,7 @@ msgstr "Geluid Uit"
 msgid "VOLUMEUP"
 msgstr "Geluid Harder"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "vSync"
 
@@ -6306,7 +6310,7 @@ msgstr "Organismestatistieken"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -6315,15 +6319,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr "Soorten:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6335,7 +6339,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Hervat"

--- a/locale/nl_BE.po
+++ b/locale/nl_BE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-07-20 09:20+0000\n"
 "Last-Translator: Simeon Duwel <tameimpalafan123@gmail.com>\n"
 "Language-Team: Dutch (Belgium) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/nl_BE/>\n"
@@ -213,7 +213,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Kunst door {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Kunst galerij"
 
@@ -315,7 +315,7 @@ msgstr "Autosave tijdens het spelen"
 msgid "AUTO_EVO"
 msgstr "Auto-evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "loopstatus:"
@@ -360,8 +360,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -625,27 +625,27 @@ msgstr "Caps Lock(toets)"
 msgid "CARBON_DIOXIDE"
 msgstr "Koolstofdioxide"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "een overvloed"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "een degelijke hoeveelheid"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "klein"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "Redelijk wat"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "een beetje"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "heel klein"
 
@@ -926,21 +926,21 @@ msgstr "Verzadigingswaarde, de hoeveelheid grijs in een bepaalde kleur"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Waarde (helderheid) waarde, helderheid of intensiteit van de kleur"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Voeg een nieuwe sneltoets toe"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "onze Wiki"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Zelfmoord"
@@ -1154,7 +1154,7 @@ msgstr "aan het maken..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Objecten creëren vanuit het opgeslagen bestand"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Dank"
 
@@ -1333,12 +1333,12 @@ msgstr "Devbuilds Supporters"
 msgid "DEVELOPERS"
 msgstr "Ontwikkelaars"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Ontwikkeling ondersteund door Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Voeg een nieuwe sneltoets toe"
@@ -1347,12 +1347,12 @@ msgstr "Voeg een nieuwe sneltoets toe"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Ontwikkeling ondersteund door Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Ontwikkelaars"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Help"
@@ -1479,7 +1479,7 @@ msgstr ""
 "Er zijn geplaatste organellen die niet geconnecteerd zijn met de rest.\n"
 "Connecteer a.u.b. alle geplaatste organellen met elkaar of maak aanpassingen ongedaan."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Voeg een nieuwe sneltoets toe"
@@ -1497,7 +1497,7 @@ msgstr ""
 "en misschien veel ambitieuzer over brokken zijn.\n"
 "Responsieve microben zullen sneller overschakelen naar nieuwe doelen."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1545,7 +1545,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Een membraan met twee lagen, heft een betere bescherming tegen schade en heeft minder energie nodig om zijn vorm te behouden. Daar komt tegenin dat het de cel vertraagt en de snelheid waarmee het grondstoffen absorbeert verkleint."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1735,15 +1735,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1799,6 +1799,20 @@ msgstr "Error bij het maken van het bestand voor de mod info"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Fout: Het opslaan van nieuwe instellingen in het configuratiebestand is mislukt."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+"Angstige microben zullen over grotere afstanden vluchten\n"
+"en hebben meer kans om te vluchten voor roofdieren in het algemeen.\n"
+"Dappere microben worden niet geïntimideerd door nabijgelegen roofdieren\n"
+"en zullen waarschijnlijk terug aanvallen."
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Error bij het maken van het bestand voor de mod info"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Fout bij het laden"
@@ -1853,7 +1867,7 @@ msgstr "Een uitzondering is opgetreden tijdens het laden van de opgeslagen gegev
 msgid "EXIT"
 msgstr "Verlaten"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Launch E(toets)"
@@ -1909,7 +1923,7 @@ msgstr "stierf uit op de planeet"
 msgid "EXTINCT_SPECIES"
 msgstr "UITSTERVEN"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extra's"
 
@@ -1917,7 +1931,7 @@ msgstr "Extra's"
 msgid "EXTRA_OPTIONS"
 msgstr "Extra opties"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Pauzeer het spel"
@@ -1951,6 +1965,23 @@ msgstr "Cheattoetsen ingeschakeld"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Februari"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Initialisatie van Steam-clientbibliotheek mislukt"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -2038,7 +2069,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Voedselketen"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -2149,7 +2180,7 @@ msgstr "Generatie:"
 msgid "GENERATION_COLON"
 msgstr "Generatie:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Zelfmoord"
@@ -2158,11 +2189,11 @@ msgstr "Zelfmoord"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 Moduswaarschuwing"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Je gebruikt GLES2 om Thrive uit te voeren. Dit is ernstig ongetest en zal waarschijnlijk problemen veroorzaken. Probeer je video drivers te updaten en/of gebruik te maken van AMD of Nvidia graphics om Thrive uit te voeren."
 
@@ -2452,7 +2483,7 @@ msgstr "Ijzer"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Ijzer Chemolithoautotrofie"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Zelfmoord"
@@ -2671,7 +2702,7 @@ msgstr "Aan deze taal wordt nog gewerkt ({0}% voltooid)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Deze vertaling is erg onvolledig ({0}% klaar) help ons alstublieft!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2835,7 +2866,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Linker muis"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licenties"
 
@@ -2977,7 +3008,8 @@ msgstr "Laden"
 msgid "LOADING"
 msgstr "Laden"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Laden..."
 
@@ -3009,12 +3041,12 @@ msgstr "Druk op de \"ongedaan maken\" knop in de \"editor\" om een fout te corri
 msgid "LOAD_FINISHED"
 msgstr "Laden voltooid"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Spel Laden"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Pauze menu"
@@ -3269,7 +3301,7 @@ msgstr "Elke generatie heb je 100 mutatie punten (MP) om uit te geven, en elke v
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Elke keer dat je reproduceert kom je in de microbe \"editor\" waar je aanpassingen aan je soort kan maken (door het toevoegen, verplaatsen en verwijderen van organellen) om je soort succesvoller te maken. Elk bezoek aan de \"editor\" in de microbe-fase weerspiegelt [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] miljoen jaar van evolutie."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Microbe Vrij Bouwen in de \"Editor\""
 
@@ -3512,11 +3544,11 @@ msgstr "Organel verplaatsen"
 msgid "MODIFY_TYPE"
 msgstr "Pas aan"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3605,11 +3637,11 @@ msgstr "Interne (folder) Naam:"
 msgid "MOD_LICENSE"
 msgstr "Mod Licentie:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Errors tijdens het laden van mods"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Er zijn fouten opgetreden bij het laden van 1 of meer mods. Logs kunnen meer informatie bevatten."
 
@@ -3849,15 +3881,19 @@ msgstr ""
 "Dit opgeslagen bestand is van een nieuwere versie van Thrive en is waarschijnlijk niet-compatibel.\n"
 "Wil je toch proberen het opgeslagen bestand te laden?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Nieuw Spel"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Pauze menu"
@@ -3963,7 +3999,7 @@ msgid "NO_AI"
 msgstr "Geen AI"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Geen data om te tonen"
 
@@ -3976,7 +4012,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Geen save folder gevonden"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Uitgeschakeld"
@@ -4007,7 +4043,7 @@ msgstr "Geen geselecteerde mod"
 msgid "NUCLEUS"
 msgstr "Nucleus"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -4026,8 +4062,8 @@ msgstr "Num Lock(toets)"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -4040,16 +4076,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr "Oktober"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Zelfmoord"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4130,11 +4166,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunistisch"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opties"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Help"
@@ -4357,7 +4393,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Grot"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Pauzeer het spel"
@@ -4418,8 +4454,8 @@ msgstr "Prestaties"
 msgid "PERFORM_UNBINDING"
 msgstr "Start ontbinden"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/seconde"
 
@@ -4470,7 +4506,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Spelerscel"
 
@@ -4549,7 +4585,7 @@ msgstr "Totale populatie:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "{0} ({1})"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4606,7 +4642,7 @@ msgstr "Soorten:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Verwerken van geladen objecten"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4650,11 +4686,11 @@ msgstr "Snel laden"
 msgid "QUICK_SAVE"
 msgstr "Snel opslaan"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Stoppen"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4700,7 +4736,7 @@ msgstr "Threads:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Aangeraden Thrive:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Hervat het spel"
@@ -4845,7 +4881,7 @@ msgstr ""
 "Ben je zeker dat terug wilt naar het hoofd menu?\n"
 "Je verliest alle niet opgeslagen voortgang."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Door Revolutionary Games Studio"
@@ -4934,7 +4970,7 @@ msgstr "Rusticyanine is een proteïne dat koolstofdioxide en zuurstof kan gebrui
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Verandert [thrive:compound type=\"iron\"][/thrive:compound] in [thrive:compound type=\"atp\"][/thrive:compound]. Ratio schaalt met concentratie van [thrive:compound type=\"carbondioxide\"][/thrive:compound] en [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4943,7 +4979,7 @@ msgstr ""
 "Dappere microben worden niet geïntimideerd door nabijgelegen roofdieren\n"
 "en zullen waarschijnlijk terug aanvallen."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Verwijder lokale Data"
@@ -5330,7 +5366,7 @@ msgstr "Ammoniak spawnen"
 msgid "SPAWN_ENEMY"
 msgstr "Vijand spawnen"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Kan geen cheat voor spawn-vijand gebruiken omdat deze patch geen vijandige soorten bevat"
 
@@ -5384,7 +5420,7 @@ msgstr "Soortnaam..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Soortnaam..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5501,17 +5537,17 @@ msgstr "Steam is momenteel niet beschikbaar, probeer het opnieuw"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Er is een onbekende Steam-fout opgetreden"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Initialisatie van Steam-clientbibliotheek mislukt"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Het upgraden van de geselecteerde save is gefaald door de volgende error:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Pauzeer het spel"
@@ -5555,7 +5591,7 @@ msgstr "Opslag"
 msgid "STORAGE_COLON"
 msgstr "Opslag"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Ingelogd als : {0}"
 
@@ -5672,7 +5708,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Testing Team"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5687,7 +5723,7 @@ msgstr ""
 "\n"
 "Als je het spel leuk vond, vertel je vrienden dan over ons."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "JE HEBT OVERWONNEN!"
@@ -5751,7 +5787,7 @@ msgstr "Deze mod is gedownload van de Steam Workshop"
 msgid "THREADS"
 msgstr "Threads:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5905,7 +5941,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Schakel ontbinding"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Hulpmiddelen"
 
@@ -6140,7 +6176,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Tutorial"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Help"
@@ -6342,7 +6378,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Bekijk de broncode"
 
@@ -6354,7 +6390,7 @@ msgstr "VIP Supporters"
 msgid "VISIBLE"
 msgstr "Zichtbaar"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6510,7 +6546,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "jaren"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Pauzeer het spel"

--- a/locale/nl_BE.po
+++ b/locale/nl_BE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-07-20 09:20+0000\n"
 "Last-Translator: Simeon Duwel <tameimpalafan123@gmail.com>\n"
 "Language-Team: Dutch (Belgium) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/nl_BE/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.13.1\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr "Editor"
 msgid "3D_MOVEMENT"
 msgstr "Beweging"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr "Actief"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Huidige discussies:"
 
@@ -152,7 +152,7 @@ msgstr "Organismestatistieken"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Sfeer volume"
 
@@ -163,11 +163,11 @@ msgstr "Sfeer volume"
 msgid "AMMONIA"
 msgstr "Ammoniak"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Hoeveelheid autosaves om bij te houden:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Hoeveelheid snel opgeslagen bestanden om bij te houden:"
 
@@ -192,11 +192,11 @@ msgstr "Pas aanpassingen toe"
 msgid "APRIL"
 msgstr "April"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Ben je zeker dat je ALLE instellingen wilt resetten naar de standaardwaarden?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Bent u zeker dat u de invoersinstellingen wilt resetten naar de standaardwaarden?"
 
@@ -213,7 +213,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Kunst door {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Kunst galerij"
 
@@ -226,7 +226,7 @@ msgstr "Mod assembly class is vereist wanneer assembly is gespecifieerd"
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "Mod assembly class is vereist wanneer assembly is gespecifieerd"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Ga er van uit dat de CPU hyperthreading heeft ingeschakeld"
 
@@ -269,7 +269,7 @@ msgstr "Auto-evo mislukt"
 msgid "AT_CURSOR"
 msgstr "Bij cursor:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Audio-uitvoerapparaat:"
 
@@ -277,8 +277,8 @@ msgstr "Audio-uitvoerapparaat:"
 msgid "AUGUST"
 msgstr "Augustus"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Auto"
 
@@ -307,7 +307,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% klaar. {1:n0}/{2:n0} stappen."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Autosave tijdens het spelen"
 
@@ -315,7 +315,7 @@ msgstr "Autosave tijdens het spelen"
 msgid "AUTO_EVO"
 msgstr "Auto-evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "loopstatus:"
@@ -346,7 +346,7 @@ msgstr "loopstatus:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Beweeg automatisch naar voor"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 #, fuzzy
 msgid "AUTO_RESOLUTION"
 msgstr "Resolutie:"
@@ -360,9 +360,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -506,7 +506,7 @@ msgstr "Maakt binding met andere cellen mogelijk. Dit is de eerste stap naar mee
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Druk [thrive:input]g_toggle_binding[/thrive:input] om verbinding modus te togglen. In verbinding modus kan je jezelf verbinden met andere cellen door tegen ze aan te bewegen. Om een kolonie te verlaten druk [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -568,7 +568,7 @@ msgstr "Dit membraan heeft een sterke schelp gemaakt van calciumcarbonaat. Het k
 msgid "CAMERA"
 msgstr "Camera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -701,7 +701,7 @@ msgstr "Verander de symmetrie"
 msgid "CHEATS"
 msgstr "Cheats"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Cheattoetsen ingeschakeld"
 
@@ -797,7 +797,7 @@ msgstr "Produceert [thrive:compound type=\"glucose\"][/thrive:compound]. Ratio s
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "De gekozen bestandsnaam ({0}) bestaat al. Wil je dit overschrijven?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Chromatische aberratie:"
 
@@ -841,15 +841,15 @@ msgstr "Ruim oude opgeslagen bestanden op"
 msgid "CLOSE"
 msgstr "Sluit"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Opties sluiten?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Wolk resolutie deler:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Wolk simulatie minimum interval:"
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr "Kleur"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Kleurenblindheid Correctie:"
 
@@ -926,26 +926,26 @@ msgstr "Verzadigingswaarde, de hoeveelheid grijs in een bepaalde kleur"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Waarde (helderheid) waarde, helderheid of intensiteit van de kleur"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Voeg een nieuwe sneltoets toe"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "onze Wiki"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Zelfmoord"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Chemische verbindingen:"
@@ -973,7 +973,7 @@ msgstr "Chemische verbindingen:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Balansen van de chemische verbindingen"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Wolken met chemische stoffen"
 
@@ -1064,7 +1064,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1078,11 +1078,11 @@ msgstr "{0} bevolking veranderd met {1} door: {2}"
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1090,11 +1090,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Kopieer fout naar het klembord"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanope (Rood-Groen)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanope (Blauw-Geel)"
 
@@ -1154,7 +1154,7 @@ msgstr "aan het maken..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Objecten creëren vanuit het opgeslagen bestand"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Dank"
 
@@ -1180,7 +1180,7 @@ msgstr "Huidige Ontwikkelaars"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Organismestatistieken"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Aangepaste gebruikersnaam:"
 
@@ -1253,7 +1253,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr "December"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Standaard uitvoer apparaat"
 
@@ -1320,7 +1320,7 @@ msgstr "Omschrijving is te lang"
 msgid "DESPAWN_ENTITIES"
 msgstr "Vijand spawnen"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Gedetecteerde CPU hoeveelheid:"
 
@@ -1333,12 +1333,12 @@ msgstr "Devbuilds Supporters"
 msgid "DEVELOPERS"
 msgstr "Ontwikkelaars"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Ontwikkeling ondersteund door Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Voeg een nieuwe sneltoets toe"
@@ -1347,12 +1347,12 @@ msgstr "Voeg een nieuwe sneltoets toe"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Ontwikkeling ondersteund door Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Ontwikkelaars"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Help"
@@ -1429,7 +1429,7 @@ msgstr "Links"
 msgid "DIRECTIONR"
 msgstr "Rechts"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Uitgeschakeld"
 
@@ -1437,7 +1437,7 @@ msgstr "Uitgeschakeld"
 msgid "DISABLE_ALL"
 msgstr "Alles uitschakelen"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Verwijderen en doorgaan"
 
@@ -1479,17 +1479,17 @@ msgstr ""
 "Er zijn geplaatste organellen die niet geconnecteerd zijn met de rest.\n"
 "Connecteer a.u.b. alle geplaatste organellen met elkaar of maak aanpassingen ongedaan."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Voeg een nieuwe sneltoets toe"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Snelheid:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
@@ -1497,19 +1497,19 @@ msgstr ""
 "en misschien veel ambitieuzer over brokken zijn.\n"
 "Responsieve microben zullen sneller overschakelen naar nieuwe doelen."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Toon vaardigheden balk"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "Toon vaardigheden balk"
@@ -1545,7 +1545,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Een membraan met twee lagen, heft een betere bescherming tegen schade en heeft minder energie nodig om zijn vorm te behouden. Daar komt tegenin dat het de cel vertraagt en de snelheid waarmee het grondstoffen absorbeert verkleint."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1707,7 +1707,7 @@ msgstr ""
 "\n"
 "Om naar het volgende tabblad te gaan druk je op de volgende knop rechts onder."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1723,7 +1723,7 @@ msgstr "Activeer alle compatibele mods"
 msgid "ENABLE_EDITOR"
 msgstr "Schakel de editor in"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Activeer GUI licht effecten"
 
@@ -1783,7 +1783,7 @@ msgstr "Toon / verstop omgeving en verbindingen"
 msgid "EPIPELAGIC"
 msgstr "Epipelagisch"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Fout"
 
@@ -1795,11 +1795,11 @@ msgstr "Fout bij het creëren van de map voor de mod"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Error bij het maken van het bestand voor de mod info"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Fout: Het opslaan van nieuwe instellingen in het configuratiebestand is mislukt."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
@@ -1808,7 +1808,7 @@ msgstr ""
 "Dappere microben worden niet geïntimideerd door nabijgelegen roofdieren\n"
 "en zullen waarschijnlijk terug aanvallen."
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Error bij het maken van het bestand voor de mod info"
@@ -1843,12 +1843,12 @@ msgstr "Door Revolutionary Games Studio"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Door Revolutionary Games Studio"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Generatie:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Zelfmoord"
@@ -1867,7 +1867,7 @@ msgstr "Een uitzondering is opgetreden tijdens het laden van de opgeslagen gegev
 msgid "EXIT"
 msgstr "Verlaten"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Launch E(toets)"
@@ -1923,7 +1923,7 @@ msgstr "stierf uit op de planeet"
 msgid "EXTINCT_SPECIES"
 msgstr "UITSTERVEN"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extra's"
 
@@ -1931,7 +1931,7 @@ msgstr "Extra's"
 msgid "EXTRA_OPTIONS"
 msgstr "Extra opties"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Pauzeer het spel"
@@ -1966,20 +1966,20 @@ msgstr "Cheattoetsen ingeschakeld"
 msgid "FEBRUARY"
 msgstr "Februari"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Initialisatie van Steam-clientbibliotheek mislukt"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2114,7 +2114,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr "Zittend"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2151,7 +2151,7 @@ msgstr ""
 "en misschien veel ambitieuzer over brokken zijn.\n"
 "Responsieve microben zullen sneller overschakelen naar nieuwe doelen."
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Volledig scherm"
 
@@ -2180,24 +2180,24 @@ msgstr "Generatie:"
 msgid "GENERATION_COLON"
 msgstr "Generatie:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Zelfmoord"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 Moduswaarschuwing"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Je gebruikt GLES2 om Thrive uit te voeren. Dit is ernstig ongetest en zal waarschijnlijk problemen veroorzaken. Probeer je video drivers te updaten en/of gebruik te maken van AMD of Nvidia graphics om Thrive uit te voeren."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2251,12 +2251,12 @@ msgstr "Begrepen"
 msgid "GPL_LICENSE_HEADING"
 msgstr "GPL licentie tekst volgt:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "Grot"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Graphics"
 
@@ -2264,7 +2264,7 @@ msgstr "Graphics"
 msgid "GRAPHICS_TEAM"
 msgstr "Grafisch Team"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2281,7 +2281,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} K"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "GUI volume"
 
@@ -2303,11 +2303,11 @@ msgstr "Help"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Help"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(hogere waarden verslechteren prestaties)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(hogere waarden verslechteren prestaties)"
 
@@ -2332,7 +2332,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Home"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Generatie:"
@@ -2407,7 +2407,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Voeg een nieuwe sneltoets toe"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Invoer"
 
@@ -2462,8 +2462,8 @@ msgstr "Ongeldig URL formaat"
 msgid "INVALID_URL_SCHEME"
 msgstr "ongeldig URL schema"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2483,7 +2483,7 @@ msgstr "Ijzer"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Ijzer Chemolithoautotrofie"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Zelfmoord"
@@ -2492,19 +2492,19 @@ msgstr "Zelfmoord"
 msgid "JANUARY"
 msgstr "Januari"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "JSON debug modus:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Altijd"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automatisch"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Nooit"
 
@@ -2686,19 +2686,19 @@ msgstr "Num .(toets)."
 msgid "KPSUBTRACT"
 msgstr "Num -(toets)"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Taal:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Deze taal is {0}% volledig"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Aan deze taal wordt nog gewerkt ({0}% voltooid)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Deze vertaling is erg onvolledig ({0}% klaar) help ons alstublieft!"
 
@@ -2866,7 +2866,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Linker muis"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licenties"
 
@@ -2942,7 +2942,7 @@ msgstr "Wiel naar rechts"
 msgid "LIGHT_MAX"
 msgstr "Licht"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "Extra's"
@@ -2957,32 +2957,32 @@ msgstr "BEVESTIGEN"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "{0} bevolking veranderd met {1} door: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "BEVESTIGEN"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr "Laden"
 msgid "LOADING"
 msgstr "Laden"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Laden..."
@@ -3041,12 +3041,12 @@ msgstr "Druk op de \"ongedaan maken\" knop in de \"editor\" om een fout te corri
 msgid "LOAD_FINISHED"
 msgstr "Laden voltooid"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Spel Laden"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Pauze menu"
@@ -3129,7 +3129,7 @@ msgstr "Maart"
 msgid "MARINE_SNOW"
 msgstr "Mariene sneeuw"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Meester volume"
 
@@ -3138,16 +3138,16 @@ msgstr "Meester volume"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "stierf uit op de planeet"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Max FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 #, fuzzy
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Max FPS:"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3301,7 +3301,7 @@ msgstr "Elke generatie heb je 100 mutatie punten (MP) om uit te geven, en elke v
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Elke keer dat je reproduceert kom je in de microbe \"editor\" waar je aanpassingen aan je soort kan maken (door het toevoegen, verplaatsen en verwijderen van organellen) om je soort succesvoller te maken. Elk bezoek aan de \"editor\" in de microbe-fase weerspiegelt [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] miljoen jaar van evolutie."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Microbe Vrij Bouwen in de \"Editor\""
 
@@ -3477,7 +3477,7 @@ msgstr "Minimum:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Niet toegestaan om minder dan {0} dataset(s) te tonen!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Varia"
 
@@ -3544,11 +3544,11 @@ msgstr "Organel verplaatsen"
 msgid "MODIFY_TYPE"
 msgstr "Pas aan"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3637,11 +3637,11 @@ msgstr "Interne (folder) Naam:"
 msgid "MOD_LICENSE"
 msgstr "Mod Licentie:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Errors tijdens het laden van mods"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Er zijn fouten opgetreden bij het laden van 1 of meer mods. Logs kunnen meer informatie bevatten."
 
@@ -3694,11 +3694,11 @@ msgstr "Mod Versie:"
 msgid "MORE_INFO"
 msgstr "Toon meer info"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3815,7 +3815,7 @@ msgstr "Organel plaatsen"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Organel plaatsen"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Multisample anti-aliasing:"
 
@@ -3827,7 +3827,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Muziek"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Muziek volume"
 
@@ -3851,9 +3851,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr "Mutatiepunten"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Dempen"
 
@@ -3889,11 +3889,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Nieuw Spel"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Pauze menu"
@@ -3962,7 +3962,7 @@ msgstr "De stikstoffixerende plastide is een proteïne dat gasvormige stikstof e
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Verandert [thrive:compound type=\"atp\"][/thrive:compound] in [thrive:compound type=\"ammonia\"][/thrive:compound]. Ratio schaalt met concentratie van [thrive:compound type=\"nitrogen\"][/thrive:compound] and [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Geen"
 
@@ -4012,7 +4012,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Geen save folder gevonden"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Uitgeschakeld"
@@ -4030,7 +4030,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Geen save folder gevonden"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Geen screenshot folder gevonden"
 
@@ -4076,16 +4076,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr "Oktober"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Zelfmoord"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4122,7 +4122,7 @@ msgstr "Open help-scherm"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Vrij bouwen"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Open Logs Map"
 
@@ -4138,7 +4138,7 @@ msgstr "Open Organel menu"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Open adresboek van opgeslagen bestanden"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Open Screenshotfolder"
 
@@ -4146,7 +4146,7 @@ msgstr "Open Screenshotfolder"
 msgid "OPEN_THE_MENU"
 msgstr "Open het menu"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Help met het spel te vertalen"
 
@@ -4166,11 +4166,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunistisch"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opties"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Help"
@@ -4393,7 +4393,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Grot"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Pauzeer het spel"
@@ -4446,7 +4446,7 @@ msgstr "Vreedzaam"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Prestaties"
 
@@ -4531,7 +4531,7 @@ msgstr "Duplicaat speler"
 msgid "PLAYER_EXTINCT"
 msgstr "Speler is uitgestorven"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Speler is uitgestorven"
@@ -4546,23 +4546,23 @@ msgstr ""
 "Speler\n"
 "Snelheid"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Speel intro video"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Speel microbe intro bij nieuw spel"
 
@@ -4686,11 +4686,11 @@ msgstr "Snel laden"
 msgid "QUICK_SAVE"
 msgstr "Snel opslaan"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Stoppen"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4736,7 +4736,7 @@ msgstr "Threads:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Aangeraden Thrive:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Hervat het spel"
@@ -4795,7 +4795,7 @@ msgstr "gereproduceerd"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Nucleus"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Resetten"
 
@@ -4804,24 +4804,24 @@ msgstr "Resetten"
 msgid "RESET_DEADZONES"
 msgstr "Standaardinstellingen herstellen?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Invoer resetten naar standaardwaarden?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Reset Invoer"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Standaardwaarden"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Standaardinstellingen herstellen?"
 
@@ -4830,7 +4830,7 @@ msgstr "Standaardinstellingen herstellen?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Resolutie:"
 
@@ -4881,7 +4881,7 @@ msgstr ""
 "Ben je zeker dat terug wilt naar het hoofd menu?\n"
 "Je verliest alle niet opgeslagen voortgang."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Door Revolutionary Games Studio"
@@ -4915,7 +4915,7 @@ msgstr "Draaien naar rechts"
 msgid "ROTATION_COLON"
 msgstr "Totale populatie:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Gebruik auto-evo tijdens gameplay"
 
@@ -4970,7 +4970,7 @@ msgstr "Rusticyanine is een proteïne dat koolstofdioxide en zuurstof kan gebrui
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Verandert [thrive:compound type=\"iron\"][/thrive:compound] in [thrive:compound type=\"atp\"][/thrive:compound]. Ratio schaalt met concentratie van [thrive:compound type=\"carbondioxide\"][/thrive:compound] en [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4979,16 +4979,16 @@ msgstr ""
 "Dappere microben worden niet geïntimideerd door nabijgelegen roofdieren\n"
 "en zullen waarschijnlijk terug aanvallen."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Verwijder lokale Data"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Opslaan"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Opslaan en doorgaan"
 
@@ -5091,21 +5091,21 @@ msgstr "Opslaan is momenteel niet mogelijk door:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Opslaan geslaagd"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr "Verbindings agent"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "voor het verhogen van de"
@@ -5210,7 +5210,7 @@ msgstr "Zittend"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Deze waarde is alleen van toepassing op nieuwe games die zijn gestart nadat deze optie is gewijzigd"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Volume Geluidseffecten"
 
@@ -5227,23 +5227,27 @@ msgstr "Laat hulp zien"
 msgid "SHOW_TUTORIALS"
 msgstr "Toon tutorials"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Laat instructies zien (in huidig spel)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Laat instructies zien (in nieuwe spellen)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Toon niet opgeslagen voortgang waarschuwing"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Zet aan / uit de waarschuwing voor niet opgeslagen voortgang wanner de speler het spel probeert te verlaten."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5296,7 +5300,7 @@ msgstr "Siliciumdioxide"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Dit membraan heeft een sterke wand van siliciumdioxide. Het kan algemene schade goed weerstaan en is zeer resistent tegen fysieke schade. Het heeft ook minder energie nodig om zijn vorm te behouden. Echter, het vertraagt de cel met een grote factor en de cel absorbeert stoffen minder snel."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5338,7 +5342,7 @@ msgstr "Verandert [thrive:compound type=\"glucose\"][/thrive:compound] in [thriv
 msgid "SMALL_IRON_CHUNK"
 msgstr "Klein Brok Ijzer"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Geluid"
 
@@ -5537,17 +5541,17 @@ msgstr "Steam is momenteel niet beschikbaar, probeer het opnieuw"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Er is een onbekende Steam-fout opgetreden"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Initialisatie van Steam-clientbibliotheek mislukt"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Het upgraden van de geselecteerde save is gefaald door de volgende error:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Pauzeer het spel"
@@ -5591,7 +5595,7 @@ msgstr "Opslag"
 msgid "STORAGE_COLON"
 msgstr "Opslag"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Ingelogd als : {0}"
 
@@ -5708,7 +5712,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Testing Team"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5723,7 +5727,7 @@ msgstr ""
 "\n"
 "Als je het spel leuk vond, vertel je vrienden dan over ons."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "JE HEBT OVERWONNEN!"
@@ -5783,11 +5787,11 @@ msgstr "Dit is een lokaal geïnstalleerde mod"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Deze mod is gedownload van de Steam Workshop"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Threads:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5941,7 +5945,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Schakel ontbinding"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Hulpmiddelen"
 
@@ -6007,7 +6011,7 @@ msgstr "Probeer wat screenshots te pakken!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Probeer een save te maken!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Probeer wat screenshots te pakken!"
 
@@ -6176,12 +6180,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Tutorial"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Help"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6207,7 +6211,7 @@ msgstr "Ontbind alles"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Ontbind modus"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6230,7 +6234,7 @@ msgstr "Maak de laatste handeling ongedaan"
 msgid "UNKNOWN"
 msgstr "Onbekend"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Toon vaardigheden balk"
@@ -6244,7 +6248,7 @@ msgstr "Onbekende muis"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Onbekende Workshop ID voor deze mod"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Mod Versie:"
@@ -6253,7 +6257,7 @@ msgstr "Mod Versie:"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Onbekende Workshop ID voor deze mod"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Je hebt niet-opgeslagen wijzigingen die worden verwijderd.\n"
@@ -6298,7 +6302,7 @@ msgstr "Upload geslaagd"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Licenties en gebruikte bibliotheken"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6316,7 +6320,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Zelfmoord"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Gebruik een gebruikersnaam naar keuze"
 
@@ -6324,11 +6328,11 @@ msgstr "Gebruik een gebruikersnaam naar keuze"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Handmatig aantal achtergrondthreads instellen"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6355,7 +6359,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr "Generatie:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Generatie:"
@@ -6366,11 +6370,11 @@ msgstr "Generatie:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Snelheid:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Bekijk de broncode"
 
@@ -6390,7 +6394,7 @@ msgstr "VIP Supporters"
 msgid "VISIBLE"
 msgstr "Zichtbaar"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6410,7 +6414,7 @@ msgstr "Volume uit"
 msgid "VOLUMEUP"
 msgstr "Volume omhoog"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSync"
 
@@ -6517,7 +6521,7 @@ msgstr "Organismestatistieken"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "voor het verhogen van de"
@@ -6526,15 +6530,15 @@ msgstr "voor het verhogen van de"
 msgid "WORST_PATCH_COLON"
 msgstr "Slechtste Zone:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6546,7 +6550,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "jaren"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Pauzeer het spel"

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-10-28 14:00+0000\n"
 "Last-Translator: Nie <tym@wrozynski.com>\n"
 "Language-Team: Polish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/pl/>\n"
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Autor: {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Galeria"
 
@@ -302,7 +302,7 @@ msgstr "Autozapis w trakcie gry"
 msgid "AUTO_EVO"
 msgstr "Auto-Ewolucja"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Narzędzie Eksploracji Auto-Ewo"
 
@@ -345,8 +345,8 @@ msgid "AWAKEN"
 msgstr "Przebudzony"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -601,27 +601,27 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Dwutlenek Węgla"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "Mnóstwo"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "Średnia Ilość"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "Mało"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "Całkiem Sporo"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "Trochę"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "Prawie Wcale"
 
@@ -889,21 +889,21 @@ msgstr "Wartość nasycenia, ilość szarości w konkretnym kolorze"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Wartość (jasność) wartość, jasność lub intensywność koloru"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Wejdź do edytora i modyfikuj swój gatunek"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "Nasza strona Wiki"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Opuść grę"
@@ -1106,7 +1106,7 @@ msgstr "Tworzenie..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Tworzenie obiektów z pliku zapisu"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Twórcy"
 
@@ -1275,12 +1275,12 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Developerzy"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Rozwój Wspierany Przez Revolutionary Games Studio"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Wejdź do edytora i modyfikuj swój gatunek"
@@ -1289,12 +1289,12 @@ msgstr "Wejdź do edytora i modyfikuj swój gatunek"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Rozwój Wspierany Przez Revolutionary Games Studio"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Developerzy"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Pomoc"
@@ -1414,7 +1414,7 @@ msgstr ""
 "Są organelle które nie są połączone do reszty komórki.\n"
 "Proszę połączyć wszystkie organelle albo cofnij zmiany."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Upłynęło {0:#,#} lat"
@@ -1427,7 +1427,7 @@ msgstr "Ukryte pop-up'y:"
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr "Należy kliknąć dwa razy żeby przejść w tryb pełnego ekranu"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Membrana z dwoma warstwami, lepiej chroni przed uszkodzeniami i potrzebuje mniej energii żeby się nie deformować. Aczkolwiek, spowalnia trochę komórkę oraz prędkość absorbcji zasobów."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Nie ostrzegaj przed tym ponownie"
 
@@ -1656,15 +1656,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Energia w {0} dla {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Źródła Energii:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "Całkowita zdobyta energia wynosi {0} z indywidualnym kosztem {1} tworzącym nieuregulowaną populację {2}"
 
@@ -1717,6 +1717,16 @@ msgstr "Błąd przy zmienianiu moda w plik"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Błąd: Nie udało się zapisać nowych ustawień w pliku konfiguracji."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(losowo generowane sekrety w grze)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Błąd przy zmienianiu moda w plik"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Błąd wczytywania"
@@ -1766,7 +1776,7 @@ msgstr "Podczas wczytywania danych zapisu nastąpił wyjątek"
 msgid "EXIT"
 msgstr "Wyjdź"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Wyjdź do Launchera"
 
@@ -1818,7 +1828,7 @@ msgstr "wymarły w obszarze"
 msgid "EXTINCT_SPECIES"
 msgstr "Wymarły Gatunek"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Dodatki"
 
@@ -1826,7 +1836,7 @@ msgstr "Dodatki"
 msgid "EXTRA_OPTIONS"
 msgstr "Dodatkowe Opcje"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Zapauzuj"
@@ -1860,6 +1870,40 @@ msgstr "Klawisze oszustw włączone"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Luty"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Czas Procesu: {0} s\n"
+"Czas Fizyki: {1} s\n"
+"Istoty: {2} Inne: {3}\n"
+"Stworzone: {4} Zniszczone: {5}\n"
+"Użyte węzły: {6}\n"
+"Użyta Pamięć: {7} MiB\n"
+"Pamięć układu graficznego: {8} MiB\n"
+"Wyrenderowane Obiekty: {9}\n"
+"Obiekty na ekranie: {10} 2D: {11}\n"
+"Wyrenderowane wierzchołki: {12}\n"
+"Zmiany Materiału: {13}\n"
+"Zmiany Shaderów: {14}\n"
+"Porzucone Węzły: {15};\n"
+"Opóźnienie Dźwięku: {16} ms\n"
+"Całkowite Wątki: {17}\n"
+"Całkowity Czas Procesora:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1943,7 +1987,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Łańcuch Pokarmowy"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0} energia: {1} (sprawność: {2}) całkowita dostępna energia: {3} (całkowita sprawność: {4})"
 
@@ -2046,7 +2090,7 @@ msgstr "Pokolenia"
 msgid "GENERATION_COLON"
 msgstr "Generacja:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Opuść grę"
@@ -2055,11 +2099,11 @@ msgstr "Opuść grę"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Ostrzeżenie Tryb GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Uruchomiłeś Thrive w GLES2. Jest to poważnie nietestowane i prawdopodobnie spowoduje problemy. Zaaktualizuj sterowniki graficzne i/lub wymuś użycie grafiki AMD lub Nvidia do uruchamiania Trive."
 
@@ -2346,7 +2390,7 @@ msgstr "Żelazo (Fe²⁺)"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Utlenianie Żelaza"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Opuść grę"
@@ -2565,7 +2609,7 @@ msgstr "Ten język nadal jest w trakcie tłumaczenia ({0}% ukończenia)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Ta wersja językowa jest bardzo słabo przetłumaczona ({0}%). Jeżeli możesz, pomóż to zmienić!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "Nie można usunąć ostatniej organelli"
 
@@ -2724,7 +2768,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Lewy przycisk myszy"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licencje"
 
@@ -2854,7 +2898,8 @@ msgstr "Wczytaj"
 msgid "LOADING"
 msgstr "Wczytywanie"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Wczytywanie..."
 
@@ -2884,12 +2929,12 @@ msgstr "Wciśnij przycisk \"cofnij\" w edytorze żeby poprawić błąd"
 msgid "LOAD_FINISHED"
 msgstr "Wczytywanie zakończone"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Wczytaj grę"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Załaduj poprzednio zapisane gry"
 
@@ -3167,7 +3212,7 @@ msgstr "Na każdą generację masz 100 punktów mutacji (PM) do wydania, i każd
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Za każdym razem kiedy się rozmnażasz, wejdziesz w Edytor Mikroba, w którym możesz wprowadzać zmiany do twojego gatunku (przez dodawanie, przenoszenie lub usuwanie organelli) aby zwiększyć sukces twojego gatunku. Każda wizyta edytora w Etapie Mikroba reprezentuje [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milionów lat ewolucji."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Kreatywny Edytor Mikroba"
 
@@ -3415,11 +3460,11 @@ msgstr "Modyfikuj Organellę"
 msgid "MODIFY_TYPE"
 msgstr "Modyfikuj Typ"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Modyfikacje"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Zainstalowane mody zostały wykryte, ale żaden mod nie jest włączony.\n"
@@ -3508,11 +3553,11 @@ msgstr "Nazwa wewnętrzna (pliku):"
 msgid "MOD_LICENSE"
 msgstr "Licencja Moda:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Błędy przy ładowaniu modów"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Doszło do błędu podczas ładowania jednego lub więcej modów. Rejestry mogą zawierać dodatkowe informacje."
 
@@ -3745,15 +3790,19 @@ msgstr ""
 "Ten zapis jest z nowszej wersji Thrive i prawdopodobnie niekompatybilny.\n"
 "Czy chcesz spróbować wczytać zapis mimo to?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Wstępna populacja dla gatunku zwiększającego bioróżnorodność"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Nowa Gra"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Zacznij nową grę"
 
@@ -3853,7 +3902,7 @@ msgid "NO_AI"
 msgstr "Brak SI"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Brak danych do pokazania"
 
@@ -3866,7 +3915,7 @@ msgstr "Nie zanotowano wydarzeń"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Nie znaleziono katalogu zapisów"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr "Brak Włączonych Modów"
 
@@ -3896,7 +3945,7 @@ msgstr "Nie wybrano Modów"
 msgid "NUCLEUS"
 msgstr "Jądro Komórkowe"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 "Nie można usunąć jądra komórkowego jako iż jest to nieodwracalna cecha.\n"
@@ -3917,8 +3966,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "Nie Dotyczy"
@@ -3931,16 +3980,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr "Październik"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Samobójstwo"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4020,11 +4069,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunizm"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opcje"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Zmień swoje ustawienia"
 
@@ -4235,7 +4284,7 @@ msgstr "Proceduralny"
 msgid "PATCH_NAME"
 msgstr "{0}: {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Zapauzuj"
@@ -4294,8 +4343,8 @@ msgstr "Wydajność"
 msgid "PERFORM_UNBINDING"
 msgstr "Dokonaj odwiązania"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/sekundę"
 
@@ -4346,7 +4395,7 @@ msgstr "Generacja planety już wkrótce!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Losowe ziarno planety"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Komórka Gracza"
 
@@ -4425,7 +4474,7 @@ msgstr "populacja:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "populacja w obszarach:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4479,7 +4528,7 @@ msgstr "poprzedni:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Przetwarzanie wczytanych obiektów"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4523,11 +4572,11 @@ msgstr "Szybkie wczytanie"
 msgid "QUICK_SAVE"
 msgstr "Szybki zapis"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Wyjdź"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Opuść grę"
@@ -4569,7 +4618,7 @@ msgstr "Gotowy"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Zalecana Wersja Gry:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Wznów"
@@ -4706,7 +4755,7 @@ msgstr ""
 "Czy na pewno chcesz wyjść do menu głównego?\n"
 "Utracisz cały niezapisany postęp."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Wykonane Przez Revolutionary Games Studio"
@@ -4794,11 +4843,11 @@ msgstr "Rusticyjanina to białko mogące użyć gazowego [thrive:compound type=\
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Utlenia [thrive:compound type=\"iron\"][/thrive:compound] wydzielając [thrive:compound type=\"atp\"][/thrive:compound]. Tempo skaluje się ze stężeniem [thrive:compound type=\"carbondioxide\"][/thrive:compound] i [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive Uruchomiło Się W Trybie Bezpiecznym"
 
@@ -5161,7 +5210,7 @@ msgstr "Stwórz amoniak"
 msgid "SPAWN_ENEMY"
 msgstr "Przywołaj Przeciwnika"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Nie można przywołać przeciwnika, gdyż ta strefa nie posiada wrogo nastawionych gatunków"
 
@@ -5221,7 +5270,7 @@ msgstr "Nazwa gatunku..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Nazwa gatunku jest za długa!"
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5336,17 +5385,17 @@ msgstr "Steam jest obecnie niedostępny, spróbuj ponownie."
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Nieznany błąd Steama"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Zapis nie zadziałał! Pojawił się błąd"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Aktualizacja wybranego zapisu zawiodła przez następujący błąd:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Zapauzuj"
@@ -5387,7 +5436,7 @@ msgstr "Magazyn"
 msgid "STORAGE_COLON"
 msgstr "Magazyn:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Zalogowano jako: {0}"
 
@@ -5504,7 +5553,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Testerzy"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Dziękujemy za wspieranie twórców Thrive przez kupowanie tej kopii gry!\n"
@@ -5520,7 +5569,7 @@ msgstr ""
 "\n"
 "Jeżeli Ci się spodobało, opowiedz o nas swoim znajomym."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "PRZETRWAŁEŚ!"
@@ -5580,7 +5629,7 @@ msgstr "Ten mod jest pobrany z Warsztatu Steam"
 msgid "THREADS"
 msgstr "Wątki:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thrivopedia"
 
@@ -5727,7 +5776,7 @@ msgstr "Pauza"
 msgid "TOGGLE_UNBINDING"
 msgstr "Przełączenie odwiązywania"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Narzędzia"
 
@@ -5953,7 +6002,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Oglądaj Teraz"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Upłynęło {0:#,#} lat"
@@ -6142,7 +6191,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Przeglądarka"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Zobacz Kod Źródłowy"
 
@@ -6154,7 +6203,7 @@ msgstr "VIP Wspierający"
 msgid "VISIBLE"
 msgstr "Widoczne"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Zasugeruj Funkcję"
 
@@ -6310,7 +6359,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "lata"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Zapauzuj"

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-10-28 14:00+0000\n"
 "Last-Translator: Nie <tym@wrozynski.com>\n"
 "Language-Team: Polish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/pl/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "Edytor 3D"
 msgid "3D_MOVEMENT"
 msgstr "Ruch 3D"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "Czynność zablokowana, kiedy inna jest w trakcie wykonywania"
 msgid "ACTIVE"
 msgstr "Ruchliwość"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Obecne wątki:"
 
@@ -144,7 +144,7 @@ msgstr "Statystyki Organizmu"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Głośność otoczenia"
 
@@ -155,11 +155,11 @@ msgstr "Głośność otoczenia"
 msgid "AMMONIA"
 msgstr "Amoniak (NH₃)"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Zachowana ilość autozapisów:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Zachowana ilość szybkich zapisów:"
 
@@ -184,11 +184,11 @@ msgstr "Zastosuj zmiany"
 msgid "APRIL"
 msgstr "Kwiecień"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Czy jesteś pewien że chcesz przywrócić WSZYSTKIE ustawienia do wartości domyślnych?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Czy jesteś pewien że chcesz zresetować ustawienia klawiszy do wartości domyślnych?"
 
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Autor: {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Galeria"
 
@@ -216,7 +216,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Załóż, że procesor pozwala na hyperthreading"
 
@@ -258,7 +258,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr "Pod kursorem:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Wyjściowe urządzenie audio:"
 
@@ -266,8 +266,8 @@ msgstr "Wyjściowe urządzenie audio:"
 msgid "AUGUST"
 msgstr "Sierpień"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Auto"
 
@@ -294,7 +294,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% zrobione. {1:n0}/{2:n0} kroków."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Autozapis w trakcie gry"
 
@@ -302,7 +302,7 @@ msgstr "Autozapis w trakcie gry"
 msgid "AUTO_EVO"
 msgstr "Auto-Ewolucja"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Narzędzie Eksploracji Auto-Ewo"
 
@@ -332,7 +332,7 @@ msgstr "Status działania:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Automatyczne poruszanie do przodu"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Auto ({0}x{1})"
 
@@ -345,9 +345,9 @@ msgid "AWAKEN"
 msgstr "Przebudzony"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -483,7 +483,7 @@ msgstr "Pomaga połączyć się z innymi komórkami. To jest pierwszy krok do wi
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Naciśnij [thrive:input]g_toggle_binding[/thrive:input] aby przełączyć tryb wiązania. W trybie wiązania możesz dołączać inne komórki twojego gatunku do swojej kolonii wpływając w nie. Aby opuścić kolonię naciśnij [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr "Złącz osie ze sobą"
 
@@ -545,7 +545,7 @@ msgstr "Ta membrana ma silną muszlę zrobioną z węglanu wapnia. Może z łatw
 msgid "CAMERA"
 msgstr "Kamera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -673,7 +673,7 @@ msgstr "Zmień symetrię"
 msgid "CHEATS"
 msgstr "Oszustwa"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Klawisze oszustw włączone"
 
@@ -763,7 +763,7 @@ msgstr "Syntezuje [thrive:compound type=\"glucose\"][/thrive:compound]. Tempo sk
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Wybrana nazwa pliku ({0}) już istnieje. Nadpisać?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Aberracja chromatyczna:"
 
@@ -804,15 +804,15 @@ msgstr "Usuń stare zapisy"
 msgid "CLOSE"
 msgstr "Zamknij"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Zamknąć opcje?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Dzielnik rozdzielczości chmur:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Minimalny interwał symulacji chmur:"
 
@@ -828,7 +828,7 @@ msgstr "Przywołaj byty z kształtami kolizji"
 msgid "COLOUR"
 msgstr "Kolor"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Korekta kolorów dla daltonistów:"
 
@@ -889,26 +889,26 @@ msgstr "Wartość nasycenia, ilość szarości w konkretnym kolorze"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Wartość (jasność) wartość, jasność lub intensywność koloru"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Wejdź do edytora i modyfikuj swój gatunek"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "Nasza strona Wiki"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Opuść grę"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr "Zbudowane w:"
 
@@ -934,7 +934,7 @@ msgstr "Związki:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Balans Związków"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Chmury związków"
 
@@ -1019,7 +1019,7 @@ msgstr "Chcesz przejść do prototypów faz rozwoju?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr "Wizualizatory Osi Kontrolera:"
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr "Strefy Martwe Kontrolera"
 
@@ -1034,11 +1034,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr "Martwa strefa:"
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr "Czułość kontrolera"
 
@@ -1046,11 +1046,11 @@ msgstr "Czułość kontrolera"
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Skopiuj Błąd Do Schowka"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanopia (Czerwony-Zielony)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanopia (Niebieski-Żółty)"
 
@@ -1106,7 +1106,7 @@ msgstr "Tworzenie..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Tworzenie obiektów z pliku zapisu"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Twórcy"
 
@@ -1132,7 +1132,7 @@ msgstr "Obecni Developerzy"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Statystyki Organizmu"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Własna nazwa użytkownika:"
 
@@ -1198,7 +1198,7 @@ msgstr "Panel Debugowania"
 msgid "DECEMBER"
 msgstr "Grudzień"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Domyślne urządzenie wyjściowe"
 
@@ -1260,7 +1260,7 @@ msgstr "Opis jest za długi"
 msgid "DESPAWN_ENTITIES"
 msgstr "Usuń Wszystkie Byty"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Ilość wykrytych CPU:"
 
@@ -1275,12 +1275,12 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Developerzy"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Rozwój Wspierany Przez Revolutionary Games Studio"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Wejdź do edytora i modyfikuj swój gatunek"
@@ -1289,12 +1289,12 @@ msgstr "Wejdź do edytora i modyfikuj swój gatunek"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Rozwój Wspierany Przez Revolutionary Games Studio"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Developerzy"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Pomoc"
@@ -1368,7 +1368,7 @@ msgstr "Lewo"
 msgid "DIRECTIONR"
 msgstr "Prawo"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Wył"
 
@@ -1376,7 +1376,7 @@ msgstr "Wył"
 msgid "DISABLE_ALL"
 msgstr "Wyłącz wszystko"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Odrzuć i kontynuuj"
 
@@ -1414,32 +1414,32 @@ msgstr ""
 "Są organelle które nie są połączone do reszty komórki.\n"
 "Proszę połączyć wszystkie organelle albo cofnij zmiany."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Upłynęło {0:#,#} lat"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Ukryte pop-up'y:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Pokaż pasek umiejętności"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Wyświetlaj cząsteczki w tle"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Pokaż nazwy przycisków wyboru części"
 
@@ -1474,7 +1474,7 @@ msgstr "Należy kliknąć dwa razy żeby przejść w tryb pełnego ekranu"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Membrana z dwoma warstwami, lepiej chroni przed uszkodzeniami i potrzebuje mniej energii żeby się nie deformować. Aczkolwiek, spowalnia trochę komórkę oraz prędkość absorbcji zasobów."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Nie ostrzegaj przed tym ponownie"
 
@@ -1628,7 +1628,7 @@ msgstr ""
 "\n"
 "Gdy będziesz gotowy, naciśnij przycisk \"dalej\" w prawym dolnym rogu by kontynuować."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1644,7 +1644,7 @@ msgstr "Włącz Wszystkie Kompatybilne Mody"
 msgid "ENABLE_EDITOR"
 msgstr "Włącz edytor"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Włącz efekty świetlne GUI"
 
@@ -1701,7 +1701,7 @@ msgstr "Pokaż / ukryj otoczenie"
 msgid "EPIPELAGIC"
 msgstr "Epipelagial"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Błąd"
 
@@ -1713,16 +1713,16 @@ msgstr "Błąd podczas tworzenia folderu dla modyfikacji"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Błąd przy zmienianiu moda w plik"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Błąd: Nie udało się zapisać nowych ustawień w pliku konfiguracji."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(losowo generowane sekrety w grze)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Błąd przy zmienianiu moda w plik"
@@ -1756,11 +1756,11 @@ msgstr "Drzewo Filogenetyczne"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Drzewo Filogenetyczne"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr "Dokładna Wersja Thrive:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "To jest dokładne zatwierdzenie kodu, z którego została złożona ta wersja Thrive"
 
@@ -1776,7 +1776,7 @@ msgstr "Podczas wczytywania danych zapisu nastąpił wyjątek"
 msgid "EXIT"
 msgstr "Wyjdź"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Wyjdź do Launchera"
 
@@ -1828,7 +1828,7 @@ msgstr "wymarły w obszarze"
 msgid "EXTINCT_SPECIES"
 msgstr "Wymarły Gatunek"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Dodatki"
 
@@ -1836,7 +1836,7 @@ msgstr "Dodatki"
 msgid "EXTRA_OPTIONS"
 msgstr "Dodatkowe Opcje"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Zapauzuj"
@@ -1871,11 +1871,11 @@ msgstr "Klawisze oszustw włączone"
 msgid "FEBRUARY"
 msgstr "Luty"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1897,11 +1897,11 @@ msgstr ""
 "Całkowity Czas Procesora:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2032,7 +2032,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr "Osiadłość"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2062,7 +2062,7 @@ msgstr "Darmowa chmura glukozy przy opuszczaniu edytora"
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(zacznij z darmową chmurą glukozy w pobliżu, każdego pokolenia)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Pełny ekran"
 
@@ -2090,24 +2090,24 @@ msgstr "Pokolenia"
 msgid "GENERATION_COLON"
 msgstr "Generacja:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Opuść grę"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Ostrzeżenie Tryb GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Uruchomiłeś Thrive w GLES2. Jest to poważnie nietestowane i prawdopodobnie spowoduje problemy. Zaaktualizuj sterowniki graficzne i/lub wymuś użycie grafiki AMD lub Nvidia do uruchamiania Trive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2160,11 +2160,11 @@ msgstr "Rozumiem"
 msgid "GPL_LICENSE_HEADING"
 msgstr "Tekst licencji GPL:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "GPU:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafika"
 
@@ -2172,7 +2172,7 @@ msgstr "Grafika"
 msgid "GRAPHICS_TEAM"
 msgstr "Graficy"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "Interfejs Graficzny"
 
@@ -2189,7 +2189,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} K"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Głośność interfejsu"
 
@@ -2211,11 +2211,11 @@ msgstr "Pomoc"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Pomoc"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(większe wartości zwiększają wydajność)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(wyższe wartością mogą obniżyć wydajność)"
 
@@ -2240,7 +2240,7 @@ msgstr "Przytrzymaj [thrive:input]g_free_cursor[/thrive:input] dla kursora"
 msgid "HOME"
 msgstr "Dom"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr "Poziom:"
 
@@ -2313,7 +2313,7 @@ msgstr "Wchłonięta Materia"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Upłynęło {0:#,#} lat"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Wejścia"
 
@@ -2366,8 +2366,8 @@ msgstr "Niepoprawny format URL"
 msgid "INVALID_URL_SCHEME"
 msgstr "Niepoprawny schemat URL"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr "Odwrócony"
 
@@ -2390,7 +2390,7 @@ msgstr "Żelazo (Fe²⁺)"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Utlenianie Żelaza"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Opuść grę"
@@ -2399,19 +2399,19 @@ msgstr "Opuść grę"
 msgid "JANUARY"
 msgstr "Styczeń"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "Tryb Debugu JSON:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Zawsze"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automatycznie"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Nigdy"
 
@@ -2593,19 +2593,19 @@ msgstr "Numeryczna ."
 msgid "KPSUBTRACT"
 msgstr "Numeryczny -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Język:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Ten język jest gotów w {0}%"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Ten język nadal jest w trakcie tłumaczenia ({0}% ukończenia)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Ta wersja językowa jest bardzo słabo przetłumaczona ({0}%). Jeżeli możesz, pomóż to zmienić!"
 
@@ -2768,7 +2768,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Lewy przycisk myszy"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licencje"
 
@@ -2838,7 +2838,7 @@ msgstr "Koło w prawo"
 msgid "LIGHT_MAX"
 msgstr "Światło"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Ekstremalny"
 
@@ -2850,31 +2850,31 @@ msgstr "Limituj użycie związków wzrostu"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(gdy włączone, limituje prędkość wzrostu, jeśli wyłączone, jedynie dostępne związki wpływają na wzrost)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Ogromny"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Duży"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Normalny"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Mały"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Malutki"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Bardzo Duży"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Bardzo mały"
 
@@ -2898,7 +2898,7 @@ msgstr "Wczytaj"
 msgid "LOADING"
 msgstr "Wczytywanie"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Wczytywanie..."
@@ -2929,12 +2929,12 @@ msgstr "Wciśnij przycisk \"cofnij\" w edytorze żeby poprawić błąd"
 msgid "LOAD_FINISHED"
 msgstr "Wczytywanie zakończone"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Wczytaj grę"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Załaduj poprzednio zapisane gry"
 
@@ -3008,7 +3008,7 @@ msgstr "Marzec"
 msgid "MARINE_SNOW"
 msgstr "Śnieg morski"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Główna głośność"
 
@@ -3016,15 +3016,15 @@ msgstr "Główna głośność"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Maksymalna liczba gatunków w obszarze"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Maksymalna ilość klatek na sekundę:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Nieograniczone"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Maksymalna ilość bytów:"
 
@@ -3212,7 +3212,7 @@ msgstr "Na każdą generację masz 100 punktów mutacji (PM) do wydania, i każd
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Za każdym razem kiedy się rozmnażasz, wejdziesz w Edytor Mikroba, w którym możesz wprowadzać zmiany do twojego gatunku (przez dodawanie, przenoszenie lub usuwanie organelli) aby zwiększyć sukces twojego gatunku. Każda wizyta edytora w Etapie Mikroba reprezentuje [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milionów lat ewolucji."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Kreatywny Edytor Mikroba"
 
@@ -3396,7 +3396,7 @@ msgstr "Minimum:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Nie można wyświetlić mniej niż {0} zbioru(ów) danych!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Inne"
 
@@ -3460,11 +3460,11 @@ msgstr "Modyfikuj Organellę"
 msgid "MODIFY_TYPE"
 msgstr "Modyfikuj Typ"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Modyfikacje"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Zainstalowane mody zostały wykryte, ale żaden mod nie jest włączony.\n"
@@ -3553,11 +3553,11 @@ msgstr "Nazwa wewnętrzna (pliku):"
 msgid "MOD_LICENSE"
 msgstr "Licencja Moda:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Błędy przy ładowaniu modów"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Doszło do błędu podczas ładowania jednego lub więcej modów. Rejestry mogą zawierać dodatkowe informacje."
 
@@ -3610,11 +3610,11 @@ msgstr "Wersja:"
 msgid "MORE_INFO"
 msgstr "Pokaż Więcej Informacji"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr "Czułość wyglądu myszy"
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr "Czułość myszy skalowana poprzez wielkość okna"
 
@@ -3728,7 +3728,7 @@ msgstr "Wiele Metakul"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Wiele Organelli"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Wygładzanie krawędzi:"
 
@@ -3740,7 +3740,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Muzyka"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Głośność muzyki"
 
@@ -3760,9 +3760,9 @@ msgstr "(koszt organelli, błon i innych przedmiotów w edytorze)"
 msgid "MUTATION_POINTS"
 msgstr "Punkty Mutacji"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Wycisz"
 
@@ -3798,11 +3798,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Wstępna populacja dla gatunku zwiększającego bioróżnorodność"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Nowa Gra"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Zacznij nową grę"
 
@@ -3867,7 +3867,7 @@ msgstr "Nitroplast to plastyd używający gazowego azotu i tlenu oraz energii ko
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Przekształca wolny N₂ i O₂ w [thrive:compound type=\"ammonia\"][/thrive:compound] zużywając [thrive:compound type=\"atp\"][/thrive:compound]. Tempo skaluje się ze stężeniem [thrive:compound type=\"nitrogen\"][/thrive:compound] i [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Brak"
 
@@ -3915,7 +3915,7 @@ msgstr "Nie zanotowano wydarzeń"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Nie znaleziono katalogu zapisów"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr "Brak Włączonych Modów"
 
@@ -3932,7 +3932,7 @@ msgstr "Nie Znaleziono Zapisów"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Nie znaleziono katalogu zapisów"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Nie znaleziono katalogu zrzutów ekranu"
 
@@ -3980,16 +3980,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr "Październik"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Samobójstwo"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4026,7 +4026,7 @@ msgstr "Otwórz ekran pomocy"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Wolna Budowa"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Otwórz Folder z Logami"
 
@@ -4042,7 +4042,7 @@ msgstr "Otwórz menu organelli"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Otwórz folder zapisów"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Otwórz Folder Zrzutów Ekranu"
 
@@ -4050,7 +4050,7 @@ msgstr "Otwórz Folder Zrzutów Ekranu"
 msgid "OPEN_THE_MENU"
 msgstr "Otwórz menu"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Pomóż W Tłumaczeniu Gry"
 
@@ -4069,11 +4069,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunizm"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opcje"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Zmień swoje ustawienia"
 
@@ -4284,7 +4284,7 @@ msgstr "Proceduralny"
 msgid "PATCH_NAME"
 msgstr "{0}: {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Zapauzuj"
@@ -4335,7 +4335,7 @@ msgstr "Pokojowość"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Wydajność"
 
@@ -4419,7 +4419,7 @@ msgstr "Powiel Gracza"
 msgid "PLAYER_EXTINCT"
 msgstr "gracz wyginął"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "gracz wyginął"
@@ -4434,26 +4434,26 @@ msgstr ""
 "Prędkość\n"
 "Gracza"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 #, fuzzy
 msgid "PLAYSTATION_3"
 msgstr "populacja:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 #, fuzzy
 msgid "PLAYSTATION_4"
 msgstr "populacja:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 #, fuzzy
 msgid "PLAYSTATION_5"
 msgstr "populacja:"
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Odtwórz wideo intro"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Odtwórz intro mikroba przy nowej grze"
 
@@ -4572,11 +4572,11 @@ msgstr "Szybkie wczytanie"
 msgid "QUICK_SAVE"
 msgstr "Szybki zapis"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Wyjdź"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Opuść grę"
@@ -4618,7 +4618,7 @@ msgstr "Gotowy"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Zalecana Wersja Gry:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Wznów"
@@ -4672,7 +4672,7 @@ msgstr "Metoda Rozmnażania:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Wymaga Jądra"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Reset"
 
@@ -4680,23 +4680,23 @@ msgstr "Reset"
 msgid "RESET_DEADZONES"
 msgstr "Resetuj Strefy Martwe"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Zresetować wejścia do domyślnych?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr "Zresetuj Skróty Klawiszowe"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Domyślne"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Przywrócić do domyślnych?"
 
@@ -4705,7 +4705,7 @@ msgstr "Przywrócić do domyślnych?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr "Odporny na podstawowe wchłonięcie"
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Rozdzielczość:"
 
@@ -4755,7 +4755,7 @@ msgstr ""
 "Czy na pewno chcesz wyjść do menu głównego?\n"
 "Utracisz cały niezapisany postęp."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Wykonane Przez Revolutionary Games Studio"
@@ -4788,7 +4788,7 @@ msgstr "Obróć w prawo"
 msgid "ROTATION_COLON"
 msgstr "Populacja:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Wykonuj auto-ewo w trakcie rozgrywki"
 
@@ -4843,19 +4843,19 @@ msgstr "Rusticyjanina to białko mogące użyć gazowego [thrive:compound type=\
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Utlenia [thrive:compound type=\"iron\"][/thrive:compound] wydzielając [thrive:compound type=\"atp\"][/thrive:compound]. Tempo skaluje się ze stężeniem [thrive:compound type=\"carbondioxide\"][/thrive:compound] i [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive Uruchomiło Się W Trybie Bezpiecznym"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Zapisz"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Zapisz i kontynuuj"
 
@@ -4953,20 +4953,20 @@ msgstr "Zapis niemożliwy z powodu:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Powodzenie zapisu"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr "Brak"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr "Skalowany"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr "Skalowany odwrotnie"
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "żeby zwiększyć ruch"
@@ -5064,7 +5064,7 @@ msgstr "Osiadłość"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Ta wartość stosuje się tylko do gier rozpoczętych po zmianie tej opcji"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Głośność efektów dźwiękowych"
 
@@ -5080,21 +5080,25 @@ msgstr "Pokaż pomoc"
 msgid "SHOW_TUTORIALS"
 msgstr "Pokazuj samouczki"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Pokazuj samouczki (w aktualnej rozgrywce)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Pokazuj samouczki (w nowych rozgrywkach)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Pokaż ostrzeżenie o niezapisanym postępie"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Włącza/wyłącza ostrzeżenia o niezapisanym postępie, gdy gracz próbuje wyjść z gry."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5142,7 +5146,7 @@ msgstr "Krzemionkowa"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Ta membrana ma silne ściany z silikonu. Może opierać się ogólnym obrażeniom i jest szczególnie odporna na uszkodzenia fizyczne. Wymaga też mniej energii do utrzymania kształtu. Jednak spowalnia mocno komórkę i zmniejsza tempo wchłaniania zasobów."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5182,7 +5186,7 @@ msgstr "Zmienia [thrive:compound type=\"glucose\"][/thrive:compound] w [thrive:c
 msgid "SMALL_IRON_CHUNK"
 msgstr "Mały Kawałek Żelaza"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Dźwięk"
 
@@ -5385,17 +5389,17 @@ msgstr "Steam jest obecnie niedostępny, spróbuj ponownie."
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Nieznany błąd Steama"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Zapis nie zadziałał! Pojawił się błąd"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Aktualizacja wybranego zapisu zawiodła przez następujący błąd:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Zapauzuj"
@@ -5436,7 +5440,7 @@ msgstr "Magazyn"
 msgid "STORAGE_COLON"
 msgstr "Magazyn:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Zalogowano jako: {0}"
 
@@ -5553,7 +5557,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Testerzy"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Dziękujemy za wspieranie twórców Thrive przez kupowanie tej kopii gry!\n"
@@ -5569,7 +5573,7 @@ msgstr ""
 "\n"
 "Jeżeli Ci się spodobało, opowiedz o nas swoim znajomym."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "PRZETRWAŁEŚ!"
@@ -5625,11 +5629,11 @@ msgstr "To jest mod zainstalowany lokalnie"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Ten mod jest pobrany z Warsztatu Steam"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Wątki:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thrivopedia"
 
@@ -5776,7 +5780,7 @@ msgstr "Pauza"
 msgid "TOGGLE_UNBINDING"
 msgstr "Przełączenie odwiązywania"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Narzędzia"
 
@@ -5841,7 +5845,7 @@ msgstr "Spróbuj zrobić kilka zrzutów ekranu!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Spróbuj zapisać!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Spróbuj zrobić kilka zrzutów ekranu!"
 
@@ -6002,12 +6006,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Oglądaj Teraz"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Upłynęło {0:#,#} lat"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6032,7 +6036,7 @@ msgstr "Odwiąż wszystkie"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Tryb rozdzielenia"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr "To jest wersja debugowania gdzie informacje poniżej są prawdopodobnie przestarzałe"
 
@@ -6052,7 +6056,7 @@ msgstr "Cofnij ostatnią czynność"
 msgid "UNKNOWN"
 msgstr "Nieznany"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Nieznany"
 
@@ -6064,7 +6068,7 @@ msgstr "Nieznany myszy"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Nieznany na Windowsie"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "Nieznana wersja"
 
@@ -6072,7 +6076,7 @@ msgstr "Nieznana wersja"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Nieznane ID Sklepu Dla Tego Moda"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Masz niezapisane zmiany które zostaną odrzucone.\n"
@@ -6116,7 +6120,7 @@ msgstr "Ładowanie Powiodło Się"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Licencje I Użyte Biblioteki Zasobów"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "Wykorzystany renderer:"
 
@@ -6132,7 +6136,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Użyj własnej nazwy użytkownika"
 
@@ -6140,11 +6144,11 @@ msgstr "Użyj własnej nazwy użytkownika"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "Utworzenie gatunku zwiększającego bioróżnorodność kradnie populację od istniejącego gatunku"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Ustaw ręcznie liczbę wątków w tle"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr "Użyj wirtualnej wielkości okna"
 
@@ -6170,7 +6174,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Wersja:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr "Pion:"
 
@@ -6179,11 +6183,11 @@ msgstr "Pion:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Pion (Oś: {0})"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "Obecnie wykorzystana pamięć wideo:"
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0} MiB"
 
@@ -6191,7 +6195,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Przeglądarka"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Zobacz Kod Źródłowy"
 
@@ -6203,7 +6207,7 @@ msgstr "VIP Wspierający"
 msgid "VISIBLE"
 msgstr "Widoczne"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Zasugeruj Funkcję"
 
@@ -6223,7 +6227,7 @@ msgstr "Wycisz"
 msgid "VOLUMEUP"
 msgstr "Zwiększ głośność"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "Synchronizacja pionowa"
 
@@ -6330,7 +6334,7 @@ msgstr "Statystyki Organizmu"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "żeby zwiększyć ruch"
@@ -6339,15 +6343,15 @@ msgstr "żeby zwiększyć ruch"
 msgid "WORST_PATCH_COLON"
 msgstr "Najgorzej radzi sobie w:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6359,7 +6363,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "lata"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Zapauzuj"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-11-10 00:00+0000\n"
 "Last-Translator: Capivaresco <deepohsix@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/pt_BR/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr "Estilo de movimento bidimensional:"
 
@@ -31,7 +31,7 @@ msgstr "Editor 3D"
 msgid "3D_MOVEMENT"
 msgstr "Movimento 3D"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr "Estilo de movimento tridimensional:"
 
@@ -62,7 +62,7 @@ msgstr "Ação bloqueada enquanto há outra em curso"
 msgid "ACTIVE"
 msgstr "Ativo"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Tarefas atuais:"
 
@@ -143,7 +143,7 @@ msgstr "Estatísticas do Organismo"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Volume do ambiente"
 
@@ -154,11 +154,11 @@ msgstr "Volume do ambiente"
 msgid "AMMONIA"
 msgstr "Amônia"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Quantidade de salvamentos automáticos para manter:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Quantidade de salvamentos rápidos para manter:"
 
@@ -183,11 +183,11 @@ msgstr "Aplicar Mudanças"
 msgid "APRIL"
 msgstr "Abril"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Redefinir TODAS as configurações para os valores padrão?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Deseja redefinir as entradas para as configurações padrão?"
 
@@ -203,7 +203,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Arte por {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Galeria de Arte"
 
@@ -216,7 +216,7 @@ msgstr "Classe do assembly do mod é requerida quando o assembly é especificado
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "A montagem do mod é necessária quando o auto harmony está ativado"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Assumir que o hiperprocessamento de CPU está habilitado"
 
@@ -258,7 +258,7 @@ msgstr "A tentativa de salvar falhou. O nome do save pode ser longo demais ou vo
 msgid "AT_CURSOR"
 msgstr "No cursor:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Dispositivo de saída de aúdio:"
 
@@ -266,8 +266,8 @@ msgstr "Dispositivo de saída de aúdio:"
 msgid "AUGUST"
 msgstr "Agosto"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Auto"
 
@@ -294,7 +294,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% feito. {1:n0}/{2:n0} passos."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Salvamento automático durante o jogo"
 
@@ -302,7 +302,7 @@ msgstr "Salvamento automático durante o jogo"
 msgid "AUTO_EVO"
 msgstr "Auto-evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Ferramenta de exploração da auto-evo"
 
@@ -331,7 +331,7 @@ msgstr "Estado da Auto-Evo:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Mover para a frente automaticamente"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Auto ({0}x{1})"
 
@@ -344,9 +344,9 @@ msgid "AWAKEN"
 msgstr "Despertar"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -482,7 +482,7 @@ msgstr "Permite a ligação com outras células. Este é o primeiro passo até a
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Aperte [thrive:input]g_toggle_binding[/thrive:input] para ativar o modo de ligação. Enquanto em modo de ligação, você pode conectar outras células de sua espécie se movendo à elas. Para sair da colônia, pressione [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr "Unir eixos"
 
@@ -544,7 +544,7 @@ msgstr "Essa membrana tem uma casca forte feita de carbonato de cálcio. Pode re
 msgid "CAMERA"
 msgstr "Câmera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -672,7 +672,7 @@ msgstr "Mudar a simetria"
 msgid "CHEATS"
 msgstr "Trapaças"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Cheats ativados"
 
@@ -762,7 +762,7 @@ msgstr "Produz [thrive:compound type=\"glucose\"][/thrive:compound]. Quantidade 
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "O nome do arquivo ({0}) já existe. Sobrescrever?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Aberração cromática:"
 
@@ -803,15 +803,15 @@ msgstr "Limpar salvamentos antigos"
 msgid "CLOSE"
 msgstr "Fechar"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Fechar opções?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Divisor da resolução de nuvens:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Intervalo mínimo da simulação de nuvens:"
 
@@ -827,7 +827,7 @@ msgstr "Gerar entidades com formas de colisão"
 msgid "COLOUR"
 msgstr "Coloração"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Correção de cor (daltonismo):"
 
@@ -888,23 +888,23 @@ msgstr "Valor de saturação, a quantidade de cinza em uma cor específica"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Brilho ou intensidade da cor"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr "Fórum comunitário"
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Junte-se à comunidade em nosso fórum comunitário (em inglês)"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr "Wiki comunitária"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Visite a nossa wiki comunitária"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr "Compilado em:"
 
@@ -930,7 +930,7 @@ msgstr "Compostos:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Compostos"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Nuvens de compostos"
 
@@ -1015,7 +1015,7 @@ msgstr "Prosseguir para o protótipo do estágio?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr "Visualizador dos eixos do controle:"
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr "Zonas mortas do controle"
 
@@ -1030,11 +1030,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr "Zona morta:"
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr "Sensibilidade do controle"
 
@@ -1042,11 +1042,11 @@ msgstr "Sensibilidade do controle"
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Copiar erro para a Área de Transferência"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanopia (Vermelho-Verde)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanopia (Azul-Amarelo)"
 
@@ -1102,7 +1102,7 @@ msgstr "Criando..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Criando objetos do jogo salvo"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Créditos"
 
@@ -1145,7 +1145,7 @@ msgstr ""
 "  Tamanho Médio das Células: {9}\n"
 "[b]Dados Gerais de Organelas:[/b]"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Nome personalizado:"
 
@@ -1210,7 +1210,7 @@ msgstr "Painel de depuração"
 msgid "DECEMBER"
 msgstr "Dezembro"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Serviço padrão de saída"
 
@@ -1272,7 +1272,7 @@ msgstr "Descrição está muito longa"
 msgid "DESPAWN_ENTITIES"
 msgstr "Destruir todas as entidades"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Número de CPU detectados:"
 
@@ -1287,11 +1287,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Desenvolvedores"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr "Fórum de desenvolvimento"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Veja as novidades da criação do jogo em nosso fórum de desenvolvimento (em inglês)"
 
@@ -1299,11 +1299,11 @@ msgstr "Veja as novidades da criação do jogo em nosso fórum de desenvolviment
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Desenvolvimento Financiado por Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr "Wiki de desenvolvimento"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Visite a nossa wiki de desenvolvimento (em inglês)"
 
@@ -1385,7 +1385,7 @@ msgstr "Esquerda"
 msgid "DIRECTIONR"
 msgstr "Direita"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Desativado"
 
@@ -1393,7 +1393,7 @@ msgstr "Desativado"
 msgid "DISABLE_ALL"
 msgstr "Desabilitar Todos"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Descartar e continuar"
 
@@ -1431,33 +1431,33 @@ msgstr ""
 "Há organelas desconectadas do resto da célula.\n"
 "Por favor conecte todas as organelas ou desfaça suas mudanças."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr "Junte-se ao servidor Discord da comunidade"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Pop-ups dispensados:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 "Isso mostra quantos pop-ups foram dispensados permanentemente pelo usuário.\n"
 "Se alguns dos pop-ups que necessita foram dispensados, o botão junto a isso pode ser usado para fazer todos os pop-ups reaparecerem."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr "Não mostrar novamente"
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Exibir barra de habilidades"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Mostrar partículas de fundo"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Exibir nomes dos botões de seleções de partes"
 
@@ -1492,7 +1492,7 @@ msgstr "Clique duas vezes para ver em tela cheia"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Uma membrana com duas camadas, tem melhor proteção contra dano e leva menos energia para não se deformar. No entanto, diminui um pouco sua velocidade e diminui a taxa em que pode absorver recursos."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Não mostrar novamente"
 
@@ -1645,7 +1645,7 @@ msgstr ""
 "\n"
 "Para ir para a próxima aba, aperte o botão “próximo” no canto inferior direito."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1661,7 +1661,7 @@ msgstr "Habilitar Todos os Mods Compatíveis"
 msgid "ENABLE_EDITOR"
 msgstr "Habilitar o editor"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Habilitar efeitos de luz na interface"
 
@@ -1718,7 +1718,7 @@ msgstr "Mostrar/esconder ambiente"
 msgid "EPIPELAGIC"
 msgstr "Epipelágico"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Erro"
 
@@ -1730,16 +1730,16 @@ msgstr "Erro ao criar pasta para o mod"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Erro ao criar arquivo info do mod"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Erro: Falha ao salvar as novas opções para o arquivo de configurações."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(incluir aleatoriamente segredos no jogo)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Erro ao criar arquivo info do mod"
@@ -1775,11 +1775,11 @@ msgstr ""
 "\n"
 "Se nenhuma das situações acima se aplicam a você, um erro deve ter ocorrido. Relate o erro à equipe de desenvolvimento e forneça os logs do jogo."
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr "Versão exata de Thrive:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Esta é a commit na qual essa versão de Thrive foi compilada"
 
@@ -1795,7 +1795,7 @@ msgstr "Uma exceção ocorreu ao carregar os dados salvos"
 msgid "EXIT"
 msgstr "Sair"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Sair para o Lançador"
 
@@ -1845,7 +1845,7 @@ msgstr "extinta na região"
 msgid "EXTINCT_SPECIES"
 msgstr "Espécies Extintas"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1853,7 +1853,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr "Opções Extra"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Visite a nossa página no Facebook"
 
@@ -1885,12 +1885,12 @@ msgstr "Ativado"
 msgid "FEBRUARY"
 msgstr "Fevereiro"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Inicialização da biblioteca do cliente Steam falhou"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1912,11 +1912,11 @@ msgstr ""
 "Tempo de Processamento Total:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgstr "Fossilizar essa espécie (já fossilizada)"
 msgid "FOSSILISE"
 msgstr "Fossilizar"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2070,7 +2070,7 @@ msgstr "Nuvem de glicose disponível ao sair do editor"
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(começar com uma nuvem de glicose próxima após cada reprodução)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Tela Cheia"
 
@@ -2098,23 +2098,23 @@ msgstr "Gerações"
 msgid "GENERATION_COLON"
 msgstr "Geração:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr "Visite o nosso repositório no GitHub"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Aviso do Modo GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Você está usando Thrive usando GLES2, que não é testado e pode causar problemas. Tente atualizar seus drivers de vídeo e/ou forçar o uso do AMD ou Nvidia."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr "GLES3"
 
@@ -2167,11 +2167,11 @@ msgstr "Entendi"
 msgid "GPL_LICENSE_HEADING"
 msgstr "Segue o texto da licença GPL:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "GPU:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Gráficos"
 
@@ -2179,7 +2179,7 @@ msgstr "Gráficos"
 msgid "GRAPHICS_TEAM"
 msgstr "Equipe Gráfica"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "GUI"
 
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "Navegação em Abas da Interface"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Volume da interface"
 
@@ -2217,11 +2217,11 @@ msgstr "Ajuda"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Ajuda"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(valores mais altos melhoram o desempenho)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(valores mais altos diminuem o desempenho)"
 
@@ -2245,7 +2245,7 @@ msgstr "Aperte [thrive:input]g_free_cursor[/thrive:input] para mostrar o cursor"
 msgid "HOME"
 msgstr "Página inicial"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr "Horizontal:"
 
@@ -2317,7 +2317,7 @@ msgstr "Matéria ingerida"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Criar um novo mundo"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Entradas"
 
@@ -2370,8 +2370,8 @@ msgstr "Formato de URL inválido"
 msgid "INVALID_URL_SCHEME"
 msgstr "Esquema URL inválido"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr "Invertido"
 
@@ -2394,7 +2394,7 @@ msgstr "Ferro"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Quimiolitoautotrofia Férrica"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr "Visite a nossa página na Itch.io"
 
@@ -2402,19 +2402,19 @@ msgstr "Visite a nossa página na Itch.io"
 msgid "JANUARY"
 msgstr "Janeiro"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "Modo de depuração JSON:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Sempre"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automaticamente"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Nunca"
 
@@ -2596,19 +2596,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Idioma:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Esta linguagem está {0}% completa"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Esta tradução ainda está em andamento ({0}% completa)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Esta tradução está muito incompleta ({0}% concluída), por favor, nos ajude com ela!"
 
@@ -2770,7 +2770,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Botão esquerdo do mouse"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licenças"
 
@@ -2838,7 +2838,7 @@ msgstr "Noite"
 msgid "LIGHT_MAX"
 msgstr "Máximo de luz"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Extremo"
 
@@ -2850,31 +2850,31 @@ msgstr "Limitar o uso dos compostos de crescimento"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(quando ativado limita a velocidade do crescimento da célula, quando desativado somente os compostos disponíveis afetam a velocidade do crescimento)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Enorme"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Grande"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Normal"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Pequeno"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Minúsculo"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Bem grande"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Bem pequeno"
 
@@ -2898,7 +2898,7 @@ msgstr "Carregar"
 msgid "LOADING"
 msgstr "Carregando"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Carregando…"
@@ -2929,12 +2929,12 @@ msgstr "Aperte o botão de desfazer no editor para corrigir um erro"
 msgid "LOAD_FINISHED"
 msgstr "Carregamento terminado"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Carregar Jogo"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Carrega jogos salvos anteriormente"
 
@@ -3008,7 +3008,7 @@ msgstr "Março"
 msgid "MARINE_SNOW"
 msgstr "Neve marinha"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Volume principal"
 
@@ -3016,15 +3016,15 @@ msgstr "Volume principal"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Máximo de espécies na região"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "FPS máximo:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Ilimitado"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Número máximo de entidades:"
 
@@ -3209,7 +3209,7 @@ msgstr "A cada geração, você tem 100 Pontos de Mutação (PM) para gastar, e 
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Toda vez que reproduzir, você vai entrar no Editor de Micróbios, onde pode fazer mudanças na sua espécie (adicionando, movendo ou removendo organelas) para aumentar o sucesso de sua espécie. Cada visita ao editor no Estágio Microbial representa [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milhões de anos de evolução."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor de Micróbio Livre"
 
@@ -3394,7 +3394,7 @@ msgstr "Mínimo:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Não é permitido mostrar menos de {0} datasets!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Diversos"
 
@@ -3457,11 +3457,11 @@ msgstr "Modificar Organela"
 msgid "MODIFY_TYPE"
 msgstr "Modificar tipo"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Foram detectados mods instalados, mas nenhum está ativado.\n"
@@ -3550,11 +3550,11 @@ msgstr "Nome Interno (da Pasta):"
 msgid "MOD_LICENSE"
 msgstr "Licenças do Mod:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Erro ao Carregar Mods"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Houve erros ao carregar um ou mais mods. Os logs podem conter mais informações."
 
@@ -3607,11 +3607,11 @@ msgstr "Versão do Mod:"
 msgid "MORE_INFO"
 msgstr "Mostrar Mais Informações"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr "Sensibilidade do mouse"
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr "Sensibilidade do mouse pelo tamanho da janela"
 
@@ -3725,7 +3725,7 @@ msgstr "Múltiplos Metaballs"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Múltiplas Organelas"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Anti-aliasing multi-amostras:"
 
@@ -3740,7 +3740,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Músicas"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Volume da música"
 
@@ -3760,9 +3760,9 @@ msgstr "(custo das organelas, membranas e outros itens do editor)"
 msgid "MUTATION_POINTS"
 msgstr "Pontos de Mutação"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Silenciar"
 
@@ -3798,11 +3798,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "População inicial para espécies que aumentam a biodiversidade"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Novo Jogo"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Começa um novo jogo"
 
@@ -3867,7 +3867,7 @@ msgstr "O Plastídeo de Fixação de Nitrogênio é uma proteína capaz de usar 
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Transforma [thrive:compound type=\"atp\"][/thrive:compound] em [thrive:compound type=\"ammonia\"][/thrive:compound]. Quantidade aumenta com a concentração de [thrive:compound type=\"nitrogen\"][/thrive:compound] e [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Nenhum"
 
@@ -3914,7 +3914,7 @@ msgstr "Nenhum evento registrado"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "O diretório de fósseis não foi encontrado"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr "Nenhum mod ativado"
 
@@ -3931,7 +3931,7 @@ msgstr "Nenhum Salvamento Encontrado"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "O diretório de salvamentos não foi encontrado"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "O diretório de capturas de tela não foi encontrado"
 
@@ -3977,15 +3977,15 @@ msgstr "N/A PM"
 msgid "OCTOBER"
 msgstr "Outubro"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr "Site oficial"
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Visite o site oficial do Revolutionary Games"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4022,7 +4022,7 @@ msgstr "Abrir a tela de ajuda"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Abrir no editor livre"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Abrir pasta de logs"
 
@@ -4038,7 +4038,7 @@ msgstr "Abrir o menu de organelas"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Abrir Diretório de Salvamentos"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Abrir a pasta de capturas de tela"
 
@@ -4046,7 +4046,7 @@ msgstr "Abrir a pasta de capturas de tela"
 msgid "OPEN_THE_MENU"
 msgstr "Abrir o menu"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Ajude a traduzir o jogo"
 
@@ -4065,11 +4065,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunista"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opções"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Muda as configurações do jogo"
 
@@ -4278,7 +4278,7 @@ msgstr "Gerado"
 msgid "PATCH_NAME"
 msgstr "{1} {0}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr "Visite a nossa página no Patreon"
 
@@ -4328,7 +4328,7 @@ msgstr "Pacífico"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Desempenho"
 
@@ -4417,7 +4417,7 @@ msgstr "Duplicar Jogador"
 msgid "PLAYER_EXTINCT"
 msgstr "O jogador foi extinto"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Relativo ao jogador"
 
@@ -4431,23 +4431,23 @@ msgstr ""
 "Jogador\n"
 "Velocidade"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr "PlayStation 3"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr "PlayStation 4"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr "PlayStation 5"
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Reproduzir o vídeo de introdução"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Reproduzir a introdução do Estágio Microbial em novo jogo"
 
@@ -4566,11 +4566,11 @@ msgstr "Carregamento rápido"
 msgid "QUICK_SAVE"
 msgstr "Salvamento rápido"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Sair"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Sai do jogo"
@@ -4612,7 +4612,7 @@ msgstr "Pronto"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Versão Recomendada:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr "Visite o nosso subreddit"
 
@@ -4665,7 +4665,7 @@ msgstr "Reprodução:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Requer um núcleo"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Redefinir"
 
@@ -4673,23 +4673,23 @@ msgstr "Redefinir"
 msgid "RESET_DEADZONES"
 msgstr "Redefinir as zonas mortas"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr "Redefinir os pop-ups dispensados"
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Redefinir entradas para configurações padrão?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr "Redefinir entradas"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Configurações padrão"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Redefinir para as configurações padrão?"
 
@@ -4698,7 +4698,7 @@ msgstr "Redefinir para as configurações padrão?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr "Resistente ao engolimento básico"
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Resolução:"
 
@@ -4748,7 +4748,7 @@ msgstr ""
 "Tem certeza que você deseja sair para o menu?\n"
 "Você vai perder seu progresso não salvo."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Visite os sites oficiais do Revolutionary Games"
 
@@ -4780,7 +4780,7 @@ msgstr "Girar à direita"
 msgid "ROTATION_COLON"
 msgstr "Rotação:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Usar a auto-evo durante o jogo"
 
@@ -4834,7 +4834,7 @@ msgstr "Rusticianina é uma proteína que consegue usar o gás carbônico e oxig
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Transforma [thrive:compound type=\"iron\"][/thrive:compound] em [thrive:compound type=\"atp\"][/thrive:compound]. Quantidade aumenta com a concentração de [thrive:compound type=\"carbondioxide\"][/thrive:compound] e [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive começou no modo seguro devido a um erro na inicialização do jogo.\n"
@@ -4846,15 +4846,15 @@ msgstr ""
 "\n"
 "Caso não solucionar o problema que causou o erro na inicialização, você deverá reiniciar e travar o jogo várias vezes para voltar ao modo seguro."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive começou no modo seguro"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Salvar"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Salvar e continuar"
 
@@ -4952,20 +4952,20 @@ msgstr "Atualmente, não é possível salvar porque:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Salvo com sucesso"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr "Nenhum"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr "Proporcional"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr "Inversamente proporcional"
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "Relativo à tela"
 
@@ -5062,7 +5062,7 @@ msgstr "Séssil"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Esse valor só é aplicado à novos jogos, criados após alterar esta opção"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Volume dos efeitos sonoros"
 
@@ -5078,21 +5078,25 @@ msgstr "Mostrar ajuda"
 msgid "SHOW_TUTORIALS"
 msgstr "Mostrar tutoriais"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Mostrar tutoriais (no jogo atual)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Mostrar tutoriais (em novos jogos)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Mostrar aviso de progresso não salvo"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Mostra/Esconde o aviso de quando o jogador tenta sair do jogo."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5140,7 +5144,7 @@ msgstr "Sílica"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Essa membrana tem uma forte parede feita de sílica. Pode resistir bem a danos no geral e é muito resistente a danos físicos. Também precisa de menos energia para manter sua forma. No entanto, diminui a velocidade da célula drasticamente e ela absorve recursos a um ritmo menor."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5180,7 +5184,7 @@ msgstr "Transforma [thrive:compound type=\"glucose\"][/thrive:compound] em [thri
 msgid "SMALL_IRON_CHUNK"
 msgstr "Pedaço de ferro pequeno"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Som"
 
@@ -5383,17 +5387,17 @@ msgstr "A Steam não está disponível no momento, tente novamente"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Ocorreu um erro desconhecido da Steam"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Inicialização da biblioteca do cliente Steam falhou"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "A atualização do arquivo salvo falhou devido ao seguinte erro:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr "Visite a nossa página na Steam"
 
@@ -5433,7 +5437,7 @@ msgstr "Armazenamento"
 msgid "STORAGE_COLON"
 msgstr "Armazenamento:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Entrou como: {0}"
 
@@ -5548,7 +5552,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Equipe de Teste"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Obrigado por apoiar o desenvolvimento de Thrive ao comprar essa cópia!\n"
@@ -5564,7 +5568,7 @@ msgstr ""
 "\n"
 "Se gostou, fale do jogo para seus amigos."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr "Obrigado"
 
@@ -5619,11 +5623,11 @@ msgstr "Este mod foi instalado localmente"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Este mod foi instalado da Oficina Steam"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Tarefas:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thrivepédia"
 
@@ -5779,7 +5783,7 @@ msgstr "Pausar"
 msgid "TOGGLE_UNBINDING"
 msgstr "Desativar modo de ligação"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Ferramentas"
 
@@ -5843,7 +5847,7 @@ msgstr "Tente fossilizar algumas espécies!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Tente salvar um jogo!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Tente fazer algumas capturas de tela!"
 
@@ -6005,11 +6009,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Ver Agora"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr "Visite a nossa conta no Twitter"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6034,7 +6038,7 @@ msgstr "Desconectar todos"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Modo de Desconexão"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr "Esta é uma build de depuração e a informação abaixo pode estar desatualizada"
 
@@ -6054,7 +6058,7 @@ msgstr "Desfazer a ultima ação"
 msgid "UNKNOWN"
 msgstr "Desconhecido"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Desconhecido"
 
@@ -6066,7 +6070,7 @@ msgstr "Botão do mouse desconhecido"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Desconhecido no Windows"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "Versão desconhecida"
 
@@ -6074,7 +6078,7 @@ msgstr "Versão desconhecida"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "ID da Oficina Desconhecido"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Você tem mudanças não salvas que serão descartadas.\n"
@@ -6118,7 +6122,7 @@ msgstr "Upload Bem-Sucedido"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Licenças e Bibliotecas Usadas"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "Renderizador usado:"
 
@@ -6134,7 +6138,7 @@ msgstr "Usar carregamento Auto Harmony"
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Carregar patches Harmony do Assembly automaticamente (não é preciso especificar a classe do mod)"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Usar um nome personalizado"
 
@@ -6142,11 +6146,11 @@ msgstr "Usar um nome personalizado"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "Espécies criadas para aumentar a biodiversidade tomam parte da população de espécies existentes"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Definir número de tarefas de fundo manualmente"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr "Usar tamanho da janela virtual"
 
@@ -6172,7 +6176,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Versão:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr "Vertical:"
 
@@ -6181,11 +6185,11 @@ msgstr "Vertical:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Vertical (Eixo: {0})"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "Memória de vídeo usada atualmente:"
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0} MiB"
 
@@ -6193,7 +6197,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Visualizador"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Ver código fonte"
 
@@ -6205,7 +6209,7 @@ msgstr "Apoiadores VIP"
 msgid "VISIBLE"
 msgstr "Visível"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Sugerir um recurso"
 
@@ -6225,7 +6229,7 @@ msgstr "Mutar Volume"
 msgid "VOLUMEUP"
 msgstr "Aumentar Volume"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSync"
 
@@ -6332,7 +6336,7 @@ msgstr ""
 "Incluir os protótipos de estágios posteriores: {0}\n"
 "Incluir easter eggs: {1}"
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "Relativo ao mundo"
 
@@ -6340,15 +6344,15 @@ msgstr "Relativo ao mundo"
 msgid "WORST_PATCH_COLON"
 msgstr "Pior Região:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr "Xbox 360"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr "Xbox One"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr "Xbox Series X"
 
@@ -6360,7 +6364,7 @@ msgstr "Xbox Series X"
 msgid "YEARS"
 msgstr "anos"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Visite o nosso canal no YouTube"
 

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-11-10 00:00+0000\n"
 "Last-Translator: Capivaresco <deepohsix@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/pt_BR/>\n"
@@ -203,7 +203,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Arte por {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Galeria de Arte"
 
@@ -302,7 +302,7 @@ msgstr "Salvamento automático durante o jogo"
 msgid "AUTO_EVO"
 msgstr "Auto-evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Ferramenta de exploração da auto-evo"
 
@@ -344,8 +344,8 @@ msgid "AWAKEN"
 msgstr "Despertar"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -600,27 +600,27 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Dióxido de Carbono"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "uma abundância"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "uma quantidade razoável"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "pouco"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "um bocado"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "alguns"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "muito pouco"
 
@@ -888,19 +888,19 @@ msgstr "Valor de saturação, a quantidade de cinza em uma cor específica"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Brilho ou intensidade da cor"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr "Fórum comunitário"
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Junte-se à comunidade em nosso fórum comunitário (em inglês)"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr "Wiki comunitária"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Visite a nossa wiki comunitária"
 
@@ -1102,7 +1102,7 @@ msgstr "Criando..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Criando objetos do jogo salvo"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Créditos"
 
@@ -1287,11 +1287,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Desenvolvedores"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr "Fórum de desenvolvimento"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Veja as novidades da criação do jogo em nosso fórum de desenvolvimento (em inglês)"
 
@@ -1299,11 +1299,11 @@ msgstr "Veja as novidades da criação do jogo em nosso fórum de desenvolviment
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Desenvolvimento Financiado por Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr "Wiki de desenvolvimento"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Visite a nossa wiki de desenvolvimento (em inglês)"
 
@@ -1431,7 +1431,7 @@ msgstr ""
 "Há organelas desconectadas do resto da célula.\n"
 "Por favor conecte todas as organelas ou desfaça suas mudanças."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr "Junte-se ao servidor Discord da comunidade"
 
@@ -1445,7 +1445,7 @@ msgstr ""
 "Isso mostra quantos pop-ups foram dispensados permanentemente pelo usuário.\n"
 "Se alguns dos pop-ups que necessita foram dispensados, o botão junto a isso pode ser usado para fazer todos os pop-ups reaparecerem."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr "Não mostrar novamente"
 
@@ -1492,7 +1492,7 @@ msgstr "Clique duas vezes para ver em tela cheia"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Uma membrana com duas camadas, tem melhor proteção contra dano e leva menos energia para não se deformar. No entanto, diminui um pouco sua velocidade e diminui a taxa em que pode absorver recursos."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Não mostrar novamente"
 
@@ -1673,15 +1673,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Energia em {0} para {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Fontes de Energia:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "A energia total coletada é {0}, a um custo de {1} por indivíduo, resultando em uma população (não ajustada) de {2}"
 
@@ -1734,6 +1734,16 @@ msgstr "Erro ao criar arquivo info do mod"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Erro: Falha ao salvar as novas opções para o arquivo de configurações."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(incluir aleatoriamente segredos no jogo)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Erro ao criar arquivo info do mod"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Erro ao carregar"
@@ -1785,7 +1795,7 @@ msgstr "Uma exceção ocorreu ao carregar os dados salvos"
 msgid "EXIT"
 msgstr "Sair"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Sair para o Lançador"
 
@@ -1835,7 +1845,7 @@ msgstr "extinta na região"
 msgid "EXTINCT_SPECIES"
 msgstr "Espécies Extintas"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1843,7 +1853,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr "Opções Extra"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Visite a nossa página no Facebook"
 
@@ -1874,6 +1884,41 @@ msgstr "Ativado"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Fevereiro"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Inicialização da biblioteca do cliente Steam falhou"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Tempo de Processamento: {0}\n"
+"Duração da Física: {1} s\n"
+"Entidades: {2} Outros: {3}\n"
+"Gerados: {4} Destruídos: {5}\n"
+"Nós Usados: {6}\n"
+"Memória Usada: {7} MiB\n"
+"Memória Gráfica: {8} MiB\n"
+"Objetos Renderizados: {9}\n"
+"Chamadas à Cena: {10} 2D: {11}\n"
+"Vértices Renderizados: {12}\n"
+"Alterações Materiais: {13}\n"
+"Alterações de Sombreamento: {14}\n"
+"Nós Órfãos: {15}\n"
+"Latência de Áudio: {16} ms\n"
+"Total de Tarefas: {17}\n"
+"Tempo de Processamento Total:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1957,7 +2002,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Cadeia Alimentar"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0} de energia: {1} (adaptação: {2}) energia total disponível: {3} (adaptação total: {4})"
 
@@ -2053,7 +2098,7 @@ msgstr "Gerações"
 msgid "GENERATION_COLON"
 msgstr "Geração:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr "Visite o nosso repositório no GitHub"
 
@@ -2061,11 +2106,11 @@ msgstr "Visite o nosso repositório no GitHub"
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Aviso do Modo GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Você está usando Thrive usando GLES2, que não é testado e pode causar problemas. Tente atualizar seus drivers de vídeo e/ou forçar o uso do AMD ou Nvidia."
 
@@ -2349,7 +2394,7 @@ msgstr "Ferro"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Quimiolitoautotrofia Férrica"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr "Visite a nossa página na Itch.io"
 
@@ -2567,7 +2612,7 @@ msgstr "Esta tradução ainda está em andamento ({0}% completa)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Esta tradução está muito incompleta ({0}% concluída), por favor, nos ajude com ela!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "Não foi possível remover a última organela"
 
@@ -2725,7 +2770,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Botão esquerdo do mouse"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licenças"
 
@@ -2853,7 +2898,8 @@ msgstr "Carregar"
 msgid "LOADING"
 msgstr "Carregando"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Carregando…"
 
@@ -2883,12 +2929,12 @@ msgstr "Aperte o botão de desfazer no editor para corrigir um erro"
 msgid "LOAD_FINISHED"
 msgstr "Carregamento terminado"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Carregar Jogo"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Carrega jogos salvos anteriormente"
 
@@ -3163,7 +3209,7 @@ msgstr "A cada geração, você tem 100 Pontos de Mutação (PM) para gastar, e 
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Toda vez que reproduzir, você vai entrar no Editor de Micróbios, onde pode fazer mudanças na sua espécie (adicionando, movendo ou removendo organelas) para aumentar o sucesso de sua espécie. Cada visita ao editor no Estágio Microbial representa [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milhões de anos de evolução."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor de Micróbio Livre"
 
@@ -3411,11 +3457,11 @@ msgstr "Modificar Organela"
 msgid "MODIFY_TYPE"
 msgstr "Modificar tipo"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Foram detectados mods instalados, mas nenhum está ativado.\n"
@@ -3504,11 +3550,11 @@ msgstr "Nome Interno (da Pasta):"
 msgid "MOD_LICENSE"
 msgstr "Licenças do Mod:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Erro ao Carregar Mods"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Houve erros ao carregar um ou mais mods. Os logs podem conter mais informações."
 
@@ -3744,15 +3790,19 @@ msgstr ""
 "Este jogo salvo é de uma versão mais nova de Thrive e é provavelmente incompatível.\n"
 "Deseja carregar o jogo mesmo assim?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "População inicial para espécies que aumentam a biodiversidade"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Novo Jogo"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Começa um novo jogo"
 
@@ -3852,7 +3902,7 @@ msgid "NO_AI"
 msgstr "Sem IA"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Nenhum Dado a Exibir"
 
@@ -3864,7 +3914,7 @@ msgstr "Nenhum evento registrado"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "O diretório de fósseis não foi encontrado"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr "Nenhum mod ativado"
 
@@ -3894,7 +3944,7 @@ msgstr "Nenhum Mod Selecionado"
 msgid "NUCLEUS"
 msgstr "Núcleo"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "O núcleo é uma mutação irreversível e é impossível removê-lo. Entretanto, se for colocado na sessão atual, é permitido desfazer ou refazer a ação"
 
@@ -3913,8 +3963,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -3927,15 +3977,15 @@ msgstr "N/A PM"
 msgid "OCTOBER"
 msgstr "Outubro"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr "Site oficial"
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Visite o site oficial do Revolutionary Games"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4015,11 +4065,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunista"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opções"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Muda as configurações do jogo"
 
@@ -4228,7 +4278,7 @@ msgstr "Gerado"
 msgid "PATCH_NAME"
 msgstr "{1} {0}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr "Visite a nossa página no Patreon"
 
@@ -4286,8 +4336,8 @@ msgstr "Desempenho"
 msgid "PERFORM_UNBINDING"
 msgstr "Desconectar"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/segundo"
 
@@ -4343,7 +4393,7 @@ msgstr "Geração de planetas em breve!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Seed aleatória do planeta"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Célula do jogador"
 
@@ -4418,7 +4468,7 @@ msgstr "população:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "população nas regiões:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4472,7 +4522,7 @@ msgstr "anterior:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Processando objetos carregados"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4516,11 +4566,11 @@ msgstr "Carregamento rápido"
 msgid "QUICK_SAVE"
 msgstr "Salvamento rápido"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Sair"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Sai do jogo"
@@ -4562,7 +4612,7 @@ msgstr "Pronto"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Versão Recomendada:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr "Visite o nosso subreddit"
 
@@ -4698,7 +4748,7 @@ msgstr ""
 "Tem certeza que você deseja sair para o menu?\n"
 "Você vai perder seu progresso não salvo."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Visite os sites oficiais do Revolutionary Games"
 
@@ -4784,7 +4834,7 @@ msgstr "Rusticianina é uma proteína que consegue usar o gás carbônico e oxig
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Transforma [thrive:compound type=\"iron\"][/thrive:compound] em [thrive:compound type=\"atp\"][/thrive:compound]. Quantidade aumenta com a concentração de [thrive:compound type=\"carbondioxide\"][/thrive:compound] e [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive começou no modo seguro devido a um erro na inicialização do jogo.\n"
@@ -4796,7 +4846,7 @@ msgstr ""
 "\n"
 "Caso não solucionar o problema que causou o erro na inicialização, você deverá reiniciar e travar o jogo várias vezes para voltar ao modo seguro."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive começou no modo seguro"
 
@@ -5158,7 +5208,7 @@ msgstr "Gerar amônia"
 msgid "SPAWN_ENEMY"
 msgstr "Gerar Inimigo"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Impossível usar comando para gerar inimigo pois essa região não contém nenhuma espécie inimiga"
 
@@ -5218,7 +5268,7 @@ msgstr "Nome da espécie…"
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "O nome da espécie é grande demais!"
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5333,17 +5383,17 @@ msgstr "A Steam não está disponível no momento, tente novamente"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Ocorreu um erro desconhecido da Steam"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Inicialização da biblioteca do cliente Steam falhou"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "A atualização do arquivo salvo falhou devido ao seguinte erro:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr "Visite a nossa página na Steam"
 
@@ -5383,7 +5433,7 @@ msgstr "Armazenamento"
 msgid "STORAGE_COLON"
 msgstr "Armazenamento:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Entrou como: {0}"
 
@@ -5498,7 +5548,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Equipe de Teste"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Obrigado por apoiar o desenvolvimento de Thrive ao comprar essa cópia!\n"
@@ -5514,7 +5564,7 @@ msgstr ""
 "\n"
 "Se gostou, fale do jogo para seus amigos."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr "Obrigado"
 
@@ -5573,7 +5623,7 @@ msgstr "Este mod foi instalado da Oficina Steam"
 msgid "THREADS"
 msgstr "Tarefas:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thrivepédia"
 
@@ -5729,7 +5779,7 @@ msgstr "Pausar"
 msgid "TOGGLE_UNBINDING"
 msgstr "Desativar modo de ligação"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Ferramentas"
 
@@ -5955,7 +6005,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Ver Agora"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr "Visite a nossa conta no Twitter"
 
@@ -6143,7 +6193,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Visualizador"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Ver código fonte"
 
@@ -6155,7 +6205,7 @@ msgstr "Apoiadores VIP"
 msgid "VISIBLE"
 msgstr "Visível"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Sugerir um recurso"
 
@@ -6310,7 +6360,7 @@ msgstr "Xbox Series X"
 msgid "YEARS"
 msgstr "anos"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Visite o nosso canal no YouTube"
 

--- a/locale/pt_PT.po
+++ b/locale/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-10-14 05:59+0000\n"
 "Last-Translator: TomDev03 <tomascsilvapro@gmail.com>\n"
 "Language-Team: Portuguese (Portugal) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/pt_PT/>\n"
@@ -212,7 +212,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Arte por {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Galeria de Arte"
 
@@ -313,7 +313,7 @@ msgstr "Guardar automaticamente durante o jogo"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Estados de execução:"
@@ -358,8 +358,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -623,27 +623,27 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Dióxido de Carbono"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "uma abundância"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "uma quantidade razoável"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "pouco"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "um bocado"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "algum"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "muito pouco"
 
@@ -920,21 +920,21 @@ msgstr "Valor de saturação, a quantidade de cinza em uma cor particular"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Valor (brilho) valor, brilho ou intensidade da cor"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Adicionar um novo atalho de teclado"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "A nossa Wiki"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Suicídio"
@@ -1141,7 +1141,7 @@ msgstr "A criar..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "A criar objetos a partir do jogo guardado"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Créditos"
 
@@ -1316,12 +1316,12 @@ msgstr "Apoiadores Devbuilds"
 msgid "DEVELOPERS"
 msgstr "Desenvolvedores"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Desenvolvimento Apoiado pela Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Adicionar um novo atalho de teclado"
@@ -1330,12 +1330,12 @@ msgstr "Adicionar um novo atalho de teclado"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Desenvolvimento Apoiado pela Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Desenvolvedores"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Ajuda"
@@ -1462,7 +1462,7 @@ msgstr ""
 "Existem organelos colocados que não estão conectadas aos restantes organelos.\n"
 "Conecte todos os organelos entre si ou reverta as alterações feitas."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Tempo Passado: {0:#,#} anos"
@@ -1480,7 +1480,7 @@ msgstr ""
 "e podem ser mais ambicioso em relação aos pedaços.\n"
 "Micróbios reativos mudarão para novos alvos depois de algum tempo."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Uma membrana com duas camadas, tem uma melhor proteção contra danos e consome menos energia para não se deformar. No entanto, abranda um pouco a célula e diminui a taxa de absorção de recursos."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1718,15 +1718,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Energia em {0} para {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Fontes de energia:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "A energia total recolhida é {0} com custo individual de {1} resultando em população inalterada de {2}"
 
@@ -1781,6 +1781,20 @@ msgstr "Erro ao criar o ficheiro de informações do mod"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Erro: Falha ao gravar as novas definições no ficheiro de configuração."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+"Os micróbios medrosos fugirão a distâncias maiores\n"
+"e são mais propensos a fugir dos predadores em geral.\n"
+"Os micróbios corajosos não se deixam intimidar pelos predadores próximos\n"
+"e, mais provavelmente, irão atacar de volta."
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Erro ao criar o ficheiro de informações do mod"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Erro ao carregar"
@@ -1833,7 +1847,7 @@ msgstr "Ocorreu um erro ao carregar os dados guardados"
 msgid "EXIT"
 msgstr "Sair"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Launch E"
@@ -1887,7 +1901,7 @@ msgstr "Extinguiram-se na região"
 msgid "EXTINCT_SPECIES"
 msgstr "Espécies Extintas"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1895,7 +1909,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr "Opções Extra"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Pausa o jogo"
@@ -1929,6 +1943,23 @@ msgstr "Chaves de Cheats ativadas"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Fevereiro"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Falha na inicialização da biblioteca do cliente Steam"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -2013,7 +2044,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Cadeia alimentar"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0} energia: {1} (aptidão: {2}) energia total disponível: {3} (aptidão total: {4})"
 
@@ -2120,7 +2151,7 @@ msgstr "Geração:"
 msgid "GENERATION_COLON"
 msgstr "Geração:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Suicídio"
@@ -2129,11 +2160,11 @@ msgstr "Suicídio"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Aviso do modo GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Estás a executar o Thrive com GLES2. Esta versão não foi testada severamente e pode causar problemas. Experimente atualizar os drivers da placa gráfica e/ou forçar a utilização da placa gráfica da AMD ou Nvidia."
 
@@ -2422,7 +2453,7 @@ msgstr "Ferro"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Quimiolitoautotrofia Férrica"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Suicídio"
@@ -2641,7 +2672,7 @@ msgstr "Esta língua é ainda um trabalho em curso ({0}% feito)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Esta tradução está muito incompleta ({0}% feita) por favor ajude-nos com ela!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2800,7 +2831,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Rato esquerdo"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licenças"
 
@@ -2936,7 +2967,8 @@ msgstr "Carregar"
 msgid "LOADING"
 msgstr "A carregar"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "A carregar..."
 
@@ -2968,12 +3000,12 @@ msgstr "Pressione o botão \"reverter\" no editor para corrigir um erro"
 msgid "LOAD_FINISHED"
 msgstr "Carregamento terminado"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Carregar Jogo"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Menu de pausa"
@@ -3229,7 +3261,7 @@ msgstr "A cada geração, tens 100 pontos de mutação (PM) para gastar, e cada 
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Cada vez que te reproduzires, entrarás no Editor de Microrganismos, onde poderás fazer alterações à tua espécie (ao adicionar, mover, ou remover organelos) de forma a aumentar o sucesso da tua espécie. Cada visita ao editor na Fase Microbial representa [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milhões de anos de evolução."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor livre para micróbios"
 
@@ -3481,11 +3513,11 @@ msgstr "Modificar organela"
 msgid "MODIFY_TYPE"
 msgstr "Modificar"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3574,11 +3606,11 @@ msgstr "Nome Interno (da Pasta):"
 msgid "MOD_LICENSE"
 msgstr "Licença do Mod:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Erro ao carregar Mods"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Ocorreram erros ao carregar um ou mais mods. Os logs podem conter informações adicionais."
 
@@ -3815,15 +3847,19 @@ msgstr ""
 "Este jogo guardado é de uma versão mais recente do Thrive e muito provavelmente incompatível.\n"
 "Quer tentar carregar o jogo mesmo assim?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Novo Jogo"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Menu de pausa"
@@ -3928,7 +3964,7 @@ msgid "NO_AI"
 msgstr "Sem IA"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Sem Dados a Mostrar"
 
@@ -3941,7 +3977,7 @@ msgstr "Sem eventos registado"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Nenhum diretório de ficheiros guardados encontrado"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Desactivado"
@@ -3972,7 +4008,7 @@ msgstr "Nenhum mod selecionado"
 msgid "NUCLEUS"
 msgstr "Núcleo"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3991,8 +4027,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -4005,16 +4041,16 @@ msgstr "N/A PM"
 msgid "OCTOBER"
 msgstr "Outubro"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Suicídio"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4094,11 +4130,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunista"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opções"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Ajuda"
@@ -4320,7 +4356,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Caverna"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Pausa o jogo"
@@ -4381,8 +4417,8 @@ msgstr "Desempenho"
 msgid "PERFORM_UNBINDING"
 msgstr "Efetuar a desconexão"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/segundo"
 
@@ -4433,7 +4469,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Célula do jogador"
 
@@ -4509,7 +4545,7 @@ msgstr "População:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "população em regiões:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4563,7 +4599,7 @@ msgstr "Anterior:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "A processar objetos carregados"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4607,11 +4643,11 @@ msgstr "Carregar rapidamente"
 msgid "QUICK_SAVE"
 msgstr "Guardar rapidamente"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Sair"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4657,7 +4693,7 @@ msgstr "Threads:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Thrive Recomendado:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Retomar o jogo"
@@ -4802,7 +4838,7 @@ msgstr ""
 "Tens a certeza de que desejas sair para o menu principal?\n"
 "Perderás todo o progresso não guardado."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Da Revolutionary Games Studio"
@@ -4891,7 +4927,7 @@ msgstr "Rusticianina é uma proteína capaz de utilizar gás carbónico e oxigé
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Transforma [thrive:compound type=\"iron\"][/thrive:compound] em [thrive:compound type=\"atp\"][/thrive:compound]. A taxa aumenta com a concentração de [thrive:compound type=\"carbondioxide\"][/thrive:compound] e [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4900,7 +4936,7 @@ msgstr ""
 "Os micróbios corajosos não se deixam intimidar pelos predadores próximos\n"
 "e, mais provavelmente, irão atacar de volta."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Remover dados locais"
@@ -5278,7 +5314,7 @@ msgstr "Gerar amoníaco"
 msgid "SPAWN_ENEMY"
 msgstr "Spawn Inimigo"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 #, fuzzy
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Impossível de usar o cheat de spawn inimigo porque esta região não contém nenhuma espécie inimiga"
@@ -5332,7 +5368,7 @@ msgstr "Nome da espécie..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Nome da espécie..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5447,19 +5483,19 @@ msgstr "O Steam não está disponível no momento, tente novamente"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Ocorreu um erro desconhecido da Steam"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Falha na inicialização da biblioteca do cliente Steam"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Atualizar o jogo guardado selecionado falhou devido ao seguinte erro:\n"
 "{0}"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Pausa o jogo"
@@ -5503,7 +5539,7 @@ msgstr "Armazenamento"
 msgid "STORAGE_COLON"
 msgstr "Armazenamento"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Entrou como: {0}"
 
@@ -5620,7 +5656,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Equipa da Testagem"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5635,7 +5671,7 @@ msgstr ""
 "\n"
 "Se gostaste do jogo, por favor diz os teus amigos sobre nós."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "TU PROSPERASTE!"
@@ -5699,7 +5735,7 @@ msgstr "Este mod é descarregado do Steam Workshop"
 msgid "THREADS"
 msgstr "Threads:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5849,7 +5885,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Desconectar"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Ferramentas"
 
@@ -6084,7 +6120,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Ver Agora"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Tempo Passado: {0:#,#} anos"
@@ -6284,7 +6320,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Ver Código Fonte"
 
@@ -6296,7 +6332,7 @@ msgstr "Apoiadores VIP"
 msgid "VISIBLE"
 msgstr "Visível"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6453,7 +6489,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "anos"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Pausa o jogo"

--- a/locale/pt_PT.po
+++ b/locale/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-10-14 05:59+0000\n"
 "Last-Translator: TomDev03 <tomascsilvapro@gmail.com>\n"
 "Language-Team: Portuguese (Portugal) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/pt_PT/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr "Editor"
 msgid "3D_MOVEMENT"
 msgstr "Movimento"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -64,7 +64,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr "Activo"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Threads atuais:"
 
@@ -150,7 +150,7 @@ msgstr "Estatísticas de Organismo"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Volume Ambiente"
 
@@ -161,11 +161,11 @@ msgstr "Volume Ambiente"
 msgid "AMMONIA"
 msgstr "Amoníaco"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Quantidade de jogos guardados automaticamente a manter:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Quantidade de jogos guardados rapidamente a manter:"
 
@@ -191,11 +191,11 @@ msgstr "Aplicar Alterações"
 msgid "APRIL"
 msgstr "Abril"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Tem a certeza que deseja repor todas as definições por defeito?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Tem certeza de que deseja repor as definições do teclado por defeito?"
 
@@ -212,7 +212,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Arte por {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Galeria de Arte"
 
@@ -225,7 +225,7 @@ msgstr "A classe de assembly do mod é necessária quando o assembly é especifi
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "A classe de assembly do mod é necessária quando o assembly é especificado"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Presumir que o CPU funciona com hyperthreading"
 
@@ -268,7 +268,7 @@ msgstr "A auto-evo falhou"
 msgid "AT_CURSOR"
 msgstr "No Cursor:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Dispositivo de saída de áudio:"
 
@@ -276,8 +276,8 @@ msgstr "Dispositivo de saída de áudio:"
 msgid "AUGUST"
 msgstr "Agosto"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "auto"
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% concluído. {1:n0}/{2:n0} etapas."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Guardar automaticamente durante o jogo"
 
@@ -313,7 +313,7 @@ msgstr "Guardar automaticamente durante o jogo"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Estados de execução:"
@@ -344,7 +344,7 @@ msgstr "Estados de execução:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Mover para a frente automaticamente"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 #, fuzzy
 msgid "AUTO_RESOLUTION"
 msgstr "Resolução:"
@@ -358,9 +358,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -504,7 +504,7 @@ msgstr "Permite conectar com outras células. Este é o primeiro passo para a mu
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Pressione [thrive:input]g_toggle_binding[/thrive:input] para ativar o modo de adesão. Quando em modo de adesão podes anexar outras células da tua espécie à tua colónia ao te aproximares das mesmas. Para deixar uma colónia pressione [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -566,7 +566,7 @@ msgstr "Esta membrana tem uma casca forte feita de carbonato de cálcio. Ele pod
 msgid "CAMERA"
 msgstr "Câmara"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -699,7 +699,7 @@ msgstr "Mudar simetria"
 msgid "CHEATS"
 msgstr "Cheats"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Chaves de Cheats ativadas"
 
@@ -792,7 +792,7 @@ msgstr "Produz [thrive:compound type=\"glucose\"][/thrive:compound]. A taxa aume
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "O nome do arquivo escolhido ({0}) já existe. Desejas substituir?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Aberração Cromática:"
 
@@ -835,15 +835,15 @@ msgstr "Limpar os jogos guardados antigos"
 msgid "CLOSE"
 msgstr "Fechar"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Fechar as opções?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Divisor da Resolução de Nuvens:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Intervalo mínimo da simulação de nuvens:"
 
@@ -859,7 +859,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr "Cor"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Correção de cor para daltónicos:"
 
@@ -920,26 +920,26 @@ msgstr "Valor de saturação, a quantidade de cinza em uma cor particular"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Valor (brilho) valor, brilho ou intensidade da cor"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Adicionar um novo atalho de teclado"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "A nossa Wiki"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Suicídio"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Compostos:"
@@ -967,7 +967,7 @@ msgstr "Compostos:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Equilíbrio de Compostos"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Nuvens de compostos"
 
@@ -1052,7 +1052,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1066,11 +1066,11 @@ msgstr "Este painel mostra os números a partir dos quais a previsão de auto-ev
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1078,11 +1078,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Copiar Erro para a Área de Transferência"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanóptico (Vermelho-Verde)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanóptico (Azul-Amarelo)"
 
@@ -1141,7 +1141,7 @@ msgstr "A criar..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "A criar objetos a partir do jogo guardado"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Créditos"
 
@@ -1167,7 +1167,7 @@ msgstr "Desenvolvedores Actuais"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Estatísticas de Organismo"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Username personalizado:"
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr "Dezembro"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Dispositivo de saída padrão"
 
@@ -1303,7 +1303,7 @@ msgstr "Descrição é demasiado longa"
 msgid "DESPAWN_ENTITIES"
 msgstr "Spawn Inimigo"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Número de threads detectados:"
 
@@ -1316,12 +1316,12 @@ msgstr "Apoiadores Devbuilds"
 msgid "DEVELOPERS"
 msgstr "Desenvolvedores"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Desenvolvimento Apoiado pela Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Adicionar um novo atalho de teclado"
@@ -1330,12 +1330,12 @@ msgstr "Adicionar um novo atalho de teclado"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Desenvolvimento Apoiado pela Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Desenvolvedores"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Ajuda"
@@ -1412,7 +1412,7 @@ msgstr "Esquerda"
 msgid "DIRECTIONR"
 msgstr "Direita"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Desactivado"
 
@@ -1420,7 +1420,7 @@ msgstr "Desactivado"
 msgid "DISABLE_ALL"
 msgstr "Desativar Todos"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Descartar e continuar"
 
@@ -1462,17 +1462,17 @@ msgstr ""
 "Existem organelos colocados que não estão conectadas aos restantes organelos.\n"
 "Conecte todos os organelos entre si ou reverta as alterações feitas."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Tempo Passado: {0:#,#} anos"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Velocidade:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
@@ -1480,19 +1480,19 @@ msgstr ""
 "e podem ser mais ambicioso em relação aos pedaços.\n"
 "Micróbios reativos mudarão para novos alvos depois de algum tempo."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Mostrar barra de habilidades"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "Mostrar barra de habilidades"
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Uma membrana com duas camadas, tem uma melhor proteção contra danos e consome menos energia para não se deformar. No entanto, abranda um pouco a célula e diminui a taxa de absorção de recursos."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1690,7 +1690,7 @@ msgstr ""
 "\n"
 "Para ir para o próximo separador do editor, pressiona o botão próximo no canto inferior direito."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1706,7 +1706,7 @@ msgstr "Ativar Todos os Mods Compatíveis"
 msgid "ENABLE_EDITOR"
 msgstr "Ativar o editor"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Ativar efeitos de luz da interface gráfica"
 
@@ -1765,7 +1765,7 @@ msgstr "Mostrar / ocultar ambiente e compostos"
 msgid "EPIPELAGIC"
 msgstr "Zona Epipelágica"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Erro"
 
@@ -1777,11 +1777,11 @@ msgstr "Erro ao criar pasta para o mod"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Erro ao criar o ficheiro de informações do mod"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Erro: Falha ao gravar as novas definições no ficheiro de configuração."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
@@ -1790,7 +1790,7 @@ msgstr ""
 "Os micróbios corajosos não se deixam intimidar pelos predadores próximos\n"
 "e, mais provavelmente, irão atacar de volta."
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Erro ao criar o ficheiro de informações do mod"
@@ -1825,12 +1825,12 @@ msgstr "Da Revolutionary Games Studio"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Da Revolutionary Games Studio"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Versão:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Suicídio"
@@ -1847,7 +1847,7 @@ msgstr "Ocorreu um erro ao carregar os dados guardados"
 msgid "EXIT"
 msgstr "Sair"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Launch E"
@@ -1901,7 +1901,7 @@ msgstr "Extinguiram-se na região"
 msgid "EXTINCT_SPECIES"
 msgstr "Espécies Extintas"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extras"
 
@@ -1909,7 +1909,7 @@ msgstr "Extras"
 msgid "EXTRA_OPTIONS"
 msgstr "Opções Extra"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Pausa o jogo"
@@ -1944,20 +1944,20 @@ msgstr "Chaves de Cheats ativadas"
 msgid "FEBRUARY"
 msgstr "Fevereiro"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Falha na inicialização da biblioteca do cliente Steam"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr "Séssil"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2122,7 +2122,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(começar com uma nuvem de glicose próxima a cada geração)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Ecrã inteiro"
 
@@ -2151,24 +2151,24 @@ msgstr "Geração:"
 msgid "GENERATION_COLON"
 msgstr "Geração:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Suicídio"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Aviso do modo GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Estás a executar o Thrive com GLES2. Esta versão não foi testada severamente e pode causar problemas. Experimente atualizar os drivers da placa gráfica e/ou forçar a utilização da placa gráfica da AMD ou Nvidia."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2222,12 +2222,12 @@ msgstr "Entendi"
 msgid "GPL_LICENSE_HEADING"
 msgstr "Segue o texto da licença GPL:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "Caverna"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Gráficos"
 
@@ -2235,7 +2235,7 @@ msgstr "Gráficos"
 msgid "GRAPHICS_TEAM"
 msgstr "Equipa dos Gráficos"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2252,7 +2252,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} m"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Volume da GUI"
 
@@ -2274,11 +2274,11 @@ msgstr "Ajuda"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Ajuda"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(valores mais altos melhoram o desempenho)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(valores mais altos pioram o desempenho)"
 
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Home"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Versão:"
@@ -2378,7 +2378,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Tempo Passado: {0:#,#} anos"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Teclado"
 
@@ -2432,8 +2432,8 @@ msgstr "Formato de URL inválido"
 msgid "INVALID_URL_SCHEME"
 msgstr "Esquema de URL inválido"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2453,7 +2453,7 @@ msgstr "Ferro"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Quimiolitoautotrofia Férrica"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Suicídio"
@@ -2462,19 +2462,19 @@ msgstr "Suicídio"
 msgid "JANUARY"
 msgstr "Janeiro"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "Modo de debug para JSON:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Sempre"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automaticamente"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Nunca"
 
@@ -2656,19 +2656,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Idioma:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Este idioma está {0}% traduzido"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Esta língua é ainda um trabalho em curso ({0}% feito)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Esta tradução está muito incompleta ({0}% feita) por favor ajude-nos com ela!"
 
@@ -2831,7 +2831,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Rato esquerdo"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licenças"
 
@@ -2902,7 +2902,7 @@ msgstr "Clique roda direita"
 msgid "LIGHT_MAX"
 msgstr "Luz"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "Extras"
@@ -2917,32 +2917,32 @@ msgstr "CONFIRMAR"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "Este painel mostra os números a partir dos quais a previsão de auto-evo funciona. A energia total que uma espécie é capaz de capturar e o custo por indivíduo da espécie determinam a população final. O Auto-evo usa um modelo simplificado da realidade para calcular o desempenho das espécies com base na energia que conseguem obter. Para cada fonte de alimento, mostra quanta energia é que a espécie ganha com isso. Além disso, aparece o total de energia disponível na fonte. A fração que a espécie ganha da energia total é baseada em quão grande a aptidão é comparada com a aptidão total. A aptidão é uma métrica de quão bem a espécie pode utilizar essa fonte de alimento."
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "CONFIRMAR"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2967,7 +2967,7 @@ msgstr "Carregar"
 msgid "LOADING"
 msgstr "A carregar"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "A carregar..."
@@ -3000,12 +3000,12 @@ msgstr "Pressione o botão \"reverter\" no editor para corrigir um erro"
 msgid "LOAD_FINISHED"
 msgstr "Carregamento terminado"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Carregar Jogo"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Menu de pausa"
@@ -3086,7 +3086,7 @@ msgstr "Março"
 msgid "MARINE_SNOW"
 msgstr "Neve marinha"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Volume principal"
 
@@ -3095,15 +3095,15 @@ msgstr "Volume principal"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Extinguiram-se na região"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Max FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Ilimitado"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3261,7 +3261,7 @@ msgstr "A cada geração, tens 100 pontos de mutação (PM) para gastar, e cada 
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Cada vez que te reproduzires, entrarás no Editor de Microrganismos, onde poderás fazer alterações à tua espécie (ao adicionar, mover, ou remover organelos) de forma a aumentar o sucesso da tua espécie. Cada visita ao editor na Fase Microbial representa [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milhões de anos de evolução."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Editor livre para micróbios"
 
@@ -3447,7 +3447,7 @@ msgstr "Mínimo:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Não é permitido mostrar menos de {0} conjunto(s) de dados!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Diversos"
 
@@ -3513,11 +3513,11 @@ msgstr "Modificar organela"
 msgid "MODIFY_TYPE"
 msgstr "Modificar"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3606,11 +3606,11 @@ msgstr "Nome Interno (da Pasta):"
 msgid "MOD_LICENSE"
 msgstr "Licença do Mod:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Erro ao carregar Mods"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Ocorreram erros ao carregar um ou mais mods. Os logs podem conter informações adicionais."
 
@@ -3663,11 +3663,11 @@ msgstr "Versão do Mod:"
 msgid "MORE_INFO"
 msgstr "Mostrar Mais Informações"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3784,7 +3784,7 @@ msgstr "Colocar organelo"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Colocar organelo"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Multisample anti-aliasing:"
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Música"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Volume da música"
 
@@ -3817,9 +3817,9 @@ msgstr "(custo de organelas, membranas e outros itens no editor)"
 msgid "MUTATION_POINTS"
 msgstr "Pontos de Mutação"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Silenciar"
 
@@ -3855,11 +3855,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Novo Jogo"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Menu de pausa"
@@ -3928,7 +3928,7 @@ msgstr "O Plastídeo Fixador de Nitrogénio é uma proteína capaz de usar nitro
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Transforma [thrive:compound type=\"atp\"][/thrive:compound] em [thrive:compound type=\"ammonia\"][/thrive:compound]. A taxa aumenta com a concentração de [thrive:compound type=\"nitrogen\"][/thrive:compound] e [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Nenhum"
 
@@ -3977,7 +3977,7 @@ msgstr "Sem eventos registado"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Nenhum diretório de ficheiros guardados encontrado"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Desactivado"
@@ -3995,7 +3995,7 @@ msgstr "Não foram encontrados jogos guardados"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Nenhum diretório de ficheiros guardados encontrado"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Nenhum diretório de captura de ecrã encontrado"
 
@@ -4041,16 +4041,16 @@ msgstr "N/A PM"
 msgid "OCTOBER"
 msgstr "Outubro"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Suicídio"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4087,7 +4087,7 @@ msgstr "Abrir o ecrã de ajuda"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Modo livre"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Abrir pasta de Logs"
 
@@ -4103,7 +4103,7 @@ msgstr "Abrir o menu da organela"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Abrir a pasta dos jogos guardados"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Abrir pasta de capturas de ecrã"
 
@@ -4111,7 +4111,7 @@ msgstr "Abrir pasta de capturas de ecrã"
 msgid "OPEN_THE_MENU"
 msgstr "Abrir o menu"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Ajude a traduzir o jogo"
 
@@ -4130,11 +4130,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunista"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opções"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Ajuda"
@@ -4356,7 +4356,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Caverna"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Pausa o jogo"
@@ -4409,7 +4409,7 @@ msgstr "Pacífico"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Desempenho"
 
@@ -4493,7 +4493,7 @@ msgstr "Duplicar Jogador"
 msgid "PLAYER_EXTINCT"
 msgstr "O jogador está extinto"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "O jogador está extinto"
@@ -4508,23 +4508,23 @@ msgstr ""
 "Jogador\n"
 "Velocidade"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Reproduzir o vídeo de introdução"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Jogar a Introdução ao Micróbio num Novo Jogo"
 
@@ -4643,11 +4643,11 @@ msgstr "Carregar rapidamente"
 msgid "QUICK_SAVE"
 msgstr "Guardar rapidamente"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Sair"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4693,7 +4693,7 @@ msgstr "Threads:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Thrive Recomendado:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Retomar o jogo"
@@ -4752,7 +4752,7 @@ msgstr "reproduzido"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Núcleo"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Repor"
 
@@ -4761,24 +4761,24 @@ msgstr "Repor"
 msgid "RESET_DEADZONES"
 msgstr "Repor as definições por defeito?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Repor as entradas por defeito?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Repor Entradas"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Repor Definições por Defeito"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Repor as definições por defeito?"
 
@@ -4787,7 +4787,7 @@ msgstr "Repor as definições por defeito?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Resolução:"
 
@@ -4838,7 +4838,7 @@ msgstr ""
 "Tens a certeza de que desejas sair para o menu principal?\n"
 "Perderás todo o progresso não guardado."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Da Revolutionary Games Studio"
@@ -4872,7 +4872,7 @@ msgstr "Rodar para a direita"
 msgid "ROTATION_COLON"
 msgstr "População:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Utilizar auto-evo durante o jogo"
 
@@ -4927,7 +4927,7 @@ msgstr "Rusticianina é uma proteína capaz de utilizar gás carbónico e oxigé
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Transforma [thrive:compound type=\"iron\"][/thrive:compound] em [thrive:compound type=\"atp\"][/thrive:compound]. A taxa aumenta com a concentração de [thrive:compound type=\"carbondioxide\"][/thrive:compound] e [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4936,16 +4936,16 @@ msgstr ""
 "Os micróbios corajosos não se deixam intimidar pelos predadores próximos\n"
 "e, mais provavelmente, irão atacar de volta."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Remover dados locais"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Gravar"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Gravar e continuar"
 
@@ -5046,21 +5046,21 @@ msgstr "Guardar o jogo não é possível devido a:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Guardado com sucesso"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr "Agente de Adesão"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5162,7 +5162,7 @@ msgstr "Séssil"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Este valor só se aplica a novos jogos iniciados após alterar esta opção"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Volume de Efeitos"
 
@@ -5179,23 +5179,27 @@ msgstr "Mostrar ajuda"
 msgid "SHOW_TUTORIALS"
 msgstr "Mostrar tutoriais"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Mostrar tutoriais (no jogo atual)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Mostrar tutoriais (em novos jogos)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Mostrar aviso de progresso não guardado"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Ativa / desativa o popup de aviso de progresso não guardado para quando o jogador tenta sair do jogo."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5244,7 +5248,7 @@ msgstr "Sílica"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Esta membrana possui uma forte parede de sílica. Ela pode resistir bem a danos gerais e é muito resistente a danos físicos. Também requer menos energia para manter a forma. No entanto, abranda a célula por um grande fator e absorve recursos em uma taxa reduzida."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5286,7 +5290,7 @@ msgstr "Transforma [thrive:compound type=\"glucose\"][/thrive:compound] em [thri
 msgid "SMALL_IRON_CHUNK"
 msgstr "Pequeno Pedaço de Ferro"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Som"
 
@@ -5483,19 +5487,19 @@ msgstr "O Steam não está disponível no momento, tente novamente"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Ocorreu um erro desconhecido da Steam"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Falha na inicialização da biblioteca do cliente Steam"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Atualizar o jogo guardado selecionado falhou devido ao seguinte erro:\n"
 "{0}"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Pausa o jogo"
@@ -5539,7 +5543,7 @@ msgstr "Armazenamento"
 msgid "STORAGE_COLON"
 msgstr "Armazenamento"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Entrou como: {0}"
 
@@ -5656,7 +5660,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Equipa da Testagem"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5671,7 +5675,7 @@ msgstr ""
 "\n"
 "Se gostaste do jogo, por favor diz os teus amigos sobre nós."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "TU PROSPERASTE!"
@@ -5731,11 +5735,11 @@ msgstr "Mod instalado localmente"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Este mod é descarregado do Steam Workshop"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Threads:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5885,7 +5889,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Desconectar"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Ferramentas"
 
@@ -5952,7 +5956,7 @@ msgstr "Tente tirar algumas capturas de ecrã!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Tente guardar!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Tente tirar algumas capturas de ecrã!"
 
@@ -6120,12 +6124,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Ver Agora"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Tempo Passado: {0:#,#} anos"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6150,7 +6154,7 @@ msgstr "Desconectar todos"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Modo de Desconexão"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6173,7 +6177,7 @@ msgstr "Reverter a última ação"
 msgid "UNKNOWN"
 msgstr "Desconhecido"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Mostrar barra de habilidades"
@@ -6187,7 +6191,7 @@ msgstr "Rato botão desconhecido"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "O ID da Steam Workshop é desconhecido para este mod"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Versão do Mod:"
@@ -6196,7 +6200,7 @@ msgstr "Versão do Mod:"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "O ID da Steam Workshop é desconhecido para este mod"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Existem alterações não guardadas que serão perdidas.\n"
@@ -6241,7 +6245,7 @@ msgstr "Carregamento bem-sucedido"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Licenças e Bibliotecas Utilizadas"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6259,7 +6263,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Suicídio"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Use um username personalizado"
 
@@ -6267,11 +6271,11 @@ msgstr "Use um username personalizado"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Escolher manualmente o número de threads"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6297,7 +6301,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr "Versão:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Versão:"
@@ -6308,11 +6312,11 @@ msgstr "Versão:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Velocidade:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6320,7 +6324,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Ver Código Fonte"
 
@@ -6332,7 +6336,7 @@ msgstr "Apoiadores VIP"
 msgid "VISIBLE"
 msgstr "Visível"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6352,7 +6356,7 @@ msgstr "Sem som"
 msgid "VOLUMEUP"
 msgstr "Aumentar o volume"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSync"
 
@@ -6460,7 +6464,7 @@ msgstr "Estatísticas de Organismo"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "Movimento Base"
@@ -6469,15 +6473,15 @@ msgstr "Movimento Base"
 msgid "WORST_PATCH_COLON"
 msgstr "Pior Região:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6489,7 +6493,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "anos"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Pausa o jogo"

--- a/locale/ro.po
+++ b/locale/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-11-17 16:00+0000\n"
 "Last-Translator: Alexia Diana Cojocaru <alexia.d.cojocaru@gmail.com>\n"
 "Language-Team: Romanian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ro/>\n"
@@ -196,7 +196,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -332,8 +332,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -588,27 +588,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -867,19 +867,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1232,11 +1232,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1244,11 +1244,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1595,15 +1595,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1656,6 +1656,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1704,7 +1712,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1754,7 +1762,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1762,7 +1770,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1788,6 +1796,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1869,7 +1893,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1965,7 +1989,7 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1973,11 +1997,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2253,7 +2277,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2469,7 +2493,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2628,7 +2652,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2756,7 +2780,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2786,12 +2811,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3021,7 +3046,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3231,11 +3256,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3321,11 +3346,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3549,15 +3574,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3657,7 +3686,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3669,7 +3698,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3699,7 +3728,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3718,8 +3747,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3732,15 +3761,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3811,11 +3840,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4020,7 +4049,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4078,8 +4107,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4129,7 +4158,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4202,7 +4231,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4256,7 +4285,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4300,11 +4329,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4344,7 +4373,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4478,7 +4507,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4564,11 +4593,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4924,7 +4953,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4974,7 +5003,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5089,15 +5118,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5137,7 +5166,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5252,7 +5281,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5260,7 +5289,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5319,7 +5348,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5466,7 +5495,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5609,7 +5638,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5793,7 +5822,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5805,7 +5834,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5958,7 +5987,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/ro.po
+++ b/locale/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-11-17 16:00+0000\n"
 "Last-Translator: Alexia Diana Cojocaru <alexia.d.cojocaru@gmail.com>\n"
 "Language-Team: Romanian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ro/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr ""
 msgid "3D_MOVEMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -147,11 +147,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -176,11 +176,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -196,7 +196,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -256,8 +256,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -282,7 +282,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -319,7 +319,7 @@ msgstr ""
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -332,9 +332,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -470,7 +470,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -660,7 +660,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -791,15 +791,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -815,7 +815,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -867,23 +867,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr ""
 
@@ -909,7 +909,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1001,11 +1001,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1013,11 +1013,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1162,7 +1162,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1220,7 +1220,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1232,11 +1232,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1244,11 +1244,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1361,31 +1361,31 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1567,7 +1567,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1583,7 +1583,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1652,15 +1652,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1692,11 +1692,11 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1712,7 +1712,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1762,7 +1762,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1770,7 +1770,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1798,19 +1798,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1931,7 +1931,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -1989,23 +1989,23 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2058,11 +2058,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2070,7 +2070,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2082,7 +2082,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2104,11 +2104,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2132,7 +2132,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr ""
 
@@ -2204,7 +2204,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2257,8 +2257,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2277,7 +2277,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2285,19 +2285,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2477,19 +2477,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2652,7 +2652,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2720,7 +2720,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2732,31 +2732,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2780,7 +2780,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2811,12 +2811,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2881,7 +2881,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2889,15 +2889,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3046,7 +3046,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3193,7 +3193,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3256,11 +3256,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3346,11 +3346,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3403,11 +3403,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3516,7 +3516,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3528,7 +3528,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Muzică"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3548,9 +3548,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3582,11 +3582,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3651,7 +3651,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3698,7 +3698,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3715,7 +3715,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3761,15 +3761,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3800,7 +3800,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3816,7 +3816,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3840,11 +3840,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4049,7 +4049,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4099,7 +4099,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4182,7 +4182,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4194,23 +4194,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4329,11 +4329,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4373,7 +4373,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4426,7 +4426,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4434,23 +4434,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4459,7 +4459,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4507,7 +4507,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4539,7 +4539,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4593,19 +4593,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4697,20 +4697,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4823,20 +4823,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4885,7 +4889,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4925,7 +4929,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5118,15 +5122,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5166,7 +5170,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5281,7 +5285,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5289,7 +5293,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5344,11 +5348,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5495,7 +5499,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5557,7 +5561,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5638,11 +5642,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5667,7 +5671,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5687,7 +5691,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5699,7 +5703,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5707,7 +5711,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5747,7 +5751,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5763,7 +5767,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5771,11 +5775,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5801,7 +5805,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr ""
 
@@ -5810,11 +5814,11 @@ msgstr ""
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5822,7 +5826,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5834,7 +5838,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5854,7 +5858,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5959,7 +5963,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5967,15 +5971,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -5987,7 +5991,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-12-09 20:00+0000\n"
 "Last-Translator: tabat-dectocoder <aliks234066aliks@gmail.com>\n"
 "Language-Team: Russian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ru/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "3D-Редактор"
 msgid "3D_MOVEMENT"
 msgstr "Перемещение в трёх измерениях"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "Действие заблокировано до окончания пр
 msgid "ACTIVE"
 msgstr "Активный"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Число потоков:"
 
@@ -144,7 +144,7 @@ msgstr "Статистика Организма"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Громкость окружения"
 
@@ -155,11 +155,11 @@ msgstr "Громкость окружения"
 msgid "AMMONIA"
 msgstr "Аммиак"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Количество записей автосохранения:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Количество записей быстрого сохранения:"
 
@@ -184,11 +184,11 @@ msgstr "Применить изменения"
 msgid "APRIL"
 msgstr "Апрель"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Вы действительно хотите сбросить ВСЕ настройки до значений по умолчанию?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Вы действительно хотите сбросить настройки ввода до значений по умолчанию?"
 
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Картина от {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Галерея изображений"
 
@@ -216,7 +216,7 @@ msgstr "Класс сборки необходим для мода, если у�
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "Сборка мода требуется c Harmony"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Предположить, что в процессоре включена гиперпоточность"
 
@@ -258,7 +258,7 @@ msgstr "Не удалось сохранить файл. Возможно, им�
 msgid "AT_CURSOR"
 msgstr "Вы смотрите на:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Устройство вывода звука:"
 
@@ -266,8 +266,8 @@ msgstr "Устройство вывода звука:"
 msgid "AUGUST"
 msgstr "Август"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Авто"
 
@@ -294,7 +294,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% завершено. {1:n0}/{2:n0} шагов."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Автосохранение во время игры"
 
@@ -302,7 +302,7 @@ msgstr "Автосохранение во время игры"
 msgid "AUTO_EVO"
 msgstr "Авто-Эволюция"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Инструмент изучения авто-эво"
 
@@ -332,7 +332,7 @@ msgstr "статус запуска:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Авто движение вперед"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Авто ({0}x{1})"
 
@@ -345,9 +345,9 @@ msgid "AWAKEN"
 msgstr "Пробудить"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -488,7 +488,7 @@ msgstr "Позволяет связываться с другими клетка
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Нажмите [thrive:input]g_toggle_binding[/thrive:input] чтобы включить режим связывания. В режиме связывания вы можете присоединить другие клетки вашего вида к вашей колонии касаясь их. Чтобы покинуть колонию нажмите [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr "Общее значение для осей"
 
@@ -550,7 +550,7 @@ msgstr "Эта мембрана имеет прочную оболочку, из
 msgid "CAMERA"
 msgstr "Камера"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -678,7 +678,7 @@ msgstr "Изменить симметрию"
 msgid "CHEATS"
 msgstr "Читы"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Чит-коды включены"
 
@@ -768,7 +768,7 @@ msgstr "Производит [thrive:compound type=\"glucose\"][/thrive:compound
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Выбранное имя файла ({0}) уже существует. Перезаписать?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Хроматическая аберрация:"
 
@@ -809,15 +809,15 @@ msgstr "Удалить устаревшие сохранения"
 msgid "CLOSE"
 msgstr "Закрыть"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Закрыть настройки?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Делитель разрешения облака:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Мин. интервал симуляции облаков:"
 
@@ -833,7 +833,7 @@ msgstr "Создавать сущности с коллизией"
 msgid "COLOUR"
 msgstr "Окраска"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Цветокоррекция для дальтоников:"
 
@@ -894,26 +894,26 @@ msgstr "Значение насыщенности, уровень серого �
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Value (brightness) значение, яркость или интенсивность цвета"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Войдите в редактор для модификации видов"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "наша Wiki"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Выйти из игры"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr "Собрано в:"
 
@@ -939,7 +939,7 @@ msgstr "Соединения:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Компонентный Баланс"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Облака веществ"
 
@@ -1025,7 +1025,7 @@ msgstr "Продолжить на прототипах следующих ста
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr "Настройка мёртвых зон контроллера"
 
@@ -1040,11 +1040,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr "Чувствительность контроллера"
 
@@ -1052,11 +1052,11 @@ msgstr "Чувствительность контроллера"
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Копировать Ошибку в Буфер Обмена"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Протанопия (Крас.-Зел.)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Тританопия (Син.-Жел.)"
 
@@ -1112,7 +1112,7 @@ msgstr "Создание..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Создание объектов из сохранения"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Титры"
 
@@ -1138,7 +1138,7 @@ msgstr "Текущие Разработчики"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Статистика Организма"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Кастомное имя пользователя:"
 
@@ -1204,7 +1204,7 @@ msgstr "Консоль Отладки"
 msgid "DECEMBER"
 msgstr "Декабрь"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Устройство вывода по умолчанию"
 
@@ -1266,7 +1266,7 @@ msgstr "Описание слишком длинное"
 msgid "DESPAWN_ENTITIES"
 msgstr "Удалить все сущности"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Число обнаруженных ядер процессора:"
 
@@ -1281,12 +1281,12 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Разработчики"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Разработка поддержана командой Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Войдите в редактор для модификации видов"
@@ -1295,12 +1295,12 @@ msgstr "Войдите в редактор для модификации вид�
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Разработка поддержана командой Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Разработчики"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Как играть в эту игру"
@@ -1384,7 +1384,7 @@ msgstr "Налево"
 msgid "DIRECTIONR"
 msgstr "Направо"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Отключено"
 
@@ -1392,7 +1392,7 @@ msgstr "Отключено"
 msgid "DISABLE_ALL"
 msgstr "Отключить все"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Отменить и продолжить"
 
@@ -1431,34 +1431,34 @@ msgstr ""
 "Среди размещённых органелл, имеются несоединённые с остальными.\n"
 "Пожалуйста соедините все размещённые органеллы с другими или отмените свои действия."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr "Присоединяйтесь к нашему Discord серверу"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Скорость переваривания:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 "Это показывает, сколько всплывающих окон было навсегда отклонено пользователем.\n"
 "Если некоторые всплывающие окна, которые действительно нужны, будут отклонены, можно использовать кнопку рядом с этим, чтобы все отклоненные всплывающие окна снова появились."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Показать панель способностей"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Отображение фоновых частиц"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Показать названия кнопок при выборе частей"
 
@@ -1493,7 +1493,7 @@ msgstr "Двойной клик для полноэкранного режима
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Мембрана с двумя слоями, имеет лучшую защиту от повреждений и требует меньше энергии, чтобы не деформироваться. Однако, несколько замедляет скорость клетки и снижает скорость, с которой она может поглощать ресурсы."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1647,7 +1647,7 @@ msgstr ""
 "\n"
 "Когда вы будете готовы, нажмите кнопку \"далее\" в правом нижнем углу, чтобы продолжить."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1663,7 +1663,7 @@ msgstr "Включить все совместимые моды"
 msgid "ENABLE_EDITOR"
 msgstr "Включить редактор"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Включить световые эффекты GUI"
 
@@ -1721,7 +1721,7 @@ msgstr "Показать/скрыть окружение и соединения
 msgid "EPIPELAGIC"
 msgstr "Эпипелагический"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Ошибка"
 
@@ -1733,16 +1733,16 @@ msgstr "Ошибка создания папки для мода"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Ошибка создания info файла мода"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Ошибка: Не удалось сохранить новые настройки в конфигурационном файле."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(случайно расположенные секреты в игре)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Ошибка создания info файла мода"
@@ -1779,11 +1779,11 @@ msgstr ""
 "\n"
 "Если ни один из них не применим, произошла ошибка. Пожалуйста, сообщите об этом команде разработчиков и предоставьте журналы игры."
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr "Точная версия Thrive:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Код коммита, с которого была скомпилирована эта версия Thrive"
 
@@ -1799,7 +1799,7 @@ msgstr "Во время загрузки сохранённых данных п�
 msgid "EXIT"
 msgstr "Выход"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Запуск E"
@@ -1852,7 +1852,7 @@ msgstr "Вымерли в биоме"
 msgid "EXTINCT_SPECIES"
 msgstr "Вымершие Виды"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Дополнительное"
 
@@ -1860,7 +1860,7 @@ msgstr "Дополнительное"
 msgid "EXTRA_OPTIONS"
 msgstr "Дополнительные Настройки"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Приостановить игру"
@@ -1895,12 +1895,12 @@ msgstr "Чит-коды включены"
 msgid "FEBRUARY"
 msgstr "Февраль"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Не удалось выполнить инициализацию клиентской библиотеки Steam"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1922,11 +1922,11 @@ msgstr ""
 "Общее время процессора:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2050,7 +2050,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr "Окаменеть"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2080,7 +2080,7 @@ msgstr "Бесплатное облако глюкозы при выходе и�
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(начало с облаком глюкозы возле каждого поколения)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Полный экран"
 
@@ -2108,24 +2108,24 @@ msgstr "Поколения"
 msgid "GENERATION_COLON"
 msgstr "Поколение:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Выйти из игры"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Предупреждение режима GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Ты запустил Thrive через GLES2. Этот режим ещё не проверен и может вызвать проблемы. Попробуй обновить свои видеодрайвера и/или вручную используй AMD или Nvidia видеокарты для запуска Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2178,11 +2178,11 @@ msgstr "Всё понятно"
 msgid "GPL_LICENSE_HEADING"
 msgstr "Текст лицензии GPL:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "Видеокарта:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Графика"
 
@@ -2190,7 +2190,7 @@ msgstr "Графика"
 msgid "GRAPHICS_TEAM"
 msgstr "Графическая Команда"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "Графический интерфейс"
 
@@ -2207,7 +2207,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} Тыс"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Громкость пользовательского интерфейса"
 
@@ -2229,11 +2229,11 @@ msgstr "Помощь"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Как играть в эту игру"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(высокие значения могут ухудшить производительность)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(высокие значения ухудшают производительность)"
 
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Home"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr "По горизонтали:"
 
@@ -2331,7 +2331,7 @@ msgstr "Поглощённая материя"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Присоединяйтесь к нашему Discord серверу"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Клавиши"
 
@@ -2384,8 +2384,8 @@ msgstr "Неверный формат URL"
 msgid "INVALID_URL_SCHEME"
 msgstr "Неверная схема URL-адреса"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr "Инвертировать"
 
@@ -2408,7 +2408,7 @@ msgstr "Железо"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Железная хемолитоавтотрофия"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Выйти из игры"
@@ -2417,19 +2417,19 @@ msgstr "Выйти из игры"
 msgid "JANUARY"
 msgstr "Январь"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "Режим отладки JSON:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Всегда"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Автоматически"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Никогда"
 
@@ -2611,19 +2611,19 @@ msgstr "Num."
 msgid "KPSUBTRACT"
 msgstr "Num-"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Язык:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Этот язык на {0}% завершён"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Этот язык всё ещё находится в стадии разработки ({0}% завершено)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Этот перевод в процессе разработки (завершён на {0}%). Пожалуйста, помогите нам с этим!"
 
@@ -2785,7 +2785,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Левая кнопка мыши"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Лицензии"
 
@@ -2855,7 +2855,7 @@ msgstr "Колёсико вправо"
 msgid "LIGHT_MAX"
 msgstr "Свет"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Экстремальное"
 
@@ -2869,31 +2869,31 @@ msgstr "Нормальное"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(скорость, с которой ИИ будет мутировать)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Огромное"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Большое"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Нормальное"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Маленькое"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Крохотное"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Очень большое"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Очень маленькое"
 
@@ -2917,7 +2917,7 @@ msgstr "Загрузить"
 msgid "LOADING"
 msgstr "Загрузка"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Загрузка..."
@@ -2948,12 +2948,12 @@ msgstr "Нажмите кнопку отмены в редакторе для и
 msgid "LOAD_FINISHED"
 msgstr "Загрузка завершена"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Загрузить игру"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Загрузить сохраненные игры"
 
@@ -3028,7 +3028,7 @@ msgstr "Март"
 msgid "MARINE_SNOW"
 msgstr "Морской снег"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Общая громкость"
 
@@ -3036,15 +3036,15 @@ msgstr "Общая громкость"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Максимум видов в биоме перед искусственным вымиранием"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Макс. FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Бесконечно"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Максимальное количество сущностей:"
 
@@ -3231,7 +3231,7 @@ msgstr "В каждом поколении у вас есть 100 очков м�
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Каждый раз размножаясь, вы можете войти в Микробный Редактор, где вы можете изменить свой вида (добавляя, передвигая или удаляя органеллы), чтобы повысить успех вашего вида. Каждое посещение редактора в Микробной Фазе представляет [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] миллионов лет эволюции."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Свободный микробный редактор"
 
@@ -3415,7 +3415,7 @@ msgstr "Минимальная версия:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Невозможно показать меньше, чем {0} наборов данных!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Дополнительное"
 
@@ -3479,11 +3479,11 @@ msgstr "Модифицировать Органеллу"
 msgid "MODIFY_TYPE"
 msgstr "Изменить Вид"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Моды"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3569,11 +3569,11 @@ msgstr "Внутреннее имя (Папки):"
 msgid "MOD_LICENSE"
 msgstr "Лицензия мода:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Ошибки при загрузке модов"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Возникли ошибки при загрузке одного или нескольких модов. Журналы могут содержать дополнительную информацию."
 
@@ -3626,11 +3626,11 @@ msgstr "Версия мода:"
 msgid "MORE_INFO"
 msgstr "Показать больше информации"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr "Чувствительность обзора мышью"
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr "Изменять чувствительность мыши в зависимости от размера окна"
 
@@ -3745,7 +3745,7 @@ msgstr "Группа метасфер"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Разместить Органеллу"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Множественная выборка сглаживания:"
 
@@ -3760,7 +3760,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Музыка"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Громкость музыки"
 
@@ -3780,9 +3780,9 @@ msgstr "(стоимость органелл, мембран и т. д. в ре�
 msgid "MUTATION_POINTS"
 msgstr "Очки мутации"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Заглушить"
 
@@ -3818,11 +3818,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Начальная популяция увеличивающих биоразнообразие видов"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Новая игра"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Начать новую игру"
 
@@ -3887,7 +3887,7 @@ msgstr "Азотфиксирующий пластид — белок, спосо
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Превращает [thrive:compound type=\"atp\"][/thrive:compound] в [thrive:compound type=\"ammonia\"][/thrive:compound]. Скорость увеличивается при повышении концентрации [thrive:compound type=\"nitrogen\"][/thrive:compound] и [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Отсутствует"
 
@@ -3936,7 +3936,7 @@ msgstr "Никаких событий не зафиксировано"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Папка сохранений не найдена"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Отключено"
@@ -3954,7 +3954,7 @@ msgstr "Не Найдено Сохранений"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Папка сохранений не найдена"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Папка скриншотов не найдена"
 
@@ -4002,16 +4002,16 @@ msgstr "Н/Д МP"
 msgid "OCTOBER"
 msgstr "Октябрь"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Самоубийство"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4050,7 +4050,7 @@ msgstr "Открыть экран помощи"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Свободное Строительство"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Открыть папку с логами"
 
@@ -4066,7 +4066,7 @@ msgstr "Открыть меню органеллы"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Открыть папку сохранений"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Открыть папку со скриншотами"
 
@@ -4074,7 +4074,7 @@ msgstr "Открыть папку со скриншотами"
 msgid "OPEN_THE_MENU"
 msgstr "Открыть меню"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Помогите перевести эту игру"
 
@@ -4093,11 +4093,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Рисковый"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Настройки"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Сменить настройки"
 
@@ -4311,7 +4311,7 @@ msgstr "Процедурная"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Приостановить игру"
@@ -4363,7 +4363,7 @@ msgstr "Мирный"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Производительность"
 
@@ -4452,7 +4452,7 @@ msgstr "Клонировать Игрока"
 msgid "PLAYER_EXTINCT"
 msgstr "Игрок вымер"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Игрок вымер"
@@ -4467,23 +4467,23 @@ msgstr ""
 "Скорость\n"
 "Игрока"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Проигрывать начальное видео"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Проигрывать вступление микроба при новой игре"
 
@@ -4602,11 +4602,11 @@ msgstr "Быстрая загрузка"
 msgid "QUICK_SAVE"
 msgstr "Быстрое сохранение"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Выйти"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Выйти из игры"
@@ -4649,7 +4649,7 @@ msgstr "Готово"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Рекомендуемая версия Thrive:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Продолжить игру"
@@ -4703,7 +4703,7 @@ msgstr "Воспроизведение:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Требуется ядро"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Сбросить"
 
@@ -4711,23 +4711,23 @@ msgstr "Сбросить"
 msgid "RESET_DEADZONES"
 msgstr "Сбросить мёртвые зоны"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Сбросить настройки ввода до значений по умолчанию?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr "Сбросить настройки клавиш"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "По умолчанию"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Сбросить по умолчанию?"
 
@@ -4736,7 +4736,7 @@ msgstr "Сбросить по умолчанию?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Разрешение:"
 
@@ -4786,7 +4786,7 @@ msgstr ""
 "Вы действительно хотите вернуться в главное меню?\n"
 "Весь несохраненный прогресс будет утерян."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Автор: Revolutionary Games Studio"
@@ -4819,7 +4819,7 @@ msgstr "Повернуть вправо"
 msgid "ROTATION_COLON"
 msgstr "Популяция:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Запускать авто-эво во время игры"
 
@@ -4874,7 +4874,7 @@ msgstr "Рустицианин - это белок, способный испо�
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Превращает [thrive:compound type=\"iron\"][/thrive:compound] в [thrive:compound type=\"atp\"][/thrive:compound]. Скорость увеличивается при повышении концентрации [thrive:compound type=\"carbondioxide\"][/thrive:compound] и [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive запущен в безопасном режиме из-за предыдущей ошибки запуска.\n"
@@ -4886,16 +4886,16 @@ msgstr ""
 "\n"
 "Если вы не устраните проблему, вызывающую сбой при запуске, вам потребуется перезапустить Thrive несколько раз, чтобы вернуться в безопасный режим."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Удаление Локальных Данных"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Сохранить"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Сохранить и продолжить"
 
@@ -4993,20 +4993,20 @@ msgstr "Сохранение сейчас невозможно по причин
 msgid "SAVING_SUCCEEDED"
 msgstr "Сохранение успешно"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr "Не изменять"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr "Увеличивать"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr "Уменьшать"
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "увеличивает передвижение"
@@ -5106,7 +5106,7 @@ msgstr "Оседлый"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Это значение начнёт работать при старте новой игры"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Громкость звуковых эффектов"
 
@@ -5122,21 +5122,25 @@ msgstr "Показать помощь"
 msgid "SHOW_TUTORIALS"
 msgstr "Показать Обучение"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Показывать руководства (в текущей игре)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Показывать руководства (в новых играх)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Показать предупреждение о несохраненном прогрессе"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Включает / отключает предупреждение о несохраненном прогрессе, когда игрок пытается выйти из игры."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5184,7 +5188,7 @@ msgstr "Кремнезём"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Эта мембрана имеет прочную стенку из кремнезема. Она может хорошо противостоять общим повреждениям и очень устойчива к физическим повреждениям. Она также требует меньше энергии для поддержания своей формы. Но клетка не может быстро поглощать ресурсы и двигается медленнее."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5224,7 +5228,7 @@ msgstr "Превращает [thrive:compound type=\"glucose\"][/thrive:compound
 msgid "SMALL_IRON_CHUNK"
 msgstr "Маленький кусок железа"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Звук"
 
@@ -5428,17 +5432,17 @@ msgstr "Steam в настоящее время недоступен, пожал�
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Произошла неизвестная ошибка Steam"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Не удалось выполнить инициализацию клиентской библиотеки Steam"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Обновление указанного сохранения не удалось выполнить из-за следующей ошибки:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Приостановить игру"
@@ -5479,7 +5483,7 @@ msgstr "Хранилище"
 msgid "STORAGE_COLON"
 msgstr "Вместимость клетки:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Авторизован как: {0}"
 
@@ -5596,7 +5600,7 @@ msgstr "Темп."
 msgid "TESTING_TEAM"
 msgstr "Команда Тестирования"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Благодарим вас за поддержку развития Thrive, купив эту копию Thrive!\n"
@@ -5612,7 +5616,7 @@ msgstr ""
 "\n"
 "Если вам понравилась игра, расскажите о нас своим друзьям."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr "Спасибо"
 
@@ -5667,11 +5671,11 @@ msgstr "Это локально установленный мод"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Этот мод загружен из Мастерской Steam"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Потоки:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5827,7 +5831,7 @@ msgstr "Пауза"
 msgid "TOGGLE_UNBINDING"
 msgstr "Переключить развязку"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Инструменты"
 
@@ -5892,7 +5896,7 @@ msgstr "Попробуйте сделать скриншоты!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Попробуйте сделать сохранение!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Попробуйте сделать скриншоты!"
 
@@ -6054,11 +6058,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Обучение"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr "Посетите нашу ленту в Twitter"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6083,7 +6087,7 @@ msgstr "Отвязать всех"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Режим Развязки"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr "Это отладочная сборка, где приведенная ниже информация, вероятно, не актуальна"
 
@@ -6103,7 +6107,7 @@ msgstr "Отменить последнее действие"
 msgid "UNKNOWN"
 msgstr "Неизвестная кнопка мыши"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Неизвестно"
 
@@ -6115,7 +6119,7 @@ msgstr "Неизвестная кнопка мыши"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Неизвестно для Windows"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "Неизвестная версия"
 
@@ -6123,7 +6127,7 @@ msgstr "Неизвестная версия"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Неизвестный Workshop ID для этого мода"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "У вас есть несохранённые изменения, которые будут утрачены.\n"
@@ -6167,7 +6171,7 @@ msgstr "Загрузка выполнена успешно"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Лицензии и использованные библиотеки"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "Движок отрисовки:"
 
@@ -6183,7 +6187,7 @@ msgstr "Использовать автозагрузку Harmony"
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Автоматически загружать патчи для сборки модов от Harmony(Специальный мод не требуется)"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Использовать кастомное имя пользователя"
 
@@ -6191,11 +6195,11 @@ msgstr "Использовать кастомное имя пользовате�
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "Создание вида для увеличения биоразнообразия забирает часть популяции существующего вида"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Установить вручную количество фоновых потоков"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6221,7 +6225,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Версия:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr "По вертикали:"
 
@@ -6230,11 +6234,11 @@ msgstr "По вертикали:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "По вертикали (ось: {0})"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "Видеопамяти используется:"
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6242,7 +6246,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Просмотр"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Открыть исходный код"
 
@@ -6254,7 +6258,7 @@ msgstr "VIP-Спонсоры"
 msgid "VISIBLE"
 msgstr "Видимый"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Предложить идею"
 
@@ -6274,7 +6278,7 @@ msgstr "VolumeMute"
 msgid "VOLUMEUP"
 msgstr "VolumeUp"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "Вертикальная синхронизация"
 
@@ -6381,7 +6385,7 @@ msgstr "Статистика Организма"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "увеличивает передвижение"
@@ -6390,15 +6394,15 @@ msgstr "увеличивает передвижение"
 msgid "WORST_PATCH_COLON"
 msgstr "Худший Путь:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6410,7 +6414,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "лет"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Приостановить игру"

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-12-09 20:00+0000\n"
 "Last-Translator: tabat-dectocoder <aliks234066aliks@gmail.com>\n"
 "Language-Team: Russian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ru/>\n"
@@ -204,7 +204,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Картина от {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Галерея изображений"
 
@@ -302,7 +302,7 @@ msgstr "Автосохранение во время игры"
 msgid "AUTO_EVO"
 msgstr "Авто-Эволюция"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Инструмент изучения авто-эво"
 
@@ -345,8 +345,8 @@ msgid "AWAKEN"
 msgstr "Пробудить"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -606,27 +606,27 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Углекислый газ"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "изобилие"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "изрядное количество"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "мало"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "немного"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "некоторое количество"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "очень мало"
 
@@ -894,21 +894,21 @@ msgstr "Значение насыщенности, уровень серого �
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Value (brightness) значение, яркость или интенсивность цвета"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Войдите в редактор для модификации видов"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "наша Wiki"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Выйти из игры"
@@ -1112,7 +1112,7 @@ msgstr "Создание..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Создание объектов из сохранения"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Титры"
 
@@ -1281,12 +1281,12 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Разработчики"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Разработка поддержана командой Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Войдите в редактор для модификации видов"
@@ -1295,12 +1295,12 @@ msgstr "Войдите в редактор для модификации вид�
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Разработка поддержана командой Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Разработчики"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Как играть в эту игру"
@@ -1431,7 +1431,7 @@ msgstr ""
 "Среди размещённых органелл, имеются несоединённые с остальными.\n"
 "Пожалуйста соедините все размещённые органеллы с другими или отмените свои действия."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr "Присоединяйтесь к нашему Discord серверу"
 
@@ -1446,7 +1446,7 @@ msgstr ""
 "Это показывает, сколько всплывающих окон было навсегда отклонено пользователем.\n"
 "Если некоторые всплывающие окна, которые действительно нужны, будут отклонены, можно использовать кнопку рядом с этим, чтобы все отклоненные всплывающие окна снова появились."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1493,7 +1493,7 @@ msgstr "Двойной клик для полноэкранного режима
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Мембрана с двумя слоями, имеет лучшую защиту от повреждений и требует меньше энергии, чтобы не деформироваться. Однако, несколько замедляет скорость клетки и снижает скорость, с которой она может поглощать ресурсы."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1675,15 +1675,15 @@ msgstr "{0}: -{1} АТФ"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} АТФ"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Энергия в {0} для {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Источники Энергии:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "Общая собранная энергия равна {0} с индивидуальными затратами {1}, результатом чего является нескорректированная популяция количеством в {2}"
 
@@ -1737,6 +1737,16 @@ msgstr "Ошибка создания info файла мода"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Ошибка: Не удалось сохранить новые настройки в конфигурационном файле."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(случайно расположенные секреты в игре)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Ошибка создания info файла мода"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Ошибка Загрузки"
@@ -1789,7 +1799,7 @@ msgstr "Во время загрузки сохранённых данных п�
 msgid "EXIT"
 msgstr "Выход"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Запуск E"
@@ -1842,7 +1852,7 @@ msgstr "Вымерли в биоме"
 msgid "EXTINCT_SPECIES"
 msgstr "Вымершие Виды"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Дополнительное"
 
@@ -1850,7 +1860,7 @@ msgstr "Дополнительное"
 msgid "EXTRA_OPTIONS"
 msgstr "Дополнительные Настройки"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Приостановить игру"
@@ -1884,6 +1894,41 @@ msgstr "Чит-коды включены"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Февраль"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Не удалось выполнить инициализацию клиентской библиотеки Steam"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Время обработки: {0} с\n"
+"Обработка физики: {1} с\n"
+"Сущностей: {2}; Другое: {3}\n"
+"Создано: {4}; Удалено: {5}\n"
+"Использовано узлов: {6}\n"
+"Использовано оперативной памяти: {7} MiB\n"
+"Использовано видеопамяти: {8} MiB\n"
+"Отрисовано объектов: {9}\n"
+"Вызовов отрисовки: {10}; 2D: {11}\n"
+"Отрисовано вершин: {12}\n"
+"Изменение материала: {13}\n"
+"Изменение шейдера: {14}\n"
+"Отключенных узлов: {15}\n"
+"Латентность звука: {16} мс\n"
+"Количество потоков: {17}\n"
+"Общее время процессора:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1967,7 +2012,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Пищевая Цепочка"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0} энергия: {1} (пригодность: {2}) общая доступная энергия: {3} (общая пригодность: {4})"
 
@@ -2063,7 +2108,7 @@ msgstr "Поколения"
 msgid "GENERATION_COLON"
 msgstr "Поколение:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Выйти из игры"
@@ -2072,11 +2117,11 @@ msgstr "Выйти из игры"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Предупреждение режима GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Ты запустил Thrive через GLES2. Этот режим ещё не проверен и может вызвать проблемы. Попробуй обновить свои видеодрайвера и/или вручную используй AMD или Nvidia видеокарты для запуска Thrive."
 
@@ -2363,7 +2408,7 @@ msgstr "Железо"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Железная хемолитоавтотрофия"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Выйти из игры"
@@ -2582,7 +2627,7 @@ msgstr "Этот язык всё ещё находится в стадии ра�
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Этот перевод в процессе разработки (завершён на {0}%). Пожалуйста, помогите нам с этим!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "Последняя органелла не может быть удалена"
 
@@ -2740,7 +2785,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Левая кнопка мыши"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Лицензии"
 
@@ -2872,7 +2917,8 @@ msgstr "Загрузить"
 msgid "LOADING"
 msgstr "Загрузка"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Загрузка..."
 
@@ -2902,12 +2948,12 @@ msgstr "Нажмите кнопку отмены в редакторе для и
 msgid "LOAD_FINISHED"
 msgstr "Загрузка завершена"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Загрузить игру"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Загрузить сохраненные игры"
 
@@ -3185,7 +3231,7 @@ msgstr "В каждом поколении у вас есть 100 очков м�
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Каждый раз размножаясь, вы можете войти в Микробный Редактор, где вы можете изменить свой вида (добавляя, передвигая или удаляя органеллы), чтобы повысить успех вашего вида. Каждое посещение редактора в Микробной Фазе представляет [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] миллионов лет эволюции."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Свободный микробный редактор"
 
@@ -3433,11 +3479,11 @@ msgstr "Модифицировать Органеллу"
 msgid "MODIFY_TYPE"
 msgstr "Изменить Вид"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Моды"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3523,11 +3569,11 @@ msgstr "Внутреннее имя (Папки):"
 msgid "MOD_LICENSE"
 msgstr "Лицензия мода:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Ошибки при загрузке модов"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Возникли ошибки при загрузке одного или нескольких модов. Журналы могут содержать дополнительную информацию."
 
@@ -3764,15 +3810,19 @@ msgstr ""
 "Это сохранение из новых версий Thrive и скорее всего несовместимо.\n"
 "Всё равно попробовать загрузить сохранение?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Начальная популяция увеличивающих биоразнообразие видов"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Новая игра"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Начать новую игру"
 
@@ -3873,7 +3923,7 @@ msgid "NO_AI"
 msgstr "Выключить ИИ"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Нет данных для отображения"
 
@@ -3886,7 +3936,7 @@ msgstr "Никаких событий не зафиксировано"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Папка сохранений не найдена"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Отключено"
@@ -3917,7 +3967,7 @@ msgstr "Ни одного мода не выбрано"
 msgid "NUCLEUS"
 msgstr "Ядро"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 "Нельзя удалить ядро, это необратимая эволюция.\n"
@@ -3938,8 +3988,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "Нет данных"
@@ -3952,16 +4002,16 @@ msgstr "Н/Д МP"
 msgid "OCTOBER"
 msgstr "Октябрь"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Самоубийство"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4043,11 +4093,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Рисковый"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Настройки"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Сменить настройки"
 
@@ -4261,7 +4311,7 @@ msgstr "Процедурная"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Приостановить игру"
@@ -4321,8 +4371,8 @@ msgstr "Производительность"
 msgid "PERFORM_UNBINDING"
 msgstr "Отвязать"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/секунд"
 
@@ -4378,7 +4428,7 @@ msgstr "Генерация планеты в разработке!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Сид планеты"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Клетка Игрока"
 
@@ -4454,7 +4504,7 @@ msgstr "популяция:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "Популяция в биомах:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4508,7 +4558,7 @@ msgstr "предыдущий:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Обработка загруженных объектов"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4552,11 +4602,11 @@ msgstr "Быстрая загрузка"
 msgid "QUICK_SAVE"
 msgstr "Быстрое сохранение"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Выйти"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Выйти из игры"
@@ -4599,7 +4649,7 @@ msgstr "Готово"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Рекомендуемая версия Thrive:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Продолжить игру"
@@ -4736,7 +4786,7 @@ msgstr ""
 "Вы действительно хотите вернуться в главное меню?\n"
 "Весь несохраненный прогресс будет утерян."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Автор: Revolutionary Games Studio"
@@ -4824,7 +4874,7 @@ msgstr "Рустицианин - это белок, способный испо�
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Превращает [thrive:compound type=\"iron\"][/thrive:compound] в [thrive:compound type=\"atp\"][/thrive:compound]. Скорость увеличивается при повышении концентрации [thrive:compound type=\"carbondioxide\"][/thrive:compound] и [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive запущен в безопасном режиме из-за предыдущей ошибки запуска.\n"
@@ -4836,7 +4886,7 @@ msgstr ""
 "\n"
 "Если вы не устраните проблему, вызывающую сбой при запуске, вам потребуется перезапустить Thrive несколько раз, чтобы вернуться в безопасный режим."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Удаление Локальных Данных"
@@ -5202,7 +5252,7 @@ msgstr "Создать аммиак"
 msgid "SPAWN_ENEMY"
 msgstr "Создать Противника"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Невозможно использовать чит Создать Противника, так как этот биом не содержит каких-либо видов противников"
 
@@ -5263,7 +5313,7 @@ msgstr "Название вида..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Название вида слишком длинное!"
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5378,17 +5428,17 @@ msgstr "Steam в настоящее время недоступен, пожал�
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Произошла неизвестная ошибка Steam"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Не удалось выполнить инициализацию клиентской библиотеки Steam"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Обновление указанного сохранения не удалось выполнить из-за следующей ошибки:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Приостановить игру"
@@ -5429,7 +5479,7 @@ msgstr "Хранилище"
 msgid "STORAGE_COLON"
 msgstr "Вместимость клетки:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Авторизован как: {0}"
 
@@ -5546,7 +5596,7 @@ msgstr "Темп."
 msgid "TESTING_TEAM"
 msgstr "Команда Тестирования"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Благодарим вас за поддержку развития Thrive, купив эту копию Thrive!\n"
@@ -5562,7 +5612,7 @@ msgstr ""
 "\n"
 "Если вам понравилась игра, расскажите о нас своим друзьям."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr "Спасибо"
 
@@ -5621,7 +5671,7 @@ msgstr "Этот мод загружен из Мастерской Steam"
 msgid "THREADS"
 msgstr "Потоки:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5777,7 +5827,7 @@ msgstr "Пауза"
 msgid "TOGGLE_UNBINDING"
 msgstr "Переключить развязку"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Инструменты"
 
@@ -6004,7 +6054,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Обучение"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr "Посетите нашу ленту в Twitter"
 
@@ -6192,7 +6242,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Просмотр"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Открыть исходный код"
 
@@ -6204,7 +6254,7 @@ msgstr "VIP-Спонсоры"
 msgid "VISIBLE"
 msgstr "Видимый"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Предложить идею"
 
@@ -6360,7 +6410,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "лет"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Приостановить игру"

--- a/locale/si_LK.po
+++ b/locale/si_LK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-03-22 18:22+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Sinhala <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/si/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.11.2\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -32,7 +32,7 @@ msgstr ""
 msgid "3D_MOVEMENT"
 msgstr "සංචලනය"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -63,7 +63,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -137,7 +137,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -177,11 +177,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -198,7 +198,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -210,7 +210,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -258,8 +258,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -284,7 +284,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr "තේරූ:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -335,9 +335,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -473,7 +473,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -535,7 +535,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -663,7 +663,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -753,7 +753,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -794,15 +794,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -818,7 +818,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -870,23 +870,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "තේරූ:"
@@ -913,7 +913,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -992,7 +992,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1005,11 +1005,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1017,11 +1017,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1102,7 +1102,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1226,7 +1226,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 #, fuzzy
 msgid "DETECTED_CPU_COUNT"
 msgstr "තේරූ:"
@@ -1239,11 +1239,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1251,11 +1251,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1337,7 +1337,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1369,32 +1369,32 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "තේරූ:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1575,7 +1575,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1591,7 +1591,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1648,7 +1648,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1660,15 +1660,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1700,12 +1700,12 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "තේරූ:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1721,7 +1721,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1771,7 +1771,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1807,19 +1807,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1941,7 +1941,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1971,7 +1971,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -1999,23 +1999,23 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2068,11 +2068,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2080,7 +2080,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2114,11 +2114,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2142,7 +2142,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "තේරූ:"
@@ -2215,7 +2215,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2268,8 +2268,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2296,19 +2296,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2488,19 +2488,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2662,7 +2662,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2730,7 +2730,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2742,31 +2742,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2791,7 +2791,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2822,12 +2822,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2892,7 +2892,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2900,15 +2900,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3027,7 +3027,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3161,7 +3161,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3224,11 +3224,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3314,11 +3314,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3371,11 +3371,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3485,7 +3485,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3497,7 +3497,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3517,9 +3517,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3551,11 +3551,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3620,7 +3620,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3669,7 +3669,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3686,7 +3686,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3733,15 +3733,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3772,7 +3772,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3812,11 +3812,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4022,7 +4022,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4072,7 +4072,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4155,7 +4155,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4167,23 +4167,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4302,11 +4302,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4347,7 +4347,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4400,7 +4400,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4408,23 +4408,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4433,7 +4433,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4481,7 +4481,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4513,7 +4513,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4567,19 +4567,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4671,20 +4671,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4786,7 +4786,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4803,20 +4803,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr "නිබන්ධන පෙන්වන්න"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4865,7 +4869,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4907,7 +4911,7 @@ msgstr "තේරූ:"
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5100,16 +5104,16 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "තේරූ:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5150,7 +5154,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr "තේරූ:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5265,7 +5269,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5273,7 +5277,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5329,11 +5333,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5481,7 +5485,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5543,7 +5547,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5624,11 +5628,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5654,7 +5658,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5674,7 +5678,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5686,7 +5690,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5694,7 +5698,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5736,7 +5740,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5752,7 +5756,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5760,11 +5764,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5790,7 +5794,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "තේරූ:"
@@ -5800,11 +5804,11 @@ msgstr "තේරූ:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5812,7 +5816,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5824,7 +5828,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5844,7 +5848,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5949,7 +5953,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5957,15 +5961,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -5977,7 +5981,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/si_LK.po
+++ b/locale/si_LK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-03-22 18:22+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Sinhala <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/si/>\n"
@@ -198,7 +198,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -335,8 +335,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -591,27 +591,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -870,19 +870,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1239,11 +1239,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1251,11 +1251,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1369,7 +1369,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr "තේරූ:"
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1603,15 +1603,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1664,6 +1664,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1713,7 +1721,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1763,7 +1771,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1771,7 +1779,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1797,6 +1805,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1879,7 +1903,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1975,7 +1999,7 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1983,11 +2007,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2264,7 +2288,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2480,7 +2504,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2638,7 +2662,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2767,7 +2791,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2797,12 +2822,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3002,7 +3027,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3199,11 +3224,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3289,11 +3314,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3518,15 +3543,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3628,7 +3657,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3640,7 +3669,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3671,7 +3700,7 @@ msgstr "තේරූ:"
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3690,8 +3719,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3704,15 +3733,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3783,11 +3812,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3993,7 +4022,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4051,8 +4080,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4102,7 +4131,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4175,7 +4204,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4229,7 +4258,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4273,11 +4302,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4318,7 +4347,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4452,7 +4481,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4538,11 +4567,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4906,7 +4935,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4956,7 +4985,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5071,16 +5100,16 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "තේරූ:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5121,7 +5150,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr "තේරූ:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5236,7 +5265,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5244,7 +5273,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5304,7 +5333,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5452,7 +5481,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5595,7 +5624,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5783,7 +5812,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5795,7 +5824,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5948,7 +5977,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/sk.po
+++ b/locale/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-07-27 06:44+0000\n"
 "Last-Translator: Matej Maceášik <m.maceasik@gmail.com>\n"
 "Language-Team: Slovak <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sk/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.13.1\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "3D Editor"
 msgid "3D_MOVEMENT"
 msgstr "3D Pohyb"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -63,7 +63,7 @@ msgstr "Akcia je zablokovaná, kým prebieha iná"
 msgid "ACTIVE"
 msgstr "Aktívny"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Súčasné vlákna:"
 
@@ -141,7 +141,7 @@ msgstr "Štatistika organizmu"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Hlasitosť prostredia"
 
@@ -152,11 +152,11 @@ msgstr "Hlasitosť prostredia"
 msgid "AMMONIA"
 msgstr "Amoniak"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Počet automatických uložení k zachovaniu:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Počet rýchlych uložení k zachovaniu:"
 
@@ -181,11 +181,11 @@ msgstr "Použiť zmeny"
 msgid "APRIL"
 msgstr "Apríl"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Naozaj chceš obnoviť VŠETKY predvolené nastavenia?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Naozaj chceš obnoviť predvolené nastavenia ovládania?"
 
@@ -202,7 +202,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Vytvoril {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Galéria"
 
@@ -214,7 +214,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Predpokladať, že CPU má povolené hypervlákna"
 
@@ -254,7 +254,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr "Na kurzore:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Výstupné zvukové zariadenie:"
 
@@ -262,8 +262,8 @@ msgstr "Výstupné zvukové zariadenie:"
 msgid "AUGUST"
 msgstr "August"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "AUTO"
 msgstr "Automatická evolúcia"
@@ -290,7 +290,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1} % hotovo. {1:n0}/{2:n0} krokov."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Automatické ukladanie počas hry"
 
@@ -298,7 +298,7 @@ msgstr "Automatické ukladanie počas hry"
 msgid "AUTO_EVO"
 msgstr "Automatická evolúcia"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Nástroj prieskumu Auto-Evo"
 
@@ -329,7 +329,7 @@ msgstr "stav spustenia:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Automatický pohyb dopredu"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Automatické ({0}x{1})"
 
@@ -343,9 +343,9 @@ msgid "AWAKEN"
 msgstr "Prebudiť sa"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -490,7 +490,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -552,7 +552,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr "Kamera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -681,7 +681,7 @@ msgstr "Zmeniť symetriu"
 msgid "CHEATS"
 msgstr "Cheaty"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Cheaty povolené"
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Chromatická aberácia:"
 
@@ -812,15 +812,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr "Zavrieť"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Zatvoriť možnosti?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Oddeľovač rozlíšenia oblakov:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Minimálny interval simulácie oblakov:"
 
@@ -837,7 +837,7 @@ msgstr "Umiestniť entity s kolíznymi tvarmi"
 msgid "COLOUR"
 msgstr "Farba"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Korekcia farieb:"
 
@@ -897,26 +897,26 @@ msgstr "Saturácia - množstvo sivej farby"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Jas - svetlosť alebo intenzita farby"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Vstúpte do editora a upravte svoj druh"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "naša Wiki"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Opustiť hru"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Zlúčeniny:"
@@ -944,7 +944,7 @@ msgstr "Zlúčeniny:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Oblaky zlúčenín"
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1038,11 +1038,11 @@ msgstr "(koeficient populácie druhu, ktorý klesne zakaždým keď hráč zomri
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1050,11 +1050,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Kopírovať chybu do schránky"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanopia (červeno-zelená)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanopia (modro-žltá)"
 
@@ -1111,7 +1111,7 @@ msgstr "Vytváranie..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Poďakovanie"
 
@@ -1137,7 +1137,7 @@ msgstr "Súčasní vývojári"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Štatistika organizmu"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Vlastné používateľské meno:"
 
@@ -1205,7 +1205,7 @@ msgstr "Debugovací panel"
 msgid "DECEMBER"
 msgstr "December"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Predvolené výstupné zariadenie"
 
@@ -1263,7 +1263,7 @@ msgstr "Popis je príliš dlhý"
 msgid "DESPAWN_ENTITIES"
 msgstr "Odstrániť všetky entity"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Zistený počet CPU:"
 
@@ -1276,12 +1276,12 @@ msgstr "Devbuilds podporovatelia"
 msgid "DEVELOPERS"
 msgstr "Vývojári"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Vývoj podporovaný štúdiom Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Vstúpte do editora a upravte svoj druh"
@@ -1290,12 +1290,12 @@ msgstr "Vstúpte do editora a upravte svoj druh"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Vývoj podporovaný štúdiom Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Vývojári"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Ako hrať hru"
@@ -1370,7 +1370,7 @@ msgstr "Doľava"
 msgid "DIRECTIONR"
 msgstr "Doprava"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Vypnuté"
 
@@ -1378,7 +1378,7 @@ msgstr "Vypnuté"
 msgid "DISABLE_ALL"
 msgstr "Zakázať všetko"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Zahodiť a pokračovať"
 
@@ -1410,34 +1410,34 @@ msgstr "Odpojené organely"
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Uplynulý čas: {0:#,#} rokov"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Rýchlosť trávenia:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "(začiatočná poloha)"
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Zobraziť panel schopností"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Zobraziť častice v pozadí"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Zobraziť názvy tlačidiel pri výbere častí"
 
@@ -1472,7 +1472,7 @@ msgstr "Dvojitým kliknutím zobraziť na celej obrazovke"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1619,7 +1619,7 @@ msgstr "Vstúpte do editora a upravte svoj druh"
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1636,7 +1636,7 @@ msgstr "Povoliť všetky kompatibilné módy"
 msgid "ENABLE_EDITOR"
 msgstr "Zapni editor"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Povoliť svetelné efekty GUI"
 
@@ -1695,7 +1695,7 @@ msgstr "Zobraziť / skryť prostredie a zlúčeniny"
 msgid "EPIPELAGIC"
 msgstr "Epipelagiál"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Chyba"
 
@@ -1707,16 +1707,16 @@ msgstr "Chyba pri vytváraní priečinka pre mód"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Chyba: Nepodarilo sa uložiť nové nastavenia."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(náhodne umiestnené tajomstvá v hre)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Chyba pri vytváraní priečinka pre mód"
@@ -1752,12 +1752,12 @@ msgstr "Od Revolutionary Games Studio"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Od Revolutionary Games Studio"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Verzia:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Vrátiť sa k základnému zobrazeniu nastavení"
@@ -1774,7 +1774,7 @@ msgstr ""
 msgid "EXIT"
 msgstr "Odísť"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Spustiť E"
@@ -1827,7 +1827,7 @@ msgstr "vyhynul v tejto oblasti"
 msgid "EXTINCT_SPECIES"
 msgstr "Vyhynuté druhy"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extra"
 
@@ -1835,7 +1835,7 @@ msgstr "Extra"
 msgid "EXTRA_OPTIONS"
 msgstr "Extra nastavenia"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Pozastaviť hru"
@@ -1866,11 +1866,11 @@ msgstr "Cheaty povolené"
 msgid "FEBRUARY"
 msgstr "Február"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1891,11 +1891,11 @@ msgstr ""
 "Celkovy počet vlákien: {17}\n"
 "Celkový čas CPU: {18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2018,7 +2018,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2048,7 +2048,7 @@ msgstr "Po opustení editora sa vytvorí oblak glukózy"
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(začni s oblakom glukózy v blízkosti každou generáciou)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Celá obrazovka"
 
@@ -2077,24 +2077,24 @@ msgstr "Generácia"
 msgid "GENERATION_COLON"
 msgstr "Generácia:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Opustiť hru"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Varovanie režimu GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Spúšťaš Thrive pomocou vykresľovača GLES2. Táto možnosť nie je otestovaná a môže spôsobiť problémy. Skús si aktualizovať svoje grafické ovládače alebo vynútiť použitie AMD alebo Nvidia grafiky pre spustenie Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2147,11 +2147,11 @@ msgstr "Rozumiem"
 msgid "GPL_LICENSE_HEADING"
 msgstr "Text licencie GPL je nasledujúci:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "GPU:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafika"
 
@@ -2159,7 +2159,7 @@ msgstr "Grafika"
 msgid "GRAPHICS_TEAM"
 msgstr "Grafici"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "GUI"
 
@@ -2172,7 +2172,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} tis"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Hlasitosť GUI"
 
@@ -2194,11 +2194,11 @@ msgstr "Pomoc"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Ako hrať hru"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(vyššie hodnoty zvyšujú výkon)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(vyššie hodnoty zhoršujú výkon)"
 
@@ -2223,7 +2223,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Home"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Verzia:"
@@ -2299,7 +2299,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Uplynulý čas: {0:#,#} rokov"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Ovládanie"
 
@@ -2352,8 +2352,8 @@ msgstr "Neplatný formát adresy URL"
 msgid "INVALID_URL_SCHEME"
 msgstr "Neplatná schéma adresy URL"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2372,7 +2372,7 @@ msgstr "Železo"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Chemolitoautotrofia železa"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Opustiť hru"
@@ -2381,19 +2381,19 @@ msgstr "Opustiť hru"
 msgid "JANUARY"
 msgstr "Január"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "Debugovací režim JSON:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Vždy"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automaticky"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Nikdy"
 
@@ -2576,19 +2576,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Jazyk:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Tento jazyk je dokončený na {0}%"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Na preklade tohto jazyka sa ešte pracuje ({0}% hotovo)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Tento preklad nie je dokončený ({0}% hotovo) prosím pomôž nám s ním!"
 
@@ -2752,7 +2752,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Ľavé tlačidlo myši"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licencie"
 
@@ -2823,7 +2823,7 @@ msgstr "Skrolovať doprava"
 msgid "LIGHT_MAX"
 msgstr "Svetlo"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Extrémny"
 
@@ -2837,31 +2837,31 @@ msgstr "Normálny"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(rýchlosť, akou druhy AI mutujú)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Obrovský"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Veľký"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Normálny"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Malý"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Maličký"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Veľmi veľký"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Veľmi malý"
 
@@ -2886,7 +2886,7 @@ msgstr "Načítať"
 msgid "LOADING"
 msgstr "Načítanie"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Načítavanie..."
@@ -2917,12 +2917,12 @@ msgstr "Chybu opravíš stlačením tlačidla Zrušiť v editore"
 msgid "LOAD_FINISHED"
 msgstr "Načítanie dokončené"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Načítať hru"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Načítať predošlé uložené hry"
 
@@ -2988,7 +2988,7 @@ msgstr "Marec"
 msgid "MARINE_SNOW"
 msgstr "Morský sneh"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Celková hlasitosť"
 
@@ -2997,15 +2997,15 @@ msgstr "Celková hlasitosť"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "vyhynul v tejto oblasti"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Maximálny počet snímkov za sekundu:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Neobmedzené"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Maximálny počet entít:"
 
@@ -3192,7 +3192,7 @@ msgstr "Každú generáciu máš k dispozícii 100 bodov mutácie (BM) a každá
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Vždy keď zahájiš reprodukciu vstúpiš do editora mikróbov, kde môžeš vykonávať zmeny tvojmu druhu (pridávaním, priemiestňovaním alebo odoberaním organel) k zvýšeniu úspešnosti. Každá návšteva editora vo fáze mikróbov reprezentuje [thrive:constant] EDITOR_TIME_JUMP_MILLION_YEARS [/thrive:constant] miliónov rokov evolúcie."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Neobmedzený editor mikróbov"
 
@@ -3339,7 +3339,7 @@ msgstr "Minimum:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Nie je povolené zobraziť menej ako {0} dátových súborov!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Rôzne"
 
@@ -3404,11 +3404,11 @@ msgstr "Upraviť organelu"
 msgid "MODIFY_TYPE"
 msgstr "Upraviť typ"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Módy"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3497,11 +3497,11 @@ msgstr "Interný názov (priečinku):"
 msgid "MOD_LICENSE"
 msgstr "Licencia módu:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Chyba načítania režimu"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Pri načítaní jedného alebo viac režimov došlo k chybám. Protokoly môžu obsahovať ďalšie informácie."
 
@@ -3557,11 +3557,11 @@ msgstr "Verzia modu:"
 msgid "MORE_INFO"
 msgstr "Zobraziť viac informácií"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3674,7 +3674,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Viacvzorové vyhladzovanie:"
 
@@ -3686,7 +3686,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Hudba"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Hlasitosť hudby"
 
@@ -3707,9 +3707,9 @@ msgstr "(náklady na organely, membrány a ďalšie predmety v editore)"
 msgid "MUTATION_POINTS"
 msgstr "Body mutácie"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Stlmiť"
 
@@ -3742,11 +3742,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Nová hra"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Začať novú hru"
 
@@ -3812,7 +3812,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Žiadne"
 
@@ -3862,7 +3862,7 @@ msgstr "Žiadne zaznamenané udalosti"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Priečinok snímkov obrazovky nebol nájdený"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Vypnuté"
@@ -3880,7 +3880,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Priečinok snímkov obrazovky nebol nájdený"
 
@@ -3927,16 +3927,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr "Október"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Samovražda"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3969,7 +3969,7 @@ msgstr "Otvoriť nápovedu"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Voľná stavba"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Otvoriť priečinok protokolov"
 
@@ -3986,7 +3986,7 @@ msgstr "Otvoriť ponuku organel"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Otvoriť priečinok snímiek obrazovky"
 
@@ -3994,7 +3994,7 @@ msgstr "Otvoriť priečinok snímiek obrazovky"
 msgid "OPEN_THE_MENU"
 msgstr "Otvoriť menu"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Pomôž preložiť hru"
 
@@ -4011,11 +4011,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunistický"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Možnosti"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Zmeniť nastavenia"
 
@@ -4227,7 +4227,7 @@ msgstr "Procedurálny"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Pozastaviť hru"
@@ -4279,7 +4279,7 @@ msgstr "Mierumilovný"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Výkon"
 
@@ -4364,7 +4364,7 @@ msgstr "Duplikovať hráča"
 msgid "PLAYER_EXTINCT"
 msgstr "Hráč vyhynul"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Hráč vyhynul"
@@ -4379,23 +4379,23 @@ msgstr ""
 "Hráč\n"
 "Rýchlosť"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Prehrať úvodné video"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Prehrať úvodné video do mikróbov v novej hre"
 
@@ -4517,11 +4517,11 @@ msgstr "Rýchle načítanie"
 msgid "QUICK_SAVE"
 msgstr "Rýchle uloženie"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Ukončiť"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Opustiť hru"
@@ -4564,7 +4564,7 @@ msgstr "Pripravené"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Odporúčaná verzia Thrive:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Vstúpte do editora a upravte svoj druh"
@@ -4618,7 +4618,7 @@ msgstr "Reprodukcia:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Vyžaduje jadro"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Resetovať"
 
@@ -4627,24 +4627,24 @@ msgstr "Resetovať"
 msgid "RESET_DEADZONES"
 msgstr "Obnoviť predvolené nastavenia?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Obnoviť predvolené nastavenia ovládania?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Resetovať ovládanie"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Predvolené"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Obnoviť predvolené nastavenia?"
 
@@ -4653,7 +4653,7 @@ msgstr "Obnoviť predvolené nastavenia?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Rozlíšenie:"
 
@@ -4703,7 +4703,7 @@ msgstr ""
 "Naozaj chceš odísť do hlavného menu?\n"
 "Všetok neuložený postup bude stratený."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Od Revolutionary Games Studio"
@@ -4736,7 +4736,7 @@ msgstr "Otočiť doprava"
 msgid "ROTATION_COLON"
 msgstr "Rotácia:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Spustiť automatickú evolúciu počas hry"
 
@@ -4793,21 +4793,21 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Premieňa [thrive:compound type=\"iron\"][/thrive:compound] na [thrive:compound type=\"atp\"][/thrive:compound]. Množstvo závisí od koncentrácie[thrive:compound type=\"carbondioxide\"]oxidu uhličitého[/thrive:compound] a [thrive:compound type=\"oxygen\"]kyslíka[/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "(začiatočná poloha)"
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Odstrániť lokálne údaje"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Uložiť"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Uložiť a pokračovať"
 
@@ -4901,21 +4901,21 @@ msgstr "Ukladanie momentálne nie je možné z dôvodu:"
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr "Bunková signalizácia"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5015,7 +5015,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Hlasitosť SFX"
 
@@ -5032,20 +5032,24 @@ msgstr "Zobraziť nápovedu"
 msgid "SHOW_TUTORIALS"
 msgstr "Zobraziť návody"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Zobraziť tutoriál (v aktuálnej hre)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Zobraziť tutoriál (v nových hrách)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Zobraziť upozornenie na neuložený postup"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -5095,7 +5099,7 @@ msgstr "Oxid kremičitý"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5136,7 +5140,7 @@ msgstr "Zvyšuje rýchlosť otáčania veľkých buniek."
 msgid "SMALL_IRON_CHUNK"
 msgstr "Malý kus železa"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Zvuk"
 
@@ -5334,17 +5338,17 @@ msgstr "Steam je momentálne nedostupný, prosím skúste to znova"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Nastala neznáma chyba služby Steam"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Steamu sa nepodarilo získať UGC lock"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Môj úžasný mod"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Pozastaviť hru"
@@ -5385,7 +5389,7 @@ msgstr "Úložný priestor"
 msgid "STORAGE_COLON"
 msgstr "Úložný priestor:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Prihlásený ako: {0}"
 
@@ -5503,7 +5507,7 @@ msgstr "Teplota."
 msgid "TESTING_TEAM"
 msgstr "Testeri"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5518,7 +5522,7 @@ msgstr ""
 "\n"
 "Ak sa ti hra páčila, nezabudni sa o nás zmieniť svojim kamarátom."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "Odstrániť lokálne údaje"
@@ -5574,11 +5578,11 @@ msgstr "Toto je lokálne nainštalovaný mód"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Vlákna:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5726,7 +5730,7 @@ msgstr "Pauza"
 msgid "TOGGLE_UNBINDING"
 msgstr "Prepnúť rozpájanie"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Nástroje"
 
@@ -5791,7 +5795,7 @@ msgstr "Skús spraviť zopár snímiek obrazovky!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Skús spraviť zopár snímiek obrazovky!"
 
@@ -5873,12 +5877,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Uplynulý čas: {0:#,#} rokov"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -5904,7 +5908,7 @@ msgstr "Rozpojiť všetky"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Rozpojovací mód"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5924,7 +5928,7 @@ msgstr "Zrušiť poslednú zmenu"
 msgid "UNKNOWN"
 msgstr "Neznáme"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Zobraziť názvy tlačidiel pri výbere častí"
@@ -5937,7 +5941,7 @@ msgstr "Neznáme tlačidlo myši"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Neznáme na Windowse"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "Neznáma verzia"
 
@@ -5945,7 +5949,7 @@ msgstr "Neznáma verzia"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Neznáme Workshop ID pre tento mód"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Máš neuložené zmeny, ktoré budú zahodené.\n"
@@ -5989,7 +5993,7 @@ msgstr "Nahrávanie bolo úspešné"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Licencie a použité knižnice"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6005,7 +6009,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Použiť vlastné používateľské meno"
 
@@ -6013,11 +6017,11 @@ msgstr "Použiť vlastné používateľské meno"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Ručne nastaviť počet vlákien na pozadí"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6043,7 +6047,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Verzia:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Verzia:"
@@ -6053,11 +6057,11 @@ msgstr "Verzia:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Vertikálne(Osa: {0})"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Zobrazovač galérie"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Zobraziť zdrojový kód"
 
@@ -6078,7 +6082,7 @@ msgstr "VIP podporovatelia"
 msgid "VISIBLE"
 msgstr "Viditeľné"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6098,7 +6102,7 @@ msgstr "Stlmenie hlasitosti"
 msgid "VOLUMEUP"
 msgstr "Zvýšiť hlasitosť"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSync"
 
@@ -6207,7 +6211,7 @@ msgstr "Štatistika organizmu"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "Základný pohyb"
@@ -6216,15 +6220,15 @@ msgstr "Základný pohyb"
 msgid "WORST_PATCH_COLON"
 msgstr "Najhoršia oblasť:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6236,7 +6240,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "roky"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Pozastaviť hru"

--- a/locale/sk.po
+++ b/locale/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-07-27 06:44+0000\n"
 "Last-Translator: Matej Maceášik <m.maceasik@gmail.com>\n"
 "Language-Team: Slovak <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sk/>\n"
@@ -202,7 +202,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Vytvoril {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Galéria"
 
@@ -298,7 +298,7 @@ msgstr "Automatické ukladanie počas hry"
 msgid "AUTO_EVO"
 msgstr "Automatická evolúcia"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Nástroj prieskumu Auto-Evo"
 
@@ -343,8 +343,8 @@ msgid "AWAKEN"
 msgstr "Prebudiť sa"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -609,27 +609,27 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Oxid uhličitý"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "veľké množstvo"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "dostatočné množstvo"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "málo"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "celkom dosť"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "trochu"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "veľmi málo"
 
@@ -897,21 +897,21 @@ msgstr "Saturácia - množstvo sivej farby"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Jas - svetlosť alebo intenzita farby"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Vstúpte do editora a upravte svoj druh"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "naša Wiki"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Opustiť hru"
@@ -1111,7 +1111,7 @@ msgstr "Vytváranie..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Poďakovanie"
 
@@ -1276,12 +1276,12 @@ msgstr "Devbuilds podporovatelia"
 msgid "DEVELOPERS"
 msgstr "Vývojári"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Vývoj podporovaný štúdiom Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Vstúpte do editora a upravte svoj druh"
@@ -1290,12 +1290,12 @@ msgstr "Vstúpte do editora a upravte svoj druh"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Vývoj podporovaný štúdiom Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Vývojári"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Ako hrať hru"
@@ -1410,7 +1410,7 @@ msgstr "Odpojené organely"
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Uplynulý čas: {0:#,#} rokov"
@@ -1425,7 +1425,7 @@ msgstr "Rýchlosť trávenia:"
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "(začiatočná poloha)"
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1472,7 +1472,7 @@ msgstr "Dvojitým kliknutím zobraziť na celej obrazovke"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1648,15 +1648,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Energia v {0} pre {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Zdroje energie:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1711,6 +1711,16 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Chyba: Nepodarilo sa uložiť nové nastavenia."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(náhodne umiestnené tajomstvá v hre)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Chyba pri vytváraní priečinka pre mód"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Chyba v načítaní"
@@ -1764,7 +1774,7 @@ msgstr ""
 msgid "EXIT"
 msgstr "Odísť"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Spustiť E"
@@ -1817,7 +1827,7 @@ msgstr "vyhynul v tejto oblasti"
 msgid "EXTINCT_SPECIES"
 msgstr "Vyhynuté druhy"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extra"
 
@@ -1825,7 +1835,7 @@ msgstr "Extra"
 msgid "EXTRA_OPTIONS"
 msgstr "Extra nastavenia"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Pozastaviť hru"
@@ -1855,6 +1865,39 @@ msgstr "Cheaty povolené"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Február"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Čas spracovania: {0} s\n"
+"Fyzikálny čas: {1} s\n"
+"Entity: {2} Iné: {3}\n"
+"Spawnuté: {4} Despawnuté: {5}\n"
+"Použité uzly: {6}\n"
+"Použitá pamäť: {7}\n"
+"GPU pamäť: {8}\n"
+"Vykreslené objekty: {9}\n"
+"Draw Calls: {10} 2D: {11}\n"
+"Vykreslené vrcholy: {12}\n"
+"Zmeny materiálu: {13}\n"
+"Zmeny tieňovača: {14}\n"
+"Osirotené uzly: {15}\n"
+"Latencia zvuku: {16} ms\n"
+"Celkovy počet vlákien: {17}\n"
+"Celkový čas CPU: {18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1935,7 +1978,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Potravový reťazec"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -2034,7 +2077,7 @@ msgstr "Generácia"
 msgid "GENERATION_COLON"
 msgstr "Generácia:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Opustiť hru"
@@ -2043,11 +2086,11 @@ msgstr "Opustiť hru"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Varovanie režimu GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Spúšťaš Thrive pomocou vykresľovača GLES2. Táto možnosť nie je otestovaná a môže spôsobiť problémy. Skús si aktualizovať svoje grafické ovládače alebo vynútiť použitie AMD alebo Nvidia grafiky pre spustenie Thrive."
 
@@ -2329,7 +2372,7 @@ msgstr "Železo"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Chemolitoautotrofia železa"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Opustiť hru"
@@ -2549,7 +2592,7 @@ msgstr "Na preklade tohto jazyka sa ešte pracuje ({0}% hotovo)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Tento preklad nie je dokončený ({0}% hotovo) prosím pomôž nám s ním!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 #, fuzzy
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "Nedá sa odstrániť posledná organela"
@@ -2709,7 +2752,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Ľavé tlačidlo myši"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licencie"
 
@@ -2843,7 +2886,8 @@ msgstr "Načítať"
 msgid "LOADING"
 msgstr "Načítanie"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Načítavanie..."
 
@@ -2873,12 +2917,12 @@ msgstr "Chybu opravíš stlačením tlačidla Zrušiť v editore"
 msgid "LOAD_FINISHED"
 msgstr "Načítanie dokončené"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Načítať hru"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Načítať predošlé uložené hry"
 
@@ -3148,7 +3192,7 @@ msgstr "Každú generáciu máš k dispozícii 100 bodov mutácie (BM) a každá
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Vždy keď zahájiš reprodukciu vstúpiš do editora mikróbov, kde môžeš vykonávať zmeny tvojmu druhu (pridávaním, priemiestňovaním alebo odoberaním organel) k zvýšeniu úspešnosti. Každá návšteva editora vo fáze mikróbov reprezentuje [thrive:constant] EDITOR_TIME_JUMP_MILLION_YEARS [/thrive:constant] miliónov rokov evolúcie."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Neobmedzený editor mikróbov"
 
@@ -3360,11 +3404,11 @@ msgstr "Upraviť organelu"
 msgid "MODIFY_TYPE"
 msgstr "Upraviť typ"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Módy"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3453,11 +3497,11 @@ msgstr "Interný názov (priečinku):"
 msgid "MOD_LICENSE"
 msgstr "Licencia módu:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Chyba načítania režimu"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Pri načítaní jedného alebo viac režimov došlo k chybám. Protokoly môžu obsahovať ďalšie informácie."
 
@@ -3690,15 +3734,19 @@ msgstr "Nový"
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Nová hra"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Začať novú hru"
 
@@ -3801,7 +3849,7 @@ msgid "NO_AI"
 msgstr "Žiadne AI"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Žiadne údaje na zobrazenie"
 
@@ -3814,7 +3862,7 @@ msgstr "Žiadne zaznamenané udalosti"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Priečinok snímkov obrazovky nebol nájdený"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Vypnuté"
@@ -3846,7 +3894,7 @@ msgstr "Žiadny vybraný mod"
 msgid "NUCLEUS"
 msgstr "Jadro"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3865,8 +3913,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -3879,16 +3927,16 @@ msgstr "N/A MP"
 msgid "OCTOBER"
 msgstr "Október"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Samovražda"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3963,11 +4011,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Oportunistický"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Možnosti"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Zmeniť nastavenia"
 
@@ -4179,7 +4227,7 @@ msgstr "Procedurálny"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Pozastaviť hru"
@@ -4239,8 +4287,8 @@ msgstr "Výkon"
 msgid "PERFORM_UNBINDING"
 msgstr "Vykonať rozviazanie"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/sekúnd"
 
@@ -4290,7 +4338,7 @@ msgstr "Generovanie planéty už čoskoro!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Náhodné semeno planéty"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Bunka hráča"
 
@@ -4368,7 +4416,7 @@ msgstr "populácia:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "populácia v oblastiach:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4424,7 +4472,7 @@ msgstr "predchádzajúce:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Spracovanie načítaných objektov"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4469,11 +4517,11 @@ msgstr "Rýchle načítanie"
 msgid "QUICK_SAVE"
 msgstr "Rýchle uloženie"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Ukončiť"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Opustiť hru"
@@ -4516,7 +4564,7 @@ msgstr "Pripravené"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Odporúčaná verzia Thrive:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Vstúpte do editora a upravte svoj druh"
@@ -4655,7 +4703,7 @@ msgstr ""
 "Naozaj chceš odísť do hlavného menu?\n"
 "Všetok neuložený postup bude stratený."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Od Revolutionary Games Studio"
@@ -4745,12 +4793,12 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Premieňa [thrive:compound type=\"iron\"][/thrive:compound] na [thrive:compound type=\"atp\"][/thrive:compound]. Množstvo závisí od koncentrácie[thrive:compound type=\"carbondioxide\"]oxidu uhličitého[/thrive:compound] a [thrive:compound type=\"oxygen\"]kyslíka[/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "(začiatočná poloha)"
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "Odstrániť lokálne údaje"
@@ -5116,7 +5164,7 @@ msgstr "Umiestniť amoniak"
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -5169,7 +5217,7 @@ msgstr "Názov druhu..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Názov druhu..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5286,17 +5334,17 @@ msgstr "Steam je momentálne nedostupný, prosím skúste to znova"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Nastala neznáma chyba služby Steam"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Steamu sa nepodarilo získať UGC lock"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Môj úžasný mod"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Pozastaviť hru"
@@ -5337,7 +5385,7 @@ msgstr "Úložný priestor"
 msgid "STORAGE_COLON"
 msgstr "Úložný priestor:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Prihlásený ako: {0}"
 
@@ -5455,7 +5503,7 @@ msgstr "Teplota."
 msgid "TESTING_TEAM"
 msgstr "Testeri"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5470,7 +5518,7 @@ msgstr ""
 "\n"
 "Ak sa ti hra páčila, nezabudni sa o nás zmieniť svojim kamarátom."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "Odstrániť lokálne údaje"
@@ -5530,7 +5578,7 @@ msgstr ""
 msgid "THREADS"
 msgstr "Vlákna:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5678,7 +5726,7 @@ msgstr "Pauza"
 msgid "TOGGLE_UNBINDING"
 msgstr "Prepnúť rozpájanie"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Nástroje"
 
@@ -5825,7 +5873,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Uplynulý čas: {0:#,#} rokov"
@@ -6018,7 +6066,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Zobrazovač galérie"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Zobraziť zdrojový kód"
 
@@ -6030,7 +6078,7 @@ msgstr "VIP podporovatelia"
 msgid "VISIBLE"
 msgstr "Viditeľné"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6188,7 +6236,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "roky"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Pozastaviť hru"

--- a/locale/sr_Cyrl.po
+++ b/locale/sr_Cyrl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2021-02-25 13:33+0000\n"
 "Last-Translator: icedjuro <milandjurovic625@gmail.com>\n"
 "Language-Team: Serbian (cyrillic) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sr_Cyrl/>\n"
@@ -211,7 +211,7 @@ msgstr "ВИ СТЕ ПРОСПЕРИРАЛИ!"
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -310,7 +310,7 @@ msgstr "Аутоматско чување током игре"
 msgid "AUTO_EVO"
 msgstr "Аутоматска-Еволуција"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "статус покретања:"
@@ -355,8 +355,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -630,27 +630,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr "Угљен Диоксид"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -939,20 +939,20 @@ msgstr "Додајте ново везивање тастера"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -1167,7 +1167,7 @@ msgstr "Тражи..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Креирање објеката из саве"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Кредити"
 
@@ -1341,11 +1341,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -1354,11 +1354,11 @@ msgstr "Додајте ново везивање тастера"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -1487,7 +1487,7 @@ msgstr ""
 "Постоје постављене органеле, које нису повезане са осталим.\n"
 "Повежите све постављене органеле једни са другима или поништите промене."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -1502,7 +1502,7 @@ msgstr "Брзина:"
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "Број популације од {0} променио се за {1} због: {2}"
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1552,7 +1552,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Мембрана са два слоја, има бољу заштиту од оштећења и узима мање енергије да се не деформише. Међутим, то успорава ћелију и смањује брзину којом може да апсорбује ресурсе."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1741,15 +1741,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1807,6 +1807,16 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Грешка: Није успело чување нових поставки у конфигурационој датотеци."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "Број популације од {0} променио се за {1} због: {2}"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Грешка при чувању"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Грешка при учитавању"
@@ -1860,7 +1870,7 @@ msgstr "Изнимка се догодила приликом учитавања
 msgid "EXIT"
 msgstr "Изаћи"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1915,7 +1925,7 @@ msgstr "Изаберите зону да бисте овде приказали 
 msgid "EXTINCT_SPECIES"
 msgstr "ИЗУМИРАЊЕ"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Додатне"
 
@@ -1923,7 +1933,7 @@ msgstr "Додатне"
 msgid "EXTRA_OPTIONS"
 msgstr "Додатне Опције"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -1954,6 +1964,22 @@ msgstr "Укључи тастери за варања"
 #, fuzzy
 msgid "FEBRUARY"
 msgstr "Ушће"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -2039,7 +2065,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Ланац Исхране"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -2143,7 +2169,7 @@ msgstr "Генерација:"
 msgid "GENERATION_COLON"
 msgstr "Генерација:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -2152,11 +2178,11 @@ msgstr "Додајте ново везивање тастера"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Упозорење у режиму GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Користите Thrive витх GLES2. Ово је озбиљно непроверено и вероватно ће изазвати проблеме. Покушајте да ажурирате управљачке програме за видео и / или присилите АМД или Нвидиа графику да се користи за покретање програма Thrive."
 
@@ -2445,7 +2471,7 @@ msgstr "Гвожђе"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Хемолитоаутотрофија гвожђа"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -2671,7 +2697,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2832,7 +2858,7 @@ msgstr "Леви миш"
 msgid "LEFT_MOUSE"
 msgstr "Леви миш"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2969,7 +2995,8 @@ msgstr "Учитавање"
 msgid "LOADING"
 msgstr "Учитавање"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Учитавање..."
@@ -3002,12 +3029,12 @@ msgstr "Притисните дугме поништи у уређивачу д�
 msgid "LOAD_FINISHED"
 msgstr "Учитавање завршено"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Учитајте Игру"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -3290,7 +3317,7 @@ msgstr "Свака генерација имаш 100 мутациски поен
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Сваки пут када се размножавате, ући ћете у уређивач микроба, где можете да измените врсту (додавањем, премештањем или уклањањем органела) да бисте повећали успех своје врсте. Свака посета уреднику на сцени микроба представља 100 милиона година еволуције."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Слободна-Градња Уређивач Микроба"
 
@@ -3547,11 +3574,11 @@ msgstr "Макните органелу"
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3642,11 +3669,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3890,15 +3917,19 @@ msgstr ""
 "Овај сачување је из новије верзије Thrive и врло вероватно некомпатибилна.\n"
 "Да ли желите да ипак покушате да учитате овај чување?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Нова игра"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -4008,7 +4039,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -4021,7 +4052,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Отворите Сачувај Директоријум"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Укључи тастери за варања"
@@ -4056,7 +4087,7 @@ msgstr "Одабрано:"
 msgid "NUCLEUS"
 msgstr "Ћелијско Језгро"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -4079,8 +4110,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 #, fuzzy
 msgid "N_A"
@@ -4094,16 +4125,16 @@ msgstr "- МП"
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4180,11 +4211,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Опције"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -4406,7 +4437,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Пећина"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -4468,8 +4499,8 @@ msgstr "Перформансе"
 msgid "PERFORM_UNBINDING"
 msgstr "Изврши одвајање"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/секунду"
 
@@ -4519,7 +4550,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 #, fuzzy
 msgid "PLAYER_CELL"
 msgstr "играч је умро"
@@ -4599,7 +4630,7 @@ msgstr "популација:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "ПОПУЛАЦИЈА:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 #, fuzzy
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "ПОПУЛАЦИЈА:"
@@ -4658,7 +4689,7 @@ msgstr "Врсте:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Обрада учитаних објеката"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4702,11 +4733,11 @@ msgstr "Учитајте брзу копију"
 msgid "QUICK_SAVE"
 msgstr "Брза копија"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Одустати"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4750,7 +4781,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Наставити"
@@ -4896,7 +4927,7 @@ msgstr "Вратите се у Мени"
 msgid "RETURN_TO_MENU_WARNING"
 msgstr "Вратите се у Мени"
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -4989,12 +5020,12 @@ msgstr "Рустицијанин је протеин који може да ко
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Рустицијанин је протеин који може да користи гасовити угљен-диоксид и кисеоник за оксидацију гвожђа из једног хемијског стања у друго. Овај процес, назван Респирација гвожђа, ослобађа енергију коју ћелија тада може да сакупи."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "Број популације од {0} променио се за {1} због: {2}"
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -5393,7 +5424,7 @@ msgstr "Поставите амонијак"
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -5447,7 +5478,7 @@ msgstr "Име врсте..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Име врсте..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 #, fuzzy
 msgid "SPECIES_N_TIMES"
 msgstr "Врсте Присутне"
@@ -5569,17 +5600,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Чување није успело! Догоди се изузетак"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Вакуола је унутрашња мембранска органела која се користи за складиштење у ћелији. Састоје се од неколико везикула, мањих опнастих структура које се широко користе у ћелијама за складиштење, а које су се стопиле. Испуњен је водом која се користи да садржи молекуле, ензиме, чврсте материје и друге супстанце. Њихов облик је течан и може се разликовати између ћелија."
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Наставити"
@@ -5622,7 +5653,7 @@ msgstr "Складиште"
 msgid "STORAGE_COLON"
 msgstr "Складиште"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5740,7 +5771,7 @@ msgstr "Темп."
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5748,7 +5779,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "ВИ СТЕ ПРОСПЕРИРАЛИ!"
@@ -5813,7 +5844,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5968,7 +5999,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Укључи одвајање"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Алати"
 
@@ -6203,7 +6234,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Погледај сад"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -6412,7 +6443,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Погледајте Изворни Код"
 
@@ -6424,7 +6455,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6588,7 +6619,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "године"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Наставити"

--- a/locale/sr_Cyrl.po
+++ b/locale/sr_Cyrl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2021-02-25 13:33+0000\n"
 "Last-Translator: icedjuro <milandjurovic625@gmail.com>\n"
 "Language-Team: Serbian (cyrillic) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sr_Cyrl/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.4\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr "Уређивач"
 msgid "3D_MOVEMENT"
 msgstr "Покрет"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 #, fuzzy
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Сачувај и настави"
@@ -149,7 +149,7 @@ msgstr "Статистика Организма"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Амбијента јачина звука"
 
@@ -160,11 +160,11 @@ msgstr "Амбијента јачина звука"
 msgid "AMMONIA"
 msgstr "Амонијак"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Количина аутоматског чувања да задржати:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Количина брзог чувања да задржати:"
 
@@ -189,11 +189,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Да ли сте сигурни да желите да вратите СВА подешавања на подразумеване вредности?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Да ли сте сигурни да желите да вратите поставке уноса на подразумеване вредности?"
 
@@ -211,7 +211,7 @@ msgstr "ВИ СТЕ ПРОСПЕРИРАЛИ!"
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -223,7 +223,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -264,7 +264,7 @@ msgstr "Аутоматска-еволуција није успела"
 msgid "AT_CURSOR"
 msgstr "На Курсору:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Уређај за аудио"
 
@@ -272,8 +272,8 @@ msgstr "Уређај за аудио"
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "аутоматски"
 
@@ -302,7 +302,7 @@ msgstr "Моћ ћелије. Митохондрион (множина: мито�
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% завршено. {1:n0}/{2:n0} корака."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Аутоматско чување током игре"
 
@@ -310,7 +310,7 @@ msgstr "Аутоматско чување током игре"
 msgid "AUTO_EVO"
 msgstr "Аутоматска-Еволуција"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "статус покретања:"
@@ -341,7 +341,7 @@ msgstr "статус покретања:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Аутоматско кретање напред"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 #, fuzzy
 msgid "AUTO_RESOLUTION"
 msgstr "Резолуција:"
@@ -355,9 +355,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -510,7 +510,7 @@ msgstr "Нитрогеназа је протеин у стању да корис
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Нитрогеназа је протеин у стању да користи гасовити азот и ћелијску енергију у облику ATP за производњу амонијака, кључног хранљивог састојка за раст ћелија. Ово је процес који се назива анаеробна фиксација азота. Пошто је нитрогеназа суспендована директно у цитоплазми, околна течност врши ферментацију."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -572,7 +572,7 @@ msgstr "Ова мембрана има јаку љуску направљену 
 msgid "CAMERA"
 msgstr "Камера"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -707,7 +707,7 @@ msgstr "Промените симетрију"
 msgid "CHEATS"
 msgstr "Варање"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Укључи тастери за варања"
 
@@ -806,7 +806,7 @@ msgstr "Хлоропласт је двострука мембранска стр
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Изабрано име датотеке ({0}) већ постоји. Преписати?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Хроматске аберације:"
 
@@ -851,15 +851,15 @@ msgstr "Очистите Старе Чување"
 msgid "CLOSE"
 msgstr "Затвори"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Затворити опције?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Делитељ Облачне Резолуције:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 "Минимум Интервал од Симулације\n"
@@ -877,7 +877,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr "Боја"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Корекција далтониста:"
 
@@ -939,25 +939,25 @@ msgstr "Додајте ново везивање тастера"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Једињења:"
@@ -985,7 +985,7 @@ msgstr "Једињења:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Облак једињења"
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1087,11 +1087,11 @@ msgstr "Број популације од {0} променио се за {1} з
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1099,11 +1099,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Копирај Грешку у Међуспремник"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr "Тражи..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Креирање објеката из саве"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Кредити"
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Статистика Организма"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Корисничко име:"
 
@@ -1261,7 +1261,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1328,7 +1328,7 @@ msgstr "Опис:"
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 #, fuzzy
 msgid "DETECTED_CPU_COUNT"
 msgstr "Одабрано:"
@@ -1341,11 +1341,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -1354,11 +1354,11 @@ msgstr "Додајте ново везивање тастера"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -1436,7 +1436,7 @@ msgstr "Опис:"
 msgid "DIRECTIONR"
 msgstr "Опис:"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1444,7 +1444,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Одбаци и настави"
 
@@ -1487,35 +1487,35 @@ msgstr ""
 "Постоје постављене органеле, које нису повезане са осталим.\n"
 "Повежите све постављене органеле једни са другима или поништите промене."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Брзина:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "Број популације од {0} променио се за {1} због: {2}"
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 #, fuzzy
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Способности"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "Способности"
@@ -1552,7 +1552,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Мембрана са два слоја, има бољу заштиту од оштећења и узима мање енергије да се не деформише. Међутим, то успорава ћелију и смањује брзину којом може да апсорбује ресурсе."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1709,7 +1709,7 @@ msgstr ""
 "\n"
 "Да бисте прешли на следећу картицу уређивача, притисните следеће дугме у доњем десном углу."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 #, fuzzy
 msgid "EIGHT_TIMES"
 msgstr "Десни миш"
@@ -1728,7 +1728,7 @@ msgstr "Изабрано чување је некомпатибилно"
 msgid "ENABLE_EDITOR"
 msgstr "Омогућите уређивач"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 #, fuzzy
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Спољни ефекти:"
@@ -1790,7 +1790,7 @@ msgstr "Додајте ново везивање тастера"
 msgid "EPIPELAGIC"
 msgstr "Епипелагик"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Грешка"
 
@@ -1803,16 +1803,16 @@ msgstr "Грешка при чувању"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Грешка: Није успело чување нових поставки у конфигурационој датотеци."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "Број популације од {0} променио се за {1} због: {2}"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Грешка при чувању"
@@ -1846,12 +1846,12 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Генерација:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -1870,7 +1870,7 @@ msgstr "Изнимка се догодила приликом учитавања
 msgid "EXIT"
 msgstr "Изаћи"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1925,7 +1925,7 @@ msgstr "Изаберите зону да бисте овде приказали 
 msgid "EXTINCT_SPECIES"
 msgstr "ИЗУМИРАЊЕ"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Додатне"
 
@@ -1933,7 +1933,7 @@ msgstr "Додатне"
 msgid "EXTRA_OPTIONS"
 msgstr "Додатне Опције"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -1965,19 +1965,19 @@ msgstr "Укључи тастери за варања"
 msgid "FEBRUARY"
 msgstr "Ушће"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2107,7 +2107,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -2139,7 +2139,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Цео екран"
 
@@ -2169,24 +2169,24 @@ msgstr "Генерација:"
 msgid "GENERATION_COLON"
 msgstr "Генерација:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Упозорење у режиму GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Користите Thrive витх GLES2. Ово је озбиљно непроверено и вероватно ће изазвати проблеме. Покушајте да ажурирате управљачке програме за видео и / или присилите АМД или Нвидиа графику да се користи за покретање програма Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2240,12 +2240,12 @@ msgstr "Схватио сам"
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "Пећина"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Графика"
 
@@ -2254,7 +2254,7 @@ msgstr "Графика"
 msgid "GRAPHICS_TEAM"
 msgstr "Графика"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2267,7 +2267,7 @@ msgstr "Моћ ћелије. Митохондрион (множина: мито�
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Тон интерфејса"
 
@@ -2290,11 +2290,11 @@ msgstr "Помоћ"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(веће вредности побољшавају перформансе)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(веће вредности погоршавају перформансе)"
 
@@ -2318,7 +2318,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Генерација:"
@@ -2394,7 +2394,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Уноси"
 
@@ -2451,8 +2451,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2471,7 +2471,7 @@ msgstr "Гвожђе"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Хемолитоаутотрофија гвожђа"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -2480,19 +2480,19 @@ msgstr "Додајте ново везивање тастера"
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2681,19 +2681,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Језик:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2858,7 +2858,7 @@ msgstr "Леви миш"
 msgid "LEFT_MOUSE"
 msgstr "Леви миш"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2929,7 +2929,7 @@ msgstr "Померите се удесно"
 msgid "LIGHT_MAX"
 msgstr "Светлост"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "Додатне"
@@ -2944,32 +2944,32 @@ msgstr "ПОТВРДИ"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "Број популације од {0} променио се за {1} због: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "ПОТВРДИ"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2995,7 +2995,7 @@ msgstr "Учитавање"
 msgid "LOADING"
 msgstr "Учитавање"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
@@ -3029,12 +3029,12 @@ msgstr "Притисните дугме поништи у уређивачу д�
 msgid "LOAD_FINISHED"
 msgstr "Учитавање завршено"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Учитајте Игру"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -3115,7 +3115,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr "Морски снег"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Главна јачина звука"
 
@@ -3124,16 +3124,16 @@ msgstr "Главна јачина звука"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Изаберите зону да бисте овде приказали детаље"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Максимални FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 #, fuzzy
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Максимални FPS:"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3317,7 +3317,7 @@ msgstr "Свака генерација имаш 100 мутациски поен
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Сваки пут када се размножавате, ући ћете у уређивач микроба, где можете да измените врсту (додавањем, премештањем или уклањањем органела) да бисте повећали успех своје врсте. Свака посета уреднику на сцени микроба представља 100 милиона година еволуције."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Слободна-Градња Уређивач Микроба"
 
@@ -3505,7 +3505,7 @@ msgstr "Верзија:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Брисање овог чувања не може се опозвати. Да ли сте сигурни да желите трајно избрисати {0}?"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Остало"
 
@@ -3574,11 +3574,11 @@ msgstr "Макните органелу"
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3669,11 +3669,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3732,11 +3732,11 @@ msgstr "Верзија:"
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3854,7 +3854,7 @@ msgstr "Поставите органелу"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Поставите органелу"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Мултисампле анти-алиасинг:"
 
@@ -3866,7 +3866,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Јачина музике"
 
@@ -3887,9 +3887,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr "Мутације Поени"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Пригуши звук"
 
@@ -3925,11 +3925,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Нова игра"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -4001,7 +4001,7 @@ msgstr "Пластид за фиксирање азота је протеин к
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Пластид за фиксирање азота је протеин који може да користи гасовити азот и кисеоник и ћелијску енергију у облику ATP за производњу амонијака, кључног хранљивог састојка за раст ћелија. Ово је процес који се назива аеробна фиксација азота."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -4052,7 +4052,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Отворите Сачувај Директоријум"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Укључи тастери за варања"
@@ -4072,7 +4072,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Отворите Сачувај Директоријум"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 #, fuzzy
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Отворите Сачувај Директоријум"
@@ -4125,16 +4125,16 @@ msgstr "- МП"
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4170,7 +4170,7 @@ msgstr "Отворите екран помоћи"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Слободна-Градећи"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -4186,7 +4186,7 @@ msgstr "Отвори мени органеле"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Отворите Сачувај Директоријум"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -4194,7 +4194,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr "Отворите мени"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -4211,11 +4211,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Опције"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -4437,7 +4437,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Пећина"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -4491,7 +4491,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Перформансе"
 
@@ -4578,7 +4578,7 @@ msgstr "играч је умро"
 msgid "PLAYER_EXTINCT"
 msgstr "играч је умро"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "играч је умро"
@@ -4592,23 +4592,23 @@ msgstr "Играч се репродуковао"
 msgid "PLAYER_SPEED"
 msgstr "играч је умро"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Пусти уводни видео"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Пустите уводни видео за микробе на Новој Игри"
 
@@ -4733,11 +4733,11 @@ msgstr "Учитајте брзу копију"
 msgid "QUICK_SAVE"
 msgstr "Брза копија"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Одустати"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4781,7 +4781,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Наставити"
@@ -4841,7 +4841,7 @@ msgstr "Производи"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Ћелијско Језгро"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Ресетовати"
 
@@ -4850,24 +4850,24 @@ msgstr "Ресетовати"
 msgid "RESET_DEADZONES"
 msgstr "Ресетуј до почетног?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Ресетовати уносе на подразумеване вредности?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Ресетујте Уноси"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Подразумеване вредности"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Ресетуј до почетног?"
 
@@ -4876,7 +4876,7 @@ msgstr "Ресетуј до почетног?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Резолуција:"
 
@@ -4927,7 +4927,7 @@ msgstr "Вратите се у Мени"
 msgid "RETURN_TO_MENU_WARNING"
 msgstr "Вратите се у Мени"
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
@@ -4962,7 +4962,7 @@ msgstr "Ротирајте десно"
 msgid "ROTATION_COLON"
 msgstr "популација:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Покрените аутоматску-еволуцију током играња"
 
@@ -5020,20 +5020,20 @@ msgstr "Рустицијанин је протеин који може да ко
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Рустицијанин је протеин који може да користи гасовити угљен-диоксид и кисеоник за оксидацију гвожђа из једног хемијског стања у друго. Овај процес, назван Респирација гвожђа, ослобађа енергију коју ћелија тада може да сакупи."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "Број популације од {0} променио се за {1} због: {2}"
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Сачувати"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Сачувај и настави"
 
@@ -5135,23 +5135,23 @@ msgstr "Чување није успело! Догоди се изузетак"
 msgid "SAVING_SUCCEEDED"
 msgstr "Чување је успело"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr ""
 "Постоји сукоб са {0}.\n"
 "Да ли желите да уклоните унос из {1}?"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "за повећање кретања"
@@ -5258,7 +5258,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Том од звучних ефеката"
 
@@ -5274,15 +5274,15 @@ msgstr "Покажите помоћ"
 msgid "SHOW_TUTORIALS"
 msgstr "Прикажи туторијале"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Прикажи водиче (у тренутној игри)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Прикажи водиче (у новим играма)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 #, fuzzy
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
@@ -5295,6 +5295,10 @@ msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr ""
 "Имате несачуване промене које ће бити одбачене.\n"
 "Да ли желите да наставите?"
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5353,7 +5357,7 @@ msgstr "Силицијум-Диоксид"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Ова мембрана има јак зид од силицијум диоксида. Може се добро одупрети укупној штети и врло је отпоран на физичка оштећења. Такође захтева мање енергије за одржавање форме. Међутим, успорава ћелију великим фактором и ћелија апсорбује ресурсе смањеном брзином."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -5395,7 +5399,7 @@ msgstr "Лепљива унутрашњост ћелије. Цитоплазма
 msgid "SMALL_IRON_CHUNK"
 msgstr "Мали гвоздени комад"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Звук"
 
@@ -5600,17 +5604,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Чување није успело! Догоди се изузетак"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Вакуола је унутрашња мембранска органела која се користи за складиштење у ћелији. Састоје се од неколико везикула, мањих опнастих структура које се широко користе у ћелијама за складиштење, а које су се стопиле. Испуњен је водом која се користи да садржи молекуле, ензиме, чврсте материје и друге супстанце. Њихов облик је течан и може се разликовати између ћелија."
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Наставити"
@@ -5653,7 +5657,7 @@ msgstr "Складиште"
 msgid "STORAGE_COLON"
 msgstr "Складиште"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5771,7 +5775,7 @@ msgstr "Темп."
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5779,7 +5783,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "ВИ СТЕ ПРОСПЕРИРАЛИ!"
@@ -5840,11 +5844,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5999,7 +6003,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Укључи одвајање"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Алати"
 
@@ -6067,7 +6071,7 @@ msgstr "Направите снимак екрана"
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 #, fuzzy
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Направите снимак екрана"
@@ -6234,12 +6238,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Погледај сад"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -6266,7 +6270,7 @@ msgstr "Одвоји све"
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6290,7 +6294,7 @@ msgstr "Опозови последњу акцију"
 msgid "UNKNOWN"
 msgstr "Непознати миш"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Способности"
@@ -6304,7 +6308,7 @@ msgstr "Непознати миш"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Непознати миш"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Верзија:"
@@ -6314,7 +6318,7 @@ msgstr "Верзија:"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Непознати миш"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Имате несачуване промене које ће бити одбачене.\n"
@@ -6362,7 +6366,7 @@ msgstr "Чување је успело"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6380,7 +6384,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Додајте ново везивање тастера"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Користите прилагођено корисничко име"
 
@@ -6388,11 +6392,11 @@ msgstr "Користите прилагођено корисничко име"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6420,7 +6424,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr "Генерација:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Генерација:"
@@ -6431,11 +6435,11 @@ msgstr "Генерација:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Брзина:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6443,7 +6447,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Погледајте Изворни Код"
 
@@ -6455,7 +6459,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6478,7 +6482,7 @@ msgstr "Том од звучних ефеката"
 msgid "VOLUMEUP"
 msgstr "Том од звучних ефеката"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "В-синц"
 
@@ -6589,7 +6593,7 @@ msgstr "Статистика Организма"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "за повећање кретања"
@@ -6599,15 +6603,15 @@ msgstr "за повећање кретања"
 msgid "WORST_PATCH_COLON"
 msgstr "Врсте:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6619,7 +6623,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "године"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Наставити"

--- a/locale/sr_Latn.po
+++ b/locale/sr_Latn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-03-21 22:25+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Serbian (latin) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sr_Latn/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.11.2\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr "Urednik"
 msgid "3D_MOVEMENT"
 msgstr "Pokret"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 #, fuzzy
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Sačuvaj i nastavi"
@@ -149,7 +149,7 @@ msgstr "Statistika Organizma"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Ambijenta jačina zvuka"
 
@@ -160,11 +160,11 @@ msgstr "Ambijenta jačina zvuka"
 msgid "AMMONIA"
 msgstr "Amonijak"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Količina automatskog čuvanja da zadržati:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Količina brzog čuvanja da zadržati:"
 
@@ -190,11 +190,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Da li ste sigurni da želite da vratite SVA podešavanja na podrazumevane vrednosti?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Da li ste sigurni da želite da vratite postavke unosa na podrazumevane vrednosti?"
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -223,7 +223,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -264,7 +264,7 @@ msgstr "Automatska-evolucija nije uspela"
 msgid "AT_CURSOR"
 msgstr "Na Kursoru:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -272,8 +272,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "automatski"
 
@@ -302,7 +302,7 @@ msgstr "Moć ćelije. Mitohondrion (množina: mitohondrije) je dvostruka membran
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% završeno. {1:n0}/{2:n0} koraka."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Automatsko čuvanje tokom igre"
 
@@ -310,7 +310,7 @@ msgstr "Automatsko čuvanje tokom igre"
 msgid "AUTO_EVO"
 msgstr "Automatska-Evolucija"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "status pokretanja:"
@@ -341,7 +341,7 @@ msgstr "status pokretanja:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Automatsko kretanje napred"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 #, fuzzy
 msgid "AUTO_RESOLUTION"
 msgstr "Rezolucija:"
@@ -355,9 +355,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -503,7 +503,7 @@ msgstr "Nitrogenaza je protein u stanju da koristi gasoviti azot i ćelijsku ene
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Nitrogenaza je protein u stanju da koristi gasoviti azot i ćelijsku energiju u obliku ATP za proizvodnju amonijaka, ključnog hranljivog sastojka za rast ćelija. Ovo je proces koji se naziva anaerobna fiksacija azota. Pošto je nitrogenaza suspendovana direktno u citoplazmi, okolna tečnost vrši fermentaciju."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -565,7 +565,7 @@ msgstr "Ova membrana ima jaku ljusku napravljenu od kalcijum-karbonata. Može se
 msgid "CAMERA"
 msgstr "Kamera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -700,7 +700,7 @@ msgstr "Promenite simetriju"
 msgid "CHEATS"
 msgstr "Varanje"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Uključi tasteri za varanja"
 
@@ -800,7 +800,7 @@ msgstr "Hloroplast je dvostruka membranska struktura koja sadrži fotosenzibilne
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Hromatske aberacije:"
 
@@ -845,15 +845,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr "Zatvori"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Zatvoriti opcije?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Delitelj Oblačne Rezolucije:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 "Minimum Interval od Simulacije\n"
@@ -871,7 +871,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr "Boja"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Korekcija daltonista:"
 
@@ -933,25 +933,25 @@ msgstr "Dodajte novo vezivanje tastera"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Jedinjenja:"
@@ -979,7 +979,7 @@ msgstr "Jedinjenja:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Oblak jedinjenja"
 
@@ -1066,7 +1066,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1080,11 +1080,11 @@ msgstr "Broj populacije od {0} promenio se za {1} zbog: {2}"
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1092,11 +1092,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr "Traži..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Krediti"
 
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Statistika Organizma"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Korisničko ime:"
 
@@ -1252,7 +1252,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1313,7 +1313,7 @@ msgstr "Generacija:"
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1325,11 +1325,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -1338,11 +1338,11 @@ msgstr "Dodajte novo vezivanje tastera"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -1420,7 +1420,7 @@ msgstr "Rezolucija:"
 msgid "DIRECTIONR"
 msgstr "Rezolucija:"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1428,7 +1428,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Odbaci i nastavi"
 
@@ -1471,35 +1471,35 @@ msgstr ""
 "Postoje postavljene organele, koje nisu povezane sa ostalim.\n"
 "Povežite sve postavljene organele jedni sa drugima ili poništite promene."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Brzina:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "Broj populacije od {0} promenio se za {1} zbog: {2}"
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 #, fuzzy
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Sposobnosti"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "Sposobnosti"
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Membrana sa dva sloja, ima bolju zaštitu od oštećenja i uzima manje energije da se ne deformiše. Međutim, to usporava ćeliju i smanjuje brzinu kojom može da apsorbuje resurse."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1692,7 +1692,7 @@ msgstr "Dodajte novo vezivanje tastera"
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 #, fuzzy
 msgid "EIGHT_TIMES"
 msgstr "Desni miš"
@@ -1710,7 +1710,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr "Omogućite uređivač"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 #, fuzzy
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Spoljni efekti:"
@@ -1770,7 +1770,7 @@ msgstr "Dodajte novo vezivanje tastera"
 msgid "EPIPELAGIC"
 msgstr "Epipelagik"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Greška"
 
@@ -1782,16 +1782,16 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Greška: Nije uspelo čuvanje novih postavki u konfiguracionoj datoteci."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "Broj populacije od {0} promenio se za {1} zbog: {2}"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1824,12 +1824,12 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Generacija:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -1846,7 +1846,7 @@ msgstr ""
 msgid "EXIT"
 msgstr "Izaći"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1898,7 +1898,7 @@ msgstr "POPULACIJA:"
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Dodatne"
 
@@ -1906,7 +1906,7 @@ msgstr "Dodatne"
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -1937,19 +1937,19 @@ msgstr "Uključi tasteri za varanja"
 msgid "FEBRUARY"
 msgstr "Ušće"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2077,7 +2077,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -2109,7 +2109,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Ceo ekran"
 
@@ -2139,24 +2139,24 @@ msgstr "Generacija:"
 msgid "GENERATION_COLON"
 msgstr "Generacija:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Upozorenje u režimu GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Koristite Thrive vith GLES2. Ovo je ozbiljno neprovereno i verovatno će izazvati probleme. Pokušajte da ažurirate upravljačke programe za video i / ili prisilite AMD ili Nvidia grafiku da se koristi za pokretanje programa Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2209,12 +2209,12 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "Pećina"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafika"
 
@@ -2223,7 +2223,7 @@ msgstr "Grafika"
 msgid "GRAPHICS_TEAM"
 msgstr "Grafika"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2236,7 +2236,7 @@ msgstr "Moć ćelije. Mitohondrion (množina: mitohondrije) je dvostruka membran
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Tom od interfejs"
 
@@ -2259,11 +2259,11 @@ msgstr "Pomoć"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(veće vrednosti poboljšavaju performanse)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(veće vrednosti pogoršavaju performanse)"
 
@@ -2287,7 +2287,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Generacija:"
@@ -2363,7 +2363,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Unosi"
 
@@ -2417,8 +2417,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2437,7 +2437,7 @@ msgstr "Gvožđe"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Hemolitoautotrofija gvožđa"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -2446,19 +2446,19 @@ msgstr "Dodajte novo vezivanje tastera"
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2646,19 +2646,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Jezik:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2823,7 +2823,7 @@ msgstr "Levi miš"
 msgid "LEFT_MOUSE"
 msgstr "Levi miš"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr "Pomerite se udesno"
 msgid "LIGHT_MAX"
 msgstr "Svetlost"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "Dodatne"
@@ -2909,32 +2909,32 @@ msgstr "POTVRDI"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "Broj populacije od {0} promenio se za {1} zbog: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "POTVRDI"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2960,7 +2960,7 @@ msgstr ""
 msgid "LOADING"
 msgstr "Učitavanje"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
@@ -2994,12 +2994,12 @@ msgstr "Pritisnite dugme poništi u uređivaču da biste ispravili grešku"
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Učitajte Igru"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -3070,7 +3070,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr "Morski sneg"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Glavna jačina zvuka"
 
@@ -3079,16 +3079,16 @@ msgstr "Glavna jačina zvuka"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "POPULACIJA:"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Maksimalni FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 #, fuzzy
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Maksimalni FPS:"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3259,7 +3259,7 @@ msgstr "Svaka generacija imaš 100 mutaciski poeni (MP), a svaka promena (ili mu
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Svaki put kada se razmnožavate, ući ćete u uređivač mikroba, gde možete da izmenite vrstu (dodavanjem, premeštanjem ili uklanjanjem organela) da biste povećali uspeh svoje vrste. Svaka poseta uredniku na sceni mikroba predstavlja 100 miliona godina evolucije."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Slobodna-Gradnja Uređivač Mikroba"
 
@@ -3409,7 +3409,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Ostalo"
 
@@ -3477,11 +3477,11 @@ msgstr "Maknite organelu"
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3572,11 +3572,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3629,11 +3629,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3752,7 +3752,7 @@ msgstr "Postavite organelu"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Postavite organelu"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Multisample anti-aliasing:"
 
@@ -3764,7 +3764,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Jačina muzike"
 
@@ -3785,9 +3785,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr "Mutacije Poeni"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Priguši zvuk"
 
@@ -3821,11 +3821,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Nova igra"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -3897,7 +3897,7 @@ msgstr "Plastid za fiksiranje azota je protein koji može da koristi gasoviti az
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Plastid za fiksiranje azota je protein koji može da koristi gasoviti azot i kiseonik i ćelijsku energiju u obliku ATP za proizvodnju amonijaka, ključnog hranljivog sastojka za rast ćelija. Ovo je proces koji se naziva aerobna fiksacija azota."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3947,7 +3947,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Uključi tasteri za varanja"
@@ -3966,7 +3966,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -4017,16 +4017,16 @@ msgstr "- МП"
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4057,7 +4057,7 @@ msgstr "Otvorite ekran pomoći"
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -4074,7 +4074,7 @@ msgstr "Maknite organelu"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -4082,7 +4082,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr "Otvorite meni"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -4099,11 +4099,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opcije"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -4321,7 +4321,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Pećina"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Performanse"
 
@@ -4461,7 +4461,7 @@ msgstr "igrač je umro"
 msgid "PLAYER_EXTINCT"
 msgstr "igrač je umro"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "igrač je umro"
@@ -4475,23 +4475,23 @@ msgstr "Igrač se reprodukovao"
 msgid "PLAYER_SPEED"
 msgstr "igrač je umro"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Pusti uvodni video"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Pustite uvodni video za mikrobe na Novoj Igri"
 
@@ -4617,11 +4617,11 @@ msgstr "Učitajte brzo"
 msgid "QUICK_SAVE"
 msgstr "Sačuvajte brzo"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Odustati"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4665,7 +4665,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Nastaviti"
@@ -4725,7 +4725,7 @@ msgstr "Proizvodi"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Ćelijsko Jezgro"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Resetovati"
 
@@ -4734,24 +4734,24 @@ msgstr "Resetovati"
 msgid "RESET_DEADZONES"
 msgstr "Resetuj do početnog?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Resetovati unose na podrazumevane vrednosti?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Resetujte Unosi"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Podrazumevane vrednosti"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Resetuj do početnog?"
 
@@ -4760,7 +4760,7 @@ msgstr "Resetuj do početnog?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Rezolucija:"
 
@@ -4811,7 +4811,7 @@ msgstr "Vratite se u Meni"
 msgid "RETURN_TO_MENU_WARNING"
 msgstr "Vratite se u Meni"
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -4846,7 +4846,7 @@ msgstr "Rotirajte desno"
 msgid "ROTATION_COLON"
 msgstr "Broj populacije od {0} promenio se za {1} zbog: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Pokrenite automatsku-evoluciju tokom igranja"
 
@@ -4906,20 +4906,20 @@ msgstr "Rusticijanin je protein koji može da koristi gasoviti ugljen-dioksid i 
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Rusticijanin je protein koji može da koristi gasoviti ugljen-dioksid i kiseonik za oksidaciju gvožđa iz jednog hemijskog stanja u drugo. Ovaj proces, nazvan Respiracija gvožđa, oslobađa energiju koju ćelija tada može da sakupi."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "Broj populacije od {0} promenio se za {1} zbog: {2}"
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Sačuvati"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Sačuvaj i nastavi"
 
@@ -5020,23 +5020,23 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr ""
 "Postoji sukob sa {0}.\n"
 "Da li želite da uklonite unos iz {1}?"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "za povećanje kretanja"
@@ -5140,7 +5140,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Tom od zvučnih efekata"
 
@@ -5156,17 +5156,17 @@ msgstr "Pokažite pomoć"
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Prikaži vodiče (u trenutnoj igri)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Prikaži vodiče (u novim igrama)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 #, fuzzy
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
@@ -5179,6 +5179,10 @@ msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr ""
 "Imate nesačuvane promene koje će biti odbačene.\n"
 "Da li želite da nastavite?"
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5237,7 +5241,7 @@ msgstr "Silicijum-Dioksid"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Ova membrana ima jak zid od silicijum dioksida. Može se dobro odupreti ukupnoj šteti i vrlo je otporan na fizička oštećenja. Takođe zahteva manje energije za održavanje forme. Međutim, usporava ćeliju velikim faktorom i ćelija apsorbuje resurse smanjenom brzinom."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -5279,7 +5283,7 @@ msgstr "Lepljiva unutrašnjost ćelije. Citoplazma je osnovna smeša jona, prote
 msgid "SMALL_IRON_CHUNK"
 msgstr "Mali gvozdeni komad"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Zvuk"
 
@@ -5482,17 +5486,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Automatska-evolucija nije uspela"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Vakuola je unutrašnja membranska organela koja se koristi za skladištenje u ćeliji. Sastoje se od nekoliko vezikula, manjih opnastih struktura koje se široko koriste u ćelijama za skladištenje, a koje su se stopile. Ispunjen je vodom koja se koristi da sadrži molekule, enzime, čvrste materije i druge supstance. Njihov oblik je tečan i može se razlikovati između ćelija."
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Nastaviti"
@@ -5535,7 +5539,7 @@ msgstr "Skladište"
 msgid "STORAGE_COLON"
 msgstr "Skladište"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5661,7 +5665,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5721,11 +5725,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5880,7 +5884,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Prebacite gutanje"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Alati"
 
@@ -5948,7 +5952,7 @@ msgstr "Napravite snimak ekrana"
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 #, fuzzy
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Napravite snimak ekrana"
@@ -6044,12 +6048,12 @@ msgstr "Slobodna-Gradnja Uređivač Mikroba"
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -6076,7 +6080,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -6097,7 +6101,7 @@ msgstr "Opozovi poslednju akciju"
 msgid "UNKNOWN"
 msgstr "Nepoznati miš"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Sposobnosti"
@@ -6111,7 +6115,7 @@ msgstr "Nepoznati miš"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Nepoznati miš"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Nepoznati miš"
@@ -6121,7 +6125,7 @@ msgstr "Nepoznati miš"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Nepoznati miš"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Imate nesačuvane promene koje će biti odbačene.\n"
@@ -6167,7 +6171,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6185,7 +6189,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Koristite prilagođeno korisničko ime"
 
@@ -6193,11 +6197,11 @@ msgstr "Koristite prilagođeno korisničko ime"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6225,7 +6229,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr "Generacija:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Generacija:"
@@ -6236,11 +6240,11 @@ msgstr "Generacija:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Brzina:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Pogledajte Izvorni Kod"
 
@@ -6260,7 +6264,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6283,7 +6287,7 @@ msgstr "Tom od zvučnih efekata"
 msgid "VOLUMEUP"
 msgstr "Tom od zvučnih efekata"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -6392,7 +6396,7 @@ msgstr "Statistika Organizma"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "za povećanje kretanja"
@@ -6402,15 +6406,15 @@ msgstr "za povećanje kretanja"
 msgid "WORST_PATCH_COLON"
 msgstr "Vrste:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6422,7 +6426,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Nastaviti"

--- a/locale/sr_Latn.po
+++ b/locale/sr_Latn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-03-21 22:25+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Serbian (latin) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sr_Latn/>\n"
@@ -211,7 +211,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -310,7 +310,7 @@ msgstr "Automatsko čuvanje tokom igre"
 msgid "AUTO_EVO"
 msgstr "Automatska-Evolucija"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "status pokretanja:"
@@ -355,8 +355,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -623,27 +623,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr "Ugljen Dioksid"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -933,20 +933,20 @@ msgstr "Dodajte novo vezivanje tastera"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -1159,7 +1159,7 @@ msgstr "Traži..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Krediti"
 
@@ -1325,11 +1325,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -1338,11 +1338,11 @@ msgstr "Dodajte novo vezivanje tastera"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -1471,7 +1471,7 @@ msgstr ""
 "Postoje postavljene organele, koje nisu povezane sa ostalim.\n"
 "Povežite sve postavljene organele jedni sa drugima ili poništite promene."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -1486,7 +1486,7 @@ msgstr "Brzina:"
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "Broj populacije od {0} promenio se za {1} zbog: {2}"
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Membrana sa dva sloja, ima bolju zaštitu od oštećenja i uzima manje energije da se ne deformiše. Međutim, to usporava ćeliju i smanjuje brzinu kojom može da apsorbuje resurse."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1723,15 +1723,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1786,6 +1786,15 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Greška: Nije uspelo čuvanje novih postavki u konfiguracionoj datoteci."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "Broj populacije od {0} promenio se za {1} zbog: {2}"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1837,7 +1846,7 @@ msgstr ""
 msgid "EXIT"
 msgstr "Izaći"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgstr "POPULACIJA:"
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Dodatne"
 
@@ -1897,7 +1906,7 @@ msgstr "Dodatne"
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -1927,6 +1936,22 @@ msgstr "Uključi tasteri za varanja"
 #, fuzzy
 msgid "FEBRUARY"
 msgstr "Ušće"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -2011,7 +2036,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Lanac Ishrane"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -2114,7 +2139,7 @@ msgstr "Generacija:"
 msgid "GENERATION_COLON"
 msgstr "Generacija:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -2123,11 +2148,11 @@ msgstr "Dodajte novo vezivanje tastera"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Upozorenje u režimu GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Koristite Thrive vith GLES2. Ovo je ozbiljno neprovereno i verovatno će izazvati probleme. Pokušajte da ažurirate upravljačke programe za video i / ili prisilite AMD ili Nvidia grafiku da se koristi za pokretanje programa Thrive."
 
@@ -2412,7 +2437,7 @@ msgstr "Gvožđe"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Hemolitoautotrofija gvožđa"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -2637,7 +2662,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2798,7 +2823,7 @@ msgstr "Levi miš"
 msgid "LEFT_MOUSE"
 msgstr "Levi miš"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2935,7 +2960,8 @@ msgstr ""
 msgid "LOADING"
 msgstr "Učitavanje"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Traži..."
@@ -2968,12 +2994,12 @@ msgstr "Pritisnite dugme poništi u uređivaču da biste ispravili grešku"
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Učitajte Igru"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -3233,7 +3259,7 @@ msgstr "Svaka generacija imaš 100 mutaciski poeni (MP), a svaka promena (ili mu
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Svaki put kada se razmnožavate, ući ćete u uređivač mikroba, gde možete da izmenite vrstu (dodavanjem, premeštanjem ili uklanjanjem organela) da biste povećali uspeh svoje vrste. Svaka poseta uredniku na sceni mikroba predstavlja 100 miliona godina evolucije."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Slobodna-Gradnja Uređivač Mikroba"
 
@@ -3451,11 +3477,11 @@ msgstr "Maknite organelu"
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3546,11 +3572,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3787,15 +3813,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Nova igra"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -3905,7 +3935,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3917,7 +3947,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Uključi tasteri za varanja"
@@ -3949,7 +3979,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr "Ćelijsko Jezgro"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3972,8 +4002,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 #, fuzzy
 msgid "N_A"
@@ -3987,16 +4017,16 @@ msgstr "- МП"
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4069,11 +4099,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Opcije"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -4291,7 +4321,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Pećina"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -4353,8 +4383,8 @@ msgstr "Performanse"
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4404,7 +4434,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4484,7 +4514,7 @@ msgstr "Broj populacije od {0} promenio se za {1} zbog: {2}"
 msgid "POPULATION_IN_PATCHES"
 msgstr "POPULACIJA:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 #, fuzzy
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "POPULACIJA:"
@@ -4543,7 +4573,7 @@ msgstr "Vrste:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4587,11 +4617,11 @@ msgstr "Učitajte brzo"
 msgid "QUICK_SAVE"
 msgstr "Sačuvajte brzo"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Odustati"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4635,7 +4665,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Nastaviti"
@@ -4781,7 +4811,7 @@ msgstr "Vratite se u Meni"
 msgid "RETURN_TO_MENU_WARNING"
 msgstr "Vratite se u Meni"
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -4876,12 +4906,12 @@ msgstr "Rusticijanin je protein koji može da koristi gasoviti ugljen-dioksid i 
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Rusticijanin je protein koji može da koristi gasoviti ugljen-dioksid i kiseonik za oksidaciju gvožđa iz jednog hemijskog stanja u drugo. Ovaj proces, nazvan Respiracija gvožđa, oslobađa energiju koju ćelija tada može da sakupi."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "Broj populacije od {0} promenio se za {1} zbog: {2}"
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -5278,7 +5308,7 @@ msgstr "Stavite amonijak"
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -5332,7 +5362,7 @@ msgstr "Ime vrste..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Ime vrste..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 #, fuzzy
 msgid "SPECIES_N_TIMES"
 msgstr "Vrste:"
@@ -5452,17 +5482,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Automatska-evolucija nije uspela"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Vakuola je unutrašnja membranska organela koja se koristi za skladištenje u ćeliji. Sastoje se od nekoliko vezikula, manjih opnastih struktura koje se široko koriste u ćelijama za skladištenje, a koje su se stopile. Ispunjen je vodom koja se koristi da sadrži molekule, enzime, čvrste materije i druge supstance. Njihov oblik je tečan i može se razlikovati između ćelija."
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Nastaviti"
@@ -5505,7 +5535,7 @@ msgstr "Skladište"
 msgid "STORAGE_COLON"
 msgstr "Skladište"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5623,7 +5653,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5631,7 +5661,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5695,7 +5725,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5850,7 +5880,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "Prebacite gutanje"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Alati"
 
@@ -6014,7 +6044,7 @@ msgstr "Slobodna-Gradnja Uređivač Mikroba"
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Dodajte novo vezivanje tastera"
@@ -6218,7 +6248,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Pogledajte Izvorni Kod"
 
@@ -6230,7 +6260,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6392,7 +6422,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Nastaviti"

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-10-03 11:25+0000\n"
 "Last-Translator: Markus Forsberg <marqsande@gmail.com>\n"
 "Language-Team: Swedish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sv/>\n"
@@ -208,7 +208,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Konst av {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Konst Galleri"
 
@@ -306,7 +306,7 @@ msgstr "Autospara i spelet"
 msgid "AUTO_EVO"
 msgstr "Auto-Evolution"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "status:"
@@ -352,8 +352,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -619,27 +619,27 @@ msgstr "Capslock"
 msgid "CARBON_DIOXIDE"
 msgstr "Koldioxid"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -923,20 +923,20 @@ msgstr "Mättnadsvärde, mängden grått i en viss färg"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Värde (ljusstyrka) värde, ljusstyrka eller intensitet för färgen"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Hjälp"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Självmord"
@@ -1149,7 +1149,7 @@ msgstr "Skapar..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "skapar objekt från sparfil"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Eftertext"
 
@@ -1319,12 +1319,12 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Utvecklare"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Utvecklingen stöds av Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Hjälp"
@@ -1333,12 +1333,12 @@ msgstr "Hjälp"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Utvecklingen stöds av Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Utvecklare"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Hjälp"
@@ -1466,7 +1466,7 @@ msgstr ""
 "Det finns placerade organeller, som inte är anslutna till resten.\n"
 "Vänligen anslut alla placerade organeller med varandra eller ångra dina ändringar."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Hjälp"
@@ -1485,7 +1485,7 @@ msgstr ""
 "Fredliga mikrober attackerar inte andra över större avstånd\n"
 "och har lägre sannolikhet att använda gifter mot rovdjur."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1716,15 +1716,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}:+{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1782,6 +1782,20 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Error: Misslyckades att spara nya intällningar till konfigurationsfil."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+"Aggressiva mikrober jagar byte över större avstånd\n"
+"och har större sannolikhet att kämpa emot när rovdjur attackerar.\n"
+"Fredliga mikrober attackerar inte andra över större avstånd\n"
+"och har lägre sannolikhet att använda gifter mot rovdjur."
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Öppna Skärmbildsmapp"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Laddningsfel"
@@ -1836,7 +1850,7 @@ msgstr "Ett undantag har uppstått medan sparad data laddades"
 msgid "EXIT"
 msgstr "Lämna"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Avfyra E"
@@ -1893,7 +1907,7 @@ msgstr "dog ut på planeten"
 msgid "EXTINCT_SPECIES"
 msgstr "UTROTNING"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Extra"
 
@@ -1901,7 +1915,7 @@ msgstr "Extra"
 msgid "EXTRA_OPTIONS"
 msgstr "Extra Inställningar"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Självmord"
@@ -1931,6 +1945,22 @@ msgstr "Fuskknappar på"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Februari"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -2014,7 +2044,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Näringskedja"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -2127,7 +2157,7 @@ msgstr "generation:"
 msgid "GENERATION_COLON"
 msgstr "generation:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Självmord"
@@ -2136,11 +2166,11 @@ msgstr "Självmord"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 Läges Varning"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Du kör just nu Thrive med GLES2. Detta är väldigt otestat och kommer troligen att orsaka problem. Försök att updatera dina video drivers och/eller tvinga AMD eller Nvidia grafik för att använda till att köra Thrive."
 
@@ -2425,7 +2455,7 @@ msgstr "Järn"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Järnkemolitoautotrofi"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Självmord"
@@ -2646,7 +2676,7 @@ msgstr "Det här språket jobbas fortfarande på ({0}% klart)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Den här översättningen är mycket ofullständig ({0}% klar) snälla hjälp oss med den!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2810,7 +2840,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Vänster musknapp"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Licenser"
 
@@ -2952,7 +2982,8 @@ msgstr "Ladda"
 msgid "LOADING"
 msgstr "Laddar"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Laddar..."
 
@@ -2984,12 +3015,12 @@ msgstr "Använd ångraknapped i cellredigeraren för att fixa ett mistag"
 msgid "LOAD_FINISHED"
 msgstr "Färdigladdat"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Ladda Spel"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Hjälp"
@@ -3231,7 +3262,7 @@ msgstr "Varje generation får du 100 mutationspoäng (MP), och varje förändrin
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Varje gång du reproducerar kommer du in i Cellredigeraren, där du kan göra ändringar i din art (genom att lägga till, flytta eller ta bort organeller) för att öka din arts framgång. Varje besök hos Cellredigeraren i mikrobstadiet representerar 100 miljoner år av utveckling."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Mikrob Fri Byggredigerare"
 
@@ -3468,11 +3499,11 @@ msgstr "Ta bort organell"
 msgid "MODIFY_TYPE"
 msgstr "Modifiera Typ"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mod"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3562,11 +3593,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Mod Inladdningsfel"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Fel uppstod när en eller flera mod laddades. Loggen kan innehålla ytterligare information."
 
@@ -3801,15 +3832,19 @@ msgstr "Ny"
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Ursprunglig population för biodiversitetsökande art"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Nytt spel"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Hjälp"
@@ -3917,7 +3952,7 @@ msgid "NO_AI"
 msgstr "Ingen AI"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Inga Data att Visa"
 
@@ -3930,7 +3965,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Hittade ingen screenshots mapp"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Avstängt"
@@ -3962,7 +3997,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr "Kärna"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3981,8 +4016,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -3995,16 +4030,16 @@ msgstr "N/A MutationsPoäng"
 msgid "OCTOBER"
 msgstr "Oktober"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Självmord"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4080,11 +4115,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunistisk"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Inställningar"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Hjälp"
@@ -4305,7 +4340,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Grotta"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Självmord"
@@ -4368,8 +4403,8 @@ msgstr "Uppförande"
 msgid "PERFORM_UNBINDING"
 msgstr "Utför lösgörande"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/sekund"
 
@@ -4420,7 +4455,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "spelarcell"
 
@@ -4496,7 +4531,7 @@ msgstr "befolkning:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "befolkning på platser:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 #, fuzzy
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "INVÅNARE:"
@@ -4553,7 +4588,7 @@ msgstr "föregående:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4597,11 +4632,11 @@ msgstr "Snabbladda"
 msgid "QUICK_SAVE"
 msgstr "Snabbspara"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Lämna"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4647,7 +4682,7 @@ msgstr "Trådar:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Fortsätt"
@@ -4792,7 +4827,7 @@ msgstr ""
 "Är du säker på att du vill tillbaka till huvudmenyn?\n"
 "Du kommer att förlora alla osparade framsteg."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Av Revolutionary Games Studio"
@@ -4882,7 +4917,7 @@ msgstr "Rusticyanin är ett protein som kan använda gasformig koldioxid och syr
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Rusticyanin är ett protein som kan använda gasformig koldioxid och syre för att oxidera järn från ett kemiskt tillstånd till ett annat. Denna process, kallad Iron Respiration, frigör energi som cellen sedan kan skörda."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4891,7 +4926,7 @@ msgstr ""
 "Fredliga mikrober attackerar inte andra över större avstånd\n"
 "och har lägre sannolikhet att använda gifter mot rovdjur."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -5279,7 +5314,7 @@ msgstr "Spawna ammoniak"
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -5341,7 +5376,7 @@ msgstr "Artnamn..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Artnamn..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 #, fuzzy
 msgid "SPECIES_N_TIMES"
 msgstr "Artlista"
@@ -5459,17 +5494,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Sparande misslyckades"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Vakuolen är en inre membranorganell som används för lagring i cellen. De består av flera blåsor, mindre membranstrukturer som ofta används i celler för lagring, som har smält samman. Den är fylld med vatten som används för att hålla kvar molekyler, enzymer, fasta ämnen och andra ämnen. Deras form är flytande och kan variera mellan celler."
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Fortsätt"
@@ -5512,7 +5547,7 @@ msgstr "Förråd"
 msgid "STORAGE_COLON"
 msgstr "Förråd"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Inloggad som: {0}"
 
@@ -5629,7 +5664,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Testning"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5644,7 +5679,7 @@ msgstr ""
 "\n"
 "Om du gillade spelet, berätta om oss för dina vänner."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "DU HAR FRODATS!"
@@ -5707,7 +5742,7 @@ msgstr ""
 msgid "THREADS"
 msgstr "Trådar:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5855,7 +5890,7 @@ msgstr "Pausa"
 msgid "TOGGLE_UNBINDING"
 msgstr "Växla avbindning av och på"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Verktyg"
 
@@ -6031,7 +6066,7 @@ msgstr "Mikrob Fri Byggredigerare"
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Hjälp"
@@ -6232,7 +6267,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Visare eller åskådare, beroende på situation"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Visa Källkod"
 
@@ -6244,7 +6279,7 @@ msgstr "VIP-supportrar"
 msgid "VISIBLE"
 msgstr "Synlig"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6403,7 +6438,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "år"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Fortsätt"

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-10-03 11:25+0000\n"
 "Last-Translator: Markus Forsberg <marqsande@gmail.com>\n"
 "Language-Team: Swedish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sv/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "Tredimensionell redigerare"
 msgid "3D_MOVEMENT"
 msgstr "Tredimensionell rörelse"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -63,7 +63,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr "Aktiv"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 #, fuzzy
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Använda trådar:"
@@ -147,7 +147,7 @@ msgstr "Organismstatistik"
 msgid "ALT"
 msgstr "ALT"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Omgivningsvolym"
 
@@ -158,11 +158,11 @@ msgstr "Omgivningsvolym"
 msgid "AMMONIA"
 msgstr "Ammoniak"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Mängd autosparningar ska behållas:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Mängd snabbsparningar att behålla:"
 
@@ -187,11 +187,11 @@ msgstr ""
 msgid "APRIL"
 msgstr "April"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Är du säker på att du vill nollställa ALLA inställningar till default värden?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Är du säker på att du vill nollställa kontrollinställningarna till default värden?"
 
@@ -208,7 +208,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Konst av {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Konst Galleri"
 
@@ -220,7 +220,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Anta att CPUn har hyperthreading aktiverad"
 
@@ -260,7 +260,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr "Vid Muspekare:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Ljudutgångsenhet:"
 
@@ -268,8 +268,8 @@ msgstr "Ljudutgångsenhet:"
 msgid "AUGUST"
 msgstr "Augusti"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "automatiskt"
 
@@ -298,7 +298,7 @@ msgstr "Vakuolen är en inre membranorganell som används för lagring i cellen.
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% klart. {1:n0}/{2:n0} steg."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Autospara i spelet"
 
@@ -306,7 +306,7 @@ msgstr "Autospara i spelet"
 msgid "AUTO_EVO"
 msgstr "Auto-Evolution"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "status:"
@@ -338,7 +338,7 @@ msgstr "status:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Auto framåt"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 #, fuzzy
 msgid "AUTO_RESOLUTION"
 msgstr "Upplösning:"
@@ -352,9 +352,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -500,7 +500,7 @@ msgstr "Nitrogenas är ett protein som kan använda gasformigt kväve och cellul
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Nitrogenas är ett protein som kan använda gasformigt kväve och cellulär energi i form av ATP för att producera ammoniak, ett viktigt tillväxtnäringsämne för celler. Detta är en process som kallas anaerob kvävefixering. Eftersom kvävgaset är suspenderat direkt i cytoplasman, utför den omgivande vätskan viss jäsning."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -562,7 +562,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr "Kamera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -694,7 +694,7 @@ msgstr "Ändra symmetrin"
 msgid "CHEATS"
 msgstr "Fusk"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Fuskknappar på"
 
@@ -790,7 +790,7 @@ msgstr "Kemoplasten är en dubbelmembranstruktur som innehåller proteiner som k
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Kromatisk Aberration:"
 
@@ -834,15 +834,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr "Stäng"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Stäng inställningar?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Molnupplösnings Divisor:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 "Molnsimulerings minimala\n"
@@ -860,7 +860,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr "Färg"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Färgblindhets Rättning:"
 
@@ -923,25 +923,25 @@ msgstr "Mättnadsvärde, mängden grått i en viss färg"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Värde (ljusstyrka) värde, ljusstyrka eller intensitet för färgen"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Hjälp"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Självmord"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "Föreningar:"
@@ -969,7 +969,7 @@ msgstr "Föreningar:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Molekylmoln"
 
@@ -1057,7 +1057,7 @@ msgstr "Fortsätt till fasprototyper?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1071,11 +1071,11 @@ msgstr "{0} befolkning förändrades av {1} på grund av: {2}"
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1083,11 +1083,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Kopiera felmeddelande till urklipp"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanope (Röd-Grön)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanope (Blå-Gul)"
 
@@ -1149,7 +1149,7 @@ msgstr "Skapar..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "skapar objekt från sparfil"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Eftertext"
 
@@ -1175,7 +1175,7 @@ msgstr "Nuvarande utvecklare"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "Organismstatistik"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Anpassat Användarnamn:"
 
@@ -1247,7 +1247,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr "December"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Standard utgångsenhet"
 
@@ -1307,7 +1307,7 @@ msgstr "ATP PRODUKTION FÖR LÅG!"
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Upptäckt CPU-antal:"
 
@@ -1319,12 +1319,12 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Utvecklare"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "Utvecklingen stöds av Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Hjälp"
@@ -1333,12 +1333,12 @@ msgstr "Hjälp"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Utvecklingen stöds av Revolutionary Games Studio ry"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "Utvecklare"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Hjälp"
@@ -1415,7 +1415,7 @@ msgstr "Vänster"
 msgid "DIRECTIONR"
 msgstr "Höger"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Avstängt"
 
@@ -1423,7 +1423,7 @@ msgstr "Avstängt"
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Radera och fortsätt"
 
@@ -1466,17 +1466,17 @@ msgstr ""
 "Det finns placerade organeller, som inte är anslutna till resten.\n"
 "Vänligen anslut alla placerade organeller med varandra eller ångra dina ändringar."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "Hjälp"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Hastighet:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
@@ -1485,19 +1485,19 @@ msgstr ""
 "Fredliga mikrober attackerar inte andra över större avstånd\n"
 "och har lägre sannolikhet att använda gifter mot rovdjur."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Visa förmågor"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "Visa förmågor"
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1687,7 +1687,7 @@ msgstr "Hjälp"
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr "Aktivera Cellredigeraren"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Aktivera GUI ljus effecter"
 
@@ -1765,7 +1765,7 @@ msgstr "Hjälp"
 msgid "EPIPELAGIC"
 msgstr "Epipelagisk"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -1778,11 +1778,11 @@ msgstr "Öppna Skärmbildsmapp"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Error: Misslyckades att spara nya intällningar till konfigurationsfil."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
@@ -1791,7 +1791,7 @@ msgstr ""
 "Fredliga mikrober attackerar inte andra över större avstånd\n"
 "och har lägre sannolikhet att använda gifter mot rovdjur."
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Öppna Skärmbildsmapp"
@@ -1826,12 +1826,12 @@ msgstr "Av Revolutionary Games Studio"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "Av Revolutionary Games Studio"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "Version:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Självmord"
@@ -1850,7 +1850,7 @@ msgstr "Ett undantag har uppstått medan sparad data laddades"
 msgid "EXIT"
 msgstr "Lämna"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Avfyra E"
@@ -1907,7 +1907,7 @@ msgstr "dog ut på planeten"
 msgid "EXTINCT_SPECIES"
 msgstr "UTROTNING"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Extra"
 
@@ -1915,7 +1915,7 @@ msgstr "Extra"
 msgid "EXTRA_OPTIONS"
 msgstr "Extra Inställningar"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Självmord"
@@ -1946,19 +1946,19 @@ msgstr "Fuskknappar på"
 msgid "FEBRUARY"
 msgstr "Februari"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2090,7 +2090,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr "Stillastående"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2128,7 +2128,7 @@ msgstr ""
 "Fredliga mikrober attackerar inte andra över större avstånd\n"
 "och har lägre sannolikhet att använda gifter mot rovdjur."
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Fullskärm"
 
@@ -2157,24 +2157,24 @@ msgstr "generation:"
 msgid "GENERATION_COLON"
 msgstr "generation:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "Självmord"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 Läges Varning"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Du kör just nu Thrive med GLES2. Detta är väldigt otestat och kommer troligen att orsaka problem. Försök att updatera dina video drivers och/eller tvinga AMD eller Nvidia grafik för att använda till att köra Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2227,12 +2227,12 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr "Licenstexten för GPL följer:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "Grotta"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafik"
 
@@ -2240,7 +2240,7 @@ msgstr "Grafik"
 msgid "GRAPHICS_TEAM"
 msgstr "Grafik"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} K"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "GUI-volym"
 
@@ -2275,11 +2275,11 @@ msgstr "Hjälp"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Hjälp"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(högre värden ökar spelhastighet)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(högre värden försämrar spelhastighet)"
 
@@ -2304,7 +2304,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Hem"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "Version:"
@@ -2379,7 +2379,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Hjälp"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "InputS"
 
@@ -2434,8 +2434,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2455,7 +2455,7 @@ msgstr "Järn"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Järnkemolitoautotrofi"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "Självmord"
@@ -2464,19 +2464,19 @@ msgstr "Självmord"
 msgid "JANUARY"
 msgstr "Januari"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "JSON debug läge:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Alltid"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Automatiskt"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Aldrig"
 
@@ -2660,19 +2660,19 @@ msgstr "Numpad Del"
 msgid "KPSUBTRACT"
 msgstr "Numpad Minus"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Språk:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Detta språk är {0}% komplett"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Det här språket jobbas fortfarande på ({0}% klart)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Den här översättningen är mycket ofullständig ({0}% klar) snälla hjälp oss med den!"
 
@@ -2840,7 +2840,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Vänster musknapp"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Licenser"
 
@@ -2916,7 +2916,7 @@ msgstr "Skrolla Höger"
 msgid "LIGHT_MAX"
 msgstr "Ljus"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "Extra"
@@ -2931,32 +2931,32 @@ msgstr "BEKRÄFTA"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "{0} befolkning förändrades av {1} på grund av: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "BEKRÄFTA"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2982,7 +2982,7 @@ msgstr "Ladda"
 msgid "LOADING"
 msgstr "Laddar"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Laddar..."
@@ -3015,12 +3015,12 @@ msgstr "Använd ångraknapped i cellredigeraren för att fixa ett mistag"
 msgid "LOAD_FINISHED"
 msgstr "Färdigladdat"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Ladda Spel"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Hjälp"
@@ -3089,7 +3089,7 @@ msgstr "Mars"
 msgid "MARINE_SNOW"
 msgstr "Marinsnö"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Huvudvolym"
 
@@ -3097,15 +3097,15 @@ msgstr "Huvudvolym"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Maximalt antal arter i ett område innan tvingade utdöenden"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Max Frames Per Sekund:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Obegränsad"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3262,7 +3262,7 @@ msgstr "Varje generation får du 100 mutationspoäng (MP), och varje förändrin
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Varje gång du reproducerar kommer du in i Cellredigeraren, där du kan göra ändringar i din art (genom att lägga till, flytta eller ta bort organeller) för att öka din arts framgång. Varje besök hos Cellredigeraren i mikrobstadiet representerar 100 miljoner år av utveckling."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Mikrob Fri Byggredigerare"
 
@@ -3431,7 +3431,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Inte tillåtet att visa mindre än {0} datauppsättning(ar)!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "B.l.a"
 
@@ -3499,11 +3499,11 @@ msgstr "Ta bort organell"
 msgid "MODIFY_TYPE"
 msgstr "Modifiera Typ"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mod"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3593,11 +3593,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Mod Inladdningsfel"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Fel uppstod när en eller flera mod laddades. Loggen kan innehålla ytterligare information."
 
@@ -3651,11 +3651,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3772,7 +3772,7 @@ msgstr "Placera organell"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Placera organell"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Multispel anti-aliasing:"
 
@@ -3784,7 +3784,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Musik"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Musikvolym"
 
@@ -3804,9 +3804,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr "Mutationspoäng"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Tyst"
 
@@ -3840,11 +3840,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Ursprunglig population för biodiversitetsökande art"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Nytt spel"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Hjälp"
@@ -3916,7 +3916,7 @@ msgstr "Nitrogen Fixing Plastid är ett protein som kan använda gasformigt kvä
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Nitrogen Fixing Plastid är ett protein som kan använda gasformigt kväve och syre och cellulär energi i form av ATP för att producera ammoniak, ett viktigt tillväxtnäringsämne för celler. Detta är en process som kallas aerob kvävefixering."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Ingen"
 
@@ -3965,7 +3965,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Hittade ingen screenshots mapp"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "Avstängt"
@@ -3984,7 +3984,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Hittade ingen screenshots mapp"
 
@@ -4030,16 +4030,16 @@ msgstr "N/A MutationsPoäng"
 msgid "OCTOBER"
 msgstr "Oktober"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Självmord"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4073,7 +4073,7 @@ msgstr "Öppna hjälpmenyn"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Fri byggredigerare"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Öppna Logmapp"
 
@@ -4090,7 +4090,7 @@ msgstr "Öppna organell meny"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Öppna Skärmbildsmapp"
 
@@ -4098,7 +4098,7 @@ msgstr "Öppna Skärmbildsmapp"
 msgid "OPEN_THE_MENU"
 msgstr "Öppna menyn"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Hjälp Översätta Spelet"
 
@@ -4115,11 +4115,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Opportunistisk"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Inställningar"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Hjälp"
@@ -4340,7 +4340,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "Grotta"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "Självmord"
@@ -4395,7 +4395,7 @@ msgstr "Fredlig"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Uppförande"
 
@@ -4481,7 +4481,7 @@ msgstr "Duplicera Spelare"
 msgid "PLAYER_EXTINCT"
 msgstr "Duplicera Spelare"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Duplicera Spelare"
@@ -4494,23 +4494,23 @@ msgstr "spelare fortplantad"
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Spela introvideo"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Spela Mikrobintro i ett nytt spel"
 
@@ -4632,11 +4632,11 @@ msgstr "Snabbladda"
 msgid "QUICK_SAVE"
 msgstr "Snabbspara"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Lämna"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4682,7 +4682,7 @@ msgstr "Trådar:"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "Fortsätt"
@@ -4740,7 +4740,7 @@ msgstr "Reproduktion:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Kärna"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Nollställ"
 
@@ -4749,24 +4749,24 @@ msgstr "Nollställ"
 msgid "RESET_DEADZONES"
 msgstr "Nollställ till default?"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Nollställ kontroller till default?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "Nollställ Inputs"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Default"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Nollställ till default?"
 
@@ -4775,7 +4775,7 @@ msgstr "Nollställ till default?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Upplösning:"
 
@@ -4827,7 +4827,7 @@ msgstr ""
 "Är du säker på att du vill tillbaka till huvudmenyn?\n"
 "Du kommer att förlora alla osparade framsteg."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Av Revolutionary Games Studio"
@@ -4861,7 +4861,7 @@ msgstr "Snurra höger"
 msgid "ROTATION_COLON"
 msgstr "befolkning:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Kör auto-evo under spelgång"
 
@@ -4917,7 +4917,7 @@ msgstr "Rusticyanin är ett protein som kan använda gasformig koldioxid och syr
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Rusticyanin är ett protein som kan använda gasformig koldioxid och syre för att oxidera järn från ett kemiskt tillstånd till ett annat. Denna process, kallad Iron Respiration, frigör energi som cellen sedan kan skörda."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4926,15 +4926,15 @@ msgstr ""
 "Fredliga mikrober attackerar inte andra över större avstånd\n"
 "och har lägre sannolikhet att använda gifter mot rovdjur."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Spara"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Spara och fortsätt"
 
@@ -5034,21 +5034,21 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr "Sparning lyckades"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr "Signaleringsmedel"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "för att öka hastigheten"
@@ -5153,7 +5153,7 @@ msgstr "Stillastående"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "SFX Volym"
 
@@ -5169,17 +5169,17 @@ msgstr "Visa hjälp"
 msgid "SHOW_TUTORIALS"
 msgstr "Visa handledningar"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Visa hjälp (i nuvarande spel)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Visa hjälp (i nya spel)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Visa osparade framstegsvarning"
 
@@ -5189,6 +5189,10 @@ msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr ""
 "Du har osparade ändringar som kommer bli raderade.\n"
 "Vill du fortsätta?"
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5244,7 +5248,7 @@ msgstr "Kiseldioxid"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5286,7 +5290,7 @@ msgstr "Det slemiga inre av en cell. Cytoplasman är den grundläggande blandnin
 msgid "SMALL_IRON_CHUNK"
 msgstr "Liten Järnbit"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Ljud"
 
@@ -5494,17 +5498,17 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Sparande misslyckades"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Vakuolen är en inre membranorganell som används för lagring i cellen. De består av flera blåsor, mindre membranstrukturer som ofta används i celler för lagring, som har smält samman. Den är fylld med vatten som används för att hålla kvar molekyler, enzymer, fasta ämnen och andra ämnen. Deras form är flytande och kan variera mellan celler."
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "Fortsätt"
@@ -5547,7 +5551,7 @@ msgstr "Förråd"
 msgid "STORAGE_COLON"
 msgstr "Förråd"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Inloggad som: {0}"
 
@@ -5664,7 +5668,7 @@ msgstr "Temp."
 msgid "TESTING_TEAM"
 msgstr "Testning"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5679,7 +5683,7 @@ msgstr ""
 "\n"
 "Om du gillade spelet, berätta om oss för dina vänner."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "DU HAR FRODATS!"
@@ -5738,11 +5742,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Trådar:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5890,7 +5894,7 @@ msgstr "Pausa"
 msgid "TOGGLE_UNBINDING"
 msgstr "Växla avbindning av och på"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Verktyg"
 
@@ -5958,7 +5962,7 @@ msgstr "Testa att ta några screenshots!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Testa att ta några screenshots!"
 
@@ -6066,12 +6070,12 @@ msgstr "Mikrob Fri Byggredigerare"
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "Hjälp"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6097,7 +6101,7 @@ msgstr "Lösgör alla"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Lösgöringsläge"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -6117,7 +6121,7 @@ msgstr "Ångra den senaste handlingen"
 msgid "UNKNOWN"
 msgstr "Okänd"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Visa förmågor"
@@ -6131,7 +6135,7 @@ msgstr "Okänd mus"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Okänd mus"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "Okänd mus"
@@ -6141,7 +6145,7 @@ msgstr "Okänd mus"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Okänd mus"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Du har osparade ändringar som kommer bli raderade.\n"
@@ -6186,7 +6190,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Licenser Och Använda Bibliotek"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6204,7 +6208,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Självmord"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Använd ett anpassat användarnamn"
 
@@ -6212,11 +6216,11 @@ msgstr "Använd ett anpassat användarnamn"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Sätt antalet bakgrundstrådar manuellt"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6243,7 +6247,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr "Version:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "Version:"
@@ -6254,11 +6258,11 @@ msgstr "Version:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Hastighet:"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6267,7 +6271,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr "Visare eller åskådare, beroende på situation"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Visa Källkod"
 
@@ -6279,7 +6283,7 @@ msgstr "VIP-supportrar"
 msgid "VISIBLE"
 msgstr "Synlig"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6299,7 +6303,7 @@ msgstr "Stäng av volymen"
 msgid "VOLUMEUP"
 msgstr "Öka Volymen"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSynk"
 
@@ -6409,7 +6413,7 @@ msgstr "Organismstatistik"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "för att öka hastigheten"
@@ -6418,15 +6422,15 @@ msgstr "för att öka hastigheten"
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6438,7 +6442,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "år"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Fortsätt"

--- a/locale/th_TH.po
+++ b/locale/th_TH.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-03-22 18:22+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Thai <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/th/>\n"
@@ -208,7 +208,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "ศิลปะโดย {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -306,7 +306,7 @@ msgstr "บันทึกอัตโนมัติระหว่างเก
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "{0: F1}% เสร็จสิ้น {1: n0} / {2: n0} ขั้นตอน"
@@ -351,8 +351,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -615,27 +615,27 @@ msgstr "ล็อคมุมมอง"
 msgid "CARBON_DIOXIDE"
 msgstr "คาร์บอนไดออกไซด์"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -911,20 +911,20 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -1135,7 +1135,7 @@ msgstr "กดปุ่ม ..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "เครดิต"
 
@@ -1298,11 +1298,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -1311,11 +1311,11 @@ msgstr "ดำเนินการต่อ"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -1447,7 +1447,7 @@ msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} 
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1497,7 +1497,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1677,15 +1677,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1741,6 +1741,16 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "ผิดพลาด: บันทึกการตั้งค่าใหม่ลงในไฟล์กำหนดค่าไม่สำเร็จ"
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "เปิดโฟลเดอร์สกรีนช็อต"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1791,7 +1801,7 @@ msgstr ""
 msgid "EXIT"
 msgstr "ออก"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "เปิด E"
@@ -1847,7 +1857,7 @@ msgstr "สูญพันธุ์ไปจากโลก"
 msgid "EXTINCT_SPECIES"
 msgstr "สูญพันธุ์ไปแล้วใน {0}"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "พิเศษ"
 
@@ -1855,7 +1865,7 @@ msgstr "พิเศษ"
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -1885,6 +1895,22 @@ msgstr "เปิดใช้งานโกงคีย์"
 #, fuzzy
 msgid "FEBRUARY"
 msgstr "ปากน้ำ"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1970,7 +1996,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -2073,7 +2099,7 @@ msgstr "ตั้งค่า"
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -2082,11 +2108,11 @@ msgstr "ดำเนินการต่อ"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "คำเตือนโหมด GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "คุณกำลังเจริญเติบโตด้วย GLES2 สิ่งนี้ยังไม่ผ่านการทดสอบอย่างรุนแรงและมีแนวโน้มที่จะทำให้เกิดปัญหา พยายามอัปเดตไดรเวอร์วิดีโอของคุณและ / หรือบังคับให้ใช้กราฟิก AMD หรือ Nvidia เพื่อเรียกใช้ Thrive"
 
@@ -2370,7 +2396,7 @@ msgstr "เหล็ก"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "เหล็กเคโมลิโทออโตโทรฟี"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -2590,7 +2616,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2751,7 +2777,7 @@ msgstr "เมาส์ซ้าย"
 msgid "LEFT_MOUSE"
 msgstr "เมาส์ซ้าย"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2887,7 +2913,8 @@ msgstr "โหลด"
 msgid "LOADING"
 msgstr "กำลังโหลด"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "กดปุ่ม ..."
@@ -2919,12 +2946,12 @@ msgstr "กดปุ่มเลิกทำในตัวแก้ไขเพ
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "โหลดเกม"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3182,7 +3209,7 @@ msgstr "แต่ละรุ่นคุณจะมีแต้มการก
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "ทุกครั้งที่คุณสืบพันธุ์คุณจะเข้าสู่ การแก้ไขจุลชีพ ซึ่งคุณสามารถทำการเปลี่ยนแปลงสายพันธุ์ของคุณ (โดยการเพิ่มย้ายหรือเอาออร์แกเนลล์ออก) เพื่อเพิ่มความสำเร็จให้กับสายพันธุ์ของคุณ การเยี่ยมชมบรรณาธิการใน Microbe Stage แต่ละครั้งแสดงถึงวิวัฒนาการ 100 ล้านปี"
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "สร้างจุลินทรีย์ฟรี"
 
@@ -3426,11 +3453,11 @@ msgstr "เอาออร์แกเนลล์ออก"
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3520,11 +3547,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3757,15 +3784,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "เกมส์ใหม่"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3874,7 +3905,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3887,7 +3918,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "เปิดโฟลเดอร์สกรีนช็อต"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "เปิดใช้งานโกงคีย์"
@@ -3919,7 +3950,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr "นิวเคลียส"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3942,8 +3973,8 @@ msgstr "ล็อคหมายเลข"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3956,16 +3987,16 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4041,11 +4072,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "ตั้งค่า"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -4261,7 +4292,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -4321,8 +4352,8 @@ msgstr "ประสิทธิภาพ"
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/ วินาที"
 
@@ -4372,7 +4403,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4450,7 +4481,7 @@ msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} 
 msgid "POPULATION_IN_PATCHES"
 msgstr "ประชากรในแพทช์:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4507,7 +4538,7 @@ msgstr "ก่อนหน้า:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4551,11 +4582,11 @@ msgstr "โหลดด่วน"
 msgid "QUICK_SAVE"
 msgstr "บันทึกด่วน"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "ออก"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4598,7 +4629,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -4741,7 +4772,7 @@ msgstr "กลับไปที่เมนู"
 msgid "RETURN_TO_MENU_WARNING"
 msgstr "กลับไปที่เมนู"
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4835,12 +4866,12 @@ msgstr "Rusticyanin เป็นโปรตีนที่สามารถใ
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Rusticyanin เป็นโปรตีนที่สามารถใช้ก๊าซคาร์บอนไดออกไซด์และออกซิเจนในการออกซิไดซ์เหล็กจากสถานะทางเคมีหนึ่งไปยังอีกสถานะหนึ่ง กระบวนการนี้เรียกว่า Iron Respiration ปล่อยพลังงานออกมาซึ่งเซลล์สามารถเก็บเกี่ยวได้"
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -5236,7 +5267,7 @@ msgstr "แอมโมเนียวางไข่"
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -5289,7 +5320,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 #, fuzzy
 msgid "SPECIES_N_TIMES"
 msgstr "เมาส์ขวา"
@@ -5407,16 +5438,16 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "แวคิวโอลเป็นออร์แกเนลล์เยื่อภายในที่ใช้สำหรับเก็บในเซลล์ ประกอบด้วยถุงหลายอันโครงสร้างของเยื่อขนาดเล็กที่ใช้กันอย่างแพร่หลายในเซลล์เพื่อการจัดเก็บที่หลอมรวมเข้าด้วยกัน เต็มไปด้วยน้ำซึ่งใช้บรรจุโมเลกุลเอนไซม์ของแข็งและสารอื่น ๆ รูปร่างของพวกมันเป็นของเหลวและอาจแตกต่างกันไประหว่างเซลล์"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -5460,7 +5491,7 @@ msgstr "การจัดเก็บ"
 msgid "STORAGE_COLON"
 msgstr "การจัดเก็บ"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5577,7 +5608,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5585,7 +5616,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5649,7 +5680,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5804,7 +5835,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "สลับเขมือบ"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "เครื่องมือ"
 
@@ -5982,7 +6013,7 @@ msgstr "สร้างจุลินทรีย์ฟรี"
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "บทช่วยสอน"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -6182,7 +6213,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "ดูซอร์สโค้ด"
 
@@ -6194,7 +6225,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6352,7 +6383,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "ดำเนินการต่อ"

--- a/locale/th_TH.po
+++ b/locale/th_TH.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-03-22 18:22+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Thai <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/th/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.11.2\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr "แก้ไข"
 msgid "3D_MOVEMENT"
 msgstr "การเคลื่อนไหว"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 #, fuzzy
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "บันทึกและดำเนินการต่อ"
@@ -146,7 +146,7 @@ msgstr "สถิติ"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "ปริมาณบรรยากาศ"
 
@@ -157,11 +157,11 @@ msgstr "ปริมาณบรรยากาศ"
 msgid "AMMONIA"
 msgstr "แอมโมเนีย"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "จำนวนการบันทึกอัตโนมัติที่จะเก็บไว้:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "จำนวนการบันทึกด่วนที่จะเก็บไว้:"
 
@@ -187,11 +187,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "แน่ใจไหมว่าต้องการรีเซ็ตการตั้งค่าทั้งหมดเป็นค่าเริ่มต้น"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "แน่ใจไหมว่าต้องการรีเซ็ตการตั้งค่าการป้อนข้อมูลเป็นค่าเริ่มต้น"
 
@@ -208,7 +208,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "ศิลปะโดย {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -220,7 +220,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -260,7 +260,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -268,8 +268,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "อัตโนมัต"
 
@@ -298,7 +298,7 @@ msgstr "โรงไฟฟ้าของเซลล์ mitochondrion (พห�
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0: F1}% เสร็จสิ้น {1: n0} / {2: n0} ขั้นตอน"
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "บันทึกอัตโนมัติระหว่างเกม"
 
@@ -306,7 +306,7 @@ msgstr "บันทึกอัตโนมัติระหว่างเก
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "{0: F1}% เสร็จสิ้น {1: n0} / {2: n0} ขั้นตอน"
@@ -337,7 +337,7 @@ msgstr "ก่อนหน้า:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "เคลื่อนที่ไปข้างหน้าอัตโนมัติ"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 #, fuzzy
 msgid "AUTO_RESOLUTION"
 msgstr "ความละเอียด:"
@@ -351,9 +351,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -496,7 +496,7 @@ msgstr "Nitrogenase เป็นโปรตีนที่สามารถใ
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Nitrogenase เป็นโปรตีนที่สามารถใช้ก๊าซไนโตรเจนและพลังงานของเซลล์ในรูปแบบของ ATP เพื่อผลิตแอมโมเนียซึ่งเป็นสารอาหารที่สำคัญในการเจริญเติบโตของเซลล์ นี่คือกระบวนการที่เรียกว่าการตรึงไนโตรเจนแบบไม่ใช้ออกซิเจน เนื่องจากไนโตรเจนเนสถูกแขวนอยู่ในไซโทพลาสซึมโดยตรงของเหลวที่อยู่รอบ ๆ จึงทำปฏิกิริยาไกลโคไลซิส"
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -558,7 +558,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr "กล้อง"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -691,7 +691,7 @@ msgstr "เปลี่ยนสมมาตร"
 msgid "CHEATS"
 msgstr "โหมดโกง"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "เปิดใช้งานโกงคีย์"
 
@@ -789,7 +789,7 @@ msgstr "คลอโรพลาสต์เป็นโครงสร้าง
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "ความผิดปกติของสี:"
 
@@ -833,15 +833,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr "ปิด"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "ปิดตัวเลือกไหม"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "ตัวหารความละเอียดของคลาวด์:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 "การจำลองคลาวด์ขั้นต่ำ\n"
@@ -859,7 +859,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "การแก้ไขคนตาบอดสี:"
 
@@ -911,25 +911,25 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
@@ -957,7 +957,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "สารประกอบของเมฆ"
 
@@ -1042,7 +1042,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1056,11 +1056,11 @@ msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} 
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1068,11 +1068,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1135,7 +1135,7 @@ msgstr "กดปุ่ม ..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "เครดิต"
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "ชื่อผู้ใช้ที่กำหนดเอง:"
 
@@ -1226,7 +1226,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1286,7 +1286,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1298,11 +1298,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -1311,11 +1311,11 @@ msgstr "ดำเนินการต่อ"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -1391,7 +1391,7 @@ msgstr "ซ้าย"
 msgid "DIRECTIONR"
 msgstr "ขวา"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1399,7 +1399,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "ทิ้งและดำเนินการต่อ"
 
@@ -1432,35 +1432,35 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "ดำเนินการต่อ"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 #, fuzzy
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "ความสามารถ"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "ความสามารถ"
@@ -1497,7 +1497,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1647,7 +1647,7 @@ msgstr "ดำเนินการต่อ"
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 #, fuzzy
 msgid "EIGHT_TIMES"
 msgstr "เมาส์ขวา"
@@ -1665,7 +1665,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr "เปิดใช้งานตัวแก้ไข"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1724,7 +1724,7 @@ msgstr "ดำเนินการต่อ"
 msgid "EPIPELAGIC"
 msgstr "พื้นผิวมหาสมุทรลึก"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "ผิดพลาด"
 
@@ -1737,16 +1737,16 @@ msgstr "เปิดโฟลเดอร์สกรีนช็อต"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "ผิดพลาด: บันทึกการตั้งค่าใหม่ลงในไฟล์กำหนดค่าไม่สำเร็จ"
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "เปิดโฟลเดอร์สกรีนช็อต"
@@ -1779,12 +1779,12 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -1801,7 +1801,7 @@ msgstr ""
 msgid "EXIT"
 msgstr "ออก"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "เปิด E"
@@ -1857,7 +1857,7 @@ msgstr "สูญพันธุ์ไปจากโลก"
 msgid "EXTINCT_SPECIES"
 msgstr "สูญพันธุ์ไปแล้วใน {0}"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "พิเศษ"
 
@@ -1865,7 +1865,7 @@ msgstr "พิเศษ"
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -1896,19 +1896,19 @@ msgstr "เปิดใช้งานโกงคีย์"
 msgid "FEBRUARY"
 msgstr "ปากน้ำ"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2037,7 +2037,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -2070,7 +2070,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "เต็มจอ"
 
@@ -2099,24 +2099,24 @@ msgstr "ตั้งค่า"
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "ดำเนินการต่อ"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "คำเตือนโหมด GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "คุณกำลังเจริญเติบโตด้วย GLES2 สิ่งนี้ยังไม่ผ่านการทดสอบอย่างรุนแรงและมีแนวโน้มที่จะทำให้เกิดปัญหา พยายามอัปเดตไดรเวอร์วิดีโอของคุณและ / หรือบังคับให้ใช้กราฟิก AMD หรือ Nvidia เพื่อเรียกใช้ Thrive"
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2169,12 +2169,12 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 #, fuzzy
 msgid "GPU_NAME"
 msgstr "เกมส์ใหม่"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "กราฟิก"
 
@@ -2183,7 +2183,7 @@ msgstr "กราฟิก"
 msgid "GRAPHICS_TEAM"
 msgstr "กราฟิก"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2197,7 +2197,7 @@ msgstr "โรงไฟฟ้าของเซลล์ mitochondrion (พห�
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} K"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "ปริมาณ GUI"
 
@@ -2219,11 +2219,11 @@ msgstr "ช่วยเหลือ"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(ค่าที่สูงขึ้นจะเพิ่มประสิทธิภาพ)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(ค่าที่สูงขึ้นทำให้ประสิทธิภาพแย่ลง)"
 
@@ -2248,7 +2248,7 @@ msgstr ""
 msgid "HOME"
 msgstr "บ้าน"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "การจัดเก็บ"
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "ดำเนินการต่อ"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "อินพุต"
 
@@ -2376,8 +2376,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2396,7 +2396,7 @@ msgstr "เหล็ก"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "เหล็กเคโมลิโทออโตโทรฟี"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -2405,19 +2405,19 @@ msgstr "ดำเนินการต่อ"
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2599,20 +2599,20 @@ msgstr "เลข ."
 msgid "KPSUBTRACT"
 msgstr "เลข -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "ภาษา:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 #, fuzzy
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "ช่วยแปลเกม"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2777,7 +2777,7 @@ msgstr "เมาส์ซ้าย"
 msgid "LEFT_MOUSE"
 msgstr "เมาส์ซ้าย"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2848,7 +2848,7 @@ msgstr "ล้อขวา"
 msgid "LIGHT_MAX"
 msgstr "แสง"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "พิเศษ"
@@ -2863,32 +2863,32 @@ msgstr "ปกติ"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "ปกติ"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2913,7 +2913,7 @@ msgstr "โหลด"
 msgid "LOADING"
 msgstr "กำลังโหลด"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
@@ -2946,12 +2946,12 @@ msgstr "กดปุ่มเลิกทำในตัวแก้ไขเพ
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "โหลดเกม"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3021,7 +3021,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr "หิมะในทะเล"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "ระดับเสียงหลัก"
 
@@ -3030,16 +3030,16 @@ msgstr "ระดับเสียงหลัก"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "สูญพันธุ์ไปจากโลก"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "FPS สูงสุด:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 #, fuzzy
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "FPS สูงสุด:"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3209,7 +3209,7 @@ msgstr "แต่ละรุ่นคุณจะมีแต้มการก
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "ทุกครั้งที่คุณสืบพันธุ์คุณจะเข้าสู่ การแก้ไขจุลชีพ ซึ่งคุณสามารถทำการเปลี่ยนแปลงสายพันธุ์ของคุณ (โดยการเพิ่มย้ายหรือเอาออร์แกเนลล์ออก) เพื่อเพิ่มความสำเร็จให้กับสายพันธุ์ของคุณ การเยี่ยมชมบรรณาธิการใน Microbe Stage แต่ละครั้งแสดงถึงวิวัฒนาการ 100 ล้านปี"
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "สร้างจุลินทรีย์ฟรี"
 
@@ -3385,7 +3385,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "ไม่อนุญาตให้แสดงน้อยกว่า {0} ชุดข้อมูล!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "เพลง"
 
@@ -3453,11 +3453,11 @@ msgstr "เอาออร์แกเนลล์ออก"
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3547,11 +3547,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3604,11 +3604,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3725,7 +3725,7 @@ msgstr "วางออร์แกเนลล์"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "วางออร์แกเนลล์"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "การลบรอยหยักหลายตัวอย่าง:"
 
@@ -3737,7 +3737,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "ระดับเสียงเพลง"
 
@@ -3758,9 +3758,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "ปิดเสียง"
 
@@ -3792,11 +3792,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "เกมส์ใหม่"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3867,7 +3867,7 @@ msgstr "Nitrogen Fixing Plastid เป็นโปรตีนที่สาม
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Nitrogen Fixing Plastid เป็นโปรตีนที่สามารถใช้ก๊าซไนโตรเจนและออกซิเจนและพลังงานของเซลล์ในรูปแบบของ ATP เพื่อผลิตแอมโมเนียซึ่งเป็นสารอาหารที่สำคัญในการเจริญเติบโตของเซลล์ นี่คือกระบวนการที่เรียกว่าการตรึงไนโตรเจนแบบแอโรบิค"
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3918,7 +3918,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "เปิดโฟลเดอร์สกรีนช็อต"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "เปิดใช้งานโกงคีย์"
@@ -3936,7 +3936,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 #, fuzzy
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "เปิดโฟลเดอร์สกรีนช็อต"
@@ -3987,16 +3987,16 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4029,7 +4029,7 @@ msgstr "เปิดหน้าจอความช่วยเหลือ"
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "เปิดโฟลเดอร์บันทึก"
 
@@ -4047,7 +4047,7 @@ msgstr "เอาออร์แกเนลล์ออก"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "เปิดโฟลเดอร์สกรีนช็อต"
 
@@ -4055,7 +4055,7 @@ msgstr "เปิดโฟลเดอร์สกรีนช็อต"
 msgid "OPEN_THE_MENU"
 msgstr "เปิดเมนู"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "ช่วยแปลเกม"
 
@@ -4072,11 +4072,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "ตั้งค่า"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -4344,7 +4344,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "ประสิทธิภาพ"
 
@@ -4429,7 +4429,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr "สูญพันธุ์ไปแล้วใน {0}"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "สูญพันธุ์ไปแล้วใน {0}"
@@ -4442,23 +4442,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "เล่นวิดีโอแนะนำ"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "เล่น Microbe Intro ในเกมใหม่"
 
@@ -4582,11 +4582,11 @@ msgstr "โหลดด่วน"
 msgid "QUICK_SAVE"
 msgstr "บันทึกด่วน"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "ออก"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4629,7 +4629,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -4686,7 +4686,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr "นิวเคลียส"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "รีเซ็ต"
 
@@ -4695,24 +4695,24 @@ msgstr "รีเซ็ต"
 msgid "RESET_DEADZONES"
 msgstr "รีเซ็ตเป็นค่าเริ่มต้นไหม"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "รีเซ็ตอินพุตเป็นค่าเริ่มต้น?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "รีเซ็ตอินพุต"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "ค่าเริ่มต้น"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "รีเซ็ตเป็นค่าเริ่มต้นไหม"
 
@@ -4721,7 +4721,7 @@ msgstr "รีเซ็ตเป็นค่าเริ่มต้นไหม
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "ความละเอียด:"
 
@@ -4772,7 +4772,7 @@ msgstr "กลับไปที่เมนู"
 msgid "RETURN_TO_MENU_WARNING"
 msgstr "กลับไปที่เมนู"
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4806,7 +4806,7 @@ msgstr "หมุนไปทางขวา"
 msgid "ROTATION_COLON"
 msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "เรียกใช้ auto-evo ระหว่างการเล่นเกม"
 
@@ -4866,20 +4866,20 @@ msgstr "Rusticyanin เป็นโปรตีนที่สามารถใ
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Rusticyanin เป็นโปรตีนที่สามารถใช้ก๊าซคาร์บอนไดออกไซด์และออกซิเจนในการออกซิไดซ์เหล็กจากสถานะทางเคมีหนึ่งไปยังอีกสถานะหนึ่ง กระบวนการนี้เรียกว่า Iron Respiration ปล่อยพลังงานออกมาซึ่งเซลล์สามารถเก็บเกี่ยวได้"
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "เซฟ"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "บันทึกและดำเนินการต่อ"
 
@@ -4979,23 +4979,23 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr ""
 "มีข้อขัดแย้งกับ {0}\n"
 "คุณต้องการลบข้อมูลที่ป้อนออกจาก {1} หรือไม่?"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "เพื่อเพิ่มการเคลื่อนไหว"
@@ -5099,7 +5099,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "ค่านี้ใช้กับเกมใหม่ที่เริ่มหลังจากเปลี่ยนตัวเลือกนี้เท่านั้น"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "ปริมาณ SFX"
 
@@ -5115,17 +5115,17 @@ msgstr "แสดงความช่วยเหลือ"
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "แสดงบทช่วยสอน (ในเกมปัจจุบัน)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "แสดงบทช่วยสอน (ในเกมใหม่)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 #, fuzzy
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
@@ -5138,6 +5138,10 @@ msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr ""
 "คุณมีการเปลี่ยนแปลงที่ยังไม่ได้บันทึกซึ่งจะถูกยกเลิก\n"
 "คุณต้องการดำเนินการต่อหรือไม่"
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5196,7 +5200,7 @@ msgstr "ซิลิกา"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr "เปลี่ยน [thrive:compound]glucose[/thrive:compound] เป�
 msgid "SMALL_IRON_CHUNK"
 msgstr "ก้อนเหล็กขนาดเล็ก"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "เสียง"
 
@@ -5438,16 +5442,16 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "แวคิวโอลเป็นออร์แกเนลล์เยื่อภายในที่ใช้สำหรับเก็บในเซลล์ ประกอบด้วยถุงหลายอันโครงสร้างของเยื่อขนาดเล็กที่ใช้กันอย่างแพร่หลายในเซลล์เพื่อการจัดเก็บที่หลอมรวมเข้าด้วยกัน เต็มไปด้วยน้ำซึ่งใช้บรรจุโมเลกุลเอนไซม์ของแข็งและสารอื่น ๆ รูปร่างของพวกมันเป็นของเหลวและอาจแตกต่างกันไประหว่างเซลล์"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "ดำเนินการต่อ"
@@ -5491,7 +5495,7 @@ msgstr "การจัดเก็บ"
 msgid "STORAGE_COLON"
 msgstr "การจัดเก็บ"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5608,7 +5612,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5616,7 +5620,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5676,11 +5680,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5835,7 +5839,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr "สลับเขมือบ"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "เครื่องมือ"
 
@@ -5904,7 +5908,7 @@ msgstr "จับภาพหน้าจอ"
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 #, fuzzy
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "จับภาพหน้าจอ"
@@ -6013,12 +6017,12 @@ msgstr "สร้างจุลินทรีย์ฟรี"
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "บทช่วยสอน"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "ดำเนินการต่อ"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -6044,7 +6048,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -6064,7 +6068,7 @@ msgstr "เลิกทำการกระทำล่าสุด"
 msgid "UNKNOWN"
 msgstr "ปลดล็อค"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "ความสามารถ"
@@ -6078,7 +6082,7 @@ msgstr "เมาส์ที่ไม่รู้จัก"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "เมาส์ที่ไม่รู้จัก"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 #, fuzzy
 msgid "UNKNOWN_VERSION"
 msgstr "เมาส์ที่ไม่รู้จัก"
@@ -6088,7 +6092,7 @@ msgstr "เมาส์ที่ไม่รู้จัก"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "เมาส์ที่ไม่รู้จัก"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "คุณมีการเปลี่ยนแปลงที่ยังไม่ได้บันทึกซึ่งจะถูกยกเลิก\n"
@@ -6134,7 +6138,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6151,7 +6155,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "ใช้ชื่อผู้ใช้ที่กำหนดเอง"
 
@@ -6159,11 +6163,11 @@ msgstr "ใช้ชื่อผู้ใช้ที่กำหนดเอง
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6190,7 +6194,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "การจัดเก็บ"
@@ -6201,11 +6205,11 @@ msgstr "การจัดเก็บ"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "เกมส์ใหม่"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6213,7 +6217,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "ดูซอร์สโค้ด"
 
@@ -6225,7 +6229,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6245,7 +6249,7 @@ msgstr "ปิดเสียง"
 msgid "VOLUMEUP"
 msgstr "ปรับระดับเสียงขึ้น"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "VSync"
 
@@ -6354,7 +6358,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "เพื่อเพิ่มการเคลื่อนไหว"
@@ -6363,15 +6367,15 @@ msgstr "เพื่อเพิ่มการเคลื่อนไหว"
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6383,7 +6387,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "ดำเนินการต่อ"

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2023-01-30 07:23+0000\n"
 "Last-Translator: punctdan <yunusemredilek@hotmail.com>\n"
 "Language-Team: Turkish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/tr/>\n"
@@ -215,7 +215,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Resmi yapan: {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Sanat Galerisi"
 
@@ -313,7 +313,7 @@ msgstr "Oyun esnasında otomatik olarak kaydet"
 msgid "AUTO_EVO"
 msgstr "Oto-Evrim"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Oto-Evrim Keşif Aracı"
 
@@ -355,8 +355,8 @@ msgid "AWAKEN"
 msgstr "Uyandır"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -611,27 +611,27 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Karbondioksit"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "bol miktarda"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "makul miktarda"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "az miktarda"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "oldukça fazla"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "biraz"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "çok az miktarda"
 
@@ -899,19 +899,19 @@ msgstr "Doygunluk değeri, belli bir renkteki gri miktarı"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Değer (parlaklık) değeri, renkteki parlaklığın şiddeti"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr "Topluluk Forumu"
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Topluluk forumumuzda Thrive topluluğuna katıl"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr "Topluluk Vikisi"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Topluluk vikimizi ziyaret et"
 
@@ -1113,7 +1113,7 @@ msgstr "Oluşturuluyor..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Kayıttan objeler oluşturuluyor"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Jenerik"
 
@@ -1298,11 +1298,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Oyun Geliştiricileri"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr "Gelişme Forumu"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Gelişme forumumuzda gelişim güncellemelerini incele"
 
@@ -1310,11 +1310,11 @@ msgstr "Gelişme forumumuzda gelişim güncellemelerini incele"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Oyunun Geliştirilmesi Revolutionary Games Studio Tarafından Desteklenmiştir"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr "Gelişme Vikisi"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Geliştirici vikimizi ziyaret et"
 
@@ -1442,7 +1442,7 @@ msgstr ""
 "Diğerlerine bağlı olmayan, yerleştirilmiş organeller var.\n"
 "Lütfen yerleştirdiğin bütün organelleri birbirine bağla veya değişikliklerini geri al."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr "Discord topluluk sunucumuza katıl"
 
@@ -1456,7 +1456,7 @@ msgstr ""
 "Bu kısım, kaç tane açılır pencerenin kullanıcı tarafından kalıcı olarak atlandığını gösterir.\n"
 "Eğer aslında görülmek istenen bazı açılır pencereler atlandıysa, bütün atlanan açılır pencerelerin tekrar görülmesi için yandaki buton kullanılabilir."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr "Bunu bir daha gösterme"
 
@@ -1503,7 +1503,7 @@ msgstr "Tam ekranda görüntülemek için çift tıkla"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "İki katmanlı bir hücre zarı. Hasara karşı koruyuculuğu daha iyidir ve şeklinin bozulmaması için daha az enerji harcar. Ancak hücreyi biraz yavaşlatır ve kaynakların emilim oranını düşürür."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Bunun için bir daha uyarma"
 
@@ -1684,15 +1684,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "{1} için {0} arazisinde bulunan enerji miktarı"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Enerji Kaynakları:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "Birey başına {1} maliyet ile kazanılan toplam enerji miktarı {0}; {2} dengelenmemiş popülasyonla sonuçlanmakta"
 
@@ -1745,6 +1745,16 @@ msgstr "Mod bilgi dosyası oluştururken hata oluştu"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Hata: Yeni ayarlar yapılandırma dosyasına kaydedilemedi."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(oyunda rastgele oluşan gizemler)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Mod bilgi dosyası oluştururken hata oluştu"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Yükleme Hatası"
@@ -1796,7 +1806,7 @@ msgstr "Kayıt verisi yüklenirken bir sorun oluştu"
 msgid "EXIT"
 msgstr "Çık"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Çık ve Başlatıcıya Dön"
 
@@ -1846,7 +1856,7 @@ msgstr "arazide nesli tükendi"
 msgid "EXTINCT_SPECIES"
 msgstr "Nesli Tükenen Tür"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Ekstralar"
 
@@ -1854,7 +1864,7 @@ msgstr "Ekstralar"
 msgid "EXTRA_OPTIONS"
 msgstr "Ek Seçenekler"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Facebook sayfamızı ziyaret et"
 
@@ -1885,6 +1895,41 @@ msgstr "Etkin"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Şubat"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Steam istemci kütüphanesi başlatma başarısız"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"İşlem Süresi: {0} s\n"
+"Fizik Süresi: {1} s\n"
+"Varlıklar: {2} Diğer: {3}\n"
+"Oluşan: {4} Kaybolan: {5}\n"
+"Kullanılan Düğümler: {6}\n"
+"Kullanılan Bellek: {7}\n"
+"GPU Belleği: {8}\n"
+"İşlenen Nesneler: {9}\n"
+"Çizim Çağrıları: {10} 2D: {11}\n"
+"İşlenen Noktalar: {12}\n"
+"Materyal Değişiklikleri: {13}\n"
+"Gölgelendirici Değişiklikleri: {14}\n"
+"Artık Düğümler: {15}\n"
+"Ses Gecikmesi: {16} ms\n"
+"Toplam İş Parçacığı: {17}\n"
+"Toplam CPU Süresi:\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1968,7 +2013,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Besin Zinciri"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0} ile açığa çıkan enerji miktarı: {1} (uyum başarısı: {2}) mevcut toplam enerji miktarı: {3} (toplam uyum başarısı: {4})"
 
@@ -2064,7 +2109,7 @@ msgstr "Kuşaklar"
 msgid "GENERATION_COLON"
 msgstr "Kuşak:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr "GitHub depomuzu ziyaret et"
 
@@ -2072,11 +2117,11 @@ msgstr "GitHub depomuzu ziyaret et"
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 Mod Uyarısı"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Thrive'ı GLES2 ile çalıştırmaktasın. Bu mod ciddi derecede test edilmemiştir ve sorunlara neden olması muhtemel. Ekran kartlarını güncelleştirmeyi dene ve/veya Thrive'ı çalıştırırken AMD ya da Nvidia grafiklerini kullanmaya zorla."
 
@@ -2360,7 +2405,7 @@ msgstr "Demir"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Demir Kemolitoototrofisi"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr "Itch.io sayfamızı ziyaret et"
 
@@ -2578,7 +2623,7 @@ msgstr "Bu dilin çevirisi halen devam etmekte (%{0} tamamlandı)"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Bu çeviri henüz bitmemiş (%{0} tamamlandı), lütfen tamamlamamıza yardımcı ol!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "Son organel silinemez"
 
@@ -2736,7 +2781,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Sol fare tuşu"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Lisanslar"
 
@@ -2864,7 +2909,8 @@ msgstr "Yükle"
 msgid "LOADING"
 msgstr "Yükleniyor"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Yükleniyor..."
 
@@ -2894,12 +2940,12 @@ msgstr "Bir hatayı düzeltmek için düzenleyicideki geri al butonuna basın"
 msgid "LOAD_FINISHED"
 msgstr "Yükleme bitti"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Oyun Yükle"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Daha önce kaydedilmiş oyunları yükle"
 
@@ -3176,7 +3222,7 @@ msgstr "Her kuşakta, harcanacak 100 mutasyon puanınız (MP) vardır ve her de�
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Her çoğaldığınızda, Mikrop Düzenleyicisi'ne giriş yaparsınız. Burada, türünüzün başarısını arttırmak için türünüzde (organelleri ekleyerek, taşıyarak veya kaldırarak) değişiklikler yapabilirsiniz. Mikrop Evresi'nde düzenleyiciye yapılan her ziyaret, [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milyon yıllık evrimi temsil eder."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Mikrop Editörü Serbest Yapım Modu"
 
@@ -3423,11 +3469,11 @@ msgstr "Organelde Değişiklik Yap"
 msgid "MODIFY_TYPE"
 msgstr "Türde Değişiklik Yap"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Modlar"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Yüklü modlar algılandı ancak etkinleştirilmiş bir mod yok.\n"
@@ -3516,11 +3562,11 @@ msgstr "İç (Klasör) Ad:"
 msgid "MOD_LICENSE"
 msgstr "Mod Lisansı:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Mod Yükleme Hataları"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Bir ya da daha fazla modu yüklerken sorun oluştu. Loglar, ek bilgi içerebilir."
 
@@ -3756,15 +3802,19 @@ msgstr ""
 "Bu kayıt Thrive'ın yeni bir sürümüne ait ve uyumsuz olması oldukça muhtemel.\n"
 "Yine de kaydı yüklemeyi denemek ister misin?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Biyoçeşitliliği artıran türler için başlangıç popülasyonu"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Yeni Oyun"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Yeni bir oyun başlat"
 
@@ -3864,7 +3914,7 @@ msgid "NO_AI"
 msgstr "AI Yok"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Gösterilecek Veri Yok"
 
@@ -3876,7 +3926,7 @@ msgstr "Hiçbir olay görülmedi"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Fosiller dizini bulunamadı"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr "Hiçbir Mod Etkinleştirilmedi"
 
@@ -3906,7 +3956,7 @@ msgstr "Seçilen Mod Yok"
 msgid "NUCLEUS"
 msgstr "Çekirdek"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 "Bu geri dönüşü olmayan bir evrim olduğu için çekirdek silinemez.\n"
@@ -3927,8 +3977,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "Bilinmeyen"
@@ -3941,15 +3991,15 @@ msgstr "Bilinmeyen MP"
 msgid "OCTOBER"
 msgstr "Ekim"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr "Resmi Web Sitesi"
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Revolutionary Games'in web sitesini ziyaret et"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4029,11 +4079,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Fırsatçı"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Ayarlar"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Ayarlarını değiştir"
 
@@ -4242,7 +4292,7 @@ msgstr "Yöntemsel"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr "Patreon sayfamızı ziyaret et"
 
@@ -4300,8 +4350,8 @@ msgstr "Performans"
 msgid "PERFORM_UNBINDING"
 msgstr "Bağ koparmayı gerçekleştir"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/saniye"
 
@@ -4357,7 +4407,7 @@ msgstr "Gezegen oluşturma çok yakında!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Rastgele gezegen tohumu"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Oyuncu Hücresi"
 
@@ -4432,7 +4482,7 @@ msgstr "popülasyonu:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "arazideki popülasyon:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4486,7 +4536,7 @@ msgstr "önceki:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Yüklenen objeler işleniyor"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4530,11 +4580,11 @@ msgstr "Hızlı yükle"
 msgid "QUICK_SAVE"
 msgstr "Hızlı kaydet"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Çıkış"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Oyundan çık"
@@ -4576,7 +4626,7 @@ msgstr "Hazır"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Önerilen Thrive:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr "Subreddit'imizi ziyaret et"
 
@@ -4712,7 +4762,7 @@ msgstr ""
 "Ana menüye dönmek istediğine emin misin?\n"
 "Kaydedilmemiş ilerlemeler kaybedilecek."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Revolutionary Games'in resmi sitelerini ziyaret et"
 
@@ -4798,7 +4848,7 @@ msgstr "Rustisiyanin, demiri bir kimyasal halden diğerine dönüştürmek için
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "[thrive:compound type=\"iron\"]Demiri[/thrive:compound] [thrive:compound type=\"atp\"]ATP'ye[/thrive:compound] dönüştürür. [thrive:compound type=\"carbondioxide\"]Karbondioksit[/thrive:compound] ve [thrive:compound type=\"oxygen\"]oksijen[/thrive:compound] konsantrasyonu ile doğru orantılıdır."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Bir önceki başlatma hatasından dolayı, Thrive güvenli modda başladı.\n"
@@ -4810,7 +4860,7 @@ msgstr ""
 "\n"
 "Eğer başlatma hatasına neden olan sorunu düzeltmezsen, güvenli moda geri dönmek için Thrive'ı defalarca yeniden başlatman gerekecek."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive, Güvenli Modda Başlatıldı"
 
@@ -5172,7 +5222,7 @@ msgstr "Amonyak oluştur"
 msgid "SPAWN_ENEMY"
 msgstr "Düşman Oluştur"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Düşman oluşturma hilesi kullanılamaz çünkü bu arazi herhangi bir düşman tür içermemekte"
 
@@ -5232,7 +5282,7 @@ msgstr "Tür adı..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Tür adı çok uzun!"
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5347,17 +5397,17 @@ msgstr "Steam şu an mevcut değil, lütfen tekrar dene"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Bilinmeyen Steam hatası meydana geldi"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr "Steam'i Başlatma Başarısız"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Steam istemci kütüphanesini başlatma işlemi başarısız oldu. Steam özellikleri mevcut olmayacak.\n"
 "Lütfen Steam'in çalıştığından ve doğru hesap ile giriş yaptığınızdan emin olun. Eğer bu hata gitmezse, lütfen oyunu Steam istemci yazılımı üzerinden çalıştırın."
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr "Steam sayfamızı ziyaret et"
 
@@ -5397,7 +5447,7 @@ msgstr "Depo"
 msgid "STORAGE_COLON"
 msgstr "Depo:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "{0} olarak giriş yapıldı"
 
@@ -5512,7 +5562,7 @@ msgstr "Sıc."
 msgid "TESTING_TEAM"
 msgstr "Deneme Ekibi"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Thrive'ın bu kopyasını satın alarak Thrive'ın gelişimine katkıda bulunduğun teşekkür ederiz.\n"
@@ -5528,7 +5578,7 @@ msgstr ""
 "\n"
 "Eğer oyunu beğendiysen, lütfen arkadaşlarına bizden bahset."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr "Teşekkürler"
 
@@ -5587,7 +5637,7 @@ msgstr "Bu mod, Steam Atölyesi'nden yüklendi"
 msgid "THREADS"
 msgstr "İş Parçacıkları:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thriveopedi"
 
@@ -5743,7 +5793,7 @@ msgstr "Oyunu duraklat"
 msgid "TOGGLE_UNBINDING"
 msgstr "Bağ koparma moduna geç"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Araçlar"
 
@@ -5969,7 +6019,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Şimdi İncele"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr "Twitter yayınımızı ziyaret et"
 
@@ -6157,7 +6207,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Görüntüleyici"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Kaynak Kodunu İncele"
 
@@ -6169,7 +6219,7 @@ msgstr "VIP Destekçiler"
 msgid "VISIBLE"
 msgstr "Görünür"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Bir Özellik Öner"
 
@@ -6324,7 +6374,7 @@ msgstr "Xbox Series X"
 msgid "YEARS"
 msgstr "yıl"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr "YouTube kanalımızı ziyaret et"
 

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2023-01-30 07:23+0000\n"
 "Last-Translator: punctdan <yunusemredilek@hotmail.com>\n"
 "Language-Team: Turkish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/tr/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr "2D hareket stili:"
 
@@ -31,7 +31,7 @@ msgstr "3D Düzenleyici"
 msgid "3D_MOVEMENT"
 msgstr "3D Hareket"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr "3D Hareket stili:"
 
@@ -62,7 +62,7 @@ msgstr "Başka bir eylem devam ettiğinden, mevcut işlem engellendi"
 msgid "ACTIVE"
 msgstr "Hareketli"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Mevcut iş parçacıkları:"
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Ortam seviyesi"
 
@@ -166,11 +166,11 @@ msgstr "Ortam seviyesi"
 msgid "AMMONIA"
 msgstr "Amonyak"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Saklanacak otomatik kayıt miktarı:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Saklanacak çabuk kayıt miktarı:"
 
@@ -195,11 +195,11 @@ msgstr "Değişiklikleri Uygula"
 msgid "APRIL"
 msgstr "Nisan"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "BÜTÜN ayarları varsayılan değerlere sıfırlamak istediğinden emin misin?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Giriş ayarlarını varsayılan değerlere sıfırlamak istediğinden emin misin?"
 
@@ -215,7 +215,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Resmi yapan: {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Sanat Galerisi"
 
@@ -227,7 +227,7 @@ msgstr "Assembly belirtildiğinde, assembly modunun sınıfı gereklidir"
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "Oto Harmony etkinleştirildiğinde, Assembly modu gereklidir"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "CPU'da hiper iş parçacığını etkin varsay"
 
@@ -269,7 +269,7 @@ msgstr "Kayıt dosyası yazma girişimi başarısız oldu. Girilen kayıt ismi �
 msgid "AT_CURSOR"
 msgstr "İmleç Üzerinde:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Ses çıkış aygıtı:"
 
@@ -277,8 +277,8 @@ msgstr "Ses çıkış aygıtı:"
 msgid "AUGUST"
 msgstr "Ağustos"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Otomatik"
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "%{0:F1} tamamlandı. {1:n0}/{2:n0} adım."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Oyun esnasında otomatik olarak kaydet"
 
@@ -313,7 +313,7 @@ msgstr "Oyun esnasında otomatik olarak kaydet"
 msgid "AUTO_EVO"
 msgstr "Oto-Evrim"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Oto-Evrim Keşif Aracı"
 
@@ -342,7 +342,7 @@ msgstr "Oto-Evrim Durumu:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "Otomatik olarak ileri git"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Otomatik ({0}x{1})"
 
@@ -355,9 +355,9 @@ msgid "AWAKEN"
 msgstr "Uyandır"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -493,7 +493,7 @@ msgstr "Diğer hücrelerle bağ kurmaya izin verir. Bu çok hücrelilikte ilk ad
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Bağ kurma modunu açmak için [thrive:input]g_toggle_binding[/thrive:input] tuşuna bas. Bağ kurma modundayken, kendi türüne ait diğer hücrelere yaklaşarak onları kolonine ekleyebilirsin. Bir koloniden ayrılmak için [thrive:input]g_unbind_all[/thrive:input] tuşuna bas. Diğer hücrelere bağlıyken editöre giremezsin."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr "Eksenleri birbirine bağla"
 
@@ -555,7 +555,7 @@ msgstr "Bu hücre zarı kalsiyum karbonattan yapılmış güçlü bir kabuğa sa
 msgid "CAMERA"
 msgstr "Kamera"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -683,7 +683,7 @@ msgstr "Simetriyi değiştir"
 msgid "CHEATS"
 msgstr "Hileler"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Hile tuşları etkin"
 
@@ -773,7 +773,7 @@ msgstr "[thrive:compound type=\"glucose\"]Glukoz[/thrive:compound] üretir. [thr
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Seçili dosya adı ({0}) zaten mevcut. Üzerine yazılsın mı?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Renk sapması:"
 
@@ -814,15 +814,15 @@ msgstr "Eski Kayıtları Temizle"
 msgid "CLOSE"
 msgstr "Kapat"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Ayarlar kapatılsın mı?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Bulut çözünürlük bölücü:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Bulut simülasyonu minimum aralığı:"
 
@@ -838,7 +838,7 @@ msgstr "Çarpışan şekillerle varlıklar oluştur"
 msgid "COLOUR"
 msgstr "Renk"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Renk düzeltme:"
 
@@ -899,23 +899,23 @@ msgstr "Doygunluk değeri, belli bir renkteki gri miktarı"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Değer (parlaklık) değeri, renkteki parlaklığın şiddeti"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr "Topluluk Forumu"
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Topluluk forumumuzda Thrive topluluğuna katıl"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr "Topluluk Vikisi"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Topluluk vikimizi ziyaret et"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr "Derlenme tarihi:"
 
@@ -941,7 +941,7 @@ msgstr "Bileşikler:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Bileşik Dengesi"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Bileşik bulutları"
 
@@ -1026,7 +1026,7 @@ msgstr "Prototip evreye devam edilsin mi?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr "Kontrol Cihazı Eksen Görüntüleyicileri:"
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr "Kontrol Cihazı Ölü Bölgeleri"
 
@@ -1041,11 +1041,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr "Ölü Bölge:"
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr "Kontrol cihazı buton istemleri türü:"
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr "Kontrol cihazı hassasiyeti"
 
@@ -1053,11 +1053,11 @@ msgstr "Kontrol cihazı hassasiyeti"
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Hatayı Panoya Kopyala"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Protanop (Kırmızı-Yeşil)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Tritanop (Mavi-Sarı)"
 
@@ -1113,7 +1113,7 @@ msgstr "Oluşturuluyor..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Kayıttan objeler oluşturuluyor"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Jenerik"
 
@@ -1156,7 +1156,7 @@ msgstr ""
 "   Ortalama altıgen boyutu: {9}\n"
 "[b]Genel Organel Verileri:[/b]"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Özel kullanıcı adı:"
 
@@ -1221,7 +1221,7 @@ msgstr "Hata Ayıklama Paneli"
 msgid "DECEMBER"
 msgstr "Aralık"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Varsayılan çıkış aygıtı"
 
@@ -1283,7 +1283,7 @@ msgstr "Açıklama çok uzun"
 msgid "DESPAWN_ENTITIES"
 msgstr "Bütün Varlıkları Yok Et"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Tespit edilen CPU sayısı:"
 
@@ -1298,11 +1298,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Oyun Geliştiricileri"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr "Gelişme Forumu"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Gelişme forumumuzda gelişim güncellemelerini incele"
 
@@ -1310,11 +1310,11 @@ msgstr "Gelişme forumumuzda gelişim güncellemelerini incele"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Oyunun Geliştirilmesi Revolutionary Games Studio Tarafından Desteklenmiştir"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr "Gelişme Vikisi"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Geliştirici vikimizi ziyaret et"
 
@@ -1396,7 +1396,7 @@ msgstr "Left"
 msgid "DIRECTIONR"
 msgstr "Right"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Devre Dışı"
 
@@ -1404,7 +1404,7 @@ msgstr "Devre Dışı"
 msgid "DISABLE_ALL"
 msgstr "Hepsini Devre Dışı Bırak"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Yoksay ve devam et"
 
@@ -1442,33 +1442,33 @@ msgstr ""
 "Diğerlerine bağlı olmayan, yerleştirilmiş organeller var.\n"
 "Lütfen yerleştirdiğin bütün organelleri birbirine bağla veya değişikliklerini geri al."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr "Discord topluluk sunucumuza katıl"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Atlanan açılır pencereler:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 "Bu kısım, kaç tane açılır pencerenin kullanıcı tarafından kalıcı olarak atlandığını gösterir.\n"
 "Eğer aslında görülmek istenen bazı açılır pencereler atlandıysa, bütün atlanan açılır pencerelerin tekrar görülmesi için yandaki buton kullanılabilir."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr "Bunu bir daha gösterme"
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Yetenekler çubuğunu göster"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Arkaplan parçacıklarını göster"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Parça seçim butonu isimlerini göster"
 
@@ -1503,7 +1503,7 @@ msgstr "Tam ekranda görüntülemek için çift tıkla"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "İki katmanlı bir hücre zarı. Hasara karşı koruyuculuğu daha iyidir ve şeklinin bozulmaması için daha az enerji harcar. Ancak hücreyi biraz yavaşlatır ve kaynakların emilim oranını düşürür."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Bunun için bir daha uyarma"
 
@@ -1656,7 +1656,7 @@ msgstr ""
 "\n"
 "Hazır olunca, devam etmek için sağ alttaki \"sonraki\" butonuna bas."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1672,7 +1672,7 @@ msgstr "Bütün Uyumlu Modları Etkinleştir"
 msgid "ENABLE_EDITOR"
 msgstr "Düzenleyiciyi aç"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Arayüz ışık efektlerini etkinleştir"
 
@@ -1729,7 +1729,7 @@ msgstr "Ortamı göster / gizle"
 msgid "EPIPELAGIC"
 msgstr "Epipelajik"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Hata"
 
@@ -1741,16 +1741,16 @@ msgstr "Mod için klasör oluştururken hata oluştu"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Mod bilgi dosyası oluştururken hata oluştu"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Hata: Yeni ayarlar yapılandırma dosyasına kaydedilemedi."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(oyunda rastgele oluşan gizemler)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Mod bilgi dosyası oluştururken hata oluştu"
@@ -1786,11 +1786,11 @@ msgstr ""
 "\n"
 "Bunlardan hiçbiri geçerli değilse, bir hata oluşmuştur. Lütfen geliştirici ekibi bilgilendirin ve oyun günlüklerini sağlayın."
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr "Tam Thrive sürümü:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Thrive'ın mevcut sürümünden derlenen tam kod işlemesi"
 
@@ -1806,7 +1806,7 @@ msgstr "Kayıt verisi yüklenirken bir sorun oluştu"
 msgid "EXIT"
 msgstr "Çık"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Çık ve Başlatıcıya Dön"
 
@@ -1856,7 +1856,7 @@ msgstr "arazide nesli tükendi"
 msgid "EXTINCT_SPECIES"
 msgstr "Nesli Tükenen Tür"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Ekstralar"
 
@@ -1864,7 +1864,7 @@ msgstr "Ekstralar"
 msgid "EXTRA_OPTIONS"
 msgstr "Ek Seçenekler"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Facebook sayfamızı ziyaret et"
 
@@ -1896,12 +1896,12 @@ msgstr "Etkin"
 msgid "FEBRUARY"
 msgstr "Şubat"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Steam istemci kütüphanesi başlatma başarısız"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1923,11 +1923,11 @@ msgstr ""
 "Toplam CPU Süresi:\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2051,7 +2051,7 @@ msgstr "Bu türü fosilleştir (zaten fosilleştirildi)"
 msgid "FOSSILISE"
 msgstr "Fosilleştir"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2081,7 +2081,7 @@ msgstr "Editörden ayrıldığında bedava glukoz bulutu"
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(her kuşağa, yakınlardaki serbest bir glukoz bulutuyla başla)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Tam ekran"
 
@@ -2109,23 +2109,23 @@ msgstr "Kuşaklar"
 msgid "GENERATION_COLON"
 msgstr "Kuşak:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr "GitHub depomuzu ziyaret et"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2 Mod Uyarısı"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Thrive'ı GLES2 ile çalıştırmaktasın. Bu mod ciddi derecede test edilmemiştir ve sorunlara neden olması muhtemel. Ekran kartlarını güncelleştirmeyi dene ve/veya Thrive'ı çalıştırırken AMD ya da Nvidia grafiklerini kullanmaya zorla."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr "GLES3"
 
@@ -2178,11 +2178,11 @@ msgstr "Anladım"
 msgid "GPL_LICENSE_HEADING"
 msgstr "GPL lisans metni aşağıdaki gibidir:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "GPU:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Grafikler"
 
@@ -2190,7 +2190,7 @@ msgstr "Grafikler"
 msgid "GRAPHICS_TEAM"
 msgstr "Grafik Ekibi"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "Arayüz"
 
@@ -2206,7 +2206,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "Kullanıcı Arayüzünde Sekme Gezinme"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Arayüz seviyesi"
 
@@ -2228,11 +2228,11 @@ msgstr "Yardım"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Oyunun nasıl oynanacağını öğren"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(üst değerler performansı arttırır)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(daha üst değerler performansı düşürür)"
 
@@ -2256,7 +2256,7 @@ msgstr "İmleci göstermek için [thrive:input]g_free_cursor[/thrive:input] tuş
 msgid "HOME"
 msgstr "Ana Sayfa"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr "Yatay:"
 
@@ -2328,7 +2328,7 @@ msgstr "İçeri Alınmış Madde"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Yeni bir dünya oluştur"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Girişler"
 
@@ -2381,8 +2381,8 @@ msgstr "Geçersiz URL formatı"
 msgid "INVALID_URL_SCHEME"
 msgstr "Geçersiz URL şeması"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr "Ters Çevrilmiş"
 
@@ -2405,7 +2405,7 @@ msgstr "Demir"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Demir Kemolitoototrofisi"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr "Itch.io sayfamızı ziyaret et"
 
@@ -2413,19 +2413,19 @@ msgstr "Itch.io sayfamızı ziyaret et"
 msgid "JANUARY"
 msgstr "Ocak"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "JSON hata ayıklama modu:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Her zaman"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Otomatik olarak"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Hiçbir zaman"
 
@@ -2607,19 +2607,19 @@ msgstr "Num ."
 msgid "KPSUBTRACT"
 msgstr "Num -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Dil:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Bu dil %{0} tamamlandı"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Bu dilin çevirisi halen devam etmekte (%{0} tamamlandı)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Bu çeviri henüz bitmemiş (%{0} tamamlandı), lütfen tamamlamamıza yardımcı ol!"
 
@@ -2781,7 +2781,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "Sol fare tuşu"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Lisanslar"
 
@@ -2849,7 +2849,7 @@ msgstr "Gece"
 msgid "LIGHT_MAX"
 msgstr "Maksimum ışık"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "En büyük"
 
@@ -2861,31 +2861,31 @@ msgstr "Büyümeyi sağlayan bileşiklerin kullanımını sınırlandır"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(etkinleştirildiğinde büyüme hızını sınırlandırır, devre dışı bırakıldığında sadece mevcut bileşikler büyüme hızını etkiler)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Aşırı büyük"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Büyük"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Normal"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Küçük"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Aşırı küçük"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Çok büyük"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Çok küçük"
 
@@ -2909,7 +2909,7 @@ msgstr "Yükle"
 msgid "LOADING"
 msgstr "Yükleniyor"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Yükleniyor..."
@@ -2940,12 +2940,12 @@ msgstr "Bir hatayı düzeltmek için düzenleyicideki geri al butonuna basın"
 msgid "LOAD_FINISHED"
 msgstr "Yükleme bitti"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Oyun Yükle"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Daha önce kaydedilmiş oyunları yükle"
 
@@ -3019,7 +3019,7 @@ msgstr "Mart"
 msgid "MARINE_SNOW"
 msgstr "Deniz karı"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Ana ses"
 
@@ -3027,15 +3027,15 @@ msgstr "Ana ses"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Zorunlu soy tükenmelerinden önce bir arazideki maksimum tür sayısı"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "Maksimum FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Sınırsız"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Maksimum varlık sayısı:"
 
@@ -3222,7 +3222,7 @@ msgstr "Her kuşakta, harcanacak 100 mutasyon puanınız (MP) vardır ve her de�
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Her çoğaldığınızda, Mikrop Düzenleyicisi'ne giriş yaparsınız. Burada, türünüzün başarısını arttırmak için türünüzde (organelleri ekleyerek, taşıyarak veya kaldırarak) değişiklikler yapabilirsiniz. Mikrop Evresi'nde düzenleyiciye yapılan her ziyaret, [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] milyon yıllık evrimi temsil eder."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Mikrop Editörü Serbest Yapım Modu"
 
@@ -3406,7 +3406,7 @@ msgstr "Minimum:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "{0} veri kümesinden daha az gösterilemez!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Diğer"
 
@@ -3469,11 +3469,11 @@ msgstr "Organelde Değişiklik Yap"
 msgid "MODIFY_TYPE"
 msgstr "Türde Değişiklik Yap"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Modlar"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Yüklü modlar algılandı ancak etkinleştirilmiş bir mod yok.\n"
@@ -3562,11 +3562,11 @@ msgstr "İç (Klasör) Ad:"
 msgid "MOD_LICENSE"
 msgstr "Mod Lisansı:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Mod Yükleme Hataları"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Bir ya da daha fazla modu yüklerken sorun oluştu. Loglar, ek bilgi içerebilir."
 
@@ -3619,11 +3619,11 @@ msgstr "Mod Sürümü:"
 msgid "MORE_INFO"
 msgstr "Daha Fazla Bilgi Göster"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr "Fare serbest bakış hassasiyeti"
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr "Fare hassasiyetini pencere büyüklüğüne göre arttırma"
 
@@ -3737,7 +3737,7 @@ msgstr "Birden Fazla Damla Formu"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Birden Fazla Organel"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Çoklu örnekleme kenar yumuşatma:"
 
@@ -3752,7 +3752,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Müzik"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Müzik seviyesi"
 
@@ -3772,9 +3772,9 @@ msgstr "(organellerin, hücre zarlarının ve diğer öğelerin editördeki mali
 msgid "MUTATION_POINTS"
 msgstr "Mutasyon Puanı"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Sessiz"
 
@@ -3810,11 +3810,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Biyoçeşitliliği artıran türler için başlangıç popülasyonu"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Yeni Oyun"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "Yeni bir oyun başlat"
 
@@ -3879,7 +3879,7 @@ msgstr "Azot Fiksasyon Plastidi, hücrelerde ana gelişim yapı maddesi olan [th
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "[thrive:compound type=\"atp\"]ATP'yi[/thrive:compound] [thrive:compound type=\"ammonia\"]amonyağa[/thrive:compound] dönüştürür. [thrive:compound type=\"nitrogen\"]Azot[/thrive:compound] ve [thrive:compound type=\"oxygen\"]oksijen[/thrive:compound] konsantrasyonu ile doğru orantılıdır."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Yok"
 
@@ -3926,7 +3926,7 @@ msgstr "Hiçbir olay görülmedi"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Fosiller dizini bulunamadı"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr "Hiçbir Mod Etkinleştirilmedi"
 
@@ -3943,7 +3943,7 @@ msgstr "Hiçbir Kayıt Bulunamadı"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Kayıt dizini bulunamadı"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Ekran görüntüsü dizini bulunamadı"
 
@@ -3991,15 +3991,15 @@ msgstr "Bilinmeyen MP"
 msgid "OCTOBER"
 msgstr "Ekim"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr "Resmi Web Sitesi"
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Revolutionary Games'in web sitesini ziyaret et"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4036,7 +4036,7 @@ msgstr "Yardım ekranını aç"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Serbest Yapım Editöründe Aç"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Log Klasörünü Aç"
 
@@ -4052,7 +4052,7 @@ msgstr "Organel menüsünü aç"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Kayıt Dizinini Aç"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Ekran Görüntüsü Klasörünü Aç"
 
@@ -4060,7 +4060,7 @@ msgstr "Ekran Görüntüsü Klasörünü Aç"
 msgid "OPEN_THE_MENU"
 msgstr "Menüyü aç"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Oyunun Çevrilmesine Yardımcı Ol"
 
@@ -4079,11 +4079,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Fırsatçı"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Ayarlar"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Ayarlarını değiştir"
 
@@ -4292,7 +4292,7 @@ msgstr "Yöntemsel"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr "Patreon sayfamızı ziyaret et"
 
@@ -4342,7 +4342,7 @@ msgstr "Barışçıl"
 msgid "PERCENTAGE_VALUE"
 msgstr "%{0}"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Performans"
 
@@ -4431,7 +4431,7 @@ msgstr "Oyuncuyu Çoğalt"
 msgid "PLAYER_EXTINCT"
 msgstr "Oyuncunun nesli tükendi"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Oyuncuya bağlı"
 
@@ -4445,23 +4445,23 @@ msgstr ""
 "Oyuncu\n"
 "Hızı"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr "PlayStation 3"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr "PlayStation 4"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr "PlayStation 5"
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Tanıtım videosunu oynat"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "Yeni oyunda mikrop tanıtımını oynat"
 
@@ -4580,11 +4580,11 @@ msgstr "Hızlı yükle"
 msgid "QUICK_SAVE"
 msgstr "Hızlı kaydet"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Çıkış"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Oyundan çık"
@@ -4626,7 +4626,7 @@ msgstr "Hazır"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Önerilen Thrive:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr "Subreddit'imizi ziyaret et"
 
@@ -4679,7 +4679,7 @@ msgstr "Üreme:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Hücre çekirdeği gerektirir"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Sıfırla"
 
@@ -4687,23 +4687,23 @@ msgstr "Sıfırla"
 msgid "RESET_DEADZONES"
 msgstr "Ölü Bölgeleri Sıfırla"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr "Atlanan Açılır Pencereleri Sıfırla"
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Girişler varsayılana sıfırlansın mı?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr "Tuş atamalarını sıfırla"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "Varsayılanlar"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Varsayılanlara sıfırlansın mı?"
 
@@ -4712,7 +4712,7 @@ msgstr "Varsayılanlara sıfırlansın mı?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr "Temel yutmaya karşı dirençli"
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Çözünürlük:"
 
@@ -4762,7 +4762,7 @@ msgstr ""
 "Ana menüye dönmek istediğine emin misin?\n"
 "Kaydedilmemiş ilerlemeler kaybedilecek."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Revolutionary Games'in resmi sitelerini ziyaret et"
 
@@ -4794,7 +4794,7 @@ msgstr "Sağa döndür"
 msgid "ROTATION_COLON"
 msgstr "Dönme:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Oyun esnasında oto-evrimi çalıştır"
 
@@ -4848,7 +4848,7 @@ msgstr "Rustisiyanin, demiri bir kimyasal halden diğerine dönüştürmek için
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "[thrive:compound type=\"iron\"]Demiri[/thrive:compound] [thrive:compound type=\"atp\"]ATP'ye[/thrive:compound] dönüştürür. [thrive:compound type=\"carbondioxide\"]Karbondioksit[/thrive:compound] ve [thrive:compound type=\"oxygen\"]oksijen[/thrive:compound] konsantrasyonu ile doğru orantılıdır."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Bir önceki başlatma hatasından dolayı, Thrive güvenli modda başladı.\n"
@@ -4860,15 +4860,15 @@ msgstr ""
 "\n"
 "Eğer başlatma hatasına neden olan sorunu düzeltmezsen, güvenli moda geri dönmek için Thrive'ı defalarca yeniden başlatman gerekecek."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive, Güvenli Modda Başlatıldı"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Kaydet"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Kaydet ve devam et"
 
@@ -4966,20 +4966,20 @@ msgstr "Kaydetmek şu an mümkün değil çünkü:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Kaydetme başarılı"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr "Yok"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr "Arttırılmış"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr "Tersine Arttırılmış"
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "Ekrana bağlı"
 
@@ -5076,7 +5076,7 @@ msgstr "Durağan"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Bu ayar değiştirilirse, değişiklik yalnızca yeni başlatılan oyunlara uygulanır"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Ses efekti seviyesi"
 
@@ -5092,21 +5092,25 @@ msgstr "Yardım menüsünü göster"
 msgid "SHOW_TUTORIALS"
 msgstr "Oyun rehberini göster"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Oyun rehberini göster (mevcut oyunda)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Oyun rehberini göster (yeni oyunlarda)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Kaydedilmemiş ilerlemeler uyarısını göster"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Oyuncu oyundan çıkmayı denediğinde, kaydedilmemiş ilerlemeler uyarısı veren açılır pencereyi etkinleştirir / devre dışı bırakır."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5154,7 +5158,7 @@ msgstr "Silika"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Bu hücre zarı silikadan yapılmış güçlü bir duvara sahiptir. Toplam hasara iyi direnir ve fiziksel hasara karşı çok dirençlidir. Ayrıca formunu korumak için daha az enerji gerektirir. Ancak hücreyi büyük oranda yavaşlatır ve hücre, kaynakları düşük oranda emer."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5194,7 +5198,7 @@ msgstr "[thrive:compound type=\"glucose\"]Glukozu[/thrive:compound], [thrive:com
 msgid "SMALL_IRON_CHUNK"
 msgstr "Küçük Demir Parçası"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Ses"
 
@@ -5397,17 +5401,17 @@ msgstr "Steam şu an mevcut değil, lütfen tekrar dene"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Bilinmeyen Steam hatası meydana geldi"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr "Steam'i Başlatma Başarısız"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 "Steam istemci kütüphanesini başlatma işlemi başarısız oldu. Steam özellikleri mevcut olmayacak.\n"
 "Lütfen Steam'in çalıştığından ve doğru hesap ile giriş yaptığınızdan emin olun. Eğer bu hata gitmezse, lütfen oyunu Steam istemci yazılımı üzerinden çalıştırın."
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr "Steam sayfamızı ziyaret et"
 
@@ -5447,7 +5451,7 @@ msgstr "Depo"
 msgid "STORAGE_COLON"
 msgstr "Depo:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "{0} olarak giriş yapıldı"
 
@@ -5562,7 +5566,7 @@ msgstr "Sıc."
 msgid "TESTING_TEAM"
 msgstr "Deneme Ekibi"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Thrive'ın bu kopyasını satın alarak Thrive'ın gelişimine katkıda bulunduğun teşekkür ederiz.\n"
@@ -5578,7 +5582,7 @@ msgstr ""
 "\n"
 "Eğer oyunu beğendiysen, lütfen arkadaşlarına bizden bahset."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr "Teşekkürler"
 
@@ -5633,11 +5637,11 @@ msgstr "Bu mod, yerel olarak yüklendi"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Bu mod, Steam Atölyesi'nden yüklendi"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "İş Parçacıkları:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thriveopedi"
 
@@ -5793,7 +5797,7 @@ msgstr "Oyunu duraklat"
 msgid "TOGGLE_UNBINDING"
 msgstr "Bağ koparma moduna geç"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Araçlar"
 
@@ -5857,7 +5861,7 @@ msgstr "Bazı türleri fosilleştirmeyi dene!"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Kaydetmeyi dene!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Bir ekran görüntüsü almayı dene!"
 
@@ -6019,11 +6023,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Şimdi İncele"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr "Twitter yayınımızı ziyaret et"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6048,7 +6052,7 @@ msgstr "Hepsinin bağını kopar"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Bağ Koparma Modu"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr "Bu bir hata ayıklama sürümü, bu yüzden aşağıdaki bilgi muhtemelen güncel değil"
 
@@ -6068,7 +6072,7 @@ msgstr "Son eylemi geri al"
 msgid "UNKNOWN"
 msgstr "Bilinmeyen"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Bilinmeyen"
 
@@ -6080,7 +6084,7 @@ msgstr "Bilinmeyen fare tuşu"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Windows'ta bilinmiyor"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "Bilinmeyen sürüm"
 
@@ -6088,7 +6092,7 @@ msgstr "Bilinmeyen sürüm"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Bu Mod İçin Bilinmeyen Atölye ID'si"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Kaydedilmemiş değişiklikler var.\n"
@@ -6132,7 +6136,7 @@ msgstr "Yükleme Başarılı"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Lisanslar ve Kullanılan Kitaplıklar"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "Kullanılan işleyici:"
 
@@ -6148,7 +6152,7 @@ msgstr "Oto Harmony Yüklemeyi Kullan"
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Assembly'den Harmony yamalarını otomatik olarak yükle (mod sınıfı belirlemeyi gerektirmez)"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Özel bir kullanıcı adı kullan"
 
@@ -6156,11 +6160,11 @@ msgstr "Özel bir kullanıcı adı kullan"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "Biyoçeşitliliği arttıran tür oluşumu mevcut türlerden popülasyon çalsın"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Arkaplanda çalışan iş parçacığı sayısını elle ayarla"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr "Sanal pencere büyüklüğünü kullan"
 
@@ -6186,7 +6190,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Sürüm:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr "Dikey:"
 
@@ -6195,11 +6199,11 @@ msgstr "Dikey:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Dikey (Eksen: {0})"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "Mevcut kullanılan grafik belleği:"
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0} MiB"
 
@@ -6207,7 +6211,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Görüntüleyici"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Kaynak Kodunu İncele"
 
@@ -6219,7 +6223,7 @@ msgstr "VIP Destekçiler"
 msgid "VISIBLE"
 msgstr "Görünür"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Bir Özellik Öner"
 
@@ -6239,7 +6243,7 @@ msgstr "Volume Mute"
 msgid "VOLUMEUP"
 msgstr "Volume Up"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "Dikey eşitleme"
 
@@ -6346,7 +6350,7 @@ msgstr ""
 "Sonraki evre prototiplerini dahil et: {0}\n"
 "Sürpriz yumurtaları dahil et: {1}"
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "Dünyaya bağlı"
 
@@ -6354,15 +6358,15 @@ msgstr "Dünyaya bağlı"
 msgid "WORST_PATCH_COLON"
 msgstr "En Kötü Arazi:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr "Xbox 360"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr "Xbox One"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr "Xbox Series X"
 
@@ -6374,7 +6378,7 @@ msgstr "Xbox Series X"
 msgid "YEARS"
 msgstr "yıl"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr "YouTube kanalımızı ziyaret et"
 

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2023-01-13 08:00+0000\n"
 "Last-Translator: PanOlexMurzohan <oleksandrkurast@gmail.com>\n"
 "Language-Team: Ukrainian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/uk/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "3D редактор"
 msgid "3D_MOVEMENT"
 msgstr "3D переміщення"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "Дія заблокована, поки не завершилася ін
 msgid "ACTIVE"
 msgstr "Рухливі"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "Поточні потоки:"
 
@@ -143,7 +143,7 @@ msgstr "Статистика Організму"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "Гучність оточення"
 
@@ -154,11 +154,11 @@ msgstr "Гучність оточення"
 msgid "AMMONIA"
 msgstr "Аміак"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "Кількість можливих автозбереженнь:"
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "Кількість можливих швидких збережень:"
 
@@ -183,11 +183,11 @@ msgstr "Застосувати зміни"
 msgid "APRIL"
 msgstr "Квітень"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "Ви точно хочете скинути УСІ налаштування до замовчуваних?"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "Ви точно хочете скинути вхідні дані до замовчуваних?"
 
@@ -203,7 +203,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Малюнок від {0}"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "Галерея"
 
@@ -215,7 +215,7 @@ msgstr "Потрібен клас збірки моду, коли її вказ�
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "Збірка модів обов'язкова, коли автоматична гармонія увімкнена"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "Вважається ЦП ввімкнув гіперчитання"
 
@@ -257,7 +257,7 @@ msgstr "Спроба записати збереження провалилас�
 msgid "AT_CURSOR"
 msgstr "Під курсором:"
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "Пристрій виведення аудіо:"
 
@@ -265,8 +265,8 @@ msgstr "Пристрій виведення аудіо:"
 msgid "AUGUST"
 msgstr "Серпень"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "Авто"
 
@@ -293,7 +293,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "{0:F1}% зроблено. {1:n0}/{2:n0} виконується."
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "Автозбереження під час гри"
 
@@ -301,7 +301,7 @@ msgstr "Автозбереження під час гри"
 msgid "AUTO_EVO"
 msgstr "Авто-ево"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Інструменти дослідження Авто-ево"
 
@@ -330,7 +330,7 @@ msgstr "Статус Авто-ево:"
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "автоматичн рухайтесь вперед"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "Автоматично ({0}x{1})"
 
@@ -343,9 +343,9 @@ msgid "AWAKEN"
 msgstr "Пробудити"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -481,7 +481,7 @@ msgstr "Дозволяє з'єднуватися з іншими клітина�
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "Натисніть [thrive:input]g_toggle_binding[/thrive:input] для переходу до зв'язувального режиму. У ньому ви можете з'єднуватись з іншими клітинами вашого ж виду прермістивши їх до своєї колонії. Щоб покинути її натисніть [thrive:input]g_unbind_all[/thrive:input]."
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr "Об'єднати осі разом"
 
@@ -543,7 +543,7 @@ msgstr "Ця мембрана має міцну оболонку з карбон
 msgid "CAMERA"
 msgstr "Камера"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -671,7 +671,7 @@ msgstr "Змінити симетрію"
 msgid "CHEATS"
 msgstr "Чити"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "Кнопки ввімкнення читів"
 
@@ -761,7 +761,7 @@ msgstr "Продукує [thrive:compound type=\"glucose\"][/thrive:compound]. �
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "Обране файлове ім'я ({0}) уже існує. Переписати?"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "Хроматична аберація:"
 
@@ -802,15 +802,15 @@ msgstr "Очистити старі збереження"
 msgid "CLOSE"
 msgstr "Закрити"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "Закрити налаштування?"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "Дільник роздільної здатності хмари:"
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "Мінімальний інтервал симуляції хмари:"
 
@@ -826,7 +826,7 @@ msgstr "Cпавнити сутності з формами зіткнення"
 msgid "COLOUR"
 msgstr "Колір"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "Кольорокорекція:"
 
@@ -887,23 +887,23 @@ msgstr "Значення насиченості, частки сірого в п
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Оцінка (яскравість) значення, яскравість або інтенсивність кольору"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr "Форум спільноти"
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Приєднуйтеся до спільноти Thrive на нашому форумі спільноти"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr "Wiki спільноти"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Відвідайте наше wiki спільноти"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr "Збірка в:"
 
@@ -929,7 +929,7 @@ msgstr "Сполуки:"
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "Баланс сполук"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "Хмари сполук"
 
@@ -1014,7 +1014,7 @@ msgstr "Продовжити створювати прототипи?"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr "Візуалізатори осі контролерів:"
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr "Контролер мертвих зон"
 
@@ -1029,11 +1029,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr "Мертва зона:"
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr "Чутливість контролера"
 
@@ -1041,11 +1041,11 @@ msgstr "Чутливість контролера"
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "Скопіювати помилку з до буферу обміну"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "Протаноп (червоно-зелений)"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "Тританоп (блакитно-жовтий)"
 
@@ -1101,7 +1101,7 @@ msgstr "Створення..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Створюємо об'єкти зі збереження"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "Титри"
 
@@ -1144,7 +1144,7 @@ msgstr ""
 "  Середній розмір гексу: {9}\n"
 "[b]Заггальні Дані про Органели:[/b]\n"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "Звичайне ім'я користувача:"
 
@@ -1209,7 +1209,7 @@ msgstr "панель налагоджування"
 msgid "DECEMBER"
 msgstr "Грудень"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "Пристрій виведення за замовчуванням"
 
@@ -1271,7 +1271,7 @@ msgstr "Опис надто довгий"
 msgid "DESPAWN_ENTITIES"
 msgstr "Деспавн усіх сутностей"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "Виявлено ядер ЦП:"
 
@@ -1286,11 +1286,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Розробники"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr "Форум розробки"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Поглянути оновлення розробки на нашому форумі"
 
@@ -1298,11 +1298,11 @@ msgstr "Поглянути оновлення розробки на нашому
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Розробницька підтримка від Revolutionary Games Studio"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr "Розробницьке wiki"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Відвідайте наше розробницьке wiki"
 
@@ -1384,7 +1384,7 @@ msgstr "Вліво"
 msgid "DIRECTIONR"
 msgstr "Вправо"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "Вимкнено"
 
@@ -1392,7 +1392,7 @@ msgstr "Вимкнено"
 msgid "DISABLE_ALL"
 msgstr "Відключити все"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "Відмінити й продовжити"
 
@@ -1430,33 +1430,33 @@ msgstr ""
 "Тут розміщені органели, які не з'єднання з рештою.\n"
 "Будь-ласка приєднайте одна з одною всі розміщені органели, або скасуйте зміни."
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr "Приєднуйтесь до спільноти Discord серверу"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "Закриті спливаючі вікна:"
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 "Це показує як багато спливаючих вікон закрито користувачем остаточно.\n"
 "Якщо деякі спливаючі вікна закриті, та вони вам потрібні, тоді можна використати кнопку поблизу, щоб знову відновити спливаючі вікна."
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr "Більше не показувати"
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "Панель здібностей дисплею"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "Показ частинок заднього плану"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "Панель назв кнопок вибору"
 
@@ -1491,7 +1491,7 @@ msgstr "Двічі клікніть, щоб переглянути в повно
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Двохшарова мембрана– це кращий захист від пошкоджень та потребує менше енергії, щоб не деформуватись. Проте вона уповільнює клітину та поглинання ресурсів."
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Більше не нагадувати про це"
 
@@ -1644,7 +1644,7 @@ msgstr ""
 "\n"
 "Коли будете готові, натисніть кнопку \"Далі\" справа знизу, щоб перейти до наступної вкладки редактора."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8х"
 
@@ -1660,7 +1660,7 @@ msgstr "Увімкнути всі сумісні моди"
 msgid "ENABLE_EDITOR"
 msgstr "Увімкнути редактор"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "Увімкнути світлові ефекти ГІК"
 
@@ -1717,7 +1717,7 @@ msgstr "Показати/ приховати оточення"
 msgid "EPIPELAGIC"
 msgstr "Поверхня моря"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "Помилка"
 
@@ -1729,16 +1729,16 @@ msgstr "Помилка створення папки для моду"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "Помилка створення інформаційного файлу"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Помилка: Невдалось зберегти нові налаштування конфігурованих файлів."
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "(рандомно заспавнені секрети в грі)"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "Помилка створення інформаційного файлу"
@@ -1774,11 +1774,11 @@ msgstr ""
 "\n"
 "Якщо нічого не підходить, то сталася помилка. Будь-ласка , повідомте розробницьку команду та внесіть це до журналу гри."
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr "Точна версія Thrive:"
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "Це точний підтверджувальний код компіляції цієї версії Thrive"
 
@@ -1794,7 +1794,7 @@ msgstr "З'явилося заперечення, коли завантажув�
 msgid "EXIT"
 msgstr "Вихід"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Вийти до лаунчера"
 
@@ -1845,7 +1845,7 @@ msgstr "вимерли в ділянці"
 msgid "EXTINCT_SPECIES"
 msgstr "Вимерлі види"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "Додаткове"
 
@@ -1853,7 +1853,7 @@ msgstr "Додаткове"
 msgid "EXTRA_OPTIONS"
 msgstr "Додаткові налаштування"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Відвідайте на сторінку Facebook"
 
@@ -1885,12 +1885,12 @@ msgstr "Увімкнути"
 msgid "FEBRUARY"
 msgstr "Лютий"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Ініціалізація бібліотеки Steam клієнту невдалася"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1912,11 +1912,11 @@ msgstr ""
 "Загальний час ЦП:\n"
 " {18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgstr "Скам'янити цей вид (вже скам'янено)"
 msgid "FOSSILISE"
 msgstr "Скам'яніти"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4х"
 
@@ -2070,7 +2070,7 @@ msgstr "Безкоштовна глюкозна хмара, коли ви вих
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "(початок з безкоштовною глюкозною хмарою біля кожної генерації)"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "Повноекрання"
 
@@ -2098,23 +2098,23 @@ msgstr "Генерації"
 msgid "GENERATION_COLON"
 msgstr "Генерація:"
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr "Відвідайте наше сховище у GitHub"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "Режим попереджень GLES2"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Ви граєте у Thrive за допомогою GLES2. Це не є перевіреним та може викликати проблеми. Спробуйте оновити свої відеодрайвери та/або використати графіку від Nvidia або AMD для запуску Thrive."
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr "GLES3"
 
@@ -2167,11 +2167,11 @@ msgstr "Зрозуміло"
 msgid "GPL_LICENSE_HEADING"
 msgstr "Відслідкований Текст ліцензії GPL:"
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "ЦПУ:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "Графіка"
 
@@ -2179,7 +2179,7 @@ msgstr "Графіка"
 msgid "GRAPHICS_TEAM"
 msgstr "Графічна команда"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "ГІК"
 
@@ -2196,7 +2196,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} Тис"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "Гучність ГІК"
 
@@ -2218,11 +2218,11 @@ msgstr "Допомога"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "Допомога"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "(вищі значення покращать продуктивність)"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "(вищі значення погіршать продуктивність)"
 
@@ -2246,7 +2246,7 @@ msgstr "Утримуйте [thrive:input]g_free_cursor[/thrive:input] для к�
 msgid "HOME"
 msgstr "Дім"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr "Горизонталь:"
 
@@ -2318,7 +2318,7 @@ msgstr "Поглинута матерія"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "Створити новий світ"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "Керування"
 
@@ -2371,8 +2371,8 @@ msgstr "Недійсний URL формат"
 msgid "INVALID_URL_SCHEME"
 msgstr "Недійсна схема URL"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr "Перевернутий"
 
@@ -2395,7 +2395,7 @@ msgstr "Залізо"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Хемолітоавтотрофія заліза"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr "Відвідайте"
 
@@ -2403,19 +2403,19 @@ msgstr "Відвідайте"
 msgid "JANUARY"
 msgstr "Січень"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "Режим направення JSON:"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "Завжди"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "Автоматично"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "Ніколи"
 
@@ -2597,19 +2597,19 @@ msgstr "Ввести."
 msgid "KPSUBTRACT"
 msgstr "Ввести-"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "Мова:"
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "Ця мова на {0}% готова"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "Прогрес перекладу на цю мову зараз солов'їну ({0}% готово)"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Цей переклад дуже неповний ({0}% готово), буь-ласка допоможіть виправити ця ситуацію!!!"
 
@@ -2771,7 +2771,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "ЛКМ"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "Ліцензія"
 
@@ -2839,7 +2839,7 @@ msgstr "Ніч"
 msgid "LIGHT_MAX"
 msgstr "Максимальне світло"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "Екстримальний"
 
@@ -2851,31 +2851,31 @@ msgstr "Ліміт використання сполук для росту"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "(Коли ввімкнено обмеження швидкісті росту, а якщо вимкнено, лише сполуки вплинуть на швидкість росту)"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "Велетенський"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "Великий"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "Нормальний"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "Малий"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "Крихітний"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "Дуже великий"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "Дуже малий"
 
@@ -2899,7 +2899,7 @@ msgstr "Завантажити"
 msgid "LOADING"
 msgstr "Завантаження"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Завантажити..."
@@ -2930,12 +2930,12 @@ msgstr "Натисніть на кнопку скасувати, аби випр
 msgid "LOAD_FINISHED"
 msgstr "Завантаження завершено"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Завантажити гру"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Завантажити раніше збережену гру"
 
@@ -3009,7 +3009,7 @@ msgstr "Березень"
 msgid "MARINE_SNOW"
 msgstr "Морський сніг"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "Загальна гучність"
 
@@ -3017,15 +3017,15 @@ msgstr "Загальна гучність"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "Максимум видів в ділянці"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "МАКСимальні кількість FPS:"
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "Необмежено"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "Максимальне число сутностей:"
 
@@ -3213,7 +3213,7 @@ msgstr "Кожного покоління ви отримуєте 100 очок �
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Ви розмножуєтесь щоразу, як заходите до Мікробного Редактора, де модна змінити свій вид (перміщати, додавати, видаляти органели) для підвищення успішності виду. Кожен візит до мікробного редактору представляє собою [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] міліон років еволюції."
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Режим творчого мікробного редактор"
 
@@ -3396,7 +3396,7 @@ msgstr "Мінімум:"
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "Не дозволено показувати менше {0} наборів данних!"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "Інше"
 
@@ -3459,11 +3459,11 @@ msgstr "Модифікувати органелу"
 msgid "MODIFY_TYPE"
 msgstr "Змінити тип"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Моди"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Встановлений мод виявлено, але увімкнених модів нема.\n"
@@ -3552,11 +3552,11 @@ msgstr "Внутрішня (папкова) назва:"
 msgid "MOD_LICENSE"
 msgstr "Ліцензія на моду:"
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Помилки завантаження модифікації"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Виникли помилки під час завантаження декількох модифікацій. Додаткова інформація міститься у журналах."
 
@@ -3609,11 +3609,11 @@ msgstr "Версія моду:"
 msgid "MORE_INFO"
 msgstr "Показати більше інформації"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr "Чутливість вказівника миші"
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr "Залежність чутливості миші від розміру вікна"
 
@@ -3727,7 +3727,7 @@ msgstr "Група метасфер"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "Група органел"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "Згладжування кількох зразків:"
 
@@ -3742,7 +3742,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "Музика"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "Гучність музики"
 
@@ -3762,9 +3762,9 @@ msgstr "(ціна органел, мембран та інших речей в �
 msgid "MUTATION_POINTS"
 msgstr "Очки мутації"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "Вимкнути"
 
@@ -3800,11 +3800,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Нове біорізноманіття збільшує видові популяції"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "Нова гра"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "почати нову гру"
 
@@ -3869,7 +3869,7 @@ msgstr "Азотофіксуючі пластиди–це білки, що ви
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "Перетворює [thrive:compound type=\"atp\"][/thrive:compound] на [thrive:compound type=\"ammonia\"][/thrive:compound]. Кількість залежить від [thrive:compound type=\"nitrogen\"][/thrive:compound] та [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "Нічого"
 
@@ -3917,7 +3917,7 @@ msgstr "Нема зафіксованих сполук"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Каталог викопувань не знайдено"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr "Жоден мод не ввімкнений"
 
@@ -3934,7 +3934,7 @@ msgstr "Збереження не знайдені"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "Каталог збережень не знайдено"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "Не знайдено каталог скріншотів"
 
@@ -3982,15 +3982,15 @@ msgstr "Н/Є ОМ"
 msgid "OCTOBER"
 msgstr "Жовтень"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr "Офіційний сайт"
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Відвідайте офіційний сайт Revolutionary Games"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4027,7 +4027,7 @@ msgstr "Відкрити вікно допомоги"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "Відкрити у Вільному конструктуюванні"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "Відкрити теку журналів"
 
@@ -4043,7 +4043,7 @@ msgstr "Відкрити меню органел"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "Відкрити каталог збережень"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "Відкрити теку скриншотів"
 
@@ -4051,7 +4051,7 @@ msgstr "Відкрити теку скриншотів"
 msgid "OPEN_THE_MENU"
 msgstr "Відкрити меню"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "Допомоти з перекладом гри"
 
@@ -4070,11 +4070,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Упереджені"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Налаштування"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Зміна ваших налаштувань"
 
@@ -4283,7 +4283,7 @@ msgstr "Процудурно"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr "Відвідайте"
 
@@ -4333,7 +4333,7 @@ msgstr "Мирність"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "Продуктивність"
 
@@ -4422,7 +4422,7 @@ msgstr "Дублікат гравця"
 msgid "PLAYER_EXTINCT"
 msgstr "Гравець вимер"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "Гравець вимер"
@@ -4437,23 +4437,23 @@ msgstr ""
 "Швидкість\n"
 "Гравця"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "Програвати інтро"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "програвати інтро з мікробом перед новою грою"
 
@@ -4572,11 +4572,11 @@ msgstr "Швидке завантаження"
 msgid "QUICK_SAVE"
 msgstr "Швидке збереження"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "Вихід"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Вихід з гри"
@@ -4618,7 +4618,7 @@ msgstr "Готово"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Рекомендовані Thrive:"
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr "Відвідайте наш subreddit"
 
@@ -4671,7 +4671,7 @@ msgstr "Розмножено:"
 msgid "REQUIRES_NUCLEUS"
 msgstr "Необхідне ядро"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "Скинути"
 
@@ -4679,23 +4679,23 @@ msgstr "Скинути"
 msgid "RESET_DEADZONES"
 msgstr "Скинути Мертві зони"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr "Скинути закриття вікон"
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "Скинути вхідні дані до замовчуваних?"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr "Скинути сполучення клавіш"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "За замовчуванням"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "Скинути до замовчування?"
 
@@ -4704,7 +4704,7 @@ msgstr "Скинути до замовчування?"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr "Стійкий до базового поглинання"
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "Резолюції:"
 
@@ -4754,7 +4754,7 @@ msgstr ""
 "Ви впевнені, що хочете вийти до головного меню?\n"
 "Увесь незбережений прогрес буде втрачено."
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Відвідайте офіційний сайт Revolutionary Games"
 
@@ -4786,7 +4786,7 @@ msgstr "Поверніть праворуч"
 msgid "ROTATION_COLON"
 msgstr "Обертання:"
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "Запускати Авто-ево під час гри"
 
@@ -4841,7 +4841,7 @@ msgstr "Рустіціанін — це білок, що використову�
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Перетворює [thrive:compound type=\"iron\"][/thrive:compound] на [thrive:compound type=\"atp\"][/thrive:compound]. Кількість залежить від [thrive:compound type=\"carbondioxide\"][/thrive:compound] та [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive запущена у безпечному режимі, бо попередній запуск не вдався.\n"
@@ -4853,15 +4853,15 @@ msgstr ""
 "\n"
 "Якщо вам невдасться вирішити проблему, котра запуску, вам доведеться перезавантажити та вимкнути Thrive кілька разів, для повернення у безпечний режим."
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive запущено в безпечному режимі"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "Зберегти"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "Зберегти й продовжити"
 
@@ -4959,20 +4959,20 @@ msgstr "Наразі збереження неможливе через:"
 msgid "SAVING_SUCCEEDED"
 msgstr "Вдале збереження"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr "Жоден"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr "Залежність"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr "Зворотня залежність"
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5069,7 +5069,7 @@ msgstr "Пасивні"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "Це значення стосується тільки до нових ігор розпочатих після зміни налаштування"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "Гучність SFX"
 
@@ -5085,21 +5085,25 @@ msgstr "Надати допомогу"
 msgid "SHOW_TUTORIALS"
 msgstr "Показати туторіали"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Показати туторіал (в поточній грі)"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "Показати туторіали (в новій грі)"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "Програвати попередження про незбережену гру"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "Вмикає / вимикає спливаюче вікно з попередженням про незбережений прогрес, як гравець намагається покинути гру."
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5147,7 +5151,7 @@ msgstr "Кремнезій"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "Ця мембрана має міцну стінку з кремнезію. Вона може опиратися загальним пошкодженням, і також особливо стійка до фізичної шкоди. Вона також вимагає менше енергії для утримання форми. Однак це сильно сповільнює клітину, і вона не так швидко поглинає ресурси."
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16х"
 
@@ -5187,7 +5191,7 @@ msgstr "Перетворює [thrive:compound type=\"glucose\"][/thrive:compound
 msgid "SMALL_IRON_CHUNK"
 msgstr "Малий шматок заліза"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "Звук"
 
@@ -5390,17 +5394,17 @@ msgstr "Steam наразі недоступний, будь-ласка повт�
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Сталася невідома помилка Steam"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Ініціалізація бібліотеки Steam клієнту невдалася"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Оновити вказане збереження не вдалося через наступну помилку:"
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr "Відвідайте нашу сторінку у Steam"
 
@@ -5440,7 +5444,7 @@ msgstr "Збереження"
 msgid "STORAGE_COLON"
 msgstr "Збереження:"
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Ви увійшли як:{0}"
 
@@ -5557,7 +5561,7 @@ msgstr "Темп."
 msgid "TESTING_TEAM"
 msgstr "Команда тестувальників"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Дякуємо за підтримку розробки Thrive, придбавши цю копію Thrive!\n"
@@ -5573,7 +5577,7 @@ msgstr ""
 "\n"
 "Якщо сподобалась гра будь-ласка роскажи друзям про нас (та про українське озвучення та переклади)."
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr "Дякуємо"
 
@@ -5628,11 +5632,11 @@ msgstr "Цей мод локально встановлений"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "Цей мод завантажений з майстерні Steam"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "Обрахунки:"
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Трайвопедія"
 
@@ -5788,7 +5792,7 @@ msgstr "Пауза"
 msgid "TOGGLE_UNBINDING"
 msgstr "Перемкнути роз'єднання"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "Інструменти"
 
@@ -5853,7 +5857,7 @@ msgstr "Спробуйте зробити декілька викопувань!
 msgid "TRY_MAKING_A_SAVE"
 msgstr "Спробуйте зробити збереження!"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "Спробуйте зробити декілька скріншотів!"
 
@@ -6015,11 +6019,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Переглянути зараз"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr "Відвідайте"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2х"
 
@@ -6044,7 +6048,7 @@ msgstr "Роз'єднати всіх"
 msgid "UNBIND_HELP_TEXT"
 msgstr "Режим зв'язування"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr "Це збірка налагоджувань, де інформація нижче, ймовірно, застаріла"
 
@@ -6064,7 +6068,7 @@ msgstr "Скасувати попередню дію"
 msgid "UNKNOWN"
 msgstr "Невідомо"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "Невідомо"
 
@@ -6076,7 +6080,7 @@ msgstr "Невідома миша"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "Невідомо на Windows"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "Невідома версія"
 
@@ -6084,7 +6088,7 @@ msgstr "Невідома версія"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "Невідомий ID магазину для цього моду"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "Ви маєте незбережені дії які будуть скасовані.\n"
@@ -6128,7 +6132,7 @@ msgstr "Відвантаження виконано"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "Ліцензії та використана література"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "Використовуваний рендер:"
 
@@ -6144,7 +6148,7 @@ msgstr "Використати завантаження авто-Гармоні�
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "Автоматичне завантаження патчів Гармонії зі збірки (не вимагає вказувати клас моду)"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "Використовувати звичайне ім'я користувача"
 
@@ -6152,11 +6156,11 @@ msgstr "Використовувати звичайне ім'я користув
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "Використання біорізноманіття розділенням сил"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "Встановити кількість фонових потоків вручну"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr "Використовувати віртуальний розмір вікна"
 
@@ -6182,7 +6186,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "Версія:"
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr "Вертикаль:"
 
@@ -6191,11 +6195,11 @@ msgstr "Вертикаль:"
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "Вертикаль (Вісь: {0})"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "Поточна використовувана відеопам'ять:"
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0} MiB"
 
@@ -6203,7 +6207,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Переглядач"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "Перегляд вихідного коду"
 
@@ -6215,7 +6219,7 @@ msgstr "VIP підтримка"
 msgid "VISIBLE"
 msgstr "Видимий"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Запропунувати функцію"
 
@@ -6235,7 +6239,7 @@ msgstr "Вимкнути звук"
 msgid "VOLUMEUP"
 msgstr "Підсилити звук"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "Вертикальна синхронізація(VSync)"
 
@@ -6342,7 +6346,7 @@ msgstr ""
 "Включити прототип пізніших етапів: {0}\n"
 "Включити великодки: {1}"
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "Базова швидкість"
@@ -6351,15 +6355,15 @@ msgstr "Базова швидкість"
 msgid "WORST_PATCH_COLON"
 msgstr "Найгірша ділянка:"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6371,7 +6375,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "роки"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Відвідайте наш YouTube канал"
 

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2023-01-13 08:00+0000\n"
 "Last-Translator: PanOlexMurzohan <oleksandrkurast@gmail.com>\n"
 "Language-Team: Ukrainian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/uk/>\n"
@@ -203,7 +203,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "Малюнок від {0}"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "Галерея"
 
@@ -301,7 +301,7 @@ msgstr "Автозбереження під час гри"
 msgid "AUTO_EVO"
 msgstr "Авто-ево"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Інструменти дослідження Авто-ево"
 
@@ -343,8 +343,8 @@ msgid "AWAKEN"
 msgstr "Пробудити"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -599,27 +599,27 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "Вуглекислий газ"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "в достатку"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "невелика кількість"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "мало"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "нормально"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "трішки"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "дуже мало"
 
@@ -887,19 +887,19 @@ msgstr "Значення насиченості, частки сірого в п
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "Оцінка (яскравість) значення, яскравість або інтенсивність кольору"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr "Форум спільноти"
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "Приєднуйтеся до спільноти Thrive на нашому форумі спільноти"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr "Wiki спільноти"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "Відвідайте наше wiki спільноти"
 
@@ -1101,7 +1101,7 @@ msgstr "Створення..."
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "Створюємо об'єкти зі збереження"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "Титри"
 
@@ -1286,11 +1286,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "Розробники"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr "Форум розробки"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "Поглянути оновлення розробки на нашому форумі"
 
@@ -1298,11 +1298,11 @@ msgstr "Поглянути оновлення розробки на нашому
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "Розробницька підтримка від Revolutionary Games Studio"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr "Розробницьке wiki"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "Відвідайте наше розробницьке wiki"
 
@@ -1430,7 +1430,7 @@ msgstr ""
 "Тут розміщені органели, які не з'єднання з рештою.\n"
 "Будь-ласка приєднайте одна з одною всі розміщені органели, або скасуйте зміни."
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr "Приєднуйтесь до спільноти Discord серверу"
 
@@ -1444,7 +1444,7 @@ msgstr ""
 "Це показує як багато спливаючих вікон закрито користувачем остаточно.\n"
 "Якщо деякі спливаючі вікна закриті, та вони вам потрібні, тоді можна використати кнопку поблизу, щоб знову відновити спливаючі вікна."
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr "Більше не показувати"
 
@@ -1491,7 +1491,7 @@ msgstr "Двічі клікніть, щоб переглянути в повно
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "Двохшарова мембрана– це кращий захист від пошкоджень та потребує менше енергії, щоб не деформуватись. Проте вона уповільнює клітину та поглинання ресурсів."
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "Більше не нагадувати про це"
 
@@ -1672,15 +1672,15 @@ msgstr "{0}: -{1} АТФ"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} АТФ"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "Енергія в {0} для {1}"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "Джерела енергії:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "Загальна зібрана енергія становить {0} з індивідуальною вартістю {1}, результатом чого є нескоригована популяція кількістю в {2}"
 
@@ -1733,6 +1733,16 @@ msgstr "Помилка створення інформаційного файл�
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "Помилка: Невдалось зберегти нові налаштування конфігурованих файлів."
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "(рандомно заспавнені секрети в грі)"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "Помилка створення інформаційного файлу"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "Помилка завантаження"
@@ -1784,7 +1794,7 @@ msgstr "З'явилося заперечення, коли завантажув�
 msgid "EXIT"
 msgstr "Вихід"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Вийти до лаунчера"
 
@@ -1835,7 +1845,7 @@ msgstr "вимерли в ділянці"
 msgid "EXTINCT_SPECIES"
 msgstr "Вимерлі види"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "Додаткове"
 
@@ -1843,7 +1853,7 @@ msgstr "Додаткове"
 msgid "EXTRA_OPTIONS"
 msgstr "Додаткові налаштування"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr "Відвідайте на сторінку Facebook"
 
@@ -1874,6 +1884,41 @@ msgstr "Увімкнути"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "Лютий"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Ініціалізація бібліотеки Steam клієнту невдалася"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"Час процесу: {0}с\n"
+"Фізичний час: {1} с\n"
+"Сутності: {2} Інше: {3}\n"
+"Заспавнено: {4} Задеспавнено: {5}\n"
+"Використовуванні вузли: {6}\n"
+"Використовувана пам'ять: {7}\n"
+"Пам'ять графічного процесора: {8}\n"
+"Відрендерені об'єкти: {9}\n"
+"Намальовані клітини: {10} 2D: {11}\n"
+"Відрендерені вершини: {12}\n"
+"Зміни матеріалу: {13}\n"
+"Зміни шейдеру: {14}\n"
+"Сирітські вузли: {15}\n"
+"Затримка в аудіо: {16} мс\n"
+"Загальна кількість потоків: {17}\n"
+"Загальний час ЦП:\n"
+" {18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1957,7 +2002,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "Ланцюг живлення"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0} енергія: {1} (пристосованість: {2}) загальна доступна енергія: {3} (загальна пристосованість: {4})"
 
@@ -2053,7 +2098,7 @@ msgstr "Генерації"
 msgid "GENERATION_COLON"
 msgstr "Генерація:"
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr "Відвідайте наше сховище у GitHub"
 
@@ -2061,11 +2106,11 @@ msgstr "Відвідайте наше сховище у GitHub"
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "Режим попереджень GLES2"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "Ви граєте у Thrive за допомогою GLES2. Це не є перевіреним та може викликати проблеми. Спробуйте оновити свої відеодрайвери та/або використати графіку від Nvidia або AMD для запуску Thrive."
 
@@ -2350,7 +2395,7 @@ msgstr "Залізо"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "Хемолітоавтотрофія заліза"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr "Відвідайте"
 
@@ -2568,7 +2613,7 @@ msgstr "Прогрес перекладу на цю мову зараз соло
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "Цей переклад дуже неповний ({0}% готово), буь-ласка допоможіть виправити ця ситуацію!!!"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "Неможна видалити останню органелу"
 
@@ -2726,7 +2771,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "ЛКМ"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "Ліцензія"
 
@@ -2854,7 +2899,8 @@ msgstr "Завантажити"
 msgid "LOADING"
 msgstr "Завантаження"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "Завантажити..."
 
@@ -2884,12 +2930,12 @@ msgstr "Натисніть на кнопку скасувати, аби випр
 msgid "LOAD_FINISHED"
 msgstr "Завантаження завершено"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "Завантажити гру"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "Завантажити раніше збережену гру"
 
@@ -3167,7 +3213,7 @@ msgstr "Кожного покоління ви отримуєте 100 очок �
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "Ви розмножуєтесь щоразу, як заходите до Мікробного Редактора, де модна змінити свій вид (перміщати, додавати, видаляти органели) для підвищення успішності виду. Кожен візит до мікробного редактору представляє собою [thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant] міліон років еволюції."
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "Режим творчого мікробного редактор"
 
@@ -3413,11 +3459,11 @@ msgstr "Модифікувати органелу"
 msgid "MODIFY_TYPE"
 msgstr "Змінити тип"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Моди"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "Встановлений мод виявлено, але увімкнених модів нема.\n"
@@ -3506,11 +3552,11 @@ msgstr "Внутрішня (папкова) назва:"
 msgid "MOD_LICENSE"
 msgstr "Ліцензія на моду:"
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Помилки завантаження модифікації"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "Виникли помилки під час завантаження декількох модифікацій. Додаткова інформація міститься у журналах."
 
@@ -3746,15 +3792,19 @@ msgstr ""
 "Це збереження з новішої версії Thrive та ймовірно несумісне.\n"
 "Ви хочете спробувати завантажити його всеодно?"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "Нове біорізноманіття збільшує видові популяції"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "Нова гра"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "почати нову гру"
 
@@ -3854,7 +3904,7 @@ msgid "NO_AI"
 msgstr "Без ШІ"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "Немає даних для показу"
 
@@ -3867,7 +3917,7 @@ msgstr "Нема зафіксованих сполук"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "Каталог викопувань не знайдено"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr "Жоден мод не ввімкнений"
 
@@ -3897,7 +3947,7 @@ msgstr "Немає вибраного моду"
 msgid "NUCLEUS"
 msgstr "Ядро"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 "Ядро не підлягає видаленю, бо це необоротна еволюція.\n"
@@ -3918,8 +3968,8 @@ msgstr "Перемикання числового регістрату(Num Lock)
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "Н/Є"
@@ -3932,15 +3982,15 @@ msgstr "Н/Є ОМ"
 msgid "OCTOBER"
 msgstr "Жовтень"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr "Офіційний сайт"
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "Відвідайте офіційний сайт Revolutionary Games"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4020,11 +4070,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "Упереджені"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "Налаштування"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "Зміна ваших налаштувань"
 
@@ -4233,7 +4283,7 @@ msgstr "Процудурно"
 msgid "PATCH_NAME"
 msgstr "{0} {1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr "Відвідайте"
 
@@ -4291,8 +4341,8 @@ msgstr "Продуктивність"
 msgid "PERFORM_UNBINDING"
 msgstr "Виконати роз'єднання"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/секунду"
 
@@ -4348,7 +4398,7 @@ msgstr "Генерація планети пройшла успішно!"
 msgid "PLANET_RANDOM_SEED"
 msgstr "Рандомний сід планети"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "Клітина гравця"
 
@@ -4424,7 +4474,7 @@ msgstr "популяція:"
 msgid "POPULATION_IN_PATCHES"
 msgstr "популяція в ділянці:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4478,7 +4528,7 @@ msgstr "попередній:"
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "Обробка об'єктів завантаження"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "у"
 
@@ -4522,11 +4572,11 @@ msgstr "Швидке завантаження"
 msgid "QUICK_SAVE"
 msgstr "Швидке збереження"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "Вихід"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "Вихід з гри"
@@ -4568,7 +4618,7 @@ msgstr "Готово"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "Рекомендовані Thrive:"
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr "Відвідайте наш subreddit"
 
@@ -4704,7 +4754,7 @@ msgstr ""
 "Ви впевнені, що хочете вийти до головного меню?\n"
 "Увесь незбережений прогрес буде втрачено."
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "Відвідайте офіційний сайт Revolutionary Games"
 
@@ -4791,7 +4841,7 @@ msgstr "Рустіціанін — це білок, що використову�
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "Перетворює [thrive:compound type=\"iron\"][/thrive:compound] на [thrive:compound type=\"atp\"][/thrive:compound]. Кількість залежить від [thrive:compound type=\"carbondioxide\"][/thrive:compound] та [thrive:compound type=\"oxygen\"][/thrive:compound]."
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "Thrive запущена у безпечному режимі, бо попередній запуск не вдався.\n"
@@ -4803,7 +4853,7 @@ msgstr ""
 "\n"
 "Якщо вам невдасться вирішити проблему, котра запуску, вам доведеться перезавантажити та вимкнути Thrive кілька разів, для повернення у безпечний режим."
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive запущено в безпечному режимі"
 
@@ -5165,7 +5215,7 @@ msgstr "Спавн амоніаку"
 msgid "SPAWN_ENEMY"
 msgstr "Спавн ворога"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "Неможливо використати спавн ворога тому що в цій ділянці немає ворожих видів"
 
@@ -5225,7 +5275,7 @@ msgstr "Назва виду..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "Назва виду за довга!"
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5340,17 +5390,17 @@ msgstr "Steam наразі недоступний, будь-ласка повт�
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "Сталася невідома помилка Steam"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Ініціалізація бібліотеки Steam клієнту невдалася"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "Оновити вказане збереження не вдалося через наступну помилку:"
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr "Відвідайте нашу сторінку у Steam"
 
@@ -5390,7 +5440,7 @@ msgstr "Збереження"
 msgid "STORAGE_COLON"
 msgstr "Збереження:"
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Ви увійшли як:{0}"
 
@@ -5507,7 +5557,7 @@ msgstr "Темп."
 msgid "TESTING_TEAM"
 msgstr "Команда тестувальників"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "Дякуємо за підтримку розробки Thrive, придбавши цю копію Thrive!\n"
@@ -5523,7 +5573,7 @@ msgstr ""
 "\n"
 "Якщо сподобалась гра будь-ласка роскажи друзям про нас (та про українське озвучення та переклади)."
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr "Дякуємо"
 
@@ -5582,7 +5632,7 @@ msgstr "Цей мод завантажений з майстерні Steam"
 msgid "THREADS"
 msgstr "Обрахунки:"
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Трайвопедія"
 
@@ -5738,7 +5788,7 @@ msgstr "Пауза"
 msgid "TOGGLE_UNBINDING"
 msgstr "Перемкнути роз'єднання"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "Інструменти"
 
@@ -5965,7 +6015,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "Переглянути зараз"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr "Відвідайте"
 
@@ -6153,7 +6203,7 @@ msgstr "{0} MiB"
 msgid "VIEWER"
 msgstr "Переглядач"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "Перегляд вихідного коду"
 
@@ -6165,7 +6215,7 @@ msgstr "VIP підтримка"
 msgid "VISIBLE"
 msgstr "Видимий"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "Запропунувати функцію"
 
@@ -6321,7 +6371,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "роки"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr "Відвідайте наш YouTube канал"
 

--- a/locale/vi.po
+++ b/locale/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -194,7 +194,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -330,8 +330,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -586,27 +586,27 @@ msgstr ""
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr ""
 
@@ -865,19 +865,19 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr ""
 
@@ -1230,11 +1230,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1242,11 +1242,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1417,7 +1417,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1591,15 +1591,15 @@ msgstr ""
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr ""
 
@@ -1652,6 +1652,14 @@ msgstr ""
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
+#: ../src/general/ThriveNewsFeed.cs:95
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:94
+msgid "ERROR_FETCHING_NEWS"
+msgstr ""
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr ""
@@ -1700,7 +1708,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1750,7 +1758,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr ""
 
@@ -1758,7 +1766,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1784,6 +1792,22 @@ msgstr ""
 
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:192
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
@@ -1865,7 +1889,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr ""
 
@@ -1961,7 +1985,7 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
@@ -1969,11 +1993,11 @@ msgstr ""
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
@@ -2249,7 +2273,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2465,7 +2489,7 @@ msgstr ""
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2623,7 +2647,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr ""
 
@@ -2751,7 +2775,8 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
 
@@ -2781,12 +2806,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2986,7 +3011,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3183,11 +3208,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3273,11 +3298,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3501,15 +3526,19 @@ msgstr ""
 msgid "NEWER_VERSION_LOADING_WARNING"
 msgstr ""
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3609,7 +3638,7 @@ msgid "NO_AI"
 msgstr ""
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr ""
 
@@ -3621,7 +3650,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3651,7 +3680,7 @@ msgstr ""
 msgid "NUCLEUS"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -3670,8 +3699,8 @@ msgstr ""
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr ""
@@ -3684,15 +3713,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3763,11 +3792,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3972,7 +4001,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4030,8 +4059,8 @@ msgstr ""
 msgid "PERFORM_UNBINDING"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr ""
 
@@ -4081,7 +4110,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr ""
 
@@ -4154,7 +4183,7 @@ msgstr ""
 msgid "POPULATION_IN_PATCHES"
 msgstr ""
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr ""
 
@@ -4208,7 +4237,7 @@ msgstr ""
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr ""
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr ""
 
@@ -4252,11 +4281,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4296,7 +4325,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4430,7 +4459,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4516,11 +4545,11 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
@@ -4876,7 +4905,7 @@ msgstr ""
 msgid "SPAWN_ENEMY"
 msgstr ""
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr ""
 
@@ -4926,7 +4955,7 @@ msgstr ""
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr ""
 
@@ -5041,15 +5070,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5089,7 +5118,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5204,7 +5233,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5212,7 +5241,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5271,7 +5300,7 @@ msgstr ""
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5418,7 +5447,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr ""
 
@@ -5561,7 +5590,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
@@ -5745,7 +5774,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5757,7 +5786,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5910,7 +5939,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/vi.po
+++ b/locale/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.10.3\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -29,7 +29,7 @@ msgstr ""
 msgid "3D_MOVEMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -60,7 +60,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr ""
 msgid "ALT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr ""
 
@@ -145,11 +145,11 @@ msgstr ""
 msgid "AMMONIA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr ""
 
@@ -174,11 +174,11 @@ msgstr ""
 msgid "APRIL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "ART_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr ""
 
@@ -246,7 +246,7 @@ msgstr ""
 msgid "AT_CURSOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -254,8 +254,8 @@ msgstr ""
 msgid "AUGUST"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr ""
 
@@ -280,7 +280,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "AUTO_EVO"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr ""
 
@@ -317,7 +317,7 @@ msgstr ""
 msgid "AUTO_MOVE_FORWARDS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr ""
 
@@ -330,9 +330,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -468,7 +468,7 @@ msgstr ""
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr ""
 msgid "CAMERA"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -658,7 +658,7 @@ msgstr ""
 msgid "CHEATS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr ""
 
@@ -748,7 +748,7 @@ msgstr ""
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr ""
 
@@ -789,15 +789,15 @@ msgstr ""
 msgid "CLOSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr ""
 
@@ -865,23 +865,23 @@ msgstr ""
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr ""
 
@@ -907,7 +907,7 @@ msgstr ""
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr ""
 
@@ -986,7 +986,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -999,11 +999,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1011,11 +1011,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr ""
 
@@ -1095,7 +1095,7 @@ msgstr ""
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr ""
 
@@ -1218,7 +1218,7 @@ msgstr ""
 msgid "DESPAWN_ENTITIES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr ""
 
@@ -1230,11 +1230,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1242,11 +1242,11 @@ msgstr ""
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -1318,7 +1318,7 @@ msgstr ""
 msgid "DIRECTIONR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr ""
 
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "DISABLE_ALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr ""
 
@@ -1358,31 +1358,31 @@ msgstr ""
 msgid "DISCONNECTED_ORGANELLES_TEXT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr ""
 
@@ -1417,7 +1417,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "EDITOR_TUTORIAL_EDITOR_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "ENABLE_EDITOR"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr ""
 
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "EPIPELAGIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr ""
 
@@ -1648,15 +1648,15 @@ msgstr ""
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 msgid "ERROR_FETCHING_NEWS"
 msgstr ""
 
@@ -1688,11 +1688,11 @@ msgstr ""
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr ""
 
@@ -1708,7 +1708,7 @@ msgstr ""
 msgid "EXIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr ""
 
@@ -1758,7 +1758,7 @@ msgstr ""
 msgid "EXTINCT_SPECIES"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr ""
 
@@ -1766,7 +1766,7 @@ msgstr ""
 msgid "EXTRA_OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr ""
 
@@ -1794,19 +1794,19 @@ msgstr ""
 msgid "FEBRUARY"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -1927,7 +1927,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr ""
 
@@ -1957,7 +1957,7 @@ msgstr ""
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr ""
 
@@ -1985,23 +1985,23 @@ msgstr ""
 msgid "GENERATION_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2054,11 +2054,11 @@ msgstr ""
 msgid "GPL_LICENSE_HEADING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr ""
 
@@ -2066,7 +2066,7 @@ msgstr ""
 msgid "GRAPHICS_TEAM"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2078,7 +2078,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr ""
 
@@ -2100,11 +2100,11 @@ msgstr ""
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr ""
 
@@ -2128,7 +2128,7 @@ msgstr ""
 msgid "HOME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr ""
 
@@ -2200,7 +2200,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr ""
 
@@ -2253,8 +2253,8 @@ msgstr ""
 msgid "INVALID_URL_SCHEME"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2273,7 +2273,7 @@ msgstr ""
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr ""
 
@@ -2281,19 +2281,19 @@ msgstr ""
 msgid "JANUARY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr ""
 
@@ -2473,19 +2473,19 @@ msgstr ""
 msgid "KPSUBTRACT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr ""
 
@@ -2647,7 +2647,7 @@ msgstr ""
 msgid "LEFT_MOUSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr ""
 
@@ -2715,7 +2715,7 @@ msgstr ""
 msgid "LIGHT_MAX"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr ""
 
@@ -2727,31 +2727,31 @@ msgstr ""
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2775,7 +2775,7 @@ msgstr ""
 msgid "LOADING"
 msgstr ""
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr ""
@@ -2806,12 +2806,12 @@ msgstr ""
 msgid "LOAD_FINISHED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "MARINE_SNOW"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr ""
 
@@ -2884,15 +2884,15 @@ msgstr ""
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3011,7 +3011,7 @@ msgstr ""
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr ""
 
@@ -3145,7 +3145,7 @@ msgstr ""
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr ""
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr ""
 
@@ -3208,11 +3208,11 @@ msgstr ""
 msgid "MODIFY_TYPE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3298,11 +3298,11 @@ msgstr ""
 msgid "MOD_LICENSE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr ""
 
@@ -3355,11 +3355,11 @@ msgstr ""
 msgid "MORE_INFO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3468,7 +3468,7 @@ msgstr ""
 msgid "MULTIPLE_ORGANELLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr ""
 
@@ -3480,7 +3480,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr ""
 
@@ -3500,9 +3500,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr ""
 
@@ -3534,11 +3534,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -3603,7 +3603,7 @@ msgstr ""
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr ""
 
@@ -3650,7 +3650,7 @@ msgstr ""
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr ""
 
@@ -3667,7 +3667,7 @@ msgstr ""
 msgid "NO_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr ""
 
@@ -3713,15 +3713,15 @@ msgstr ""
 msgid "OCTOBER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -3752,7 +3752,7 @@ msgstr ""
 msgid "OPEN_IN_FREEBUILD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr ""
 
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr ""
 
@@ -3776,7 +3776,7 @@ msgstr ""
 msgid "OPEN_THE_MENU"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr ""
 
@@ -3792,11 +3792,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr ""
 
@@ -4001,7 +4001,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "PERCENTAGE_VALUE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr ""
 
@@ -4134,7 +4134,7 @@ msgstr ""
 msgid "PLAYER_EXTINCT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4146,23 +4146,23 @@ msgstr ""
 msgid "PLAYER_SPEED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr ""
 
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "QUICK_SAVE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr ""
@@ -4325,7 +4325,7 @@ msgstr ""
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr ""
 
@@ -4378,7 +4378,7 @@ msgstr ""
 msgid "REQUIRES_NUCLEUS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr ""
 
@@ -4386,23 +4386,23 @@ msgstr ""
 msgid "RESET_DEADZONES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr ""
 
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr ""
 
@@ -4459,7 +4459,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr ""
 
@@ -4491,7 +4491,7 @@ msgstr ""
 msgid "ROTATION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr ""
 
@@ -4545,19 +4545,19 @@ msgstr ""
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr ""
 
@@ -4649,20 +4649,20 @@ msgstr ""
 msgid "SAVING_SUCCEEDED"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgstr ""
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr ""
 
@@ -4775,20 +4775,24 @@ msgstr ""
 msgid "SHOW_TUTORIALS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr ""
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
+msgstr ""
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
@@ -4837,7 +4841,7 @@ msgstr ""
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr ""
 
@@ -4877,7 +4881,7 @@ msgstr ""
 msgid "SMALL_IRON_CHUNK"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr ""
 
@@ -5070,15 +5074,15 @@ msgstr ""
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 msgid "STEAM_INIT_FAILED"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr ""
 
@@ -5118,7 +5122,7 @@ msgstr ""
 msgid "STORAGE_COLON"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
 
@@ -5233,7 +5237,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 
@@ -5241,7 +5245,7 @@ msgstr ""
 msgid "THANKS_FOR_PLAYING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr ""
 
@@ -5296,11 +5300,11 @@ msgstr ""
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5447,7 +5451,7 @@ msgstr ""
 msgid "TOGGLE_UNBINDING"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr ""
 
@@ -5509,7 +5513,7 @@ msgstr ""
 msgid "TRY_MAKING_A_SAVE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
@@ -5590,11 +5594,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr ""
 
@@ -5619,7 +5623,7 @@ msgstr ""
 msgid "UNBIND_HELP_TEXT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
 
@@ -5639,7 +5643,7 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr ""
 
@@ -5651,7 +5655,7 @@ msgstr ""
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr ""
 
@@ -5659,7 +5663,7 @@ msgstr ""
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 
@@ -5699,7 +5703,7 @@ msgstr ""
 msgid "USED_LIBRARIES_LICENSES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -5715,7 +5719,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr ""
 
@@ -5723,11 +5727,11 @@ msgstr ""
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -5753,7 +5757,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr ""
 
@@ -5762,11 +5766,11 @@ msgstr ""
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -5774,7 +5778,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr ""
 
@@ -5786,7 +5790,7 @@ msgstr ""
 msgid "VISIBLE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -5806,7 +5810,7 @@ msgstr ""
 msgid "VOLUMEUP"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr ""
 
@@ -5911,7 +5915,7 @@ msgstr ""
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5919,15 +5923,15 @@ msgstr ""
 msgid "WORST_PATCH_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "YEARS"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr ""
 

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-12-15 06:57+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Chinese (Simplified) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/zh_Hans/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.14\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "3D编辑器"
 msgid "3D_MOVEMENT"
 msgstr "3D移动"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "当另一个行动在进行时无法进行行动"
 msgid "ACTIVE"
 msgstr "活泼"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "当前线程："
 
@@ -144,7 +144,7 @@ msgstr "生物数据"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "环境声效"
 
@@ -155,11 +155,11 @@ msgstr "环境声效"
 msgid "AMMONIA"
 msgstr "氨"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "要保留的自动保存存档数："
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "要保留的快速保存存档数："
 
@@ -184,11 +184,11 @@ msgstr "应用更变"
 msgid "APRIL"
 msgstr "四月"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "你确定要把「所有」设置都重置为默认值吗？"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "你确定要把输入设置重置为默认值吗？"
 
@@ -204,7 +204,7 @@ msgstr "“{0}” - {1}"
 msgid "ART_BY"
 msgstr "由{0}创作"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "艺术画廊"
 
@@ -216,7 +216,7 @@ msgstr "当指定了Mod的assembly后你还需要Mod assembly class"
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "当自动Harmony启用时需要指定Mod的assembly"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "假设CPU已启用超线程"
 
@@ -258,7 +258,7 @@ msgstr "尝试写入存档失败了。存档名称可能过长，或者你没有
 msgid "AT_CURSOR"
 msgstr "鼠标指针处："
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "音频输出设备："
 
@@ -266,8 +266,8 @@ msgstr "音频输出设备："
 msgid "AUGUST"
 msgstr "八月"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "自动"
 
@@ -294,7 +294,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "已完成{0:F1}%。{1:n0}/{2:n0}步剩余。"
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "游戏中启用自动保存"
 
@@ -302,7 +302,7 @@ msgstr "游戏中启用自动保存"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Auto-Evo探索工具"
 
@@ -332,7 +332,7 @@ msgstr "运行状态："
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "自动前移"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "自动（{0}x{1}）"
 
@@ -345,9 +345,9 @@ msgid "AWAKEN"
 msgstr "唤醒"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -483,7 +483,7 @@ msgstr "允许与其他细胞结合。这是迈向多细胞的第一步。在连
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "按[thrive:input]g_toggle_binding[/thrive:input]来切换连接模式。在连接模式中，通过接触同种细胞，你可以让它成为你的细胞群的一员。要离开细胞群，按[thrive:input]g_unbind_all[/thrive:input]。"
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr "将坐标轴绑定在一起"
 
@@ -545,7 +545,7 @@ msgstr "这个细胞膜额外配置了一层碳酸钙组成的强力外壳。它
 msgid "CAMERA"
 msgstr "视角"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -673,7 +673,7 @@ msgstr "改变对称"
 msgid "CHEATS"
 msgstr "作弊"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "启用作弊键"
 
@@ -763,7 +763,7 @@ msgstr "产出[thrive:compound type=\"glucose\"][/thrive:compound]。速率跟[t
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "目标文件名{0}已存在。确定要覆盖吗？"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "色差："
 
@@ -804,15 +804,15 @@ msgstr "清除旧存档"
 msgid "CLOSE"
 msgstr "关闭"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "关闭选项菜单？"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "云分辨率除数："
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "云仿真最小间隔时间："
 
@@ -828,7 +828,7 @@ msgstr "生成具有碰撞形状的实体"
 msgid "COLOUR"
 msgstr "颜色"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "色盲修正："
 
@@ -889,23 +889,23 @@ msgstr "S值，决定饱和度"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "V值，决定明度"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr "社区论坛"
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "在我们的社区论坛上加入Thrive社区"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 msgid "COMMUNITY_WIKI"
 msgstr "社区wiki"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "访问我们的社区wiki"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 msgid "COMPILED_AT_COLON"
 msgstr "编译于："
 
@@ -931,7 +931,7 @@ msgstr "化合物："
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "化合物收支"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "化合物云"
 
@@ -1016,7 +1016,7 @@ msgstr "进入尚在开发中的阶段？"
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr "控制器轴可视化："
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr "控制器死区"
 
@@ -1031,11 +1031,11 @@ msgstr ""
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr "死区："
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr "控制器灵敏度"
 
@@ -1043,11 +1043,11 @@ msgstr "控制器灵敏度"
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "将错误复制到剪贴板"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "红绿色盲"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "蓝黄色盲"
 
@@ -1103,7 +1103,7 @@ msgstr "创建中……"
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "从存档数据中创建物体"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "制作人名单"
 
@@ -1129,7 +1129,7 @@ msgstr "当前开发人员"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "生物数据"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "自定义用户名："
 
@@ -1194,7 +1194,7 @@ msgstr "调试菜单"
 msgid "DECEMBER"
 msgstr "十二月"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "默认输出设备"
 
@@ -1256,7 +1256,7 @@ msgstr "描叙过长"
 msgid "DESPAWN_ENTITIES"
 msgstr "杀死所有实体"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "检测到的CPU数量："
 
@@ -1271,11 +1271,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "开发者"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 msgid "DEVELOPMENT_FORUM"
 msgstr "开发论坛"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "在开发论坛上了解开发进度"
 
@@ -1283,11 +1283,11 @@ msgstr "在开发论坛上了解开发进度"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "由Revolutionary Games Studio ry支持的开发"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 msgid "DEVELOPMENT_WIKI"
 msgstr "开发者wiki"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "访问我们的开发者wiki"
 
@@ -1369,7 +1369,7 @@ msgstr "左"
 msgid "DIRECTIONR"
 msgstr "右"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "已禁用"
 
@@ -1377,7 +1377,7 @@ msgstr "已禁用"
 msgid "DISABLE_ALL"
 msgstr "全部禁用"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "放弃更改并继续"
 
@@ -1415,33 +1415,33 @@ msgstr ""
 "有一些细胞器没有连接到其它细胞器上。\n"
 "请把所有细胞器连接起来，或者删掉未连接的细胞器。"
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 msgid "DISCORD_TOOLTIP"
 msgstr "加入我们社区的Discord服务器"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "被禁用的弹出窗口："
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
 "这显示了多少弹出窗口已被永久禁用。\n"
 "如果有一些你想要看到的弹出窗口被禁用了，旁边的那个按钮可以使所有被禁用的弹出窗口再次出现。"
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr "不再显示"
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "显示能力栏"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr "显示背景粒子"
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 msgid "DISPLAY_PART_NAMES"
 msgstr "显示细胞器名称"
 
@@ -1476,7 +1476,7 @@ msgstr "双击可全屏查看"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "有两层的细胞膜，对伤害有更好的防护能力，也不需要花费那么多能量避免变形。不管怎样，它也会减缓细胞的移动速度，并降低其吸收营养的速率。"
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "不再提醒这项内容"
 
@@ -1629,7 +1629,7 @@ msgstr ""
 "\n"
 "当你准备好了，按右下角的 \"下一步 \"按钮以继续。"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1645,7 +1645,7 @@ msgstr "启用所有兼容的Mod"
 msgid "ENABLE_EDITOR"
 msgstr "启用编辑器"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "启用GUI闪烁特效"
 
@@ -1702,7 +1702,7 @@ msgstr "显示/隐藏环境"
 msgid "EPIPELAGIC"
 msgstr "上远洋带"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "错误"
 
@@ -1714,16 +1714,16 @@ msgstr "为mod创建文件夹时出错"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "为mod创建info文件时出错"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "错误：无法将新设置保存到配置文件。"
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr "（游戏中会随机生成彩蛋）"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "为mod创建info文件时出错"
@@ -1759,11 +1759,11 @@ msgstr ""
 "\n"
 "如果不是因为以上两种原因，那就是出bug了。请通知开发团队并提供游戏日志。"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 msgid "EXACT_VERSION_COLON"
 msgstr "精确版本："
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "这是编译此版本 Thrive 的确切 Commit"
 
@@ -1779,7 +1779,7 @@ msgstr "加载存档数据时发生异常"
 msgid "EXIT"
 msgstr "退出"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 msgid "EXIT_TO_LAUNCHER"
 msgstr "退出至启动器"
 
@@ -1831,7 +1831,7 @@ msgstr "在这个地区里灭绝了"
 msgid "EXTINCT_SPECIES"
 msgstr "灭绝物种"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "额外内容"
 
@@ -1839,7 +1839,7 @@ msgstr "额外内容"
 msgid "EXTRA_OPTIONS"
 msgstr "额外选项"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 msgid "FACEBOOK_TOOLTIP"
 msgstr "访问我们的Facebook页面"
 
@@ -1871,12 +1871,12 @@ msgstr "已启用"
 msgid "FEBRUARY"
 msgstr "二月"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Steam 客户端库初始化失败"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 #, fuzzy
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
@@ -1898,11 +1898,11 @@ msgstr ""
 "CPU时间：\n"
 "{18}"
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2026,7 +2026,7 @@ msgstr "保存该物种到化石中（已保存）"
 msgid "FOSSILISE"
 msgstr "保存至化石中"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2056,7 +2056,7 @@ msgstr "在离开编辑器时额外的葡萄糖云"
 msgid "FREE_GLUCOSE_CLOUD_EXPLANATION"
 msgstr "（每一代开始时在玩家旁自动生成一块葡萄糖云）"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "全屏"
 
@@ -2084,23 +2084,23 @@ msgstr "世代"
 msgid "GENERATION_COLON"
 msgstr "世代："
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 msgid "GITHUB_TOOLTIP"
 msgstr "访问我们在GitHub上的代码仓库"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2模式警告"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "你在用GLES2模式运行Thrive。这种情况没有被测试过并且很可能导致种种问题。你应该考虑更新下你的显卡驱动，或者强制使用你的AMD/Nvidia显卡来运行Thrive。"
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr "GLES3"
 
@@ -2153,11 +2153,11 @@ msgstr "明白了"
 msgid "GPL_LICENSE_HEADING"
 msgstr "GPL 许可文本如下："
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "GPU:"
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "图像"
 
@@ -2165,7 +2165,7 @@ msgstr "图像"
 msgid "GRAPHICS_TEAM"
 msgstr "图形团队"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr "GUI"
 
@@ -2182,7 +2182,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0}*10³"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "GUI音量"
 
@@ -2204,11 +2204,11 @@ msgstr "帮助"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "帮助菜单"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "（更高的数值有助于提升性能）"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "（设置的太高会影响性能）"
 
@@ -2232,7 +2232,7 @@ msgstr "按住[thrive:input]g_free_cursor[/thrive:input]以显示鼠标指针"
 msgid "HOME"
 msgstr "主页"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 msgid "HORIZONTAL_COLON"
 msgstr "水平："
 
@@ -2305,7 +2305,7 @@ msgstr "摄入的物质"
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "加入我们社区的Discord服务器"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "输入"
 
@@ -2358,8 +2358,8 @@ msgstr "无效的网址格式"
 msgid "INVALID_URL_SCHEME"
 msgstr "无效的URL Schemes"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr "已反转"
 
@@ -2382,7 +2382,7 @@ msgstr "铁"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "铁化能无机自养"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 msgid "ITCH_TOOLTIP"
 msgstr "访问我们在Itch.io上的页面"
 
@@ -2390,19 +2390,19 @@ msgstr "访问我们在Itch.io上的页面"
 msgid "JANUARY"
 msgstr "一月"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "JSON调试模式："
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "总是"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "自动"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "从不"
 
@@ -2584,19 +2584,19 @@ msgstr "小键盘.键"
 msgid "KPSUBTRACT"
 msgstr "小键盘-键"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "语言："
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "此翻译已完成 {0}%"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "此翻译仍在开发中（已完成 {0}%）"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "此翻译非常不完整（已完成 {0}%）请帮助我们！"
 
@@ -2758,7 +2758,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "鼠标左键"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "许可"
 
@@ -2826,7 +2826,7 @@ msgstr "夜晚"
 msgid "LIGHT_MAX"
 msgstr "光强最大值"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_EXTREME"
 msgstr "极多"
 
@@ -2838,31 +2838,31 @@ msgstr "限制繁殖化合物使用"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "（启用时会限制生长速度，如果关闭的话那么生长速度便仅受可用的化合物数量的影响）"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr "很多"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr "较多"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_NORMAL"
 msgstr "一般"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr "较少"
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr "极少"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr "多"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr "少"
 
@@ -2886,7 +2886,7 @@ msgstr "载入"
 msgid "LOADING"
 msgstr "载入中"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "载入中……"
@@ -2917,12 +2917,12 @@ msgstr "在编辑器中按下撤消键以纠正错误"
 msgid "LOAD_FINISHED"
 msgstr "载入完成"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "载入游戏"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "载入之前保存的游戏"
 
@@ -2996,7 +2996,7 @@ msgstr "三月"
 msgid "MARINE_SNOW"
 msgstr "海洋雪"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "主音量"
 
@@ -3004,15 +3004,15 @@ msgstr "主音量"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "在启用强制灭绝之前一个地区所能容纳的最大物种数量"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "最高FPS："
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "不受限"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr "实体数量限制："
 
@@ -3195,7 +3195,7 @@ msgstr "每一代，你都有100个变异点可供花费，任何变化都需要
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "你每次繁殖时都会进入微生物编辑器，你可以在那改变你的物种（通过添加，移动或删除细胞器）以强化你物种的生存力。在微生物阶段每次进入编辑器都代表[thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant]x10⁶年的进化时间。"
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "微生物阶段自由编辑器"
 
@@ -3379,7 +3379,7 @@ msgstr "最低："
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "不允许显示少于{0}个数据集！"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "杂项"
 
@@ -3442,11 +3442,11 @@ msgstr "修改细胞器"
 msgid "MODIFY_TYPE"
 msgstr "修改类型"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "检测到安装的模组，但没有启用的模组。\n"
@@ -3535,11 +3535,11 @@ msgstr "内部（文件夹）名称："
 msgid "MOD_LICENSE"
 msgstr "此Mod的许可："
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Mod加载错误"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "在加载一个或多个mod时发生了错误。日志可能包含其它信息。"
 
@@ -3592,11 +3592,11 @@ msgstr "Mod版本："
 msgid "MORE_INFO"
 msgstr "显示更多信息"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr "鼠标灵敏度"
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr "由窗口大小决定鼠标灵敏度"
 
@@ -3710,7 +3710,7 @@ msgstr "多个元球"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "多个细胞器"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "多重采样抗锯齿："
 
@@ -3725,7 +3725,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "音乐"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "音乐音量"
 
@@ -3745,9 +3745,9 @@ msgstr "（细胞器，膜和编辑器中其它选项的耗费）"
 msgid "MUTATION_POINTS"
 msgstr "变异点（MP）"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "静音"
 
@@ -3783,11 +3783,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "增加生物多样性物种的初始种群数量"
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "新游戏"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "开始新游戏"
 
@@ -3852,7 +3852,7 @@ msgstr "固氮质体是一种可以用氮和氧还有ATP制造氨的蛋白质，
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "将[thrive:compound type=\"atp\"][/thrive:compound]转换成[thrive:compound type=\"ammonia\"][/thrive:compound]。速率跟[thrive:compound type=\"nitrogen\"][/thrive:compound]与[thrive:compound type=\"oxygen\"][/thrive:compound]浓度成正比。"
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "无"
 
@@ -3900,7 +3900,7 @@ msgstr "无事件记录"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "找不到存档目录"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 msgid "NO_MODS_ENABLED"
 msgstr "模组已禁用"
 
@@ -3917,7 +3917,7 @@ msgstr "未找到存档"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "找不到存档目录"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "找不到截图目录"
 
@@ -3965,15 +3965,15 @@ msgstr "不消耗变异点"
 msgid "OCTOBER"
 msgstr "十月"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr "官方网站"
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "访问Revolutionary Games的官方网站"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4011,7 +4011,7 @@ msgstr "打开帮助页面"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "在自由编辑器中打开"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "打开日志文件夹"
 
@@ -4027,7 +4027,7 @@ msgstr "打开细胞器菜单"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "打开存档文件夹"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "打开截图存放文件夹"
 
@@ -4035,7 +4035,7 @@ msgstr "打开截图存放文件夹"
 msgid "OPEN_THE_MENU"
 msgstr "打开主菜单"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "帮忙翻译这个游戏"
 
@@ -4054,11 +4054,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "机会主义"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "选项"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "改变你的设置"
 
@@ -4267,7 +4267,7 @@ msgstr "生成图"
 msgid "PATCH_NAME"
 msgstr "{0}{1}"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 msgid "PATREON_TOOLTIP"
 msgstr "访问我们在Patreon上的页面"
 
@@ -4317,7 +4317,7 @@ msgstr "和平"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "性能"
 
@@ -4406,7 +4406,7 @@ msgstr "玩家分裂"
 msgid "PLAYER_EXTINCT"
 msgstr "玩家已灭绝"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "玩家已灭绝"
@@ -4421,23 +4421,23 @@ msgstr ""
 "玩家\n"
 "速度"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "播放游戏开场动画"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "在开始新游戏时播放微生物阶段开场动画"
 
@@ -4556,11 +4556,11 @@ msgstr "快速读档"
 msgid "QUICK_SAVE"
 msgstr "快速保存"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "退出"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "退出游戏"
@@ -4602,7 +4602,7 @@ msgstr "准备就绪"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "推荐的Thrive版本："
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 msgid "REDDIT_TOOLTIP"
 msgstr "访问我们的subreddit页面"
 
@@ -4655,7 +4655,7 @@ msgstr "繁殖："
 msgid "REQUIRES_NUCLEUS"
 msgstr "需要细胞核"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "重置"
 
@@ -4663,23 +4663,23 @@ msgstr "重置"
 msgid "RESET_DEADZONES"
 msgstr "重置死区"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr "重置被禁用的弹出窗口"
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "将输入重置为默认值？"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 msgid "RESET_KEYBINDINGS"
 msgstr "重置按键绑定"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "默认"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "重置为默认值？"
 
@@ -4688,7 +4688,7 @@ msgstr "重置为默认值？"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr "不会被没有对应酶的细胞吞噬并消化"
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "分辨率："
 
@@ -4738,7 +4738,7 @@ msgstr ""
 "你确定要退出到主菜单吗？\n"
 "你会失去任何未保存的进度。"
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "访问Revolutionary Games Studio网站"
 
@@ -4770,7 +4770,7 @@ msgstr "向右转"
 msgid "ROTATION_COLON"
 msgstr "旋转："
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "在游戏中启用auto-evo"
 
@@ -4825,7 +4825,7 @@ msgstr "铁硫菌蓝蛋白能够利用气态二氧化碳和氧将铁从一种化
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "将[thrive:compound type=\"iron\"][/thrive:compound]转换成[thrive:compound type=\"atp\"][/thrive:compound]。速率跟[thrive:compound type=\"carbondioxide\"][/thrive:compound]和[thrive:compound type=\"oxygen\"][/thrive:compound]的浓度成正比。"
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "由于先前的启动错误，Thrive已在安全模式下启动。\n"
@@ -4837,15 +4837,15 @@ msgstr ""
 "\n"
 "如果你未能修复导致启动错误的问题，你在未来几次启动中将会崩溃数次并最后再次返回安全模式。"
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive在安全模式下启动"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "保存"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "保存并继续"
 
@@ -4943,20 +4943,20 @@ msgstr "当前情况下无法保存："
 msgid "SAVING_SUCCEEDED"
 msgstr "保存成功"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr "无"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON"
 msgstr "成正比"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr "成反比"
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr "来加快细胞的移动"
@@ -5054,7 +5054,7 @@ msgstr "沉着"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "这个数值只对你改变选项后新开的存档有效"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "音效音量"
 
@@ -5070,21 +5070,25 @@ msgstr "显示帮助"
 msgid "SHOW_TUTORIALS"
 msgstr "显示教程"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "现有游戏中显示教程"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "开始新游戏时显示教程"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "显示未保存的进度警告"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "当玩家试图退出游戏时，启用/禁用未保存的进度警告弹出框。"
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5132,7 +5136,7 @@ msgstr "二氧化硅"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "这个细胞膜额外配置了一层二氧化硅外壳。各方面都有更好的防御力，尤其是物防高的惊人。同时也不需要多少能量来维持形状，但吸收营养和移动的速度都很慢。"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5172,7 +5176,7 @@ msgstr "将 [thrive:compound type=\"glucose\"][/thrive:compound] 转化为 [thri
 msgid "SMALL_IRON_CHUNK"
 msgstr "小铁块"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "声音"
 
@@ -5375,17 +5379,17 @@ msgstr "Steam系统目前不可用，请重试"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "发生了未知的Steam错误"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Steam 客户端库初始化失败"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "更新此存档失败，错误："
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 msgid "STEAM_TOOLTIP"
 msgstr "访问我们在Steam上的页面"
 
@@ -5425,7 +5429,7 @@ msgstr "存储"
 msgid "STORAGE_COLON"
 msgstr "存储："
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "已登录为：{0}"
 
@@ -5542,7 +5546,7 @@ msgstr "温度"
 msgid "TESTING_TEAM"
 msgstr "测试团队"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "感谢你的游玩！如果你喜欢这款游戏，请记得也向你的朋友们推荐一下。\n"
@@ -5558,7 +5562,7 @@ msgstr ""
 "\n"
 "如果你喜欢这款游戏，记得也向你的朋友们推荐下。"
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 msgid "THANK_YOU_TITLE"
 msgstr "感谢"
 
@@ -5613,11 +5617,11 @@ msgstr "这个mod是本地安装的"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "这个mod是在Steam创意工坊下载的"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "线程："
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thrive百科"
 
@@ -5773,7 +5777,7 @@ msgstr "暂停"
 msgid "TOGGLE_UNBINDING"
 msgstr "切换解除连接模式"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "工具"
 
@@ -5836,7 +5840,7 @@ msgstr "试着截一些图吧！"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "试着存个档吧！"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "试着截一些图吧！"
 
@@ -5999,11 +6003,11 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "现在就查看"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 msgid "TWITTER_TOOLTIP"
 msgstr "访问我们的推特"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6028,7 +6032,7 @@ msgstr "取消所有连接"
 msgid "UNBIND_HELP_TEXT"
 msgstr "解连接模式"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr "这是一个调试版本，下面的信息可能不是最新的"
 
@@ -6048,7 +6052,7 @@ msgstr "撤销上一个动作"
 msgid "UNKNOWN"
 msgstr "鼠标未知键"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "未知"
 
@@ -6060,7 +6064,7 @@ msgstr "鼠标未知键"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "在Windows上未知"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "未知版本"
 
@@ -6068,7 +6072,7 @@ msgstr "未知版本"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "此Mod的创意工坊编号未知"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "未保存的更改将被丢弃。\n"
@@ -6112,7 +6116,7 @@ msgstr "上传成功"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "许可证和使用的库"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr "使用的渲染器："
 
@@ -6128,7 +6132,7 @@ msgstr "使用自动Harmony加载"
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "从Assembly中自动加载Harmony补丁（不需要指定mod class）"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "使用自定义用户名"
 
@@ -6136,11 +6140,11 @@ msgstr "使用自定义用户名"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr "增加生物多样性的物种在创造时从现有的物种中窃取种群数量"
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "手动设置后台线程数"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr "使用虚拟窗口大小"
 
@@ -6166,7 +6170,7 @@ msgstr "{0} {1}"
 msgid "VERSION_COLON"
 msgstr "版本："
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 msgid "VERTICAL_COLON"
 msgstr "垂直："
 
@@ -6175,11 +6179,11 @@ msgstr "垂直："
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "垂直（{0}轴）"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr "当前使用的视频内存："
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr "{0}MiB"
 
@@ -6187,7 +6191,7 @@ msgstr "{0}MiB"
 msgid "VIEWER"
 msgstr "查看器"
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "查看源代码"
 
@@ -6199,7 +6203,7 @@ msgstr "VIP 支持者"
 msgid "VISIBLE"
 msgstr "可见"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "提出功能建议"
 
@@ -6219,7 +6223,7 @@ msgstr "静音"
 msgid "VOLUMEUP"
 msgstr "提高音量"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "垂直同步"
 
@@ -6328,7 +6332,7 @@ msgstr ""
 "包含测试阶段: {0}\n"
 "包含彩蛋: {1}"
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "来加快细胞的移动"
@@ -6337,15 +6341,15 @@ msgstr "来加快细胞的移动"
 msgid "WORST_PATCH_COLON"
 msgstr "表现最糟的地区："
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6357,7 +6361,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "年"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 msgid "YOUTUBE_TOOLTIP"
 msgstr "访问我们的YouTube频道"
 

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-12-15 06:57+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Chinese (Simplified) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/zh_Hans/>\n"
@@ -204,7 +204,7 @@ msgstr "“{0}” - {1}"
 msgid "ART_BY"
 msgstr "由{0}创作"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "艺术画廊"
 
@@ -302,7 +302,7 @@ msgstr "游戏中启用自动保存"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "Auto-Evo探索工具"
 
@@ -345,8 +345,8 @@ msgid "AWAKEN"
 msgstr "唤醒"
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -601,27 +601,27 @@ msgstr "大写锁定"
 msgid "CARBON_DIOXIDE"
 msgstr "二氧化碳"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "很多"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "较多"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "少"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "多"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "中等"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "很少"
 
@@ -889,19 +889,19 @@ msgstr "S值，决定饱和度"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "V值，决定明度"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr "社区论坛"
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "在我们的社区论坛上加入Thrive社区"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 msgid "COMMUNITY_WIKI"
 msgstr "社区wiki"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "访问我们的社区wiki"
 
@@ -1103,7 +1103,7 @@ msgstr "创建中……"
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "从存档数据中创建物体"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "制作人名单"
 
@@ -1271,11 +1271,11 @@ msgstr ""
 msgid "DEVELOPERS"
 msgstr "开发者"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 msgid "DEVELOPMENT_FORUM"
 msgstr "开发论坛"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "在开发论坛上了解开发进度"
 
@@ -1283,11 +1283,11 @@ msgstr "在开发论坛上了解开发进度"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "由Revolutionary Games Studio ry支持的开发"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 msgid "DEVELOPMENT_WIKI"
 msgstr "开发者wiki"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "访问我们的开发者wiki"
 
@@ -1415,7 +1415,7 @@ msgstr ""
 "有一些细胞器没有连接到其它细胞器上。\n"
 "请把所有细胞器连接起来，或者删掉未连接的细胞器。"
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 msgid "DISCORD_TOOLTIP"
 msgstr "加入我们社区的Discord服务器"
 
@@ -1429,7 +1429,7 @@ msgstr ""
 "这显示了多少弹出窗口已被永久禁用。\n"
 "如果有一些你想要看到的弹出窗口被禁用了，旁边的那个按钮可以使所有被禁用的弹出窗口再次出现。"
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr "不再显示"
 
@@ -1476,7 +1476,7 @@ msgstr "双击可全屏查看"
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "有两层的细胞膜，对伤害有更好的防护能力，也不需要花费那么多能量避免变形。不管怎样，它也会减缓细胞的移动速度，并降低其吸收营养的速率。"
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr "不再提醒这项内容"
 
@@ -1657,15 +1657,15 @@ msgstr "{0}：-{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}： +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "{1}在{0}的能量"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "能量来源："
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "收集的总能量为{0}，每个体的成本为{1}，在修正前的种群数量为{2}"
 
@@ -1718,6 +1718,16 @@ msgstr "为mod创建info文件时出错"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "错误：无法将新设置保存到配置文件。"
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr "（游戏中会随机生成彩蛋）"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "为mod创建info文件时出错"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "载入时出错"
@@ -1769,7 +1779,7 @@ msgstr "加载存档数据时发生异常"
 msgid "EXIT"
 msgstr "退出"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 msgid "EXIT_TO_LAUNCHER"
 msgstr "退出至启动器"
 
@@ -1821,7 +1831,7 @@ msgstr "在这个地区里灭绝了"
 msgid "EXTINCT_SPECIES"
 msgstr "灭绝物种"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "额外内容"
 
@@ -1829,7 +1839,7 @@ msgstr "额外内容"
 msgid "EXTRA_OPTIONS"
 msgstr "额外选项"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 msgid "FACEBOOK_TOOLTIP"
 msgstr "访问我们的Facebook页面"
 
@@ -1860,6 +1870,41 @@ msgstr "已启用"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "二月"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Steam 客户端库初始化失败"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#, fuzzy
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+"帧时间：{0} s\n"
+"物理过程时间：{1} s\n"
+"实体数：{2} 其它：{3}\n"
+"生成数：{4} 销毁数：{5}\n"
+"总节点数：{6}\n"
+"内存占用：{7}\n"
+"GPU内存：{8}\n"
+"渲染物体数：{9}\n"
+"绘图调用数：{10} 2D：{11}\n"
+"渲染顶点数：{12}\n"
+"材料更改数：{13}\n"
+"着色器更改数：{14}\n"
+"孤立节点数：{15}\n"
+"音频延迟：{16} ms\n"
+"线程数：{17}\n"
+"CPU时间：\n"
+"{18}"
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -1943,7 +1988,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "食物链"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0}能量：{1}（适应性：{2}）总可用能量：{3}（总适应性：{4}）"
 
@@ -2039,7 +2084,7 @@ msgstr "世代"
 msgid "GENERATION_COLON"
 msgstr "世代："
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 msgid "GITHUB_TOOLTIP"
 msgstr "访问我们在GitHub上的代码仓库"
 
@@ -2047,11 +2092,11 @@ msgstr "访问我们在GitHub上的代码仓库"
 msgid "GLES2"
 msgstr "GLES2"
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2模式警告"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "你在用GLES2模式运行Thrive。这种情况没有被测试过并且很可能导致种种问题。你应该考虑更新下你的显卡驱动，或者强制使用你的AMD/Nvidia显卡来运行Thrive。"
 
@@ -2337,7 +2382,7 @@ msgstr "铁"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "铁化能无机自养"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 msgid "ITCH_TOOLTIP"
 msgstr "访问我们在Itch.io上的页面"
 
@@ -2555,7 +2600,7 @@ msgstr "此翻译仍在开发中（已完成 {0}%）"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "此翻译非常不完整（已完成 {0}%）请帮助我们！"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr "无法删除最后的细胞器"
 
@@ -2713,7 +2758,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "鼠标左键"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "许可"
 
@@ -2841,7 +2886,8 @@ msgstr "载入"
 msgid "LOADING"
 msgstr "载入中"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "载入中……"
 
@@ -2871,12 +2917,12 @@ msgstr "在编辑器中按下撤消键以纠正错误"
 msgid "LOAD_FINISHED"
 msgstr "载入完成"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "载入游戏"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "载入之前保存的游戏"
 
@@ -3149,7 +3195,7 @@ msgstr "每一代，你都有100个变异点可供花费，任何变化都需要
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "你每次繁殖时都会进入微生物编辑器，你可以在那改变你的物种（通过添加，移动或删除细胞器）以强化你物种的生存力。在微生物阶段每次进入编辑器都代表[thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant]x10⁶年的进化时间。"
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "微生物阶段自由编辑器"
 
@@ -3396,11 +3442,11 @@ msgstr "修改细胞器"
 msgid "MODIFY_TYPE"
 msgstr "修改类型"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 "检测到安装的模组，但没有启用的模组。\n"
@@ -3489,11 +3535,11 @@ msgstr "内部（文件夹）名称："
 msgid "MOD_LICENSE"
 msgstr "此Mod的许可："
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Mod加载错误"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "在加载一个或多个mod时发生了错误。日志可能包含其它信息。"
 
@@ -3729,15 +3775,19 @@ msgstr ""
 "这个存档是来自更新版本的Thrive的并且很可能不兼容。\n"
 "你确定要强行载入这个存档吗？"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr "增加生物多样性物种的初始种群数量"
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "新游戏"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "开始新游戏"
 
@@ -3837,7 +3887,7 @@ msgid "NO_AI"
 msgstr "AI关闭"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "没有数据可显示"
 
@@ -3850,7 +3900,7 @@ msgstr "无事件记录"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "找不到存档目录"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 msgid "NO_MODS_ENABLED"
 msgstr "模组已禁用"
 
@@ -3880,7 +3930,7 @@ msgstr "未选择Mod"
 msgid "NUCLEUS"
 msgstr "细胞核"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 "不能删除细胞核，因为这是个不可逆的进化。\n"
@@ -3901,8 +3951,8 @@ msgstr "数字锁定"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -3915,15 +3965,15 @@ msgstr "不消耗变异点"
 msgid "OCTOBER"
 msgstr "十月"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr "官方网站"
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "访问Revolutionary Games的官方网站"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4004,11 +4054,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "机会主义"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "选项"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "改变你的设置"
 
@@ -4217,7 +4267,7 @@ msgstr "生成图"
 msgid "PATCH_NAME"
 msgstr "{0}{1}"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 msgid "PATREON_TOOLTIP"
 msgstr "访问我们在Patreon上的页面"
 
@@ -4275,8 +4325,8 @@ msgstr "性能"
 msgid "PERFORM_UNBINDING"
 msgstr "取消连接"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "每秒"
 
@@ -4332,7 +4382,7 @@ msgstr "行星生成即将发布！"
 msgid "PLANET_RANDOM_SEED"
 msgstr "世界生成种子"
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "玩家细胞"
 
@@ -4408,7 +4458,7 @@ msgstr "种群数量："
 msgid "POPULATION_IN_PATCHES"
 msgstr "地区中的种群数量："
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} （{1}）"
 
@@ -4462,7 +4512,7 @@ msgstr "之前："
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "处理载入的物体中"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4506,11 +4556,11 @@ msgstr "快速读档"
 msgid "QUICK_SAVE"
 msgstr "快速保存"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "退出"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 msgid "QUIT_BUTTON_TOOLTIP"
 msgstr "退出游戏"
@@ -4552,7 +4602,7 @@ msgstr "准备就绪"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "推荐的Thrive版本："
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 msgid "REDDIT_TOOLTIP"
 msgstr "访问我们的subreddit页面"
 
@@ -4688,7 +4738,7 @@ msgstr ""
 "你确定要退出到主菜单吗？\n"
 "你会失去任何未保存的进度。"
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "访问Revolutionary Games Studio网站"
 
@@ -4775,7 +4825,7 @@ msgstr "铁硫菌蓝蛋白能够利用气态二氧化碳和氧将铁从一种化
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "将[thrive:compound type=\"iron\"][/thrive:compound]转换成[thrive:compound type=\"atp\"][/thrive:compound]。速率跟[thrive:compound type=\"carbondioxide\"][/thrive:compound]和[thrive:compound type=\"oxygen\"][/thrive:compound]的浓度成正比。"
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
 "由于先前的启动错误，Thrive已在安全模式下启动。\n"
@@ -4787,7 +4837,7 @@ msgstr ""
 "\n"
 "如果你未能修复导致启动错误的问题，你在未来几次启动中将会崩溃数次并最后再次返回安全模式。"
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 msgid "SAFE_MODE_TITLE"
 msgstr "Thrive在安全模式下启动"
 
@@ -5150,7 +5200,7 @@ msgstr "生成氨"
 msgid "SPAWN_ENEMY"
 msgstr "生成敌人"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "无法使用生成敌人作弊，因为这个地区没有任何敌对物种"
 
@@ -5210,7 +5260,7 @@ msgstr "物种名…"
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "物种名过长！"
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0}（x{1}）"
 
@@ -5325,17 +5375,17 @@ msgstr "Steam系统目前不可用，请重试"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "发生了未知的Steam错误"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Steam 客户端库初始化失败"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "更新此存档失败，错误："
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 msgid "STEAM_TOOLTIP"
 msgstr "访问我们在Steam上的页面"
 
@@ -5375,7 +5425,7 @@ msgstr "存储"
 msgid "STORAGE_COLON"
 msgstr "存储："
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "已登录为：{0}"
 
@@ -5492,7 +5542,7 @@ msgstr "温度"
 msgid "TESTING_TEAM"
 msgstr "测试团队"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
 "感谢你的游玩！如果你喜欢这款游戏，请记得也向你的朋友们推荐一下。\n"
@@ -5508,7 +5558,7 @@ msgstr ""
 "\n"
 "如果你喜欢这款游戏，记得也向你的朋友们推荐下。"
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 msgid "THANK_YOU_TITLE"
 msgstr "感谢"
 
@@ -5567,7 +5617,7 @@ msgstr "这个mod是在Steam创意工坊下载的"
 msgid "THREADS"
 msgstr "线程："
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr "Thrive百科"
 
@@ -5723,7 +5773,7 @@ msgstr "暂停"
 msgid "TOGGLE_UNBINDING"
 msgstr "切换解除连接模式"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "工具"
 
@@ -5949,7 +5999,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "现在就查看"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 msgid "TWITTER_TOOLTIP"
 msgstr "访问我们的推特"
 
@@ -6137,7 +6187,7 @@ msgstr "{0}MiB"
 msgid "VIEWER"
 msgstr "查看器"
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "查看源代码"
 
@@ -6149,7 +6199,7 @@ msgstr "VIP 支持者"
 msgid "VISIBLE"
 msgstr "可见"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr "提出功能建议"
 
@@ -6307,7 +6357,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "年"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 msgid "YOUTUBE_TOOLTIP"
 msgstr "访问我们的YouTube频道"
 

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-31 14:35+0200\n"
+"POT-Creation-Date: 2023-02-02 12:16+0200\n"
 "PO-Revision-Date: 2022-07-26 06:43+0000\n"
 "Last-Translator: ben001109 <a0903932792@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/zh_Hant/>\n"
@@ -211,7 +211,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "由{0}創作"
 
-#: ../src/general/MainMenu.tscn:490
+#: ../src/general/MainMenu.tscn:492
 msgid "ART_GALLERY"
 msgstr "藝術畫廊"
 
@@ -311,7 +311,7 @@ msgstr "遊戲過程中自動保存"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:381
+#: ../src/general/MainMenu.tscn:383
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "運行狀態："
@@ -355,8 +355,8 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:430 ../src/general/MainMenu.tscn:532
-#: ../src/general/MainMenu.tscn:842 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
+#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
 #: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
@@ -620,27 +620,27 @@ msgstr "Caps Lock"
 msgid "CARBON_DIOXIDE"
 msgstr "二氧化碳"
 
-#: ../src/general/StageHUDBase.cs:1032
+#: ../src/general/StageHUDBase.cs:1028
 msgid "CATEGORY_AN_ABUNDANCE"
 msgstr "充裕"
 
-#: ../src/general/StageHUDBase.cs:1036
+#: ../src/general/StageHUDBase.cs:1032
 msgid "CATEGORY_A_FAIR_AMOUNT"
 msgstr "相當數量"
 
-#: ../src/general/StageHUDBase.cs:1040
+#: ../src/general/StageHUDBase.cs:1036
 msgid "CATEGORY_LITTLE"
 msgstr "少"
 
-#: ../src/general/StageHUDBase.cs:1034
+#: ../src/general/StageHUDBase.cs:1030
 msgid "CATEGORY_QUITE_A_BIT"
 msgstr "不少"
 
-#: ../src/general/StageHUDBase.cs:1038
+#: ../src/general/StageHUDBase.cs:1034
 msgid "CATEGORY_SOME"
 msgstr "中等"
 
-#: ../src/general/StageHUDBase.cs:1042
+#: ../src/general/StageHUDBase.cs:1038
 msgid "CATEGORY_VERY_LITTLE"
 msgstr "很少"
 
@@ -917,21 +917,21 @@ msgstr "S值，決定飽和度"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "V值，決定明亮度"
 
-#: ../src/general/MainMenu.tscn:592
+#: ../src/general/MainMenu.tscn:594
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:587
+#: ../src/general/MainMenu.tscn:589
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "添加新的綁定鍵位"
 
-#: ../src/general/MainMenu.tscn:634
+#: ../src/general/MainMenu.tscn:636
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "我們的Wiki"
 
-#: ../src/general/MainMenu.tscn:629
+#: ../src/general/MainMenu.tscn:631
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "自殺"
@@ -1143,7 +1143,7 @@ msgstr "創建中……"
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "從存檔中建立物體"
 
-#: ../src/general/MainMenu.tscn:315
+#: ../src/general/MainMenu.tscn:317
 msgid "CREDITS"
 msgstr "鳴謝"
 
@@ -1321,12 +1321,12 @@ msgstr "Devbuilds 支持者"
 msgid "DEVELOPERS"
 msgstr "開發者"
 
-#: ../src/general/MainMenu.tscn:606
+#: ../src/general/MainMenu.tscn:608
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "由Revolutionary Games Studio ry支持的開發"
 
-#: ../src/general/MainMenu.tscn:601
+#: ../src/general/MainMenu.tscn:603
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "添加新的綁定鍵位"
@@ -1335,12 +1335,12 @@ msgstr "添加新的綁定鍵位"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "由Revolutionary Games Studio ry支持的開發"
 
-#: ../src/general/MainMenu.tscn:620
+#: ../src/general/MainMenu.tscn:622
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "開發者"
 
-#: ../src/general/MainMenu.tscn:615
+#: ../src/general/MainMenu.tscn:617
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "幫助"
@@ -1465,7 +1465,7 @@ msgstr ""
 "有一些细胞器没有连接到其它细胞器上。\n"
 "请把所有细胞器连接起来，或者删掉未连接的细胞器。"
 
-#: ../src/general/MainMenu.tscn:765
+#: ../src/general/MainMenu.tscn:774
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "經過的時間：{0:#,#} 年"
@@ -1483,7 +1483,7 @@ msgstr ""
 "並且對物質塊更有渴求。\n"
 "應變型微生物將更快的轉向新的目標。"
 
-#: ../src/general/MainMenu.tscn:953
+#: ../src/general/MainMenu.tscn:962
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "有兩層的細胞膜，對傷害有更好的防護能力，也不需要花費那麼多能量避免變形。然而它也會減慢細胞的移動速度，並降低其吸收營養的速率。"
 
-#: ../src/general/MainMenu.tscn:896
+#: ../src/general/MainMenu.tscn:905
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1720,15 +1720,15 @@ msgstr "{0}: -{1} ATP"
 msgid "ENERGY_BALANCE_TOOLTIP_PRODUCTION"
 msgstr "{0}: +{1} ATP"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2404
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2406
 msgid "ENERGY_IN_PATCH_FOR"
 msgstr "{1}在{0}的能量"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2415
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2417
 msgid "ENERGY_SOURCES"
 msgstr "能量來源："
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2408
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2410
 msgid "ENERGY_SUMMARY_LINE"
 msgstr "收集的總能量為{0}，每個體的成本為{1}，在修正前的種群數量為{2}"
 
@@ -1784,6 +1784,20 @@ msgstr "創建MOD信息文件出錯"
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "錯誤：無法將新設置保存至配置文件。"
 
+#: ../src/general/ThriveNewsFeed.cs:95
+#, fuzzy
+msgid "ERROR_FETCHING_EXPLANATION"
+msgstr ""
+"膽小型微生物會逃到更遠的地方，\n"
+"並且總體上更有可能逃離掠食者。\n"
+"勇敢型微生物則不會被靠近的掠食者嚇到\n"
+"而且更有可能反擊。"
+
+#: ../src/general/ThriveNewsFeed.cs:94
+#, fuzzy
+msgid "ERROR_FETCHING_NEWS"
+msgstr "創建MOD信息文件出錯"
+
 #: ../src/saving/InProgressLoad.cs:201
 msgid "ERROR_LOADING"
 msgstr "加載時出錯"
@@ -1838,7 +1852,7 @@ msgstr "加載存檔數據時發生異常"
 msgid "EXIT"
 msgstr "退出"
 
-#: ../src/general/MainMenu.tscn:325
+#: ../src/general/MainMenu.tscn:327
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Launch E"
@@ -1892,7 +1906,7 @@ msgstr "從這個區域滅絕了"
 msgid "EXTINCT_SPECIES"
 msgstr "物種滅絕"
 
-#: ../src/general/MainMenu.tscn:306
+#: ../src/general/MainMenu.tscn:308
 msgid "EXTRAS"
 msgstr "額外內容"
 
@@ -1900,7 +1914,7 @@ msgstr "額外內容"
 msgid "EXTRA_OPTIONS"
 msgstr "額外選項"
 
-#: ../src/general/MainMenu.tscn:777
+#: ../src/general/MainMenu.tscn:786
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "暫停遊戲"
@@ -1934,6 +1948,23 @@ msgstr "啟用作弊鍵"
 #: ../src/gui_common/CreditsScroll.cs:510
 msgid "FEBRUARY"
 msgstr "二月"
+
+#: ../src/general/ThriveNewsFeed.cs:192
+#, fuzzy
+msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
+msgstr "Steam 客戶端庫初始化失敗"
+
+#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+msgid "FEED_ITEM_MISSING_CONTENT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:167
+msgid "FEED_ITEM_PUBLISHED_AT"
+msgstr ""
+
+#: ../src/general/ThriveNewsFeed.cs:206
+msgid "FEED_ITEM_TRUNCATED_NOTICE"
+msgstr ""
 
 #: ../src/gui_common/art_gallery/GalleryViewer.tscn:70
 msgid "FILTER_ITEMS_BY_CATEGORY_COLON"
@@ -2021,7 +2052,7 @@ msgstr ""
 msgid "FOOD_CHAIN"
 msgstr "食物鏈"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2421
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2423
 msgid "FOOD_SOURCE_ENERGY_INFO"
 msgstr "{0}能量：{1}（適應性：{2}）總可用能量：{3}（總適應性：{4}）"
 
@@ -2128,7 +2159,7 @@ msgstr "世代"
 msgid "GENERATION_COLON"
 msgstr "世代："
 
-#: ../src/general/MainMenu.tscn:729
+#: ../src/general/MainMenu.tscn:738
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "自殺"
@@ -2137,11 +2168,11 @@ msgstr "自殺"
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:862
+#: ../src/general/MainMenu.tscn:871
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2模式警告"
 
-#: ../src/general/MainMenu.tscn:864
+#: ../src/general/MainMenu.tscn:873
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "你在用GLES2模式運行Thrive。這種情況沒有被測試過並且很可能導致種種問題。你應該考慮更新下你的顯卡驅動，或者強制使用你的AMD/Nvidia顯卡來運行Thrive。"
 
@@ -2429,7 +2460,7 @@ msgstr "鐵"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "鐵化能無機自養"
 
-#: ../src/general/MainMenu.tscn:705
+#: ../src/general/MainMenu.tscn:714
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "自殺"
@@ -2648,7 +2679,7 @@ msgstr "此語言仍在翻譯中（已完成 {0}%）"
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "此翻譯非常不完整（已完成 {0}%）請幫助我們！"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1348
 msgid "LAST_ORGANELLE_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -2812,7 +2843,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "鼠標左鍵"
 
-#: ../src/general/MainMenu.tscn:501
+#: ../src/general/MainMenu.tscn:503
 msgid "LICENSES"
 msgstr "許可"
 
@@ -2953,7 +2984,8 @@ msgstr "加載"
 msgid "LOADING"
 msgstr "加載中"
 
-#: ../src/saving/SaveList.tscn:59 ../src/saving/SaveListItem.tscn:105
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
 msgstr "上傳中……"
@@ -2986,12 +3018,12 @@ msgstr "在編輯器中點擊撤消按鈕以糾正錯誤"
 msgid "LOAD_FINISHED"
 msgstr "加載完成"
 
-#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "讀取遊戲"
 
-#: ../src/general/MainMenu.tscn:266 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "暫停菜單"
@@ -3268,7 +3300,7 @@ msgstr "每一代，你都有100個變異點(MP)可供花費，任何變化都�
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "你每次繁殖時都會進入微生物編輯器，你可以在那改變你的物種（通過添加，移動或刪除細胞器）以強化你物種的生存力。在微生物階段每次進入編輯器都代表[thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant]百萬年的進化時間。"
 
-#: ../src/general/MainMenu.tscn:369
+#: ../src/general/MainMenu.tscn:371
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "微生物階段自由編輯器"
 
@@ -3508,11 +3540,11 @@ msgstr "修改細胞器"
 msgid "MODIFY_TYPE"
 msgstr "修改"
 
-#: ../src/general/MainMenu.tscn:476
+#: ../src/general/MainMenu.tscn:478
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:880
+#: ../src/general/MainMenu.tscn:889
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3601,11 +3633,11 @@ msgstr "內部（文件夾）名稱："
 msgid "MOD_LICENSE"
 msgstr "Mod許可："
 
-#: ../src/general/MainMenu.tscn:920
+#: ../src/general/MainMenu.tscn:929
 msgid "MOD_LOAD_ERRORS"
 msgstr "Mod加載錯誤"
 
-#: ../src/general/MainMenu.tscn:921
+#: ../src/general/MainMenu.tscn:930
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "在加載一個或多個mods時發生錯誤。日誌可能包含其他信息。"
 
@@ -3843,15 +3875,19 @@ msgstr ""
 "這個存檔是來自更新版本的Thrive的並且很可能不兼容。\n"
 "你確定要強行載入這個存檔嗎？"
 
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:24
+msgid "NEWS"
+msgstr ""
+
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:638
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:256
+#: ../src/general/MainMenu.tscn:258
 msgid "NEW_GAME"
 msgstr "新遊戲"
 
-#: ../src/general/MainMenu.tscn:250
+#: ../src/general/MainMenu.tscn:252
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "暫停菜單"
@@ -3957,7 +3993,7 @@ msgid "NO_AI"
 msgstr "沒有AI"
 
 #: ../src/gui_common/charts/line/LineChart.cs:674
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2436
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2438
 msgid "NO_DATA_TO_SHOW"
 msgstr "沒有數據可顯示"
 
@@ -3970,7 +4006,7 @@ msgstr "沒有事件被記錄"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "找不到存檔目錄"
 
-#: ../src/general/MainMenu.tscn:867
+#: ../src/general/MainMenu.tscn:876
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "已禁用"
@@ -4001,7 +4037,7 @@ msgstr "沒有被選取的MOD"
 msgid "NUCLEUS"
 msgstr "細胞核"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:1344
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:1346
 msgid "NUCLEUS_DELETE_OPTION_DISABLED_TOOLTIP"
 msgstr ""
 
@@ -4020,8 +4056,8 @@ msgstr "Num Lock"
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:26
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:36
 #: ../src/gui_common/art_gallery/GalleryDetailsTooltip.cs:46
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2294
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2304
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2296
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2306
 #: ../src/microbe_stage/editor/MicrobePartSelection.tscn:140
 msgid "N_A"
 msgstr "N/A"
@@ -4034,16 +4070,16 @@ msgstr "N/A 變異點"
 msgid "OCTOBER"
 msgstr "十月"
 
-#: ../src/general/MainMenu.tscn:578
+#: ../src/general/MainMenu.tscn:580
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:569
+#: ../src/general/MainMenu.tscn:571
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "自殺"
 
-#: ../src/general/MainMenu.tscn:910 ../src/general/MainMenu.tscn:967
+#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4124,11 +4160,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "機會主義"
 
-#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "選項"
 
-#: ../src/general/MainMenu.tscn:276 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "幫助"
@@ -4350,7 +4386,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "洞穴"
 
-#: ../src/general/MainMenu.tscn:717
+#: ../src/general/MainMenu.tscn:726
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "暫停遊戲"
@@ -4411,8 +4447,8 @@ msgstr "性能"
 msgid "PERFORM_UNBINDING"
 msgstr "取消連接"
 
-#: ../src/gui_common/ChemicalEquation.cs:145
-#: ../src/gui_common/ChemicalEquation.cs:203
+#: ../src/gui_common/ChemicalEquation.cs:141
+#: ../src/gui_common/ChemicalEquation.cs:199
 msgid "PER_SECOND_SLASH"
 msgstr "/秒"
 
@@ -4462,7 +4498,7 @@ msgstr ""
 msgid "PLANET_RANDOM_SEED"
 msgstr ""
 
-#: ../src/general/StageHUDBase.cs:1252
+#: ../src/general/StageHUDBase.cs:1240
 msgid "PLAYER_CELL"
 msgstr "玩家細胞"
 
@@ -4540,7 +4576,7 @@ msgstr "總人口："
 msgid "POPULATION_IN_PATCHES"
 msgstr "該區域人口:"
 
-#: ../src/microbe_stage/editor/CellEditorComponent.cs:2285
+#: ../src/microbe_stage/editor/CellEditorComponent.cs:2287
 msgid "POPULATION_IN_PATCH_SHORT"
 msgstr "{0} ({1})"
 
@@ -4595,7 +4631,7 @@ msgstr "物種："
 msgid "PROCESSING_LOADED_OBJECTS"
 msgstr "處理載入的物體中"
 
-#: ../src/gui_common/ChemicalEquation.cs:327
+#: ../src/gui_common/ChemicalEquation.cs:323
 msgid "PROCESS_ENVIRONMENT_SEPARATOR"
 msgstr "@"
 
@@ -4639,11 +4675,11 @@ msgstr "快速讀檔"
 msgid "QUICK_SAVE"
 msgstr "快速存檔"
 
-#: ../src/general/MainMenu.tscn:338
+#: ../src/general/MainMenu.tscn:340
 msgid "QUIT"
 msgstr "離開"
 
-#: ../src/general/MainMenu.tscn:322 ../src/general/MainMenu.tscn:332
+#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4688,7 +4724,7 @@ msgstr "已就緒"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "推薦Thrive："
 
-#: ../src/general/MainMenu.tscn:753
+#: ../src/general/MainMenu.tscn:762
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "返回遊戲"
@@ -4832,7 +4868,7 @@ msgstr ""
 "你確定要退出到主菜單嗎？\n"
 "你會失去任何未保存的進度。"
 
-#: ../src/general/MainMenu.tscn:680
+#: ../src/general/MainMenu.tscn:689
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "由Revolutionary Games Studio製作"
@@ -4921,7 +4957,7 @@ msgstr "鐵硫菌藍蛋白[Rusticyanin]能夠利用二氧化碳和氧將鐵從�
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "將[thrive:compound type=\"iron\"][/thrive:compound]轉換為thrive:compound type=\"atp\"][/thrive:compound]。速率跟[thrive:compound type=\"carbondioxide\"][/thrive:compound]和[thrive:compound type=\"oxygen\"][/thrive:compound]的濃度成正比。"
 
-#: ../src/general/MainMenu.tscn:916
+#: ../src/general/MainMenu.tscn:925
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4930,7 +4966,7 @@ msgstr ""
 "勇敢型微生物則不會被靠近的掠食者嚇到\n"
 "而且更有可能反擊。"
 
-#: ../src/general/MainMenu.tscn:914
+#: ../src/general/MainMenu.tscn:923
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "移除本地數據"
@@ -5315,7 +5351,7 @@ msgstr "生成氨"
 msgid "SPAWN_ENEMY"
 msgstr "生成敵人"
 
-#: ../src/microbe_stage/MicrobeStage.cs:769
+#: ../src/microbe_stage/MicrobeStage.cs:765
 msgid "SPAWN_ENEMY_CHEAT_FAIL"
 msgstr "無法使用生成敵人作弊，因為這個地區沒有任何敵對物種"
 
@@ -5369,7 +5405,7 @@ msgstr "物種名..."
 msgid "SPECIES_NAME_TOO_LONG_POPUP"
 msgstr "物種名..."
 
-#: ../src/general/StageHUDBase.cs:1265
+#: ../src/general/StageHUDBase.cs:1253
 msgid "SPECIES_N_TIMES"
 msgstr "{0} (x{1})"
 
@@ -5486,17 +5522,17 @@ msgstr "Steam系統目前不可用，請重試"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "發生了未知的Steam錯誤"
 
-#: ../src/general/MainMenu.tscn:971
+#: ../src/general/MainMenu.tscn:980
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Steam 客戶端庫初始化失敗"
 
-#: ../src/general/MainMenu.tscn:973
+#: ../src/general/MainMenu.tscn:982
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "更新此存檔失敗，錯誤："
 
-#: ../src/general/MainMenu.tscn:693
+#: ../src/general/MainMenu.tscn:702
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "暫停遊戲"
@@ -5540,7 +5576,7 @@ msgstr "儲存"
 msgid "STORAGE_COLON"
 msgstr "儲存："
 
-#: ../src/general/MainMenu.cs:467
+#: ../src/general/MainMenu.cs:474
 msgid "STORE_LOGGED_IN_AS"
 msgstr "已登錄為：{0}"
 
@@ -5657,7 +5693,7 @@ msgstr "溫度"
 msgid "TESTING_TEAM"
 msgstr "測試團隊"
 
-#: ../src/general/MainMenu.cs:202 ../src/general/MainMenu.tscn:937
+#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5672,7 +5708,7 @@ msgstr ""
 "\n"
 "如果你喜歡這款遊戲，記得也向你的朋友們推薦下。"
 
-#: ../src/general/MainMenu.tscn:927
+#: ../src/general/MainMenu.tscn:936
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "你已經茁壯繁盛了!"
@@ -5736,7 +5772,7 @@ msgstr "這個MOD是在Steam工作坊下載的"
 msgid "THREADS"
 msgstr "線程："
 
-#: ../src/general/MainMenu.tscn:462 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5885,7 +5921,7 @@ msgstr "暫停"
 msgid "TOGGLE_UNBINDING"
 msgstr "解除鏈接模式"
 
-#: ../src/general/MainMenu.tscn:288
+#: ../src/general/MainMenu.tscn:290
 msgid "TOOLS"
 msgstr "工具"
 
@@ -6118,7 +6154,7 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "教學"
 
-#: ../src/general/MainMenu.tscn:789
+#: ../src/general/MainMenu.tscn:798
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "經過的時間：{0:#,#} 年"
@@ -6318,7 +6354,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:297
+#: ../src/general/MainMenu.tscn:299
 msgid "VIEW_SOURCE_CODE"
 msgstr "查看源代碼"
 
@@ -6330,7 +6366,7 @@ msgstr "VIP 支持者"
 msgid "VISIBLE"
 msgstr "可見"
 
-#: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:652
+#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6486,7 +6522,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "年"
 
-#: ../src/general/MainMenu.tscn:741
+#: ../src/general/MainMenu.tscn:750
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "暫停遊戲"

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-02 12:16+0200\n"
+"POT-Creation-Date: 2023-02-02 15:23+0200\n"
 "PO-Revision-Date: 2022-07-26 06:43+0000\n"
 "Last-Translator: ben001109 <a0903932792@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/zh_Hant/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Weblate 4.13.1\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: ../src/general/OptionsMenu.tscn:1452
+#: ../src/general/OptionsMenu.tscn:1453
 msgid "2D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr "3D編輯器"
 msgid "3D_MOVEMENT"
 msgstr "3D移動"
 
-#: ../src/general/OptionsMenu.tscn:1484
+#: ../src/general/OptionsMenu.tscn:1485
 msgid "3D_MOVEMENT_TYPE_SELECTION"
 msgstr ""
 
@@ -63,7 +63,7 @@ msgstr ""
 msgid "ACTIVE"
 msgstr "活潑"
 
-#: ../src/general/OptionsMenu.tscn:1087
+#: ../src/general/OptionsMenu.tscn:1088
 msgid "ACTIVE_THREAD_COUNT"
 msgstr "當前線程："
 
@@ -150,7 +150,7 @@ msgstr "生物統計"
 msgid "ALT"
 msgstr "Alt"
 
-#: ../src/general/OptionsMenu.tscn:734
+#: ../src/general/OptionsMenu.tscn:735
 msgid "AMBIANCE_VOLUME"
 msgstr "環境音量"
 
@@ -161,11 +161,11 @@ msgstr "環境音量"
 msgid "AMMONIA"
 msgstr "氨"
 
-#: ../src/general/OptionsMenu.tscn:1629
+#: ../src/general/OptionsMenu.tscn:1630
 msgid "AMOUNT_OF_AUTOSAVE_TO_KEEP"
 msgstr "保留的自動存檔數量："
 
-#: ../src/general/OptionsMenu.tscn:1657
+#: ../src/general/OptionsMenu.tscn:1658
 msgid "AMOUNT_OF_QUICKSAVE_TO_KEEP"
 msgstr "保留的快速存檔數量："
 
@@ -190,11 +190,11 @@ msgstr "應用變更"
 msgid "APRIL"
 msgstr "四月"
 
-#: ../src/general/OptionsMenu.tscn:1967
+#: ../src/general/OptionsMenu.tscn:1976
 msgid "ARE_YOU_SURE_TO_RESET_ALL_SETTINGS"
 msgstr "你確定要把「所有」設置都重置為默認值嗎？"
 
-#: ../src/general/OptionsMenu.tscn:1976
+#: ../src/general/OptionsMenu.tscn:1985
 msgid "ARE_YOU_SURE_TO_RESET_INPUT_SETTINGS"
 msgstr "您確定要將輸入設置重置為默認嗎？"
 
@@ -211,7 +211,7 @@ msgstr "\"{0}\" - {1}"
 msgid "ART_BY"
 msgstr "由{0}創作"
 
-#: ../src/general/MainMenu.tscn:492
+#: ../src/general/MainMenu.tscn:493
 msgid "ART_GALLERY"
 msgstr "藝術畫廊"
 
@@ -224,7 +224,7 @@ msgstr "當指定裝配時，需要Mod裝配類"
 msgid "ASSEMBLY_REQUIRED_WITH_HARMONY"
 msgstr "當指定裝配時，需要Mod裝配類"
 
-#: ../src/general/OptionsMenu.tscn:1101
+#: ../src/general/OptionsMenu.tscn:1102
 msgid "ASSUME_HYPERTHREADING"
 msgstr "假設CPU已啟用超線程"
 
@@ -267,7 +267,7 @@ msgstr "Auto-evo啟動失敗"
 msgid "AT_CURSOR"
 msgstr "鼠標指針處："
 
-#: ../src/general/OptionsMenu.tscn:851
+#: ../src/general/OptionsMenu.tscn:852
 msgid "AUDIO_OUTPUT_DEVICE"
 msgstr "音頻輸出設備："
 
@@ -275,8 +275,8 @@ msgstr "音頻輸出設備："
 msgid "AUGUST"
 msgstr "八月"
 
-#: ../src/general/OptionsMenu.tscn:590 ../src/general/OptionsMenu.tscn:591
-#: ../src/general/OptionsMenu.tscn:1469 ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:591 ../src/general/OptionsMenu.tscn:592
+#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1471
 msgid "AUTO"
 msgstr "自動"
 
@@ -303,7 +303,7 @@ msgstr ""
 msgid "AUTO-EVO_STEPS_DONE"
 msgstr "已完成{0:F1}%。{1:n0}/{2:n0}步剩餘。"
 
-#: ../src/general/OptionsMenu.tscn:1618
+#: ../src/general/OptionsMenu.tscn:1619
 msgid "AUTOSAVE_DURING_THE_GAME"
 msgstr "遊戲過程中自動保存"
 
@@ -311,7 +311,7 @@ msgstr "遊戲過程中自動保存"
 msgid "AUTO_EVO"
 msgstr "Auto-Evo"
 
-#: ../src/general/MainMenu.tscn:383
+#: ../src/general/MainMenu.tscn:384
 #, fuzzy
 msgid "AUTO_EVO_EXPLORING_TOOL"
 msgstr "運行狀態："
@@ -342,7 +342,7 @@ msgstr "運行狀態："
 msgid "AUTO_MOVE_FORWARDS"
 msgstr "自動前進"
 
-#: ../src/general/OptionsMenu.cs:911 ../src/general/OptionsMenu.tscn:353
+#: ../src/general/OptionsMenu.cs:918 ../src/general/OptionsMenu.tscn:354
 msgid "AUTO_RESOLUTION"
 msgstr "自動（{0}x{1}）"
 
@@ -355,9 +355,9 @@ msgid "AWAKEN"
 msgstr ""
 
 #: ../src/auto-evo/AutoEvoExploringTool.tscn:998
-#: ../src/general/MainMenu.tscn:432 ../src/general/MainMenu.tscn:534
-#: ../src/general/MainMenu.tscn:851 ../src/general/NewGameSettings.tscn:1184
-#: ../src/general/OptionsMenu.tscn:1904 ../src/general/PauseMenu.tscn:275
+#: ../src/general/MainMenu.tscn:433 ../src/general/MainMenu.tscn:535
+#: ../src/general/MainMenu.tscn:861 ../src/general/NewGameSettings.tscn:1184
+#: ../src/general/OptionsMenu.tscn:1913 ../src/general/PauseMenu.tscn:275
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:76
 #: ../src/modding/ModManager.tscn:79 ../src/saving/NewSaveMenu.tscn:122
 #: ../src/saving/SaveManagerGUI.tscn:115
@@ -501,7 +501,7 @@ msgstr "允許與其他細胞結合。這是邁向多細胞性的第一步。當
 msgid "BINDING_AGENT_PROCESSES_DESCRIPTION"
 msgstr "按[thrive:input]g_toggle_binding[/thrive:input]來切換連接模式。在連接模式中，通過接觸同種細胞，你可以讓它成為你的細胞群的一員。要離開細胞群，按[thrive:input]g_unbind_all[/thrive:input]。"
 
-#: ../src/general/OptionsMenu.tscn:1273 ../src/general/OptionsMenu.tscn:1383
+#: ../src/general/OptionsMenu.tscn:1274 ../src/general/OptionsMenu.tscn:1384
 msgid "BIND_AXES_SENSITIVITY"
 msgstr ""
 
@@ -563,7 +563,7 @@ msgstr "這種膜有一層額外的碳酸鈣堅固外殼。它可以很容易地
 msgid "CAMERA"
 msgstr "視角"
 
-#: ../src/general/OptionsMenu.tscn:2055
+#: ../src/general/OptionsMenu.tscn:2064
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:58
 #: ../src/modding/NewModGUI.tscn:472
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:207
@@ -696,7 +696,7 @@ msgstr "改變對稱"
 msgid "CHEATS"
 msgstr "作弊"
 
-#: ../src/general/OptionsMenu.tscn:1711
+#: ../src/general/OptionsMenu.tscn:1712
 msgid "CHEAT_KEYS_ENABLED"
 msgstr "啟用作弊鍵"
 
@@ -789,7 +789,7 @@ msgstr "產出[thrive:compound type=\"glucose\"][/thrive:compound]。速率跟[t
 msgid "CHOSEN_FILENAME_ALREADY_EXISTS"
 msgstr "目標文件名{0}已存在。確定要覆蓋嗎？"
 
-#: ../src/general/OptionsMenu.tscn:433
+#: ../src/general/OptionsMenu.tscn:434
 msgid "CHROMATIC_ABERRATION"
 msgstr "色差："
 
@@ -832,15 +832,15 @@ msgstr "清除舊存檔"
 msgid "CLOSE"
 msgstr "關閉"
 
-#: ../src/general/OptionsMenu.tscn:1985
+#: ../src/general/OptionsMenu.tscn:1994
 msgid "CLOSE_OPTIONS"
 msgstr "關閉選項菜單？"
 
-#: ../src/general/OptionsMenu.tscn:1008
+#: ../src/general/OptionsMenu.tscn:1009
 msgid "CLOUD_RESOLUTION_DIVISOR"
 msgstr "雲解像度除數："
 
-#: ../src/general/OptionsMenu.tscn:958
+#: ../src/general/OptionsMenu.tscn:959
 msgid "CLOUD_SIMULATION_MINIMUM_INTERVAL"
 msgstr "模擬雲的最小時間間隔："
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "COLOUR"
 msgstr "顏色"
 
-#: ../src/general/OptionsMenu.tscn:395
+#: ../src/general/OptionsMenu.tscn:396
 msgid "COLOURBLIND_CORRECTION"
 msgstr "色盲修正："
 
@@ -917,26 +917,26 @@ msgstr "S值，決定飽和度"
 msgid "COLOUR_PICKER_V_TOOLTIP"
 msgstr "V值，決定明亮度"
 
-#: ../src/general/MainMenu.tscn:594
+#: ../src/general/MainMenu.tscn:595
 msgid "COMMUNITY_FORUM"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:589
+#: ../src/general/MainMenu.tscn:590
 #, fuzzy
 msgid "COMMUNITY_FORUM_BUTTON_TOOLTIP"
 msgstr "添加新的綁定鍵位"
 
-#: ../src/general/MainMenu.tscn:636
+#: ../src/general/MainMenu.tscn:637
 #, fuzzy
 msgid "COMMUNITY_WIKI"
 msgstr "我們的Wiki"
 
-#: ../src/general/MainMenu.tscn:631
+#: ../src/general/MainMenu.tscn:632
 #, fuzzy
 msgid "COMMUNITY_WIKI_BUTTON_TOOLTIP"
 msgstr "自殺"
 
-#: ../src/general/OptionsMenu.tscn:1873
+#: ../src/general/OptionsMenu.tscn:1882
 #, fuzzy
 msgid "COMPILED_AT_COLON"
 msgstr "化合物："
@@ -964,7 +964,7 @@ msgstr "化合物："
 msgid "COMPOUND_BALANCE_TITLE"
 msgstr "化合物平衡"
 
-#: ../src/general/OptionsMenu.tscn:943
+#: ../src/general/OptionsMenu.tscn:944
 msgid "COMPOUND_CLOUDS"
 msgstr "化合物雲"
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "CONTROLLER_AXIS_VISUALIZERS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1442
+#: ../src/general/OptionsMenu.tscn:1443
 msgid "CONTROLLER_DEADZONES"
 msgstr ""
 
@@ -1067,11 +1067,11 @@ msgstr "這個板塊顯示了auto-evo預測工作所依據的數字。一個物�
 msgid "CONTROLLER_DEADZONE_COLON"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:573
+#: ../src/general/OptionsMenu.tscn:574
 msgid "CONTROLLER_PROMPT_TYPE_SETTING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1370
+#: ../src/general/OptionsMenu.tscn:1371
 msgid "CONTROLLER_SENSITIVITY"
 msgstr ""
 
@@ -1079,11 +1079,11 @@ msgstr ""
 msgid "COPY_ERROR_TO_CLIPBOARD"
 msgstr "將錯誤複製到剪貼板"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_PROTANOPE"
 msgstr "紅綠色盲"
 
-#: ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:413
 msgid "CORRECTION_TRITANOPE"
 msgstr "蓝黄色盲"
 
@@ -1143,7 +1143,7 @@ msgstr "創建中……"
 msgid "CREATING_OBJECTS_FROM_SAVE"
 msgstr "從存檔中建立物體"
 
-#: ../src/general/MainMenu.tscn:317
+#: ../src/general/MainMenu.tscn:318
 msgid "CREDITS"
 msgstr "鳴謝"
 
@@ -1169,7 +1169,7 @@ msgstr "當前開發人員"
 msgid "CURRENT_WORLD_STATISTICS"
 msgstr "生物統計"
 
-#: ../src/general/OptionsMenu.tscn:1730
+#: ../src/general/OptionsMenu.tscn:1731
 msgid "CUSTOM_USERNAME"
 msgstr "自定義用戶名："
 
@@ -1242,7 +1242,7 @@ msgstr ""
 msgid "DECEMBER"
 msgstr "十二月"
 
-#: ../src/general/OptionsMenu.cs:1377
+#: ../src/general/OptionsMenu.cs:1384
 msgid "DEFAULT_AUDIO_OUTPUT_DEVICE"
 msgstr "默認輸出設備"
 
@@ -1308,7 +1308,7 @@ msgstr "描述太長"
 msgid "DESPAWN_ENTITIES"
 msgstr "生成敵人"
 
-#: ../src/general/OptionsMenu.tscn:1070
+#: ../src/general/OptionsMenu.tscn:1071
 msgid "DETECTED_CPU_COUNT"
 msgstr "檢測到的CPU數量："
 
@@ -1321,12 +1321,12 @@ msgstr "Devbuilds 支持者"
 msgid "DEVELOPERS"
 msgstr "開發者"
 
-#: ../src/general/MainMenu.tscn:608
+#: ../src/general/MainMenu.tscn:609
 #, fuzzy
 msgid "DEVELOPMENT_FORUM"
 msgstr "由Revolutionary Games Studio ry支持的開發"
 
-#: ../src/general/MainMenu.tscn:603
+#: ../src/general/MainMenu.tscn:604
 #, fuzzy
 msgid "DEVELOPMENT_FORUM_BUTTON_TOOLTIP"
 msgstr "添加新的綁定鍵位"
@@ -1335,12 +1335,12 @@ msgstr "添加新的綁定鍵位"
 msgid "DEVELOPMENT_SUPPORTED_BY"
 msgstr "由Revolutionary Games Studio ry支持的開發"
 
-#: ../src/general/MainMenu.tscn:622
+#: ../src/general/MainMenu.tscn:623
 #, fuzzy
 msgid "DEVELOPMENT_WIKI"
 msgstr "開發者"
 
-#: ../src/general/MainMenu.tscn:617
+#: ../src/general/MainMenu.tscn:618
 #, fuzzy
 msgid "DEVELOPMENT_WIKI_BUTTON_TOOLTIP"
 msgstr "幫助"
@@ -1415,7 +1415,7 @@ msgstr "左"
 msgid "DIRECTIONR"
 msgstr "右"
 
-#: ../src/general/OptionsMenu.tscn:325 ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:326 ../src/general/OptionsMenu.tscn:327
 msgid "DISABLED"
 msgstr "已禁用"
 
@@ -1423,7 +1423,7 @@ msgstr "已禁用"
 msgid "DISABLE_ALL"
 msgstr "禁用所有"
 
-#: ../src/general/OptionsMenu.tscn:2038
+#: ../src/general/OptionsMenu.tscn:2047
 msgid "DISCARD_AND_CONTINUE"
 msgstr "取消並繼續"
 
@@ -1465,17 +1465,17 @@ msgstr ""
 "有一些细胞器没有连接到其它细胞器上。\n"
 "请把所有细胞器连接起来，或者删掉未连接的细胞器。"
 
-#: ../src/general/MainMenu.tscn:774
+#: ../src/general/MainMenu.tscn:784
 #, fuzzy
 msgid "DISCORD_TOOLTIP"
 msgstr "經過的時間：{0:#,#} 年"
 
-#: ../src/general/OptionsMenu.tscn:1779
+#: ../src/general/OptionsMenu.tscn:1788
 #, fuzzy
 msgid "DISMISSED_POPUPS_COLON"
 msgstr "速度："
 
-#: ../src/general/OptionsMenu.tscn:1777 ../src/general/OptionsMenu.tscn:1786
+#: ../src/general/OptionsMenu.tscn:1786 ../src/general/OptionsMenu.tscn:1795
 #, fuzzy
 msgid "DISMISSED_POPUPS_EXPLANATION"
 msgstr ""
@@ -1483,19 +1483,19 @@ msgstr ""
 "並且對物質塊更有渴求。\n"
 "應變型微生物將更快的轉向新的目標。"
 
-#: ../src/general/MainMenu.tscn:962
+#: ../src/general/MainMenu.tscn:972
 msgid "DISMISS_PERMANENTLY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:605
+#: ../src/general/OptionsMenu.tscn:606
 msgid "DISPLAY_ABILITIES_BAR"
 msgstr "顯示能力界面"
 
-#: ../src/general/OptionsMenu.tscn:462
+#: ../src/general/OptionsMenu.tscn:463
 msgid "DISPLAY_BACKGROUND_PARTICLES"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:622
+#: ../src/general/OptionsMenu.tscn:623
 #, fuzzy
 msgid "DISPLAY_PART_NAMES"
 msgstr "顯示能力界面"
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "DOUBLE_MEMBRANE_DESCRIPTION"
 msgstr "有兩層的細胞膜，對傷害有更好的防護能力，也不需要花費那麼多能量避免變形。然而它也會減慢細胞的移動速度，並降低其吸收營養的速率。"
 
-#: ../src/general/MainMenu.tscn:905
+#: ../src/general/MainMenu.tscn:915
 msgid "DO_NOT_SHOW_AGAIN"
 msgstr ""
 
@@ -1692,7 +1692,7 @@ msgstr ""
 "\n"
 "要進入下一個編輯器選項卡，請按右下角的下一個按鈕。"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "EIGHT_TIMES"
 msgstr "8x"
 
@@ -1708,7 +1708,7 @@ msgstr "啟用所有兼容Mods"
 msgid "ENABLE_EDITOR"
 msgstr "啟用編輯器"
 
-#: ../src/general/OptionsMenu.tscn:613
+#: ../src/general/OptionsMenu.tscn:614
 msgid "ENABLE_GUI_LIGHT_EFFECTS"
 msgstr "啟用 GUI 光效效果"
 
@@ -1768,7 +1768,7 @@ msgstr "顯示/隱藏環境和化合物"
 msgid "EPIPELAGIC"
 msgstr "遠洋表層帶"
 
-#: ../src/general/OptionsMenu.tscn:2066 ../src/general/OptionsMenu.tscn:2074
+#: ../src/general/OptionsMenu.tscn:2075 ../src/general/OptionsMenu.tscn:2083
 msgid "ERROR"
 msgstr "錯誤"
 
@@ -1780,11 +1780,11 @@ msgstr "為mod創建文件夾時出錯"
 msgid "ERROR_CREATING_INFO_FILE"
 msgstr "創建MOD信息文件出錯"
 
-#: ../src/general/OptionsMenu.tscn:2076
+#: ../src/general/OptionsMenu.tscn:2085
 msgid "ERROR_FAILED_TO_SAVE_NEW_SETTINGS"
 msgstr "錯誤：無法將新設置保存至配置文件。"
 
-#: ../src/general/ThriveNewsFeed.cs:95
+#: ../src/general/ThriveNewsFeed.cs:96
 #, fuzzy
 msgid "ERROR_FETCHING_EXPLANATION"
 msgstr ""
@@ -1793,7 +1793,7 @@ msgstr ""
 "勇敢型微生物則不會被靠近的掠食者嚇到\n"
 "而且更有可能反擊。"
 
-#: ../src/general/ThriveNewsFeed.cs:94
+#: ../src/general/ThriveNewsFeed.cs:95
 #, fuzzy
 msgid "ERROR_FETCHING_NEWS"
 msgstr "創建MOD信息文件出錯"
@@ -1828,12 +1828,12 @@ msgstr "由Revolutionary Games Studio製作"
 msgid "EVOLUTIONARY_TREE_DISABLED_LABEL"
 msgstr "由Revolutionary Games Studio製作"
 
-#: ../src/general/OptionsMenu.tscn:1845
+#: ../src/general/OptionsMenu.tscn:1854
 #, fuzzy
 msgid "EXACT_VERSION_COLON"
 msgstr "世代："
 
-#: ../src/general/OptionsMenu.tscn:1843 ../src/general/OptionsMenu.tscn:1854
+#: ../src/general/OptionsMenu.tscn:1852 ../src/general/OptionsMenu.tscn:1863
 #, fuzzy
 msgid "EXACT_VERSION_TOOLTIP"
 msgstr "自殺"
@@ -1852,7 +1852,7 @@ msgstr "加載存檔數據時發生異常"
 msgid "EXIT"
 msgstr "退出"
 
-#: ../src/general/MainMenu.tscn:327
+#: ../src/general/MainMenu.tscn:328
 #, fuzzy
 msgid "EXIT_TO_LAUNCHER"
 msgstr "Launch E"
@@ -1906,7 +1906,7 @@ msgstr "從這個區域滅絕了"
 msgid "EXTINCT_SPECIES"
 msgstr "物種滅絕"
 
-#: ../src/general/MainMenu.tscn:308
+#: ../src/general/MainMenu.tscn:309
 msgid "EXTRAS"
 msgstr "額外內容"
 
@@ -1914,7 +1914,7 @@ msgstr "額外內容"
 msgid "EXTRA_OPTIONS"
 msgstr "額外選項"
 
-#: ../src/general/MainMenu.tscn:786
+#: ../src/general/MainMenu.tscn:796
 #, fuzzy
 msgid "FACEBOOK_TOOLTIP"
 msgstr "暫停遊戲"
@@ -1949,20 +1949,20 @@ msgstr "啟用作弊鍵"
 msgid "FEBRUARY"
 msgstr "二月"
 
-#: ../src/general/ThriveNewsFeed.cs:192
+#: ../src/general/ThriveNewsFeed.cs:182
 #, fuzzy
 msgid "FEED_ITEM_CONTENT_PARSING_FAILED"
 msgstr "Steam 客戶端庫初始化失敗"
 
-#: ../src/general/ThriveNewsFeed.cs:175 ../src/general/ThriveNewsFeed.cs:200
+#: ../src/general/ThriveNewsFeed.cs:165 ../src/general/ThriveNewsFeed.cs:190
 msgid "FEED_ITEM_MISSING_CONTENT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:167
+#: ../src/general/ThriveNewsFeed.cs:226
 msgid "FEED_ITEM_PUBLISHED_AT"
 msgstr ""
 
-#: ../src/general/ThriveNewsFeed.cs:206
+#: ../src/general/ThriveNewsFeed.cs:232
 msgid "FEED_ITEM_TRUNCATED_NOTICE"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "FOSSILISE"
 msgstr "沉着"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "FOUR_TIMES"
 msgstr "4x"
 
@@ -2131,7 +2131,7 @@ msgstr ""
 "並且對物質塊更有渴求。\n"
 "應變型微生物將更快的轉向新的目標。"
 
-#: ../src/general/OptionsMenu.tscn:279
+#: ../src/general/OptionsMenu.tscn:280
 msgid "FULLSCREEN"
 msgstr "全螢幕"
 
@@ -2159,24 +2159,24 @@ msgstr "世代"
 msgid "GENERATION_COLON"
 msgstr "世代："
 
-#: ../src/general/MainMenu.tscn:738
+#: ../src/general/MainMenu.tscn:748
 #, fuzzy
 msgid "GITHUB_TOOLTIP"
 msgstr "自殺"
 
-#: ../src/general/OptionsMenu.cs:925
+#: ../src/general/OptionsMenu.cs:932
 msgid "GLES2"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:871
+#: ../src/general/MainMenu.tscn:881
 msgid "GLES2_MODE_WARNING"
 msgstr "GLES2模式警告"
 
-#: ../src/general/MainMenu.tscn:873
+#: ../src/general/MainMenu.tscn:883
 msgid "GLES2_MODE_WARNING_TEXT"
 msgstr "你在用GLES2模式運行Thrive。這種情況沒有被測試過並且很可能導致種種問題。你應該考慮更新下你的顯卡驅動，或者強制使用你的AMD/Nvidia顯卡來運行Thrive。"
 
-#: ../src/general/OptionsMenu.cs:930
+#: ../src/general/OptionsMenu.cs:937
 msgid "GLES3"
 msgstr ""
 
@@ -2230,11 +2230,11 @@ msgstr "明白了"
 msgid "GPL_LICENSE_HEADING"
 msgstr "GPL 許可文本如下："
 
-#: ../src/general/OptionsMenu.tscn:472
+#: ../src/general/OptionsMenu.tscn:473
 msgid "GPU_NAME"
 msgstr "GPU："
 
-#: ../src/general/OptionsMenu.tscn:166
+#: ../src/general/OptionsMenu.tscn:167
 msgid "GRAPHICS"
 msgstr "圖形"
 
@@ -2242,7 +2242,7 @@ msgstr "圖形"
 msgid "GRAPHICS_TEAM"
 msgstr "圖形團隊"
 
-#: ../src/general/OptionsMenu.tscn:556
+#: ../src/general/OptionsMenu.tscn:557
 msgid "GUI"
 msgstr ""
 
@@ -2259,7 +2259,7 @@ msgstr ""
 msgid "GUI_TAB_NAVIGATION"
 msgstr "{0} 千"
 
-#: ../src/general/OptionsMenu.tscn:804
+#: ../src/general/OptionsMenu.tscn:805
 msgid "GUI_VOLUME"
 msgstr "界面音量"
 
@@ -2281,11 +2281,11 @@ msgstr "幫助"
 msgid "HELP_BUTTON_TOOLTIP"
 msgstr "幫助"
 
-#: ../src/general/OptionsMenu.tscn:965 ../src/general/OptionsMenu.tscn:1015
+#: ../src/general/OptionsMenu.tscn:966 ../src/general/OptionsMenu.tscn:1016
 msgid "HIGHER_VALUES_INCREASE_PERFORMANCE"
 msgstr "（數值越高越提升性能）"
 
-#: ../src/general/OptionsMenu.tscn:310 ../src/general/OptionsMenu.tscn:1173
+#: ../src/general/OptionsMenu.tscn:311 ../src/general/OptionsMenu.tscn:1174
 msgid "HIGHER_VALUES_WORSEN_PERFORMANCE"
 msgstr "（設置越高越影響性能）"
 
@@ -2310,7 +2310,7 @@ msgstr ""
 msgid "HOME"
 msgstr "Home"
 
-#: ../src/general/OptionsMenu.tscn:1285 ../src/general/OptionsMenu.tscn:1395
+#: ../src/general/OptionsMenu.tscn:1286 ../src/general/OptionsMenu.tscn:1396
 #, fuzzy
 msgid "HORIZONTAL_COLON"
 msgstr "世代："
@@ -2385,7 +2385,7 @@ msgstr ""
 msgid "INIT_NEW_WORLD_TOOLTIP"
 msgstr "經過的時間：{0:#,#} 年"
 
-#: ../src/general/OptionsMenu.tscn:199
+#: ../src/general/OptionsMenu.tscn:200
 msgid "INPUTS"
 msgstr "輸入"
 
@@ -2439,8 +2439,8 @@ msgstr "無效的網址格式"
 msgid "INVALID_URL_SCHEME"
 msgstr "無效的URL方案"
 
-#: ../src/general/OptionsMenu.tscn:1298 ../src/general/OptionsMenu.tscn:1320
-#: ../src/general/OptionsMenu.tscn:1408 ../src/general/OptionsMenu.tscn:1431
+#: ../src/general/OptionsMenu.tscn:1299 ../src/general/OptionsMenu.tscn:1321
+#: ../src/general/OptionsMenu.tscn:1409 ../src/general/OptionsMenu.tscn:1432
 msgid "INVERTED"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr "鐵"
 msgid "IRON_CHEMOLITHOAUTOTROPHY"
 msgstr "鐵化能無機自養"
 
-#: ../src/general/MainMenu.tscn:714
+#: ../src/general/MainMenu.tscn:724
 #, fuzzy
 msgid "ITCH_TOOLTIP"
 msgstr "自殺"
@@ -2469,19 +2469,19 @@ msgstr "自殺"
 msgid "JANUARY"
 msgstr "一月"
 
-#: ../src/general/OptionsMenu.tscn:1811
+#: ../src/general/OptionsMenu.tscn:1820
 msgid "JSON_DEBUG_MODE"
 msgstr "JSON debug模式："
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_ALWAYS"
 msgstr "總是"
 
-#: ../src/general/OptionsMenu.tscn:1826 ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1835 ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_AUTO"
 msgstr "自動"
 
-#: ../src/general/OptionsMenu.tscn:1827
+#: ../src/general/OptionsMenu.tscn:1836
 msgid "JSON_DEBUG_MODE_NEVER"
 msgstr "從不"
 
@@ -2663,19 +2663,19 @@ msgstr "數字鍵盤 ."
 msgid "KPSUBTRACT"
 msgstr "數字鍵盤 -"
 
-#: ../src/general/OptionsMenu.tscn:880
+#: ../src/general/OptionsMenu.tscn:881
 msgid "LANGUAGE"
 msgstr "語言："
 
-#: ../src/general/OptionsMenu.cs:1417
+#: ../src/general/OptionsMenu.cs:1424
 msgid "LANGUAGE_TRANSLATION_PROGRESS"
 msgstr "此語言已翻譯完成 {0}%"
 
-#: ../src/general/OptionsMenu.cs:1413
+#: ../src/general/OptionsMenu.cs:1420
 msgid "LANGUAGE_TRANSLATION_PROGRESS_LOW"
 msgstr "此語言仍在翻譯中（已完成 {0}%）"
 
-#: ../src/general/OptionsMenu.cs:1409
+#: ../src/general/OptionsMenu.cs:1416
 msgid "LANGUAGE_TRANSLATION_PROGRESS_REALLY_LOW"
 msgstr "此翻譯非常不完整（已完成 {0}%）請幫助我們！"
 
@@ -2843,7 +2843,7 @@ msgstr "←"
 msgid "LEFT_MOUSE"
 msgstr "鼠標左鍵"
 
-#: ../src/general/MainMenu.tscn:503
+#: ../src/general/MainMenu.tscn:504
 msgid "LICENSES"
 msgstr "許可"
 
@@ -2919,7 +2919,7 @@ msgstr "向右滾輪"
 msgid "LIGHT_MAX"
 msgstr "光"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_EXTREME"
 msgstr "額外內容"
@@ -2934,32 +2934,32 @@ msgstr "確認"
 msgid "LIMIT_GROWTH_RATE_EXPLANATION"
 msgstr "這個板塊顯示了auto-evo預測工作所依據的數字。一個物種能夠捕獲的總能量以及該物種個體的成本決定最終的人口。 Auto-evo使用一個簡化的現實模型，根據物種能夠採集的能量來計算其表現如何。對於每個食物來源，它顯示了該物種從其獲得的能量以及該食物來源能提供的總能量。物種從總能量中獲得的量基於與總適應性相比的適應性的大小。適應性是衡量該物種對該食物來源的利用程度的指標。"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_HUGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 #, fuzzy
 msgid "LIMIT_NORMAL"
 msgstr "確認"
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_SMALL"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1189 ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1190 ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_TINY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_LARGE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1190
+#: ../src/general/OptionsMenu.tscn:1191
 msgid "LIMIT_VERY_SMALL"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr "加載"
 msgid "LOADING"
 msgstr "加載中"
 
-#: ../src/gui_common/ThriveFeedDisplayer.tscn:42 ../src/saving/SaveList.tscn:59
+#: ../src/gui_common/ThriveFeedDisplayer.tscn:43 ../src/saving/SaveList.tscn:59
 #: ../src/saving/SaveListItem.tscn:105
 #, fuzzy
 msgid "LOADING_DOT_DOT_DOT"
@@ -3018,12 +3018,12 @@ msgstr "在編輯器中點擊撤消按鈕以糾正錯誤"
 msgid "LOAD_FINISHED"
 msgstr "加載完成"
 
-#: ../src/general/MainMenu.tscn:271 ../src/general/PauseMenu.tscn:200
+#: ../src/general/MainMenu.tscn:272 ../src/general/PauseMenu.tscn:200
 #: ../src/microbe_stage/gui/ExtinctionBox.tscn:146
 msgid "LOAD_GAME"
 msgstr "讀取遊戲"
 
-#: ../src/general/MainMenu.tscn:268 ../src/general/PauseMenu.tscn:199
+#: ../src/general/MainMenu.tscn:269 ../src/general/PauseMenu.tscn:199
 #, fuzzy
 msgid "LOAD_GAME_BUTTON_TOOLTIP"
 msgstr "暫停菜單"
@@ -3106,7 +3106,7 @@ msgstr "三月"
 msgid "MARINE_SNOW"
 msgstr "海洋雪(有機物碎屑)"
 
-#: ../src/general/OptionsMenu.tscn:648
+#: ../src/general/OptionsMenu.tscn:649
 msgid "MASTER_VOLUME"
 msgstr "主音量"
 
@@ -3115,15 +3115,15 @@ msgstr "主音量"
 msgid "MAXIMUM_SPECIES_IN_PATCH"
 msgstr "從這個區域滅絕了"
 
-#: ../src/general/OptionsMenu.tscn:364
+#: ../src/general/OptionsMenu.tscn:365
 msgid "MAX_FPS"
 msgstr "最高FPS："
 
-#: ../src/general/OptionsMenu.tscn:379
+#: ../src/general/OptionsMenu.tscn:380
 msgid "MAX_FPS_NO_LIMIT"
 msgstr "不受限"
 
-#: ../src/general/OptionsMenu.tscn:1166
+#: ../src/general/OptionsMenu.tscn:1167
 msgid "MAX_SPAWNED_ENTITIES"
 msgstr ""
 
@@ -3300,7 +3300,7 @@ msgstr "每一代，你都有100個變異點(MP)可供花費，任何變化都�
 msgid "MICROBE_EDITOR_HELP_MESSAGE_5"
 msgstr "你每次繁殖時都會進入微生物編輯器，你可以在那改變你的物種（通過添加，移動或刪除細胞器）以強化你物種的生存力。在微生物階段每次進入編輯器都代表[thrive:constant]EDITOR_TIME_JUMP_MILLION_YEARS[/thrive:constant]百萬年的進化時間。"
 
-#: ../src/general/MainMenu.tscn:371
+#: ../src/general/MainMenu.tscn:372
 msgid "MICROBE_FREEBUILD_EDITOR"
 msgstr "微生物階段自由編輯器"
 
@@ -3475,7 +3475,7 @@ msgstr "最低："
 msgid "MIN_VISIBLE_DATASET_WARNING"
 msgstr "不允許顯示少於 {0} 個數據集！"
 
-#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:210
+#: ../src/general/NewGameSettings.tscn:312 ../src/general/OptionsMenu.tscn:211
 msgid "MISC"
 msgstr "雜項"
 
@@ -3540,11 +3540,11 @@ msgstr "修改細胞器"
 msgid "MODIFY_TYPE"
 msgstr "修改"
 
-#: ../src/general/MainMenu.tscn:478
+#: ../src/general/MainMenu.tscn:479
 msgid "MODS"
 msgstr "Mods"
 
-#: ../src/general/MainMenu.tscn:889
+#: ../src/general/MainMenu.tscn:899
 msgid "MODS_INSTALLED_BUT_NOT_ENABLED"
 msgstr ""
 
@@ -3633,11 +3633,11 @@ msgstr "內部（文件夾）名稱："
 msgid "MOD_LICENSE"
 msgstr "Mod許可："
 
-#: ../src/general/MainMenu.tscn:929
+#: ../src/general/MainMenu.tscn:939
 msgid "MOD_LOAD_ERRORS"
 msgstr "Mod加載錯誤"
 
-#: ../src/general/MainMenu.tscn:930
+#: ../src/general/MainMenu.tscn:940
 msgid "MOD_LOAD_ERRORS_OCCURRED"
 msgstr "在加載一個或多個mods時發生錯誤。日誌可能包含其他信息。"
 
@@ -3690,11 +3690,11 @@ msgstr "MOD版本："
 msgid "MORE_INFO"
 msgstr "顯示更多信息"
 
-#: ../src/general/OptionsMenu.tscn:1252
+#: ../src/general/OptionsMenu.tscn:1253
 msgid "MOUSE_LOOK_SENSITIVITY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1326
+#: ../src/general/OptionsMenu.tscn:1327
 msgid "MOUSE_SENSITIVITY_WINDOW_SIZE_ADJUSTMENT"
 msgstr ""
 
@@ -3809,7 +3809,7 @@ msgstr "放置細胞器"
 msgid "MULTIPLE_ORGANELLES"
 msgstr "放置細胞器"
 
-#: ../src/general/OptionsMenu.tscn:303
+#: ../src/general/OptionsMenu.tscn:304
 msgid "MULTISAMPLE_ANTI_ALIASING"
 msgstr "多重採樣抗鋸齒："
 
@@ -3821,7 +3821,7 @@ msgstr ""
 msgid "MUSIC"
 msgstr "音樂"
 
-#: ../src/general/OptionsMenu.tscn:699
+#: ../src/general/OptionsMenu.tscn:700
 msgid "MUSIC_VOLUME"
 msgstr "音樂音量"
 
@@ -3845,9 +3845,9 @@ msgstr ""
 msgid "MUTATION_POINTS"
 msgstr "突變點數"
 
-#: ../src/general/OptionsMenu.tscn:677 ../src/general/OptionsMenu.tscn:728
-#: ../src/general/OptionsMenu.tscn:763 ../src/general/OptionsMenu.tscn:798
-#: ../src/general/OptionsMenu.tscn:833
+#: ../src/general/OptionsMenu.tscn:678 ../src/general/OptionsMenu.tscn:729
+#: ../src/general/OptionsMenu.tscn:764 ../src/general/OptionsMenu.tscn:799
+#: ../src/general/OptionsMenu.tscn:834
 msgid "MUTE"
 msgstr "靜音"
 
@@ -3883,11 +3883,11 @@ msgstr ""
 msgid "NEW_BIODIVERSITY_INCREASING_SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:258
+#: ../src/general/MainMenu.tscn:259
 msgid "NEW_GAME"
 msgstr "新遊戲"
 
-#: ../src/general/MainMenu.tscn:252
+#: ../src/general/MainMenu.tscn:253
 #, fuzzy
 msgid "NEW_GAME_BUTTON_TOOLTIP"
 msgstr "暫停菜單"
@@ -3956,7 +3956,7 @@ msgstr "固氮質體是一種蛋白質，能夠利用氣態氮和氧以及ATP形
 msgid "NITROGEN_FIXING_PLASTID_PROCESSES_DESCRIPTION"
 msgstr "將[thrive:compound type=\"atp\"][/thrive:compound]轉換為[thrive:compound type=\"ammonia\"][/thrive:compound]。速率跟[thrive:compound type=\"nitrogen\"][/thrive:compound]與[thrive:compound type=\"oxygen\"][/thrive:compound]濃度成正比。"
 
-#: ../src/general/OptionsMenu.tscn:411 ../src/general/OptionsMenu.tscn:412
+#: ../src/general/OptionsMenu.tscn:412 ../src/general/OptionsMenu.tscn:413
 msgid "NONE"
 msgstr "無"
 
@@ -4006,7 +4006,7 @@ msgstr "沒有事件被記錄"
 msgid "NO_FOSSIL_DIRECTORY"
 msgstr "找不到存檔目錄"
 
-#: ../src/general/MainMenu.tscn:876
+#: ../src/general/MainMenu.tscn:886
 #, fuzzy
 msgid "NO_MODS_ENABLED"
 msgstr "已禁用"
@@ -4024,7 +4024,7 @@ msgstr "未找到存檔"
 msgid "NO_SAVE_DIRECTORY"
 msgstr "找不到存檔目錄"
 
-#: ../src/general/OptionsMenu.tscn:2084
+#: ../src/general/OptionsMenu.tscn:2093
 msgid "NO_SCREENSHOT_DIRECTORY"
 msgstr "找不到截圖目錄"
 
@@ -4070,16 +4070,16 @@ msgstr "N/A 變異點"
 msgid "OCTOBER"
 msgstr "十月"
 
-#: ../src/general/MainMenu.tscn:580
+#: ../src/general/MainMenu.tscn:581
 msgid "OFFICIAL_WEBSITE"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:571
+#: ../src/general/MainMenu.tscn:572
 #, fuzzy
 msgid "OFFICIAL_WEBSITE_BUTTON_TOOLTIP"
 msgstr "自殺"
 
-#: ../src/general/MainMenu.tscn:919 ../src/general/MainMenu.tscn:976
+#: ../src/general/MainMenu.tscn:929 ../src/general/MainMenu.tscn:986
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/gui_common/dialogs/ErrorDialog.tscn:118
 #: ../src/modding/ModUploader.tscn:357
@@ -4116,7 +4116,7 @@ msgstr "打開幫助界面"
 msgid "OPEN_IN_FREEBUILD"
 msgstr "自由編輯器"
 
-#: ../src/general/OptionsMenu.tscn:1765
+#: ../src/general/OptionsMenu.tscn:1766
 msgid "OPEN_LOGS_FOLDER"
 msgstr "打開日誌文件夾"
 
@@ -4132,7 +4132,7 @@ msgstr "打開細胞器菜單"
 msgid "OPEN_SAVE_DIRECTORY"
 msgstr "打開存檔文件夾"
 
-#: ../src/general/OptionsMenu.tscn:1757
+#: ../src/general/OptionsMenu.tscn:1758
 msgid "OPEN_SCREENSHOT_FOLDER"
 msgstr "打開截圖文件夾"
 
@@ -4140,7 +4140,7 @@ msgstr "打開截圖文件夾"
 msgid "OPEN_THE_MENU"
 msgstr "打開主菜單"
 
-#: ../src/general/OptionsMenu.tscn:917
+#: ../src/general/OptionsMenu.tscn:918
 msgid "OPEN_TRANSLATION_SITE"
 msgstr "幫忙翻譯這個遊戲"
 
@@ -4160,11 +4160,11 @@ msgstr ""
 msgid "OPPORTUNISTIC"
 msgstr "機會主義"
 
-#: ../src/general/MainMenu.tscn:281 ../src/general/PauseMenu.tscn:224
+#: ../src/general/MainMenu.tscn:282 ../src/general/PauseMenu.tscn:224
 msgid "OPTIONS"
 msgstr "選項"
 
-#: ../src/general/MainMenu.tscn:278 ../src/general/PauseMenu.tscn:223
+#: ../src/general/MainMenu.tscn:279 ../src/general/PauseMenu.tscn:223
 #, fuzzy
 msgid "OPTIONS_BUTTON_TOOLTIP"
 msgstr "幫助"
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "PATCH_NAME"
 msgstr "洞穴"
 
-#: ../src/general/MainMenu.tscn:726
+#: ../src/general/MainMenu.tscn:736
 #, fuzzy
 msgid "PATREON_TOOLTIP"
 msgstr "暫停遊戲"
@@ -4439,7 +4439,7 @@ msgstr "和平"
 msgid "PERCENTAGE_VALUE"
 msgstr "{0}%"
 
-#: ../src/general/OptionsMenu.tscn:188
+#: ../src/general/OptionsMenu.tscn:189
 msgid "PERFORMANCE"
 msgstr "性能"
 
@@ -4523,7 +4523,7 @@ msgstr "玩家分裂"
 msgid "PLAYER_EXTINCT"
 msgstr "玩家已滅絕"
 
-#: ../src/general/OptionsMenu.tscn:1470
+#: ../src/general/OptionsMenu.tscn:1471
 #, fuzzy
 msgid "PLAYER_RELATIVE_MOVEMENT"
 msgstr "玩家已滅絕"
@@ -4538,23 +4538,23 @@ msgstr ""
 "玩家\n"
 "速度"
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_3"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_4"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "PLAYSTATION_5"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1594
+#: ../src/general/OptionsMenu.tscn:1595
 msgid "PLAY_INTRO_VIDEO"
 msgstr "播放開場動畫"
 
-#: ../src/general/OptionsMenu.tscn:1602
+#: ../src/general/OptionsMenu.tscn:1603
 msgid "PLAY_MICROBE_INTRO_ON_NEW_GAME"
 msgstr "在開始新遊戲時播放微生物開場動畫"
 
@@ -4675,11 +4675,11 @@ msgstr "快速讀檔"
 msgid "QUICK_SAVE"
 msgstr "快速存檔"
 
-#: ../src/general/MainMenu.tscn:340
+#: ../src/general/MainMenu.tscn:341
 msgid "QUIT"
 msgstr "離開"
 
-#: ../src/general/MainMenu.tscn:324 ../src/general/MainMenu.tscn:334
+#: ../src/general/MainMenu.tscn:325 ../src/general/MainMenu.tscn:335
 #: ../src/general/PauseMenu.tscn:239
 #, fuzzy
 msgid "QUIT_BUTTON_TOOLTIP"
@@ -4724,7 +4724,7 @@ msgstr "已就緒"
 msgid "RECOMMENDED_THRIVE_VERSION"
 msgstr "推薦Thrive："
 
-#: ../src/general/MainMenu.tscn:762
+#: ../src/general/MainMenu.tscn:772
 #, fuzzy
 msgid "REDDIT_TOOLTIP"
 msgstr "返回遊戲"
@@ -4782,7 +4782,7 @@ msgstr "繁殖："
 msgid "REQUIRES_NUCLEUS"
 msgstr "細胞核"
 
-#: ../src/general/OptionsMenu.tscn:898 ../src/general/OptionsMenu.tscn:1915
+#: ../src/general/OptionsMenu.tscn:899 ../src/general/OptionsMenu.tscn:1924
 msgid "RESET"
 msgstr "重置"
 
@@ -4791,24 +4791,24 @@ msgstr "重置"
 msgid "RESET_DEADZONES"
 msgstr "重置為默認"
 
-#: ../src/general/OptionsMenu.tscn:1801
+#: ../src/general/OptionsMenu.tscn:1810
 msgid "RESET_DISMISSED_POPUPS"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1975
+#: ../src/general/OptionsMenu.tscn:1984
 msgid "RESET_INPUTS_TO_DEFAULTS"
 msgstr "將輸入重置為默認？"
 
-#: ../src/general/OptionsMenu.tscn:1553
+#: ../src/general/OptionsMenu.tscn:1554
 #, fuzzy
 msgid "RESET_KEYBINDINGS"
 msgstr "重置輸入"
 
-#: ../src/general/OptionsMenu.tscn:1955
+#: ../src/general/OptionsMenu.tscn:1964
 msgid "RESET_SETTINGS_TO_DEFAULTS"
 msgstr "默認"
 
-#: ../src/general/OptionsMenu.tscn:1966
+#: ../src/general/OptionsMenu.tscn:1975
 msgid "RESET_TO_DEFAULTS"
 msgstr "重置為默認？"
 
@@ -4817,7 +4817,7 @@ msgstr "重置為默認？"
 msgid "RESISTANT_TO_BASIC_ENGULFMENT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:340
+#: ../src/general/OptionsMenu.tscn:341
 msgid "RESOLUTION"
 msgstr "解像度："
 
@@ -4868,7 +4868,7 @@ msgstr ""
 "你確定要退出到主菜單嗎？\n"
 "你會失去任何未保存的進度。"
 
-#: ../src/general/MainMenu.tscn:689
+#: ../src/general/MainMenu.tscn:699
 #, fuzzy
 msgid "REVOLUTIONARY_GAMES_SOCIAL_TOOLTIP"
 msgstr "由Revolutionary Games Studio製作"
@@ -4902,7 +4902,7 @@ msgstr "向右旋轉"
 msgid "ROTATION_COLON"
 msgstr "總人口："
 
-#: ../src/general/OptionsMenu.tscn:1050
+#: ../src/general/OptionsMenu.tscn:1051
 msgid "RUN_AUTO_EVO_DURING_GAMEPLAY"
 msgstr "在遊戲中啟用auto-evo"
 
@@ -4957,7 +4957,7 @@ msgstr "鐵硫菌藍蛋白[Rusticyanin]能夠利用二氧化碳和氧將鐵從�
 msgid "RUSTICYANIN_PROCESSES_DESCRIPTION"
 msgstr "將[thrive:compound type=\"iron\"][/thrive:compound]轉換為thrive:compound type=\"atp\"][/thrive:compound]。速率跟[thrive:compound type=\"carbondioxide\"][/thrive:compound]和[thrive:compound type=\"oxygen\"][/thrive:compound]的濃度成正比。"
 
-#: ../src/general/MainMenu.tscn:925
+#: ../src/general/MainMenu.tscn:935
 #, fuzzy
 msgid "SAFE_MODE_EXPLANATION"
 msgstr ""
@@ -4966,16 +4966,16 @@ msgstr ""
 "勇敢型微生物則不會被靠近的掠食者嚇到\n"
 "而且更有可能反擊。"
 
-#: ../src/general/MainMenu.tscn:923
+#: ../src/general/MainMenu.tscn:933
 #, fuzzy
 msgid "SAFE_MODE_TITLE"
 msgstr "移除本地數據"
 
-#: ../src/general/OptionsMenu.tscn:1929 ../src/saving/NewSaveMenu.tscn:80
+#: ../src/general/OptionsMenu.tscn:1938 ../src/saving/NewSaveMenu.tscn:80
 msgid "SAVE"
 msgstr "儲存"
 
-#: ../src/general/OptionsMenu.tscn:2028
+#: ../src/general/OptionsMenu.tscn:2037
 msgid "SAVE_AND_CONTINUE"
 msgstr "保存並繼續"
 
@@ -5078,21 +5078,21 @@ msgstr "當前情況下無法保存："
 msgid "SAVING_SUCCEEDED"
 msgstr "保存成功"
 
-#: ../src/general/OptionsMenu.tscn:1338 ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1339 ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_NONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 #, fuzzy
 msgid "SCALING_ON"
 msgstr "結合劑"
 
-#: ../src/general/OptionsMenu.tscn:1339
+#: ../src/general/OptionsMenu.tscn:1340
 msgid "SCALING_ON_INVERSE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1470 ../src/general/OptionsMenu.tscn:1503
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1471 ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 msgid "SCREEN_RELATIVE_MOVEMENT"
 msgstr ""
 
@@ -5195,7 +5195,7 @@ msgstr "沉着"
 msgid "SETTING_ONLY_APPLIES_TO_NEW_GAMES"
 msgstr "這個數值只對你改變選項後新開的存檔有效"
 
-#: ../src/general/OptionsMenu.tscn:769
+#: ../src/general/OptionsMenu.tscn:770
 msgid "SFX_VOLUME"
 msgstr "特效音量"
 
@@ -5212,23 +5212,27 @@ msgstr "顯示幫助"
 msgid "SHOW_TUTORIALS"
 msgstr "顯示教學"
 
-#: ../src/general/OptionsMenu.tscn:1692
+#: ../src/general/OptionsMenu.tscn:1693
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "顯示教程（在當前遊戲中）"
 
-#: ../src/general/OptionsMenu.tscn:1684
+#: ../src/general/OptionsMenu.tscn:1685
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_GAMES_OPTION"
 msgstr "顯示教程（在新遊戲中）"
 
-#: ../src/general/OptionsMenu.tscn:1699
+#: ../src/general/OptionsMenu.tscn:1700
 msgid "SHOW_UNSAVED_PROGRESS_WARNING"
 msgstr "顯示未保存的進度警告"
 
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:4065
 msgid "SHOW_UNSAVED_PROGRESS_WARNING_TOOLTIP"
 msgstr "當玩家試圖退出遊戲時，啟用/禁用未保存的進度警告彈出框。"
+
+#: ../src/general/OptionsMenu.tscn:1774
+msgid "SHOW_WEB_NEWS_FEED"
+msgstr ""
 
 #: ../simulation_parameters/microbe_stage/organelles.json:779
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:2323
@@ -5281,7 +5285,7 @@ msgstr "二氧化矽"
 msgid "SILICA_MEMBRANE_DESCRIPTION"
 msgstr "這種膜有一層堅固的二氧化矽細胞壁。它能很好地抵抗整體的損害，對物理損害的抵抗力很強。它還需要更少的能量來維持其形態。然而，它使細胞的速度降低了一大截，細胞吸收資源的速度也降低了。"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "SIXTEEN_TIMES"
 msgstr "16x"
 
@@ -5323,7 +5327,7 @@ msgstr "將[thrive:compound type=\"glucose\"][/thrive:compound]轉換為[thrive:
 msgid "SMALL_IRON_CHUNK"
 msgstr "小鐵塊"
 
-#: ../src/general/OptionsMenu.tscn:177
+#: ../src/general/OptionsMenu.tscn:178
 msgid "SOUND"
 msgstr "聲音"
 
@@ -5522,17 +5526,17 @@ msgstr "Steam系統目前不可用，請重試"
 msgid "STEAM_ERROR_UNKNOWN"
 msgstr "發生了未知的Steam錯誤"
 
-#: ../src/general/MainMenu.tscn:980
+#: ../src/general/MainMenu.tscn:990
 #, fuzzy
 msgid "STEAM_INIT_FAILED"
 msgstr "Steam 客戶端庫初始化失敗"
 
-#: ../src/general/MainMenu.tscn:982
+#: ../src/general/MainMenu.tscn:992
 #, fuzzy
 msgid "STEAM_INIT_FAILED_DESCRIPTION"
 msgstr "更新此存檔失敗，錯誤："
 
-#: ../src/general/MainMenu.tscn:702
+#: ../src/general/MainMenu.tscn:712
 #, fuzzy
 msgid "STEAM_TOOLTIP"
 msgstr "暫停遊戲"
@@ -5576,7 +5580,7 @@ msgstr "儲存"
 msgid "STORAGE_COLON"
 msgstr "儲存："
 
-#: ../src/general/MainMenu.cs:474
+#: ../src/general/MainMenu.cs:481
 msgid "STORE_LOGGED_IN_AS"
 msgstr "已登錄為：{0}"
 
@@ -5693,7 +5697,7 @@ msgstr "溫度"
 msgid "TESTING_TEAM"
 msgstr "測試團隊"
 
-#: ../src/general/MainMenu.cs:207 ../src/general/MainMenu.tscn:946
+#: ../src/general/MainMenu.cs:211 ../src/general/MainMenu.tscn:956
 #, fuzzy
 msgid "THANKS_FOR_BUYING_THRIVE"
 msgstr ""
@@ -5708,7 +5712,7 @@ msgstr ""
 "\n"
 "如果你喜歡這款遊戲，記得也向你的朋友們推薦下。"
 
-#: ../src/general/MainMenu.tscn:936
+#: ../src/general/MainMenu.tscn:946
 #, fuzzy
 msgid "THANK_YOU_TITLE"
 msgstr "你已經茁壯繁盛了!"
@@ -5768,11 +5772,11 @@ msgstr "這是一個本地安裝的MOD"
 msgid "THIS_IS_WORKSHOP_MOD"
 msgstr "這個MOD是在Steam工作坊下載的"
 
-#: ../src/general/OptionsMenu.tscn:1119
+#: ../src/general/OptionsMenu.tscn:1120
 msgid "THREADS"
 msgstr "線程："
 
-#: ../src/general/MainMenu.tscn:464 ../src/general/PauseMenu.tscn:208
+#: ../src/general/MainMenu.tscn:465 ../src/general/PauseMenu.tscn:208
 msgid "THRIVEOPEDIA"
 msgstr ""
 
@@ -5921,7 +5925,7 @@ msgstr "暫停"
 msgid "TOGGLE_UNBINDING"
 msgstr "解除鏈接模式"
 
-#: ../src/general/MainMenu.tscn:290
+#: ../src/general/MainMenu.tscn:291
 msgid "TOOLS"
 msgstr "工具"
 
@@ -5987,7 +5991,7 @@ msgstr "嘗試截一些圖吧！"
 msgid "TRY_MAKING_A_SAVE"
 msgstr "試著存個檔吧！"
 
-#: ../src/general/OptionsMenu.tscn:2086
+#: ../src/general/OptionsMenu.tscn:2095
 msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr "嘗試截一些圖吧！"
 
@@ -6154,12 +6158,12 @@ msgstr ""
 msgid "TUTORIAL_VIEW_NOW"
 msgstr "教學"
 
-#: ../src/general/MainMenu.tscn:798
+#: ../src/general/MainMenu.tscn:808
 #, fuzzy
 msgid "TWITTER_TOOLTIP"
 msgstr "經過的時間：{0:#,#} 年"
 
-#: ../src/general/OptionsMenu.tscn:326
+#: ../src/general/OptionsMenu.tscn:327
 msgid "TWO_TIMES"
 msgstr "2x"
 
@@ -6185,7 +6189,7 @@ msgstr "解除所有連接"
 msgid "UNBIND_HELP_TEXT"
 msgstr "解鏈接模式"
 
-#: ../src/general/OptionsMenu.cs:1477
+#: ../src/general/OptionsMenu.cs:1484
 #, fuzzy
 msgid "UNCERTAIN_VERSION_WARNING"
 msgstr ""
@@ -6208,7 +6212,7 @@ msgstr "撤銷上一個動作"
 msgid "UNKNOWN"
 msgstr "未知"
 
-#: ../src/general/OptionsMenu.cs:935
+#: ../src/general/OptionsMenu.cs:942
 #, fuzzy
 msgid "UNKNOWN_DISPLAY_DRIVER"
 msgstr "顯示能力界面"
@@ -6222,7 +6226,7 @@ msgstr "鼠標未知鍵"
 msgid "UNKNOWN_ON_WINDOWS"
 msgstr "此Mod的創意工坊編號未知"
 
-#: ../src/general/OptionsMenu.cs:1484
+#: ../src/general/OptionsMenu.cs:1491
 msgid "UNKNOWN_VERSION"
 msgstr "未知的版本"
 
@@ -6230,7 +6234,7 @@ msgstr "未知的版本"
 msgid "UNKNOWN_WORKSHOP_ID"
 msgstr "此Mod的創意工坊編號未知"
 
-#: ../src/general/OptionsMenu.tscn:2005
+#: ../src/general/OptionsMenu.tscn:2014
 msgid "UNSAVED_CHANGE_WARNING"
 msgstr ""
 "未保存的更改將被丟棄。\n"
@@ -6275,7 +6279,7 @@ msgstr "上傳成功"
 msgid "USED_LIBRARIES_LICENSES"
 msgstr "許可證和使用的庫"
 
-#: ../src/general/OptionsMenu.tscn:502
+#: ../src/general/OptionsMenu.tscn:503
 msgid "USED_RENDERER_NAME"
 msgstr ""
 
@@ -6293,7 +6297,7 @@ msgstr ""
 msgid "USE_AUTO_HARMONY_TOOLTIP"
 msgstr "自殺"
 
-#: ../src/general/OptionsMenu.tscn:1719
+#: ../src/general/OptionsMenu.tscn:1720
 msgid "USE_A_CUSTOM_USERNAME"
 msgstr "使用自定義用戶名"
 
@@ -6301,11 +6305,11 @@ msgstr "使用自定義用戶名"
 msgid "USE_BIODIVERSITY_FORCE_SPLIT"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1109
+#: ../src/general/OptionsMenu.tscn:1110
 msgid "USE_MANUAL_THREAD_COUNT"
 msgstr "手動設置後台線程數"
 
-#: ../src/general/OptionsMenu.tscn:1353
+#: ../src/general/OptionsMenu.tscn:1354
 msgid "USE_VIRTUAL_WINDOW_SIZE"
 msgstr ""
 
@@ -6332,7 +6336,7 @@ msgstr ""
 msgid "VERSION_COLON"
 msgstr "世代："
 
-#: ../src/general/OptionsMenu.tscn:1304 ../src/general/OptionsMenu.tscn:1414
+#: ../src/general/OptionsMenu.tscn:1305 ../src/general/OptionsMenu.tscn:1415
 #, fuzzy
 msgid "VERTICAL_COLON"
 msgstr "世代："
@@ -6342,11 +6346,11 @@ msgstr "世代："
 msgid "VERTICAL_WITH_AXIS_NAME_COLON"
 msgstr "速度（軸：{0}）"
 
-#: ../src/general/OptionsMenu.tscn:529
+#: ../src/general/OptionsMenu.tscn:530
 msgid "VIDEO_MEMORY"
 msgstr ""
 
-#: ../src/general/OptionsMenu.cs:944 ../src/general/OptionsMenu.tscn:542
+#: ../src/general/OptionsMenu.cs:951 ../src/general/OptionsMenu.tscn:543
 msgid "VIDEO_MEMORY_MIB"
 msgstr ""
 
@@ -6354,7 +6358,7 @@ msgstr ""
 msgid "VIEWER"
 msgstr ""
 
-#: ../src/general/MainMenu.tscn:299
+#: ../src/general/MainMenu.tscn:300
 msgid "VIEW_SOURCE_CODE"
 msgstr "查看源代碼"
 
@@ -6366,7 +6370,7 @@ msgstr "VIP 支持者"
 msgid "VISIBLE"
 msgstr "可見"
 
-#: ../src/general/MainMenu.tscn:517 ../src/general/MainMenu.tscn:654
+#: ../src/general/MainMenu.tscn:518 ../src/general/MainMenu.tscn:655
 msgid "VISIT_SUGGESTIONS_SITE"
 msgstr ""
 
@@ -6386,7 +6390,7 @@ msgstr "静音"
 msgid "VOLUMEUP"
 msgstr "音量增加"
 
-#: ../src/general/OptionsMenu.tscn:271
+#: ../src/general/OptionsMenu.tscn:272
 msgid "VSYNC"
 msgstr "垂直同步"
 
@@ -6493,7 +6497,7 @@ msgstr "生物統計"
 msgid "WORLD_MISC_DETAILS_STRING"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:1504
+#: ../src/general/OptionsMenu.tscn:1505
 #, fuzzy
 msgid "WORLD_RELATIVE_MOVEMENT"
 msgstr "Base Movement"
@@ -6502,15 +6506,15 @@ msgstr "Base Movement"
 msgid "WORST_PATCH_COLON"
 msgstr "表現最差的區域："
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX360"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_ONE"
 msgstr ""
 
-#: ../src/general/OptionsMenu.tscn:591
+#: ../src/general/OptionsMenu.tscn:592
 msgid "XBOX_SERIES"
 msgstr ""
 
@@ -6522,7 +6526,7 @@ msgstr ""
 msgid "YEARS"
 msgstr "年"
 
-#: ../src/general/MainMenu.tscn:750
+#: ../src/general/MainMenu.tscn:760
 #, fuzzy
 msgid "YOUTUBE_TOOLTIP"
 msgstr "暫停遊戲"

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1135,7 +1135,7 @@ public static class Constants
     public const int FORCE_CLOSE_AFTER_TRIES = 3;
 
     public const int MAX_NEWS_FEED_ITEMS_TO_SHOW = 15;
-    public const int MAX_NEWS_FEED_ITEM_LENGTH = 500;
+    public const int MAX_NEWS_FEED_ITEM_LENGTH = 1000;
 
     /// <summary>
     ///   The duration for which a save is considered recently performed.

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1137,6 +1137,9 @@ public static class Constants
     public const int MAX_NEWS_FEED_ITEMS_TO_SHOW = 15;
     public const int MAX_NEWS_FEED_ITEM_LENGTH = 1000;
 
+    public const string CLICKABLE_TEXT_BBCODE = "[color=#3796e1]";
+    public const string CLICKABLE_TEXT_BBCODE_END = "[/color]";
+
     /// <summary>
     ///   The duration for which a save is considered recently performed.
     /// </summary>
@@ -1189,6 +1192,9 @@ public static class Constants
     };
 
     public static readonly Uri MainSiteFeedURL = new("https://thrivefeeds.b-cdn.net/feed.rss");
+
+    public static readonly Regex NewsFeedRegexDeleteContent =
+        new(@"\s*The\spost\s*.*appeared\sfirst\son.*Revolutionary\sGames\sStudio.*$");
 
     // Following is a hacky way to ensure some conditions apply on the constants defined here.
     // When the constants don't follow a set of conditions a warning is raised, which CI treats as an error.

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -945,8 +945,6 @@ public static class Constants
 
     public const string EXPLICIT_PATH_PREFIX = "file://";
 
-    public const int MAX_PATH_LENGTH = 1024;
-
     public const string SCREENSHOT_FOLDER = "user://screenshots";
 
     public const string LOGS_FOLDER_NAME = "logs";

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1136,6 +1136,9 @@ public static class Constants
 
     public const int FORCE_CLOSE_AFTER_TRIES = 3;
 
+    public const int MAX_NEWS_FEED_ITEMS_TO_SHOW = 15;
+    public const int MAX_NEWS_FEED_ITEM_LENGTH = 500;
+
     /// <summary>
     ///   The duration for which a save is considered recently performed.
     /// </summary>
@@ -1186,6 +1189,8 @@ public static class Constants
         "screenshot",
         "toggle_FPS",
     };
+
+    public static readonly Uri MainSiteFeedURL = new("https://thrivefeeds.b-cdn.net/feed.rss");
 
     // Following is a hacky way to ensure some conditions apply on the constants defined here.
     // When the constants don't follow a set of conditions a warning is raised, which CI treats as an error.

--- a/src/engine/Settings.cs
+++ b/src/engine/Settings.cs
@@ -261,6 +261,11 @@ public class Settings
     public SettingValue<bool> CheatsEnabled { get; set; } = new(false);
 
     /// <summary>
+    ///   Enables online news feed
+    /// </summary>
+    public SettingValue<bool> ThriveNewsFeedEnabled { get; set; } = new(true);
+
+    /// <summary>
     ///   If false username will be set to System username
     /// </summary>
     public SettingValue<bool> CustomUsernameEnabled { get; set; } = new(false);

--- a/src/general/HtmlToBbCodeConverter.cs
+++ b/src/general/HtmlToBbCodeConverter.cs
@@ -1,0 +1,346 @@
+﻿using System;
+using System.Text;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using AngleSharp.Html.Parser;
+
+/// <summary>
+///   Converts HTML to Godot BBCode
+/// </summary>
+public class HtmlToBbCodeConverter
+{
+    private readonly StringBuilder stringBuilder = new();
+
+    private readonly HtmlParser htmlParser;
+    private readonly IElement dummyDom;
+
+    private bool paragraphBreakQueued;
+
+    public HtmlToBbCodeConverter()
+    {
+        htmlParser = new HtmlParser(new HtmlParserOptions
+        {
+            IsStrictMode = false,
+        });
+
+        dummyDom = htmlParser.ParseDocument(string.Empty).DocumentElement;
+    }
+
+    public static string SanitizeUrlForBbCode(string text)
+    {
+        return text.Replace("[", "%5B").Replace("]", "%5D").Replace("\"", "%22");
+    }
+
+    public string Convert(string html, out bool truncated)
+    {
+        truncated = false;
+        paragraphBreakQueued = false;
+
+        var document = htmlParser.ParseFragment(html, dummyDom);
+
+        stringBuilder.Clear();
+
+        foreach (var topLevelNode in document)
+        {
+            HandleNode(topLevelNode, ref truncated);
+        }
+
+        return stringBuilder.ToString();
+    }
+
+    private void HandleNode(INode node, ref bool truncated)
+    {
+        switch (node)
+        {
+            // Ignoring nodes we don't want to do anything with
+            case IHtmlHeadElement:
+            case IHtmlBodyElement:
+                break;
+
+            // Elements that only have post actions
+            case IHtmlParagraphElement:
+                break;
+
+            case IText text:
+            {
+                if (truncated)
+                    break;
+
+                if (paragraphBreakQueued)
+                {
+                    paragraphBreakQueued = false;
+                    AddLastTextIfDoesNotEndWithAlready("\n\n");
+                }
+
+                // var textToAdd = text.Data.Trim();
+                var textToAdd = text.Data;
+
+                if (stringBuilder.Length < 1)
+                {
+                    textToAdd = textToAdd.TrimStart();
+                }
+
+                if (stringBuilder.Length + textToAdd.Length >= Constants.MAX_NEWS_FEED_ITEM_LENGTH)
+                {
+                    textToAdd = textToAdd.Substring(0,
+                        Math.Max(Constants.MAX_NEWS_FEED_ITEM_LENGTH - stringBuilder.Length, textToAdd.Length));
+                    truncated = true;
+                }
+
+                // TODO: escaping Bbcode tags that are present in the text already
+
+                stringBuilder.Append(textToAdd);
+
+                if (truncated)
+                    stringBuilder.Append("...");
+
+                break;
+            }
+
+            case IHtmlAnchorElement anchorElement:
+            {
+                // We specifically ignore empty links (contained text), as AngleSharp seems to make multiple links
+                // out of one for some reason
+                if (!truncated && !string.IsNullOrWhiteSpace(anchorElement.Text))
+                {
+                    stringBuilder.Append($"[url={anchorElement.Href}]{anchorElement.Text.Trim()}[/url]");
+                }
+
+                // Anchor element children are not handled
+                return;
+            }
+
+            // TODO: handling for the following element types:
+            /*case IHtmlInlineFrameElement iFrame:
+            {
+                FlushTextIfPending();
+                var match = LauncherConstants.YoutubeURLRegex.Match(iFrame.Source ?? string.Empty);
+
+                if (match.Success)
+                {
+                    FinishCurrentItem();
+
+                    currentItem = new Link(match.Groups[1].Value);
+                }
+                else
+                {
+                    logger.LogDebug("Removing iframe to: {Source}", iFrame.Source);
+                }
+
+                break;
+            }
+
+            case IHtmlImageElement:
+            {
+                // TODO: image support
+                truncated = true;
+                break;
+            }
+
+            case ISvgElement:
+            {
+                // TODO: svg support
+                truncated = true;
+                break;
+            }*/
+
+            case IHtmlUnorderedListElement or IHtmlOrderedListElement or IHtmlQuoteElement:
+                stringBuilder.Append("[indent]");
+                break;
+
+            case IHtmlListItemElement:
+            {
+                AddLastTextIfDoesNotEndWithAlready("\n");
+                stringBuilder.Append("- ");
+                break;
+            }
+
+            case IHtmlHrElement:
+            {
+                AddLastTextIfDoesNotEndWithAlready("\n");
+                stringBuilder.Append("---\n");
+                break;
+            }
+
+            default:
+            {
+                var name = node.NodeName.ToLowerInvariant();
+
+                if (name == TagNames.B || name == TagNames.Em || name == TagNames.Strong)
+                {
+                    stringBuilder.Append("[b]");
+                    break;
+                }
+
+                if (name == TagNames.Strike)
+                {
+                    stringBuilder.Append("[s]");
+                    break;
+                }
+
+                if (name == TagNames.Code || name ==
+                    TagNames.Pre)
+                {
+                    stringBuilder.Append("[code]");
+                    break;
+                }
+
+                if (name == TagNames.I)
+                {
+                    stringBuilder.Append("[i]");
+                    break;
+                }
+
+                if (name == TagNames.U)
+                {
+                    stringBuilder.Append("[u]");
+                    break;
+                }
+
+                if (name == TagNames.Dd || name == TagNames.Dt || name == TagNames.Big || name == TagNames.S ||
+                    name == TagNames.Small || name == TagNames.Tt || name == TagNames.NoBr)
+                {
+                    // TODO: implement more text styling
+                    break;
+                }
+
+                if (name is "aside" or "article")
+                {
+                    if (stringBuilder.Length > 0)
+                        AddLastTextIfDoesNotEndWithAlready("\n");
+
+                    stringBuilder.Append("[indent]");
+                    break;
+                }
+
+                if (name == TagNames.Header)
+                {
+                    // TODO: bigger font
+
+                    stringBuilder.Append("[center]");
+                    break;
+                }
+
+                // Unknown node, so we are losing info here
+                truncated = true;
+                break;
+            }
+        }
+
+        if (node.HasChildNodes)
+        {
+            foreach (var child in node.ChildNodes)
+            {
+                HandleNode(child, ref truncated);
+            }
+        }
+
+        switch (node)
+        {
+            case IHtmlParagraphElement or IHtmlHeadingElement or IHtmlBreakRowElement or IHtmlDivElement:
+            {
+                paragraphBreakQueued = true;
+                break;
+            }
+
+            case IHtmlUnorderedListElement or IHtmlOrderedListElement or IHtmlQuoteElement:
+            {
+                stringBuilder.Append("[/indent]\n");
+                break;
+            }
+
+            case IHtmlSpanElement:
+            {
+                if (stringBuilder.Length > 0)
+                    AddLastTextIfDoesNotEndWithAlready(" ");
+
+                break;
+            }
+
+            default:
+            {
+                var name = node.NodeName.ToLowerInvariant();
+
+                if (name == TagNames.B || name == TagNames.Em || name == TagNames.Strong)
+                {
+                    stringBuilder.Append("[/b]");
+                    break;
+                }
+
+                if (name == TagNames.Strike)
+                {
+                    stringBuilder.Append("[/s]");
+                    break;
+                }
+
+                if (name == TagNames.Code || name ==
+                    TagNames.Pre)
+                {
+                    stringBuilder.Append("[/code]");
+                    break;
+                }
+
+                if (name == TagNames.I)
+                {
+                    stringBuilder.Append("[/i]");
+                    break;
+                }
+
+                if (name == TagNames.U)
+                {
+                    stringBuilder.Append("[/u]");
+                    break;
+                }
+
+                if (name == TagNames.Dd || name == TagNames.Dt || name == TagNames.Big || name == TagNames.S ||
+                    name == TagNames.Small || name == TagNames.Tt || name == TagNames.NoBr)
+                {
+                    // This is placeholder for closing styles once more are implemented
+                    break;
+                }
+
+                if (name is "aside" or "article")
+                {
+                    if (stringBuilder.Length > 0)
+                        AddLastTextIfDoesNotEndWithAlready("\n");
+
+                    stringBuilder.Append("[/indent]\n");
+                    break;
+                }
+
+                if (name == TagNames.Header)
+                {
+                    // TODO: bigger font
+
+                    stringBuilder.Append("[/center]");
+                }
+
+                break;
+            }
+        }
+    }
+
+    // The following methods are general utility methods shared between the feed parser in the common module
+    // TODO: combine these separate implementations into one once Thrive uses a general module
+    private void AddLastTextIfDoesNotEndWithAlready(string text)
+    {
+        if (stringBuilder.Length < text.Length)
+        {
+            stringBuilder.Append(text);
+        }
+
+        bool match = true;
+
+        for (int i = text.Length; i > 0; --i)
+        {
+            if (stringBuilder[stringBuilder.Length - i] != text[text.Length - i])
+            {
+                match = false;
+                break;
+            }
+        }
+
+        if (!match)
+            stringBuilder.Append(text);
+    }
+}

--- a/src/general/HtmlToBbCodeConverter.cs
+++ b/src/general/HtmlToBbCodeConverter.cs
@@ -103,7 +103,12 @@ public class HtmlToBbCodeConverter
                 // out of one for some reason
                 if (!truncated && !string.IsNullOrWhiteSpace(anchorElement.Text))
                 {
+                    // We need to do our own clickable link colour setting for Godot
+                    stringBuilder.Append(Constants.CLICKABLE_TEXT_BBCODE);
+
                     stringBuilder.Append($"[url={anchorElement.Href}]{anchorElement.Text.Trim()}[/url]");
+
+                    stringBuilder.Append(Constants.CLICKABLE_TEXT_BBCODE_END);
                 }
 
                 // Anchor element children are not handled

--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -83,6 +83,9 @@ public class MainMenu : NodeWithInput
     public NodePath NewsFeedPath = null!;
 
     [Export]
+    public NodePath NewsFeedPositionerPath = null!;
+
+    [Export]
     public NodePath ThanksDialogPath = null!;
 
     [Export]
@@ -104,6 +107,7 @@ public class MainMenu : NodeWithInput
     private GalleryViewer galleryViewer = null!;
 
     private ThriveFeedDisplayer newsFeed = null!;
+    private Control newsFeedPositioner = null!;
 
     private Control creditsContainer = null!;
     private CreditsScroll credits = null!;
@@ -262,6 +266,7 @@ public class MainMenu : NodeWithInput
         // if a menu is visible
         websiteButtonsContainer.Visible = false;
         socialMediaContainer.Visible = index != uint.MaxValue;
+        newsFeedPositioner.Visible = index != uint.MaxValue;
 
         // Allow disabling all the menus for going to the options menu
         if (index > menuArray.Count - 1 && index != uint.MaxValue)
@@ -336,6 +341,7 @@ public class MainMenu : NodeWithInput
                 ModManagerPath.Dispose();
                 GalleryViewerPath.Dispose();
                 NewsFeedPath.Dispose();
+                NewsFeedPositionerPath.Dispose();
                 ThanksDialogPath.Dispose();
                 ThanksDialogTextPath.Dispose();
                 PermanentlyDismissThanksDialogPath.Dispose();
@@ -365,6 +371,7 @@ public class MainMenu : NodeWithInput
         modManager = GetNode<ModManager>(ModManagerPath);
         galleryViewer = GetNode<GalleryViewer>(GalleryViewerPath);
         newsFeed = GetNode<ThriveFeedDisplayer>(NewsFeedPath);
+        newsFeedPositioner = GetNode<Control>(NewsFeedPositionerPath);
         socialMediaContainer = GetNode<Control>(SocialMediaContainerPath);
         websiteButtonsContainer = GetNode<PopupPanel>(WebsiteButtonsContainerPath);
 

--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -80,6 +80,9 @@ public class MainMenu : NodeWithInput
     public NodePath GalleryViewerPath = null!;
 
     [Export]
+    public NodePath NewsFeedPath = null!;
+
+    [Export]
     public NodePath ThanksDialogPath = null!;
 
     [Export]
@@ -99,6 +102,8 @@ public class MainMenu : NodeWithInput
     private Thriveopedia thriveopedia = null!;
     private ModManager modManager = null!;
     private GalleryViewer galleryViewer = null!;
+
+    private ThriveFeedDisplayer newsFeed = null!;
 
     private Control creditsContainer = null!;
     private CreditsScroll credits = null!;
@@ -179,13 +184,6 @@ public class MainMenu : NodeWithInput
         TemporaryLoadedNodeDeleter.Instance.ReleaseAllHolds();
 
         CheckModFailures();
-
-        if (!IsReturningToMenu && Settings.Instance.ThriveNewsFeedEnabled.Value)
-        {
-            // Start feed fetch here as early as possible to not make the user wait a long time after the menu is
-            // visible to see it
-            ThriveNewsFeed.GetFeedContents();
-        }
     }
 
     public override void _Process(float delta)
@@ -337,6 +335,7 @@ public class MainMenu : NodeWithInput
                 StoreLoggedInDisplayPath.Dispose();
                 ModManagerPath.Dispose();
                 GalleryViewerPath.Dispose();
+                NewsFeedPath.Dispose();
                 ThanksDialogPath.Dispose();
                 ThanksDialogTextPath.Dispose();
                 PermanentlyDismissThanksDialogPath.Dispose();
@@ -365,6 +364,7 @@ public class MainMenu : NodeWithInput
         storeLoggedInDisplay = GetNode<Label>(StoreLoggedInDisplayPath);
         modManager = GetNode<ModManager>(ModManagerPath);
         galleryViewer = GetNode<GalleryViewer>(GalleryViewerPath);
+        newsFeed = GetNode<ThriveFeedDisplayer>(NewsFeedPath);
         socialMediaContainer = GetNode<Control>(SocialMediaContainerPath);
         websiteButtonsContainer = GetNode<PopupPanel>(WebsiteButtonsContainerPath);
 
@@ -679,6 +679,9 @@ public class MainMenu : NodeWithInput
     {
         options.Visible = false;
         SetCurrentMenu(0, false);
+
+        // In case news settings are changed, update that state
+        newsFeed.CheckStartFetchNews();
     }
 
     private void OnReturnFromNewGameSettings()

--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -179,6 +179,13 @@ public class MainMenu : NodeWithInput
         TemporaryLoadedNodeDeleter.Instance.ReleaseAllHolds();
 
         CheckModFailures();
+
+        if (!IsReturningToMenu && Settings.Instance.ThriveNewsFeedEnabled.Value)
+        {
+            // Start feed fetch here as early as possible to not make the user wait a long time after the menu is
+            // visible to see it
+            ThriveNewsFeed.GetFeedContents();
+        }
     }
 
     public override void _Process(float delta)

--- a/src/general/MainMenu.tscn
+++ b/src/general/MainMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=59 format=2]
+[gd_scene load_steps=60 format=2]
 
 [ext_resource path="res://src/gui_common/thrive_theme.tres" type="Theme" id=1]
 [ext_resource path="res://src/saving/SaveManagerGUI.tscn" type="PackedScene" id=2]
@@ -56,6 +56,7 @@
 [ext_resource path="res://src/gui_common/CustomCheckBox.tscn" type="PackedScene" id=54]
 [ext_resource path="res://src/gui_common/CustomRichTextLabel.tscn" type="PackedScene" id=55]
 [ext_resource path="res://src/gui_common/FocusGrabber.tscn" type="PackedScene" id=56]
+[ext_resource path="res://src/gui_common/ThriveFeedDisplayer.tscn" type="PackedScene" id=57]
 
 [sub_resource type="StyleBoxFlat" id=2]
 content_margin_left = 5.0
@@ -141,6 +142,7 @@ PatreonButtonPath = NodePath("MenuContainers/SocialMedia/PatreonButton")
 StoreLoggedInDisplayPath = NodePath("StoreUser")
 ModManagerPath = NodePath("ModManager")
 GalleryViewerPath = NodePath("GalleryViewer")
+NewsFeedPath = NodePath("MenuContainers/ThriveFeedDisplayer")
 ThanksDialogPath = NodePath("ThanksForBuyingDialog")
 ThanksDialogTextPath = NodePath("ThanksForBuyingDialog/VBoxContainer/ThanksText")
 PermanentlyDismissThanksDialogPath = NodePath("ThanksForBuyingDialog/VBoxContainer/CheckBox")
@@ -662,6 +664,13 @@ SkipOverridingFocusForElements = [ NodePath("../../..") ]
 Priority = 10
 NodeToGiveFocusTo = NodePath("../OfficialWebsiteButton")
 AlwaysOverrideFocus = true
+
+[node name="ThriveFeedDisplayer" parent="MenuContainers" instance=ExtResource( 57 )]
+anchor_left = 0.601
+margin_left = 55.72
+margin_top = 112.0
+margin_right = -32.0
+margin_bottom = -124.0
 
 [node name="SocialMedia" type="HBoxContainer" parent="MenuContainers"]
 anchor_top = 1.0

--- a/src/general/MainMenu.tscn
+++ b/src/general/MainMenu.tscn
@@ -142,7 +142,8 @@ PatreonButtonPath = NodePath("MenuContainers/SocialMedia/PatreonButton")
 StoreLoggedInDisplayPath = NodePath("StoreUser")
 ModManagerPath = NodePath("ModManager")
 GalleryViewerPath = NodePath("GalleryViewer")
-NewsFeedPath = NodePath("MenuContainers/ThriveFeedDisplayer")
+NewsFeedPath = NodePath("MenuContainers/FeedPositioner/ThriveFeedDisplayer")
+NewsFeedPositionerPath = NodePath("MenuContainers/FeedPositioner")
 ThanksDialogPath = NodePath("ThanksForBuyingDialog")
 ThanksDialogTextPath = NodePath("ThanksForBuyingDialog/VBoxContainer/ThanksText")
 PermanentlyDismissThanksDialogPath = NodePath("ThanksForBuyingDialog/VBoxContainer/CheckBox")
@@ -665,12 +666,21 @@ Priority = 10
 NodeToGiveFocusTo = NodePath("../OfficialWebsiteButton")
 AlwaysOverrideFocus = true
 
-[node name="ThriveFeedDisplayer" parent="MenuContainers" instance=ExtResource( 57 )]
-anchor_left = 0.601
-margin_left = 55.72
-margin_top = 112.0
+[node name="FeedPositioner" type="MarginContainer" parent="MenuContainers"]
+anchor_left = 0.597
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 35.0
+margin_top = 125.0
 margin_right = -32.0
-margin_bottom = -124.0
+margin_bottom = -125.0
+mouse_filter = 2
+
+[node name="ThriveFeedDisplayer" parent="MenuContainers/FeedPositioner" instance=ExtResource( 57 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 448.0
+margin_bottom = 470.0
 
 [node name="SocialMedia" type="HBoxContainer" parent="MenuContainers"]
 anchor_top = 1.0

--- a/src/general/OptionsMenu.cs
+++ b/src/general/OptionsMenu.cs
@@ -273,6 +273,9 @@ public class OptionsMenu : ControlWithInput
     public NodePath CustomUsernamePath = null!;
 
     [Export]
+    public NodePath WebFeedsEnabledPath = null!;
+
+    [Export]
     public NodePath DismissedNoticeCountPath = null!;
 
     [Export]
@@ -392,6 +395,7 @@ public class OptionsMenu : ControlWithInput
     private SpinBox maxQuickSaves = null!;
     private CustomCheckBox customUsernameEnabled = null!;
     private LineEdit customUsername = null!;
+    private CustomCheckBox webFeedsEnabled = null!;
     private Label dismissedNoticeCount = null!;
     private OptionButton jsonDebugMode = null!;
     private Label commitLabel = null!;
@@ -549,6 +553,7 @@ public class OptionsMenu : ControlWithInput
         tutorialsEnabled = GetNode<CustomCheckBox>(TutorialsEnabledPath);
         customUsernameEnabled = GetNode<CustomCheckBox>(CustomUsernameEnabledPath);
         customUsername = GetNode<LineEdit>(CustomUsernamePath);
+        webFeedsEnabled = GetNode<CustomCheckBox>(WebFeedsEnabledPath);
         dismissedNoticeCount = GetNode<Label>(DismissedNoticeCountPath);
         jsonDebugMode = GetNode<OptionButton>(JSONDebugModePath);
         commitLabel = GetNode<Label>(CommitLabelPath);
@@ -732,6 +737,7 @@ public class OptionsMenu : ControlWithInput
             settings.CustomUsername :
             Settings.EnvironmentUserName;
         customUsername.Editable = settings.CustomUsernameEnabled;
+        webFeedsEnabled.Pressed = settings.ThriveNewsFeedEnabled;
         jsonDebugMode.Selected = JSONDebugModeToIndex(settings.JSONDebugMode);
         unsavedProgressWarningEnabled.Pressed = settings.ShowUnsavedProgressWarning;
 
@@ -856,6 +862,7 @@ public class OptionsMenu : ControlWithInput
                 ErrorAcceptBoxPath.Dispose();
                 CustomUsernameEnabledPath.Dispose();
                 CustomUsernamePath.Dispose();
+                WebFeedsEnabledPath.Dispose();
                 DismissedNoticeCountPath.Dispose();
                 JSONDebugModePath.Dispose();
                 CommitLabelPath.Dispose();
@@ -2174,6 +2181,13 @@ public class OptionsMenu : ControlWithInput
         {
             Settings.Instance.CustomUsername.Value = text;
         }
+
+        UpdateResetSaveButtonState();
+    }
+
+    private void OnWebFeedsEnabledToggled(bool pressed)
+    {
+        Settings.Instance.ThriveNewsFeedEnabled.Value = pressed;
 
         UpdateResetSaveButtonState();
     }

--- a/src/general/OptionsMenu.tscn
+++ b/src/general/OptionsMenu.tscn
@@ -126,6 +126,7 @@ DefaultsConfirmationBoxPath = NodePath("CenterContainer/DefaultsConfirm")
 ErrorAcceptBoxPath = NodePath("CenterContainer/ErrorDialog")
 CustomUsernameEnabledPath = NodePath("CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/CustomUsernameEnabled")
 CustomUsernamePath = NodePath("CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer3/CustomUsername")
+WebFeedsEnabledPath = NodePath("CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/WebFeeds")
 DismissedNoticeCountPath = NodePath("CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer8/DismissedCount")
 JSONDebugModePath = NodePath("CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer5/JSONDebug")
 CommitLabelPath = NodePath("CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer6/Commit")
@@ -1572,7 +1573,7 @@ follow_focus = true
 
 [node name="MarginContainer" type="MarginContainer" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer"]
 margin_right = 718.0
-margin_bottom = 665.0
+margin_bottom = 700.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_constants/margin_right = 10
@@ -1580,7 +1581,7 @@ custom_constants/margin_bottom = 10
 
 [node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer"]
 margin_right = 708.0
-margin_bottom = 655.0
+margin_bottom = 690.0
 size_flags_horizontal = 3
 custom_constants/separation = 10
 __meta__ = {
@@ -1764,10 +1765,18 @@ size_flags_horizontal = 3
 action_mode = 0
 text = "OPEN_LOGS_FOLDER"
 
-[node name="HBoxContainer8" type="HBoxContainer" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="WebFeeds" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer" instance=ExtResource( 10 )]
 margin_top = 472.0
+margin_right = 259.0
+margin_bottom = 497.0
+rect_pivot_offset = Vector2( 114, 23 )
+size_flags_horizontal = 0
+text = "SHOW_WEB_NEWS_FEED"
+
+[node name="HBoxContainer8" type="HBoxContainer" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer"]
+margin_top = 507.0
 margin_right = 702.0
-margin_bottom = 507.0
+margin_bottom = 542.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer8"]
@@ -1801,9 +1810,9 @@ action_mode = 0
 text = "RESET_DISMISSED_POPUPS"
 
 [node name="HBoxContainer5" type="HBoxContainer" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer"]
-margin_top = 517.0
+margin_top = 552.0
 margin_right = 702.0
-margin_bottom = 542.0
+margin_bottom = 577.0
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer5"]
 margin_right = 197.0
@@ -1828,14 +1837,14 @@ items = [ "JSON_DEBUG_MODE_AUTO", null, false, 0, null, "JSON_DEBUG_MODE_ALWAYS"
 selected = 0
 
 [node name="HSeparator2" type="HSeparator" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer"]
-margin_top = 552.0
+margin_top = 587.0
 margin_right = 702.0
-margin_bottom = 556.0
+margin_bottom = 591.0
 
 [node name="HBoxContainer6" type="VBoxContainer" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer"]
-margin_top = 566.0
+margin_top = 601.0
 margin_right = 702.0
-margin_bottom = 620.0
+margin_bottom = 655.0
 
 [node name="CommitInfo" type="Label" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer6"]
 margin_right = 702.0
@@ -1862,9 +1871,9 @@ __meta__ = {
 }
 
 [node name="HBoxContainer7" type="HBoxContainer" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer"]
-margin_top = 630.0
+margin_top = 665.0
 margin_right = 702.0
-margin_bottom = 655.0
+margin_bottom = 690.0
 
 [node name="BuiltTimeInfo" type="Label" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer7"]
 margin_right = 209.0
@@ -2154,6 +2163,7 @@ DialogText = "TRY_TAKING_SOME_SCREENSHOTS"
 [connection signal="text_changed" from="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer3/CustomUsername" to="." method="OnCustomUsernameTextChanged"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer4/ScreenshotFolder" to="." method="OnOpenScreenshotFolder"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer4/LogButton" to="." method="OnLogButtonPressed"]
+[connection signal="toggled" from="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/WebFeeds" to="." method="OnWebFeedsEnabledToggled"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer8/ResetDismissed" to="." method="OnResetDismissedPopups"]
 [connection signal="item_selected" from="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Misc/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer5/JSONDebug" to="." method="OnJSONDebugModeSelected"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer/Back" to="." method="OnBackPressed"]

--- a/src/general/ThriveNewsFeed.cs
+++ b/src/general/ThriveNewsFeed.cs
@@ -1,0 +1,473 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using AngleSharp.Html.Parser;
+using Godot;
+
+/// <summary>
+///   Manages downloading and parsing the Thrive news feed into Godot-friendly bbcode
+/// </summary>
+public static class ThriveNewsFeed
+{
+    private static readonly Lazy<Task<IReadOnlyCollection<FeedItem>>> FeedItemsTask = new(StartFetchingFeed);
+
+    /// <summary>
+    ///   Gets the news feed contents. If already retrieved returns the existing copy
+    /// </summary>
+    /// <returns>Task that resolves with the feed content once ready (or an error representing item)</returns>
+    public static Task<IReadOnlyCollection<FeedItem>> GetFeedContents()
+    {
+        return FeedItemsTask.Value;
+    }
+
+    private static Task<IReadOnlyCollection<FeedItem>> StartFetchingFeed()
+    {
+        GD.Print("Beginning Thrive news feed fetch");
+        var task = new Task<IReadOnlyCollection<FeedItem>>(FetchFeed);
+
+        TaskExecutor.Instance.AddTask(task);
+
+        return task;
+    }
+
+    private static IReadOnlyCollection<FeedItem> FetchFeed()
+    {
+        using var client = SetupHttpClient();
+
+        var timeout = TimeSpan.FromMinutes(1);
+
+        try
+        {
+            // This done a bit awkwardly to allow running this easily on our executor pool
+            var responseTask = client.GetAsync(Constants.MainSiteFeedURL, HttpCompletionOption.ResponseHeadersRead);
+            if (!responseTask.Wait(timeout))
+                throw new Exception("Download timed out");
+
+            var response = responseTask.Result;
+
+            response.EnsureSuccessStatusCode();
+
+            var readTask = response.Content.ReadAsStreamAsync();
+
+            if (!readTask.Wait(timeout))
+                throw new Exception("Data read timed out");
+
+            var responseStream = readTask.Result;
+            var feedDocument = XDocument.Load(responseStream);
+
+            var items = ExtractFeedItems(feedDocument);
+
+            return ParseHtmlItemsToBbCode(items);
+        }
+        catch (Exception e)
+        {
+            return new[] { CreateErrorItem(e.Message) };
+        }
+    }
+
+    private static HttpClient SetupHttpClient()
+    {
+        var client = new HttpClient();
+        client.Timeout = TimeSpan.FromSeconds(45);
+
+        var version = Constants.Version;
+
+        if (version.Contains("error"))
+        {
+            GD.PrintErr("Can't access our version, sending web requests with unknown version");
+            version = "unknown";
+        }
+
+        client.DefaultRequestHeaders.UserAgent.Clear();
+        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Thrive", version));
+
+        return client;
+    }
+
+    // TODO: test displaying this
+    private static FeedItem CreateErrorItem(string error)
+    {
+        GD.PrintErr($"Fetching Thrive news feed failed due to: {error}");
+
+        return new FeedItem(TranslationServer.Translate("ERROR_FETCHING_NEWS"), null,
+            TranslationServer.Translate("ERROR_FETCHING_EXPLANATION").FormatSafe(error), string.Empty);
+    }
+
+    private static IEnumerable<ExtractedFeedItem> ExtractFeedItems(XDocument document)
+    {
+        var potentialItems = document.Descendants().Where(e => e.Name.LocalName == "item");
+
+        int seenItems = 0;
+
+        foreach (var element in potentialItems)
+        {
+            // This code is duplicated from FeedParser
+            // TODO: combine this to use the same code once possible (for now this is a slightly cut down version
+            // as not all data is needed by Thrive to reduce the amount of duplication)
+            var id = element.Descendants().FirstOrDefault(p => p.Name.LocalName is "id" or "guid")
+                ?.Value;
+
+            // Can't handle entries with no id
+            if (id == null)
+                continue;
+
+            var link = "Link is missing";
+
+            var linkElement = element.Descendants().FirstOrDefault(p => p.Name.LocalName == "link");
+
+            if (linkElement != null)
+            {
+                link = linkElement.Attribute("href")?.Value ?? linkElement.Value;
+            }
+
+            // TODO: link should be sanitized against bbcode
+
+            var title = element.Descendants().FirstOrDefault(p => p.Name.LocalName == "title")?.Value ??
+                "Unknown title";
+
+            var parsed = new ExtractedFeedItem(id, link, title)
+            {
+                Summary = element.Descendants().FirstOrDefault(p => p.Name.LocalName == "summary")?.Value ??
+                    element.Descendants().FirstOrDefault(p => p.Name.LocalName == "description")?.Value ??
+                    element.Descendants().FirstOrDefault(p => p.Name.LocalName == "content")?.Value,
+            };
+
+            var published = element.Descendants().FirstOrDefault(p => p.Name.LocalName is "published" or "pubDate")
+                ?.Value;
+
+            if (published != null && DateTime.TryParse(published, out var parsedTime))
+            {
+                parsed.PublishedAt = parsedTime.ToUniversalTime();
+            }
+
+            yield return parsed;
+
+            if (++seenItems > Constants.MAX_NEWS_FEED_ITEMS_TO_SHOW)
+                break;
+        }
+    }
+
+    private static List<FeedItem> ParseHtmlItemsToBbCode(IEnumerable<ExtractedFeedItem> items)
+    {
+        var htmlParser = new HtmlParser(new HtmlParserOptions
+        {
+            IsStrictMode = false,
+        });
+
+        var dummyDom = htmlParser.ParseDocument(string.Empty).DocumentElement;
+
+        var stringBuilder = new StringBuilder();
+
+        var results = new List<FeedItem>();
+
+        foreach (var item in items)
+        {
+            stringBuilder.Clear();
+
+            string footer = string.Empty;
+
+            if (item.PublishedAt != null)
+            {
+                footer = TranslationServer.Translate("FEED_ITEM_PUBLISHED_AT")
+                    .FormatSafe(item.PublishedAt.Value.ToLocalTime().ToLongTimeString());
+            }
+
+            // Special handling for items that don't have a summary for some reason
+            if (string.IsNullOrWhiteSpace(item.Summary))
+            {
+                results.Add(new FeedItem(item.Title, item.Link,
+                    TranslationServer.Translate("FEED_ITEM_MISSING_CONTENT"), footer));
+
+                continue;
+            }
+
+            bool truncated = false;
+
+            try
+            {
+                var document = htmlParser.ParseFragment(item.Summary!, dummyDom);
+
+                foreach (var topLevelNode in document)
+                {
+                    HandleNode(topLevelNode, stringBuilder, ref truncated);
+                }
+            }
+            catch (Exception e)
+            {
+                GD.PrintErr($"Failed to parse content of feed item ({item.ID}): {e}");
+
+                results.Add(new FeedItem(item.Title, item.Link,
+                    TranslationServer.Translate("FEED_ITEM_CONTENT_PARSING_FAILED"), footer));
+                continue;
+            }
+
+            if (truncated)
+                footer = TranslationServer.Translate("FEED_ITEM_TRUNCATED_NOTICE").FormatSafe(footer);
+
+            results.Add(new FeedItem(item.Title, item.Link, stringBuilder.ToString(), footer));
+        }
+
+        return results;
+    }
+
+    private static void HandleNode(INode node, StringBuilder stringBuilder, ref bool truncated)
+    {
+        // TODO: escaping Bbcode tags that are present in the text already
+        switch (node)
+        {
+            case IText text:
+            {
+                if (!truncated)
+                {
+                    var textToAdd = text.Data;
+
+                    if (stringBuilder.Length < 1)
+                    {
+                        textToAdd = textToAdd.TrimStart();
+                    }
+
+                    if (stringBuilder.Length + textToAdd.Length >= Constants.MAX_NEWS_FEED_ITEM_LENGTH)
+                    {
+                        textToAdd = textToAdd.Substring(0, Constants.MAX_NEWS_FEED_ITEM_LENGTH - stringBuilder.Length);
+                        truncated = true;
+                    }
+
+                    // Avoid a bunch of useless whitespace
+                    if (string.IsNullOrWhiteSpace(textToAdd))
+                    {
+                        if (stringBuilder.Length > 0)
+                        {
+                            var newLines = textToAdd.Count(c => c == '\n');
+                            if (newLines > 0)
+                            {
+                                // TODO:
+                                // if (CountEndingCharactersMatching('\n') < 3)
+                                {
+                                    stringBuilder.Append('\n');
+                                }
+                            }
+                            else
+                            {
+                                // AddLastTextIfDoesNotEndWithAlready(" ");
+                            }
+                        }
+                    }
+                    else
+                    {
+                        stringBuilder.Append(textToAdd);
+                    }
+                }
+
+                break;
+            }
+
+            case IHtmlAnchorElement anchorElement:
+            {
+                if (!truncated)
+                {
+                    stringBuilder.Append($"[url={anchorElement.Href}]{anchorElement.Text}[/url]");
+                }
+
+                // Anchor element children are not handled
+                return;
+            }
+        }
+
+        // int length = Constants.MAX_NEWS_FEED_ITEM_LENGTH;
+
+        if (node.HasChildNodes)
+        {
+            foreach (var child in node.ChildNodes)
+            {
+                HandleNode(child, stringBuilder, ref truncated);
+            }
+        }
+
+        switch (node)
+        {
+            case IHtmlParagraphElement or IHtmlHeadingElement or IHtmlBreakRowElement:
+            {
+                // TODO: add the AddLastTextIfDoesNotEndWIthAlready
+                if (!truncated)
+                    stringBuilder.Append("\n\n");
+                break;
+            }
+        }
+
+        /*
+                    case IHtmlUnorderedListElement or IHtmlOrderedListElement:
+                        // These are handled in the below case
+                        break;
+
+                    case IHtmlListItemElement:
+                    {
+                        AddLastTextIfDoesNotEndWithAlready("\n");
+                        stringBuilder.Append("- ");
+                        break;
+                    }
+
+                    case IHtmlHrElement:
+                    {
+                        AddLastTextIfDoesNotEndWithAlready("\n");
+                        stringBuilder.Append("---\n");
+                        break;
+                    }
+
+                    case IHtmlParagraphElement or IHtmlHeadingElement or IHtmlBreakRowElement:
+                    {
+                        if (PendingText)
+                        {
+                            AddLastTextIfDoesNotEndWithAlready("\n\n");
+                        }
+
+                        break;
+                    }
+
+                    case IHtmlQuoteElement:
+                    {
+                        AddLastTextIfDoesNotEndWithAlready("> ");
+
+                        break;
+                    }
+
+                    case IHtmlSpanElement or IHtmlDivElement:
+                    {
+                        if (PendingText)
+                            AddLastTextIfDoesNotEndWithAlready(" ");
+
+                        break;
+                    }
+
+                    case IHtmlInlineFrameElement iFrame:
+                    {
+                        FlushTextIfPending();
+                        var match = LauncherConstants.YoutubeURLRegex.Match(iFrame.Source ?? string.Empty);
+
+                        if (match.Success)
+                        {
+                            FinishCurrentItem();
+
+                            currentItem = new Link(match.Groups[1].Value);
+                        }
+                        else
+                        {
+                            logger.LogDebug("Removing iframe to: {Source}", iFrame.Source);
+                        }
+
+                        break;
+                    }
+
+                    case IHtmlAnchorElement aElement:
+                    {
+                        HandleAElement(aElement, ref seenLength, length);
+                        break;
+                    }
+
+                    case IHtmlImageElement:
+                    {
+                        // TODO: image support
+                        truncated = true;
+                        break;
+                    }
+
+                    case ISvgElement:
+                    {
+                        // TODO: svg support
+                        truncated = true;
+                        break;
+                    }
+
+                    default:
+                    {
+                        var name = node.NodeName.ToLowerInvariant();
+
+                        if (name == TagNames.Dd || name ==
+                            TagNames.Dt || name ==
+                            TagNames.B || name ==
+                            TagNames.Big || name ==
+                            TagNames.Strike || name ==
+                            TagNames.Code || name ==
+                            TagNames.Em || name ==
+                            TagNames.I || name ==
+                            TagNames.S || name ==
+                            TagNames.Small || name ==
+                            TagNames.Strong || name ==
+                            TagNames.U || name ==
+                            TagNames.Tt || name ==
+                            TagNames.Pre || name ==
+                            TagNames.NoBr)
+                        {
+                            // TODO: implement text styling
+                            continue;
+                        }
+
+                        if (name is "aside" or "article")
+                        {
+                            if (!string.IsNullOrEmpty(AsideStart))
+                            {
+                                if (PendingText)
+                                    AddLastTextIfDoesNotEndWithAlready("\n\n");
+
+                                stringBuilder.Append(AsideStart);
+                            }
+
+                            continue;
+                        }
+
+                        if (name == TagNames.Header)
+                        {
+                            // TODO: better handling for this
+                            AddLastTextIfDoesNotEndWithAlready("# ");
+                            continue;
+                        }
+
+                        // Unknown node, so we are losing info here
+                        truncated = true;
+                        FlushTextIfPending();
+
+                        logger.LogDebug("Not parsing unknown HTML in feed: {Node}", node);
+                        break;
+                    }
+         *
+         */
+    }
+
+    public class FeedItem
+    {
+        public FeedItem(string title, string? readLink, string contentBbCode, string footerLine)
+        {
+            Title = title;
+            ReadLink = readLink;
+            ContentBbCode = contentBbCode;
+            FooterLine = footerLine;
+        }
+
+        public string Title { get; }
+        public string? ReadLink { get; }
+        public string ContentBbCode { get; }
+        public string FooterLine { get; }
+    }
+
+    private class ExtractedFeedItem
+    {
+        public ExtractedFeedItem(string id, string link, string title)
+        {
+            ID = id;
+            Link = link;
+            Title = title;
+        }
+
+        public string ID { get; }
+        public string Link { get; }
+        public string Title { get; }
+        public string? Summary { get; set; }
+        public DateTime? PublishedAt { get; set; }
+    }
+}

--- a/src/gui_common/ThriveFeedDisplayer.cs
+++ b/src/gui_common/ThriveFeedDisplayer.cs
@@ -1,0 +1,163 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Godot;
+
+public class ThriveFeedDisplayer : VBoxContainer
+{
+    [Export]
+    public NodePath? NewsContainerPath;
+
+    [Export]
+    public NodePath LoadingIndicatorPath = null!;
+
+#pragma warning disable CA2213
+    private Container newsContainer = null!;
+    private Control loadingIndicator = null!;
+
+    private PackedScene customRichTextScene = null!;
+#pragma warning restore CA2213
+
+    private Task<IReadOnlyCollection<ThriveNewsFeed.FeedItem>>? newsTask;
+
+    private IEnumerator<ThriveNewsFeed.FeedItem>? newsEnumerator;
+
+    private bool processingFirstNewsItem;
+
+    public override void _Ready()
+    {
+        newsContainer = GetNode<Container>(NewsContainerPath);
+        loadingIndicator = GetNode<Control>(LoadingIndicatorPath);
+
+        customRichTextScene = GD.Load<PackedScene>("res://src/gui_common/CustomRichTextLabel.tscn");
+
+        // This doesn't check the returning to menu as if we have downloaded the data twice, we don't do that again
+        // and if we should be hidden we'll need the logic to run to hide ourselves anyway
+
+        // Start feed fetch here as early as possible to not make the user wait a long time after the menu is
+        // visible to see it
+        CheckStartFetchNews();
+    }
+
+    public override void _Process(float delta)
+    {
+        if (newsEnumerator != null)
+        {
+            // Process one item per frame to avoid huge lag spikes
+            while (newsEnumerator.MoveNext())
+            {
+                var feedItem = newsEnumerator.Current;
+
+                if (feedItem == null)
+                {
+                    GD.PrintErr("Feed item enumerator item is unexpectedly null");
+                    continue;
+                }
+
+                var itemContainer = new VBoxContainer();
+
+                if (processingFirstNewsItem)
+                    itemContainer.MarginTop = 10;
+
+                processingFirstNewsItem = false;
+
+                // TODO: big font
+                // TODO: make into a clickable button
+                var title = new Label
+                {
+                    Text = feedItem.Title,
+                };
+
+                // feedItem.ReadLink
+
+                itemContainer.AddChild(title);
+
+                var textDisplayer = customRichTextScene.Instance<CustomRichTextLabel>();
+
+                textDisplayer.ExtendedBbcode = feedItem.ContentBbCode;
+
+                itemContainer.AddChild(textDisplayer);
+
+                if (!string.IsNullOrWhiteSpace(feedItem.FooterLine))
+                {
+                    var footerText = new Label
+                    {
+                        Text = feedItem.FooterLine,
+                    };
+
+                    itemContainer.AddChild(footerText);
+                }
+
+                newsContainer.AddChild(itemContainer);
+
+                return;
+            }
+
+            // All processed
+            newsEnumerator.Dispose();
+            newsEnumerator = null;
+            return;
+        }
+
+        if (newsTask == null)
+            return;
+
+        if (!newsTask.IsCompleted)
+            return;
+
+        // News are now ready for showing
+        newsEnumerator = newsTask.Result.GetEnumerator();
+        newsTask = null;
+
+        newsContainer.QueueFreeChildren();
+        loadingIndicator.Visible = false;
+        processingFirstNewsItem = true;
+    }
+
+    public override void _Notification(int what)
+    {
+        base._Notification(what);
+
+        if (what == NotificationTranslationChanged)
+        {
+            // Rebuild the displayed data if we have data currently
+            // As the data is cached by the fetcher, we can very cheaply just start the fetch task again
+            if (newsTask == null)
+                CheckStartFetchNews();
+        }
+    }
+
+    public void CheckStartFetchNews()
+    {
+        if (Settings.Instance.ThriveNewsFeedEnabled)
+        {
+            Visible = true;
+
+            if (newsTask != null)
+                return;
+
+            newsTask = ThriveNewsFeed.GetFeedContents();
+            loadingIndicator.Visible = true;
+        }
+        else
+        {
+            Visible = false;
+            newsContainer.QueueFreeChildren();
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            if (NewsContainerPath != null)
+            {
+                NewsContainerPath.Dispose();
+                LoadingIndicatorPath.Dispose();
+            }
+
+            newsEnumerator?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/gui_common/ThriveFeedDisplayer.tscn
+++ b/src/gui_common/ThriveFeedDisplayer.tscn
@@ -1,0 +1,44 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://src/gui_common/thrive_theme.tres" type="Theme" id=1]
+[ext_resource path="res://src/gui_common/fonts/Jura-DemiBold-Huge.tres" type="DynamicFont" id=2]
+[ext_resource path="res://src/gui_common/ThriveFeedDisplayer.cs" type="Script" id=3]
+
+[node name="ThriveFeedDisplayer" type="VBoxContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme = ExtResource( 1 )
+script = ExtResource( 3 )
+NewsContainerPath = NodePath("ScrollContainer/VBoxContainer/NewsContainer")
+LoadingIndicatorPath = NodePath("ScrollContainer/VBoxContainer/LoadingIndicator")
+
+[node name="Label" type="Label" parent="."]
+margin_right = 1280.0
+margin_bottom = 41.0
+custom_fonts/font = ExtResource( 2 )
+text = "NEWS"
+
+[node name="ScrollContainer" type="ScrollContainer" parent="."]
+margin_top = 45.0
+margin_right = 1280.0
+margin_bottom = 720.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+follow_focus = true
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer"]
+margin_right = 1280.0
+margin_bottom = 29.0
+size_flags_horizontal = 3
+
+[node name="LoadingIndicator" type="Label" parent="ScrollContainer/VBoxContainer"]
+margin_right = 1280.0
+margin_bottom = 25.0
+text = "LOADING_DOT_DOT_DOT"
+
+[node name="NewsContainer" type="VBoxContainer" parent="ScrollContainer/VBoxContainer"]
+margin_top = 29.0
+margin_right = 1280.0
+margin_bottom = 29.0
+size_flags_horizontal = 3

--- a/src/gui_common/ThriveFeedDisplayer.tscn
+++ b/src/gui_common/ThriveFeedDisplayer.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://src/gui_common/thrive_theme.tres" type="Theme" id=1]
 [ext_resource path="res://src/gui_common/fonts/Jura-DemiBold-Huge.tres" type="DynamicFont" id=2]
 [ext_resource path="res://src/gui_common/ThriveFeedDisplayer.cs" type="Script" id=3]
+[ext_resource path="res://src/gui_common/fonts/Lato-Regular-Tiny.tres" type="DynamicFont" id=4]
+[ext_resource path="res://src/gui_common/fonts/Lato-Regular-Big.tres" type="DynamicFont" id=5]
 
 [node name="ThriveFeedDisplayer" type="VBoxContainer"]
 anchor_right = 1.0
@@ -12,6 +14,8 @@ theme = ExtResource( 1 )
 script = ExtResource( 3 )
 NewsContainerPath = NodePath("ScrollContainer/VBoxContainer/NewsContainer")
 LoadingIndicatorPath = NodePath("ScrollContainer/VBoxContainer/LoadingIndicator")
+TitleFont = ExtResource( 5 )
+FooterFont = ExtResource( 4 )
 
 [node name="Label" type="Label" parent="."]
 margin_right = 1280.0
@@ -26,6 +30,7 @@ margin_bottom = 720.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 follow_focus = true
+scroll_horizontal_enabled = false
 
 [node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer"]
 margin_right = 1280.0
@@ -42,3 +47,4 @@ margin_top = 29.0
 margin_right = 1280.0
 margin_bottom = 29.0
 size_flags_horizontal = 3
+custom_constants/separation = 15


### PR DESCRIPTION
**Brief Description of What This PR Does**
Adds the main website posts feed to the main menu of Thrive as that was no longer visible anywhere when using seamless launcher mode. There's an option in the menu to disable the news.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
