### PR TITLE
Visualize at most 3 digits for resources

### DIFF
--- a/src/general/StageHUDBase.cs
+++ b/src/general/StageHUDBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using Godot;
 using Newtonsoft.Json;
 using Array = Godot.Collections.Array;
@@ -1049,31 +1048,38 @@ public abstract class StageHUDBase<TStage> : Control, IStageHUD
 
         glucoseBar.MaxValue = compounds.GetCapacityForCompound(glucose);
         GUICommon.SmoothlyUpdateBar(glucoseBar, compounds.GetCompoundAmount(glucose), delta);
-        glucoseBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(glucoseBar.Value, glucoseBar.MaxValue);
+        glucoseBar.GetNode<Label>("Value").Text =
+            StringUtils.SlashSeparatedNumbersFormat(glucoseBar.Value, glucoseBar.MaxValue);
 
         ammoniaBar.MaxValue = compounds.GetCapacityForCompound(ammonia);
         GUICommon.SmoothlyUpdateBar(ammoniaBar, compounds.GetCompoundAmount(ammonia), delta);
-        ammoniaBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(ammoniaBar.Value, ammoniaBar.MaxValue);
+        ammoniaBar.GetNode<Label>("Value").Text =
+            StringUtils.SlashSeparatedNumbersFormat(ammoniaBar.Value, ammoniaBar.MaxValue);
 
         phosphateBar.MaxValue = compounds.GetCapacityForCompound(phosphates);
         GUICommon.SmoothlyUpdateBar(phosphateBar, compounds.GetCompoundAmount(phosphates), delta);
-        phosphateBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(phosphateBar.Value, phosphateBar.MaxValue);
+        phosphateBar.GetNode<Label>("Value").Text =
+            StringUtils.SlashSeparatedNumbersFormat(phosphateBar.Value, phosphateBar.MaxValue);
 
         hydrogenSulfideBar.MaxValue = compounds.GetCapacityForCompound(hydrogensulfide);
         GUICommon.SmoothlyUpdateBar(hydrogenSulfideBar, compounds.GetCompoundAmount(hydrogensulfide), delta);
-        hydrogenSulfideBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(hydrogenSulfideBar.Value, hydrogenSulfideBar.MaxValue);
+        hydrogenSulfideBar.GetNode<Label>("Value").Text =
+            StringUtils.SlashSeparatedNumbersFormat(hydrogenSulfideBar.Value, hydrogenSulfideBar.MaxValue);
 
         ironBar.MaxValue = compounds.GetCapacityForCompound(iron);
         GUICommon.SmoothlyUpdateBar(ironBar, compounds.GetCompoundAmount(iron), delta);
-        ironBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(ironBar.Value, ironBar.MaxValue);
+        ironBar.GetNode<Label>("Value").Text =
+            StringUtils.SlashSeparatedNumbersFormat(ironBar.Value, ironBar.MaxValue);
 
         oxytoxyBar.MaxValue = compounds.GetCapacityForCompound(oxytoxy);
         GUICommon.SmoothlyUpdateBar(oxytoxyBar, compounds.GetCompoundAmount(oxytoxy), delta);
-        oxytoxyBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(oxytoxyBar.Value, oxytoxyBar.MaxValue);
+        oxytoxyBar.GetNode<Label>("Value").Text =
+            StringUtils.SlashSeparatedNumbersFormat(oxytoxyBar.Value, oxytoxyBar.MaxValue);
 
         mucilageBar.MaxValue = compounds.GetCapacityForCompound(mucilage);
         GUICommon.SmoothlyUpdateBar(mucilageBar, compounds.GetCompoundAmount(mucilage), delta);
-        mucilageBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(mucilageBar.Value, mucilageBar.MaxValue);
+        mucilageBar.GetNode<Label>("Value").Text =
+            StringUtils.SlashSeparatedNumbersFormat(mucilageBar.Value, mucilageBar.MaxValue);
     }
 
     protected void UpdateReproductionProgress()

