### PR TITLE
Exclude temperature "compound" from any patch statistics graph

### DIFF
--- a/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
+++ b/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
@@ -500,13 +500,14 @@ public class MicrobeEditorReportComponent : EditorComponentBase<IEditorReportDat
     /// <summary>
     ///   Returns a chart which should contain the given compound.
     /// </summary>
+    /// <returns>Null if the given compound shouldn't be included in any chart.</returns>
     private LineChart? GetChartForCompound(string compoundName)
     {
         switch (compoundName)
         {
             case "atp":
-                return null;
             case "oxytoxy":
+            case "temperature":
                 return null;
             case "sunlight":
                 return sunlightChart;


### PR DESCRIPTION
**Brief Description of What This PR Does**

A case for `temperature` was missing from `MicrobeEditorReportComponent.GetChartForCompound`, this is now added and returns null, meaning it shouldn't be included in the patch compounds graph.

**Related Issues**

Fixes #4024 

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
