### PR TITLE
Update stats at do/undo of move action

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
@@ -122,6 +122,8 @@ public partial class CellEditorComponent
 
             // Organelle placement *might* affect auto-evo in the future so this is here for that reason
             StartAutoEvoPrediction();
+
+            UpdateStats();
         }
         else
         {
@@ -140,6 +142,7 @@ public partial class CellEditorComponent
 
         UpdateAlreadyPlacedVisuals();
         StartAutoEvoPrediction();
+        UpdateStats();
 
         // TODO: dynamic MP PR had this line:
         // OnMembraneChanged();

--- a/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
@@ -282,6 +282,8 @@ public partial class CellEditorComponent
         // Uncomment when upgrades can visually affect the cell
         // UpdateAlreadyPlacedVisuals();
 
+        UpdateStats();
+
         // Organelle upgrades will in the future affect auto-evo
         StartAutoEvoPrediction();
     }
@@ -293,6 +295,8 @@ public partial class CellEditorComponent
 
         // Uncomment when upgrades can visually affect the cell
         // UpdateAlreadyPlacedVisuals();
+
+        UpdateStats();
 
         // Organelle upgrades will in the future affect auto-evo
         StartAutoEvoPrediction();

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1869,11 +1869,7 @@ public partial class CellEditorComponent :
 
         // Send to gui current status of cell
         UpdateSize(MicrobeHexSize);
-        UpdateSpeed(CalculateSpeed());
-        UpdateRotationSpeed(CalculateRotationSpeed());
-        UpdateStorage(CalculateStorage());
-        UpdateTotalDigestionSpeed(CalculateTotalDigestionSpeed());
-        UpdateDigestionEfficiencies(CalculateDigestionEfficiencies());
+        UpdateStats();
 
         UpdateCellVisualization();
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Update stats when a do/undo of the Move action for organelle is performed. Since this was not called, the stats were incorrect when moving a flagellum to a place that changes the speed. Fixing the undo is not enough, because that would cause the opposite problem.

I think other actions, such as moving an organelle inside empty cytoplasm and undoing it, might have also caused similar issues but this should solve them as well, as all stats are updated.

**Related Issues**

Closes #4022

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
