### PR TITLE
Immediately snap to current patch the first time patch map is drawn

### DIFF
--- a/Thrive.sln.DotSettings
+++ b/Thrive.sln.DotSettings
@@ -586,6 +586,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Latn/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lato/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lerped/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=lerping/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lethargicness/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=limitor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Linietsky/@EntryIndexedValue">True</s:Boolean>

--- a/src/gui_common/DraggableScrollContainer.cs
+++ b/src/gui_common/DraggableScrollContainer.cs
@@ -24,7 +24,8 @@ public class DraggableScrollContainer : ScrollContainer
     private bool zooming;
 
     /// <summary>
-    ///   Whether we're currently centering to a specific coordinate, to prevent dragging while it's still happening.
+    ///   Whether we're currently centering (with Lerp) to a specific coordinate, to prevent dragging while
+    ///   still lerping.
     /// </summary>
     private bool centering;
 
@@ -204,11 +205,21 @@ public class DraggableScrollContainer : ScrollContainer
         Zoom(1, 1.0f);
     }
 
-    public void CenterTo(Vector2 coordinates)
+    public void CenterTo(Vector2 coordinates, bool smoothed)
     {
-        centering = true;
+        var viewCoords = coordinates - GetRect().End / 2.0f;
+
+        if (smoothed)
+        {
+            centering = true;
+            Pan(viewCoords, () => centering = false, 1.0f);
+        }
+        else
+        {
+            ImmediatePan(viewCoords);
+        }
+
         ResetZoom();
-        Pan(coordinates - GetRect().End / 2.0f, () => centering = false, 1.0f);
     }
 
     private void ImmediateZoom(float value)

--- a/src/microbe_stage/editor/PatchMapDrawer.cs
+++ b/src/microbe_stage/editor/PatchMapDrawer.cs
@@ -46,7 +46,7 @@ public class PatchMapDrawer : Control
     private Patch? playerPatch;
 
     [Signal]
-    public delegate void OnCurrentPatchCentered(Vector2 coordinates);
+    public delegate void OnCurrentPatchCentered(Vector2 coordinates, bool smoothed);
 
     public PatchMap? Map
     {
@@ -66,6 +66,9 @@ public class PatchMapDrawer : Control
         }
     }
 
+    /// <summary>
+    ///   The current patch the player is in.
+    /// </summary>
     public Patch? PlayerPatch
     {
         get => playerPatch;
@@ -150,14 +153,20 @@ public class PatchMapDrawer : Control
         // Scroll to player patch only when first drawn
         if (!alreadyDrawn)
         {
-            CenterScroll();
+            // Just snap, it can get pretty annoying otherwise
+            CenterToCurrentPatch(false);
+
             alreadyDrawn = true;
         }
     }
 
-    public void CenterScroll()
+    /// <summary>
+    ///   Centers the map to the coordinates of current patch.
+    /// </summary>
+    /// <param name="smoothed">If true, smoothly pans the view to the destination, otherwise just snaps.</param>
+    public void CenterToCurrentPatch(bool smoothed = true)
     {
-        EmitSignal(nameof(OnCurrentPatchCentered), PlayerPatch!.ScreenCoordinates);
+        EmitSignal(nameof(OnCurrentPatchCentered), PlayerPatch!.ScreenCoordinates, smoothed);
     }
 
     public void MarkDirty()

--- a/src/microbe_stage/editor/PatchMapEditorComponent.cs
+++ b/src/microbe_stage/editor/PatchMapEditorComponent.cs
@@ -237,7 +237,7 @@ public abstract class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEd
 
     private void OnFindCurrentPatchPressed()
     {
-        mapDrawer.CenterScroll();
+        mapDrawer.CenterToCurrentPatch();
         mapDrawer.SelectedPatch = mapDrawer.PlayerPatch;
     }
 

--- a/src/microbe_stage/gui/PatchExtinctionBox.cs
+++ b/src/microbe_stage/gui/PatchExtinctionBox.cs
@@ -108,6 +108,6 @@ public class PatchExtinctionBox : Control
     private void OnFindCurrentPatchPressed()
     {
         // Unlike the editor patch map, don't select the player patch here, since it's disabled
-        mapDrawer.CenterScroll();
+        mapDrawer.CenterToCurrentPatch();
     }
 }

--- a/src/thriveopedia/pages/ThriveopediaPatchMapPage.cs
+++ b/src/thriveopedia/pages/ThriveopediaPatchMapPage.cs
@@ -118,7 +118,7 @@ public class ThriveopediaPatchMapPage : ThriveopediaPage
 
     private void OnFindCurrentPatchPressed()
     {
-        mapDrawer.CenterScroll();
+        mapDrawer.CenterToCurrentPatch();
         mapDrawer.SelectedPatch = mapDrawer.PlayerPatch;
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Removes the smooth panning to the current patch when you're initially opening the patch map everytime you're in a new editor cycle, as it can get pretty annoying.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