--- a/src/general/StageHUDBase.cs
+++ b/src/general/StageHUDBase.cs
@@ -1049,32 +1049,31 @@ public abstract class StageHUDBase<TStage> : Control, IStageHUD
 
         glucoseBar.MaxValue = compounds.GetCapacityForCompound(glucose);
         GUICommon.SmoothlyUpdateBar(glucoseBar, compounds.GetCompoundAmount(glucose), delta);
-        glucoseBar.GetNode<Label>("Value").Text = glucoseBar.Value + " / " + glucoseBar.MaxValue;
+        glucoseBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(glucoseBar.Value, glucoseBar.MaxValue);
 
         ammoniaBar.MaxValue = compounds.GetCapacityForCompound(ammonia);
         GUICommon.SmoothlyUpdateBar(ammoniaBar, compounds.GetCompoundAmount(ammonia), delta);
-        ammoniaBar.GetNode<Label>("Value").Text = ammoniaBar.Value + " / " + ammoniaBar.MaxValue;
+        ammoniaBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(ammoniaBar.Value, ammoniaBar.MaxValue);
 
         phosphateBar.MaxValue = compounds.GetCapacityForCompound(phosphates);
         GUICommon.SmoothlyUpdateBar(phosphateBar, compounds.GetCompoundAmount(phosphates), delta);
-        phosphateBar.GetNode<Label>("Value").Text = phosphateBar.Value + " / " + phosphateBar.MaxValue;
+        phosphateBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(phosphateBar.Value, phosphateBar.MaxValue);
 
         hydrogenSulfideBar.MaxValue = compounds.GetCapacityForCompound(hydrogensulfide);
         GUICommon.SmoothlyUpdateBar(hydrogenSulfideBar, compounds.GetCompoundAmount(hydrogensulfide), delta);
-        hydrogenSulfideBar.GetNode<Label>("Value").Text = hydrogenSulfideBar.Value + " / " +
-            hydrogenSulfideBar.MaxValue;
+        hydrogenSulfideBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(hydrogenSulfideBar.Value, hydrogenSulfideBar.MaxValue);
 
         ironBar.MaxValue = compounds.GetCapacityForCompound(iron);
         GUICommon.SmoothlyUpdateBar(ironBar, compounds.GetCompoundAmount(iron), delta);
-        ironBar.GetNode<Label>("Value").Text = ironBar.Value + " / " + ironBar.MaxValue;
+        ironBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(ironBar.Value, ironBar.MaxValue);
 
         oxytoxyBar.MaxValue = compounds.GetCapacityForCompound(oxytoxy);
         GUICommon.SmoothlyUpdateBar(oxytoxyBar, compounds.GetCompoundAmount(oxytoxy), delta);
-        oxytoxyBar.GetNode<Label>("Value").Text = oxytoxyBar.Value + " / " + oxytoxyBar.MaxValue;
+        oxytoxyBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(oxytoxyBar.Value, oxytoxyBar.MaxValue);
 
         mucilageBar.MaxValue = compounds.GetCapacityForCompound(mucilage);
         GUICommon.SmoothlyUpdateBar(mucilageBar, compounds.GetCompoundAmount(mucilage), delta);
-        mucilageBar.GetNode<Label>("Value").Text = mucilageBar.Value + " / " + mucilageBar.MaxValue;
+        mucilageBar.GetNode<Label>("Value").Text = StringUtils.SlashSeparatedNumbersFormat(mucilageBar.Value, mucilageBar.MaxValue);
     }
 
     protected void UpdateReproductionProgress()
@@ -1136,8 +1135,8 @@ public abstract class StageHUDBase<TStage> : Control, IStageHUD
         }
 
         GUICommon.SmoothlyUpdateBar(atpBar, atpAmount * 10.0f, delta);
