### PR TITLE
Fixed organelle tooltip process numbers not reacting to patch change

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -426,6 +426,7 @@
     <Compile Include="src\microbe_stage\organelle_components\AgentVacuoleComponent.cs" />
     <Compile Include="src\microbe_stage\organelle_components\MovementComponent.cs" />
     <Compile Include="src\microbe_stage\organelle_components\PilusComponent.cs" />
+    <Compile Include="src\microbe_stage\StrictProcessDisplayInfoEquality.cs" />
     <Compile Include="src\microbe_stage\TweakedProcess.cs" />
     <Compile Include="src\microbe_stage\CompoundBag.cs" />
     <Compile Include="src\microbe_stage\CompoundCloudSystem.cs" />

--- a/src/microbe_stage/ProcessList.cs
+++ b/src/microbe_stage/ProcessList.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Godot;
 
 /// <summary>
@@ -10,9 +11,13 @@ public class ProcessList : VBoxContainer
     private PackedScene chemicalEquationScene = null!;
 #pragma warning restore CA2213
 
-    private ChildObjectCache<IProcessDisplayInfo, ChemicalEquation> createdProcessControls = null!;
+    private ChildObjectCache<StrictProcessDisplayInfoEquality, ChemicalEquation> createdProcessControls = null!;
+    private List<StrictProcessDisplayInfoEquality>? processesToShow;
 
-    public List<IProcessDisplayInfo>? ProcessesToShow { get; set; }
+    public IEnumerable<IProcessDisplayInfo>? ProcessesToShow
+    {
+        set => processesToShow = value?.Select(d => new StrictProcessDisplayInfoEquality(d)).ToList();
+    }
 
     public bool ShowSpinners { get; set; } = true;
 
@@ -31,7 +36,12 @@ public class ProcessList : VBoxContainer
     {
         chemicalEquationScene = GD.Load<PackedScene>("res://src/gui_common/ChemicalEquation.tscn");
 
-        createdProcessControls = new ChildObjectCache<IProcessDisplayInfo, ChemicalEquation>(this, CreateEquation);
+        // To ensure chemical equations are up to date we use this strict comparison helper here as now normal
+        // process equality doesn't take speed into account to make some other parts of the code work much better
+        // TODO: would it be ultimately more performant to just let the chemical equations auto update themselves
+        // while this is visible? As the comparison operator is pretty expensive for the strict value equality.
+        createdProcessControls =
+            new ChildObjectCache<StrictProcessDisplayInfoEquality, ChemicalEquation>(this, CreateEquation);
     }
 
     public override void _Process(float delta)
@@ -39,7 +49,7 @@ public class ProcessList : VBoxContainer
         if (!IsVisibleInTree())
             return;
 
-        if (ProcessesToShow == null)
+        if (processesToShow == null)
         {
             createdProcessControls.Clear();
             return;
@@ -48,7 +58,7 @@ public class ProcessList : VBoxContainer
         // Check that all children are up to date
         createdProcessControls.UnMarkAll();
 
-        foreach (var process in ProcessesToShow)
+        foreach (var process in processesToShow)
         {
             createdProcessControls.GetChild(process);
         }
@@ -62,11 +72,11 @@ public class ProcessList : VBoxContainer
         this.FreeChildren();
     }
 
-    private ChemicalEquation CreateEquation(IProcessDisplayInfo process)
+    private ChemicalEquation CreateEquation(StrictProcessDisplayInfoEquality process)
     {
         var equation = (ChemicalEquation)chemicalEquationScene.Instance();
         equation.ShowSpinner = ShowSpinners;
-        equation.EquationFromProcess = process;
+        equation.EquationFromProcess = process.DisplayInfo;
         equation.DefaultTitleColour = ProcessesTitleColour;
         equation.MarkRedOnLimitingCompounds = MarkRedOnLimitingCompounds;
 

--- a/src/microbe_stage/ProcessPanel.cs
+++ b/src/microbe_stage/ProcessPanel.cs
@@ -42,7 +42,7 @@ public class ProcessPanel : CustomDialog
         if (ShownData != null)
         {
             // Update the list object
-            processList.ProcessesToShow = ShownData.Processes.Select(p => p.Value.ComputeAverageValues()).ToList();
+            processList.ProcessesToShow = ShownData.Processes.Select(p => p.Value.ComputeAverageValues());
         }
         else
         {

--- a/src/microbe_stage/ProcessSpeedInformation.cs
+++ b/src/microbe_stage/ProcessSpeedInformation.cs
@@ -68,6 +68,11 @@ public class ProcessSpeedInformation : IProcessDisplayInfo
         return 239 ^ Process.GetHashCode();
     }
 
+    public override string ToString()
+    {
+        return $"Process speed {CurrentSpeed} for {Process}";
+    }
+
     protected bool Equals(ProcessSpeedInformation other)
     {
         return Process.Equals(other.Process);

--- a/src/microbe_stage/ProcessStatistics.cs
+++ b/src/microbe_stage/ProcessStatistics.cs
@@ -285,6 +285,11 @@ public class SingleProcessStatistics : IProcessDisplayInfo
         return 233 ^ Process.GetHashCode();
     }
 
+    public override string ToString()
+    {
+        return $"Single process speed {CurrentSpeed} for {Process}";
+    }
+
     /// <summary>
     ///   Single point in time when statistics were collected
     /// </summary>
@@ -363,5 +368,10 @@ public class AverageProcessStatistics : IProcessDisplayInfo
     public override int GetHashCode()
     {
         return 211 ^ owner.GetHashCode();
+    }
+
+    public override string ToString()
+    {
+        return $"Average process speed {CurrentSpeed} for {Name}";
     }
 }