-        var atpText = atpAmount.ToString("F1", CultureInfo.CurrentCulture) + " / "
-            + maxATP.ToString("F1", CultureInfo.CurrentCulture);
+
+        var atpText = StringUtils.SlashSeparatedNumbersFormat(atpAmount, maxATP);
         atpLabel.Text = atpText;
         atpLabel.HintTooltip = atpText;
     }

--- a/src/general/StringUtils.cs
+++ b/src/general/StringUtils.cs
@@ -81,9 +81,11 @@ public static class StringUtils
     ///   Splits string into different chunks by whitespace.
     /// </summary>
     /// <remarks>
-    ///   Only handles a single whitespace ( ) and not tabs, multiple spaces, etc. For quoted
-    ///   substrings handling, this only considers double quotes (") and not apostrophes (').
-    ///   If there is no closing quote after an opening quote, the rest of string is considered within quotes.
+    ///  <para>
+    ///     Only handles a single whitespace ( ) and not tabs, multiple spaces, etc. For quoted
+    ///     substrings handling, this only considers double quotes (") and not apostrophes (').
+    ///     If there is no closing quote after an opening quote, the rest of string is considered within quotes.
+    ///   </para>
     /// </remarks>
     /// <param name="input">String to split.</param>
     /// <param name="ignoreWithinQuotes">Ignore whitespace within quotation marks.</param>
@@ -192,18 +194,21 @@ public static class StringUtils
     ///   Convert a value in a string with up to 3 digits.
     /// </summary>
     /// <remarks>
-    ///   If greater than 100, it should use F0, otherwise it should use F1.
-    ///   Above 1000 it should use the number formatting which uses K for
-    ///   thousands, M for millions etc.
+    ///   <para>
+    ///     If greater than 100, it should use F0, otherwise it should use F1.
+    ///     Above 1000 it should use the number formatting which uses K for
+    ///     thousands, M for millions etc. It can handle negative numbers
+    ///   </para>
     /// </remarks>
     /// <param name="value">The value to format</param>
     /// <returns>The formatted string</returns>
     public static string ThreeDigitFormat(double value)
     {
-        if (value >= 1000)
+        double absoluteValue = Math.Abs(value);
+        if (absoluteValue >= 1000)
             return FormatNumber(value);
 
-        if (value >= 100)
+        if (absoluteValue >= 100)
             return value.ToString("F0", CultureInfo.CurrentCulture);
 
         return value.ToString("F1", CultureInfo.CurrentCulture);
@@ -213,11 +218,11 @@ public static class StringUtils
     ///   Formats two numbers separated by a slash. The numbers will have
     ///   up to 3 digits each.
     /// </summary>
-    /// <param name="v1">The first number (numerator)</param>
-    /// <param name="v2">The second number (denominator)</param>
+    /// <param name="numerator">The first number (numerator)</param>
+    /// <param name="denominator">The second number (denominator)</param>
     /// <returns>The formatted string</returns>
-    public static string SlashSeparatedNumbersFormat(double v1, double v2)
+    public static string SlashSeparatedNumbersFormat(double numerator, double denominator)
     {
-        return ThreeDigitFormat(v1) + " / " + ThreeDigitFormat(v2);
+        return ThreeDigitFormat(numerator) + " / " + ThreeDigitFormat(denominator);
     }
 }

--- a/src/general/StringUtils.cs
+++ b/src/general/StringUtils.cs
@@ -189,30 +189,29 @@ public static class StringUtils
     }
 
     /// <summary>
-    // utility function to get the correct text for the ATP label, taking
-    // a number as an input. If greater than 100, it should use F0, otherwise
-    // it should use F1. Above 1000 it should use F0 and add a K.
+    ///   Convert a value in a string with up to 3 digits.
     /// </summary>