--- a/src/microbe_stage/StrictProcessDisplayInfoEquality.cs
+++ b/src/microbe_stage/StrictProcessDisplayInfoEquality.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+
+/// <summary>
+///   A strict equality comparison for <see cref="IProcessDisplayInfo"/>
+/// </summary>
+public class StrictProcessDisplayInfoEquality : IEquatable<StrictProcessDisplayInfoEquality>
+{
+    public StrictProcessDisplayInfoEquality(IProcessDisplayInfo displayInfo)
+    {
+        DisplayInfo = displayInfo;
+    }
+
+    public IProcessDisplayInfo DisplayInfo { get; }
+
+    public static bool operator ==(StrictProcessDisplayInfoEquality? left, StrictProcessDisplayInfoEquality? right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(StrictProcessDisplayInfoEquality? left, StrictProcessDisplayInfoEquality? right)
+    {
+        return !Equals(left, right);
+    }
+
+    public bool Equals(StrictProcessDisplayInfoEquality? other)
+    {
+        if (ReferenceEquals(null, other))
+            return false;
+        if (ReferenceEquals(this, other))
+            return true;
+
+        var our = DisplayInfo;
+        var theirs = other.DisplayInfo;
+
+        if (our.Name != theirs.Name)
+            return false;
+
+        if (Math.Abs(our.CurrentSpeed - theirs.CurrentSpeed) > MathUtils.EPSILON)
+            return false;
+
+        if (ReferenceEquals(our.Inputs, null) != ReferenceEquals(theirs.Inputs, null))
+            return false;
+        if (our.Inputs != null && !our.Inputs.SequenceEqual(theirs.Inputs!))
+            return false;
+
+        if (ReferenceEquals(our.EnvironmentalInputs, null) != ReferenceEquals(theirs.EnvironmentalInputs, null))
+            return false;
+        if (our.EnvironmentalInputs != null && !our.EnvironmentalInputs.SequenceEqual(theirs.EnvironmentalInputs!))
+            return false;
+
+        if (ReferenceEquals(our.FullSpeedRequiredEnvironmentalInputs, null) != ReferenceEquals(
+                theirs.FullSpeedRequiredEnvironmentalInputs, null))
+        {
+            return false;
+        }
+
+        if (our.FullSpeedRequiredEnvironmentalInputs != null && !our.FullSpeedRequiredEnvironmentalInputs.SequenceEqual(
+                theirs.FullSpeedRequiredEnvironmentalInputs!))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(our.Outputs, null) != ReferenceEquals(theirs.Outputs, null))
+            return false;
+        if (our.Outputs != null && !our.Outputs.SequenceEqual(theirs.Outputs!))
+            return false;
+
+        if (ReferenceEquals(our.LimitingCompounds, null) != ReferenceEquals(theirs.LimitingCompounds, null))
+            return false;
+        if (our.LimitingCompounds != null && !our.LimitingCompounds.SequenceEqual(theirs.LimitingCompounds!))
+            return false;
+
+        return true;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(null, obj))
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj.GetType() != GetType())
+            return false;
+
+        return Equals((StrictProcessDisplayInfoEquality)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return DisplayInfo.GetHashCode();
+    }
+}

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -211,11 +211,16 @@ public partial class CellEditorComponent
     {
         foreach (var organelleInternalName in organelleEfficiency.Keys)
         {
-            if (organelleInternalName == protoplasm.InternalName)
+            var efficiency = organelleEfficiency[organelleInternalName];
+
+            if (efficiency.Organelle.Unimplemented ||
+                efficiency.Organelle.EditorButtonGroup == OrganelleDefinition.OrganelleGroup.Hidden)
+            {
                 continue;
+            }
 
             var tooltip = GetSelectionTooltip(organelleInternalName, "organelleSelection");
-            tooltip?.WriteOrganelleProcessList(organelleEfficiency[organelleInternalName].Processes);
+            tooltip?.WriteOrganelleProcessList(efficiency.Processes);
         }
     }
 
@@ -224,7 +229,7 @@ public partial class CellEditorComponent
         var organelles = SimulationParameters.Instance.GetAllOrganelles();
         foreach (var organelle in organelles)
         {
-            if (organelle.InternalName == protoplasm.InternalName)
+            if (organelle.Unimplemented || organelle.EditorButtonGroup == OrganelleDefinition.OrganelleGroup.Hidden)
                 continue;
 
             var tooltip = GetSelectionTooltip(organelle.InternalName, "organelleSelection");

--- a/src/microbe_stage/editor/tooltips/SelectionMenuToolTip.cs
+++ b/src/microbe_stage/editor/tooltips/SelectionMenuToolTip.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Godot;
 
 /// <summary>
@@ -207,7 +206,7 @@ public class SelectionMenuToolTip : Control, ICustomToolTip
         processList.ShowSpinners = false;
         processList.ProcessesTitleColour = new Color(1.0f, 0.83f, 0.0f);
         processList.MarkRedOnLimitingCompounds = true;
-        processList.ProcessesToShow = processes.Cast<IProcessDisplayInfo>().ToList();
+        processList.ProcessesToShow = processes;
     }
 
     /// <summary>


### PR DESCRIPTION
**Brief Description of What This PR Does**

this was caused by the process objects now having much more relaxed equality comparison, fixed by adding a stricter equality comparer wrapper object for use cases like this

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #4139

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