+    /// <remarks>
+    ///   If greater than 100, it should use F0, otherwise it should use F1.
+    ///   Above 1000 it should use the number formatting which uses K for
+    ///   thousands, M for millions etc.
+    /// </remarks>
     /// <param name="value">The value to format</param>
     /// <returns>The formatted string</returns>
     public static string ThreeDigitFormat(double value)
     {
         if (value >= 1000)
-            return (value / 1000).ToString("F1", CultureInfo.CurrentCulture) + "K";
-        else if (value >= 100)
-            return value.ToString("F0", CultureInfo.CurrentCulture);
-        else
-            return value.ToString("F1", CultureInfo.CurrentCulture);
-    }
+            return FormatNumber(value);
 
-    /// <summary> Implements <see cref="ThreeDigitFormat(double)"/> for floats </summary>
-    public static string ThreeDigitFormat(float value)
-    {
-        return ThreeDigitFormat((double)value);
+        if (value >= 100)
+            return value.ToString("F0", CultureInfo.CurrentCulture);
+
+        return value.ToString("F1", CultureInfo.CurrentCulture);
     }
 
     /// <summary>
-    /// Formats two numbers separated by a slash
+    ///   Formats two numbers separated by a slash. The numbers will have
+    ///   up to 3 digits each.
     /// </summary>
     /// <param name="v1">The first number (numerator)</param>
     /// <param name="v2">The second number (denominator)</param>

--- a/src/general/StringUtils.cs
+++ b/src/general/StringUtils.cs
@@ -187,4 +187,38 @@ public static class StringUtils
 
         return result.ToString();
     }
+
+    /// <summary>
+    // utility function to get the correct text for the ATP label, taking
+    // a number as an input. If greater than 100, it should use F0, otherwise
+    // it should use F1. Above 1000 it should use F0 and add a K.
+    /// </summary>
+    /// <param name="value">The value to format</param>
+    /// <returns>The formatted string</returns>
+    public static string ThreeDigitFormat(double value)
+    {
+        if (value >= 1000)
+            return (value / 1000).ToString("F1", CultureInfo.CurrentCulture) + "K";
+        else if (value >= 100)
+            return value.ToString("F0", CultureInfo.CurrentCulture);
+        else
+            return value.ToString("F1", CultureInfo.CurrentCulture);
+    }
+
+    /// <summary> Implements <see cref="ThreeDigitFormat(double)"/> for floats </summary>
+    public static string ThreeDigitFormat(float value)
+    {
+        return ThreeDigitFormat((double)value);
+    }
+
+    /// <summary>
+    /// Formats two numbers separated by a slash
+    /// </summary>
+    /// <param name="v1">The first number (numerator)</param>
+    /// <param name="v2">The second number (denominator)</param>
+    /// <returns>The formatted string</returns>
+    public static string SlashSeparatedNumbersFormat(double v1, double v2)
+    {
+        return ThreeDigitFormat(v1) + " / " + ThreeDigitFormat(v2);
+    }
 }

--- a/src/general/StringUtils.cs
+++ b/src/general/StringUtils.cs
@@ -204,11 +204,10 @@ public static class StringUtils
     /// <returns>The formatted string</returns>
     public static string ThreeDigitFormat(double value)
     {
-        double absoluteValue = Math.Abs(value);
-        if (absoluteValue >= 1000)
+        if (value is >= 1000 or <= -1000)
             return FormatNumber(value);
 
-        if (absoluteValue >= 100)
+        if (value is >= 100 or <= -100)
             return value.ToString("F0", CultureInfo.CurrentCulture);
 
         return value.ToString("F1", CultureInfo.CurrentCulture);


### PR DESCRIPTION
**Brief Description of What This PR Does**

There is a known issue that sometimes there are too many digits in the ATP visualization and it can't be displayed properly. Here the issue is mitigated by removing the decimal place for numbers between 100 and 999 and using the "K" with one decimal number after that.

A related issue is the display of the resources, which suffers a similar problem but only in the smaller, more compact view.

Closes #3902

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
