### PR TITLE
Allow specialized engulfing in microbe colony

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -367,6 +367,7 @@
     <Compile Include="src\microbe_stage\MicrobeColony.cs" />
     <Compile Include="src\microbe_stage\CompoundBalance.cs" />
     <Compile Include="src\microbe_stage\CompoundCloudPlane.cs" />
+    <Compile Include="src\microbe_stage\MicrobeState.cs" />
     <Compile Include="src\microbe_stage\MicrobeSystem.cs" />
     <Compile Include="src\microbe_stage\organelle_components\CiliaComponent.cs" />
     <Compile Include="src\microbe_stage\organelle_components\SlimeJetComponent.cs" />

--- a/src/auto-evo/simulation/food_source/ChunkFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/ChunkFoodSource.cs
@@ -65,7 +65,7 @@
             score *= chunkEaterSpeed * species.Behaviour.Activity;
 
             // If the species can't engulf, then they are dependent on only eating the runoff compounds
-            if (microbeSpecies.MembraneType.CellWall ||
+            if (!microbeSpecies.CanEngulf ||
                 simulationCache.GetBaseHexSizeForSpecies(microbeSpecies) < chunkSize * Constants.ENGULF_SIZE_RATIO_REQ)
             {
                 score *= Constants.AUTO_EVO_CHUNK_LEAK_MULTIPLIER;

--- a/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
@@ -46,7 +46,7 @@
             // Only assign engulf score if one can actually engulf
             var engulfScore = 0.0f;
             if (microbeSpeciesHexSize / preyHexSize >
-                Constants.ENGULF_SIZE_RATIO_REQ && !microbeSpecies.MembraneType.CellWall)
+                Constants.ENGULF_SIZE_RATIO_REQ && microbeSpecies.CanEngulf)
             {
                 // Catch scores grossly accounts for how many preys you catch in a run;
                 var catchScore = 0.0f;

--- a/src/early_multicellular_stage/CellTemplate.cs
+++ b/src/early_multicellular_stage/CellTemplate.cs
@@ -49,6 +49,9 @@ public class CellTemplate : IPositionedCell, ICloneable, IActionHex
     public float BaseRotationSpeed { get => CellType.BaseRotationSpeed; set => CellType.BaseRotationSpeed = value; }
 
     [JsonIgnore]
+    public bool CanEngulf => CellType.CanEngulf;
+
+    [JsonIgnore]
     public string FormattedName => CellType.TypeName;
 
     [JsonIgnore]

--- a/src/early_multicellular_stage/CellType.cs
+++ b/src/early_multicellular_stage/CellType.cs
@@ -36,6 +36,7 @@ public class CellType : ICellProperties, IPhotographable, ICloneable
         MembraneRigidity = microbeSpecies.MembraneRigidity;
         Colour = microbeSpecies.Colour;
         IsBacteria = microbeSpecies.IsBacteria;
+        CanEngulf = microbeSpecies.CanEngulf;
         TypeName = TranslationServer.Translate("STEM_CELL_NAME");
     }
 
@@ -50,6 +51,7 @@ public class CellType : ICellProperties, IPhotographable, ICloneable
     public Color Colour { get; set; }
     public bool IsBacteria { get; set; }
     public float BaseRotationSpeed { get; set; }
+    public bool CanEngulf { get; }
 
     /// <summary>
     ///   Total mass of all the organelles in this cell type

--- a/src/engine/DebugOverlays.EntityLabel.cs
+++ b/src/engine/DebugOverlays.EntityLabel.cs
@@ -52,19 +52,19 @@ public partial class DebugOverlays
             {
                 switch (microbe.State)
                 {
-                    case Microbe.MicrobeState.Binding:
+                    case MicrobeState.Binding:
                     {
                         label.AddColorOverride("font_color", new Color(0.2f, 0.5f, 0.0f));
                         break;
                     }
 
-                    case Microbe.MicrobeState.Engulf:
+                    case MicrobeState.Engulf:
                     {
                         label.AddColorOverride("font_color", new Color(0.2f, 0.5f, 1.0f));
                         break;
                     }
 
-                    case Microbe.MicrobeState.Unbinding:
+                    case MicrobeState.Unbinding:
                     {
                         label.AddColorOverride("font_color", new Color(1.0f, 0.5f, 0.2f));
                         break;

--- a/src/microbe_stage/ICellProperties.cs
+++ b/src/microbe_stage/ICellProperties.cs
@@ -14,7 +14,7 @@ public interface ICellProperties
     public float BaseRotationSpeed { get; set; }
 
     /// <summary>
-    ///   Returns true if this cell fills all the requirements it needs to be able to engulf.
+    ///   Returns true if this cell fills all the requirements needed to engulf.
     /// </summary>
     public bool CanEngulf { get; }
 

--- a/src/microbe_stage/ICellProperties.cs
+++ b/src/microbe_stage/ICellProperties.cs
@@ -14,7 +14,7 @@ public interface ICellProperties
     public float BaseRotationSpeed { get; set; }
 
     /// <summary>
-    ///   Returns true if this cell has all the requirements it needs for engulfing.
+    ///   Returns true if this cell fills all the requirements it needs to be able to engulf.
     /// </summary>
     public bool CanEngulf { get; }
 

--- a/src/microbe_stage/ICellProperties.cs
+++ b/src/microbe_stage/ICellProperties.cs
@@ -13,6 +13,11 @@ public interface ICellProperties
     public bool IsBacteria { get; set; }
     public float BaseRotationSpeed { get; set; }
 
+    /// <summary>
+    ///   Returns true if this cell has all the requirements it needs for engulfing.
+    /// </summary>
+    public bool CanEngulf { get; }
+
     public string FormattedName { get; }
 
     /// <summary>

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -193,7 +193,7 @@ public partial class Microbe
     ///   Just like <see cref="ICellProperties.CanEngulf"/> but decoupled from Species and is based on the local
     ///   condition of the microbe instead.
     /// </summary>
-    /// <returns>True if this cell fills all the requirements it needs to be able to enter engulf mode.</returns>
+    /// <returns>True if this cell fills all the requirements needed to enter engulf mode.</returns>
     [JsonIgnore]
     public bool CanEngulf => !Membrane.Type.CellWall;
 
@@ -1115,10 +1115,9 @@ public partial class Microbe
     /// </summary>
     private void HandleEngulfing(float delta)
     {
-        if (!CanEngulf)
-            return;
+        var actuallyEngulfing = State == MicrobeState.Engulf && CanEngulf;
 
-        if (State == MicrobeState.Engulf)
+        if (actuallyEngulfing)
         {
             // Drain atp
             var cost = Constants.ENGULFING_ATP_COST_PER_SECOND * delta;
@@ -1134,7 +1133,7 @@ public partial class Microbe
         }
 
         // Play sound
-        if (State == MicrobeState.Engulf)
+        if (actuallyEngulfing)
         {
             if (!engulfAudio.Playing)
                 engulfAudio.Play();
@@ -1165,7 +1164,7 @@ public partial class Microbe
         }
 
         // Movement modifier
-        if (State == MicrobeState.Engulf)
+        if (actuallyEngulfing)
         {
             MovementFactor /= Constants.ENGULFING_MOVEMENT_DIVISION;
         }

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -910,7 +910,7 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
             throw new ArgumentException("searchRadius must be >= 1");
 
         // If the microbe cannot absorb, no need for this
-        if (!CheckEngulfCapability())
+        if (!CanEngulf)
             return null;
 
         Vector3? nearestPoint = null;
@@ -930,7 +930,7 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
                 continue;
 
             // Skip non-engulfable entities
-            if (!CanEngulf(entity))
+            if (!CanEngulfObject(entity))
                 continue;
 
             // Skip entities that have no useful compounds
@@ -1024,7 +1024,7 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
 
         SetMembraneFromSpecies();
 
-        if (!CheckEngulfCapability())
+        if (!CanEngulf)
         {
             // Reset engulf mode if the new membrane doesn't allow it
             if (State == MicrobeState.Engulf)

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -910,7 +910,7 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
             throw new ArgumentException("searchRadius must be >= 1");
 
         // If the microbe cannot absorb, no need for this
-        if (Membrane.Type.CellWall)
+        if (!CheckEngulfCapability())
             return null;
 
         Vector3? nearestPoint = null;
@@ -1024,7 +1024,7 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
 
         SetMembraneFromSpecies();
 
-        if (Membrane.Type.CellWall)
+        if (!CheckEngulfCapability())
         {
             // Reset engulf mode if the new membrane doesn't allow it
             if (State == MicrobeState.Engulf)

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -211,7 +211,7 @@ public class MicrobeAI
             case MicrobeSignalCommand.FleeFromMe:
                 if (signaler != null && DistanceFromMe(signaler.Translation) < Constants.AI_FLEE_DISTANCE_SQUARED)
                 {
-                    microbe.State = Microbe.MicrobeState.Normal;
+                    microbe.State = MicrobeState.Normal;
                     SetMoveSpeed(Constants.AI_BASE_MOVEMENT);
 
                     // Direction is calculated to be the opposite from where we should flee
@@ -243,7 +243,7 @@ public class MicrobeAI
         }
 
         // If there are no threats, look for a chunk to eat
-        if (!microbe.CellTypeProperties.MembraneType.CellWall)
+        if (microbe.CheckEngulfCapability())
         {
             var targetChunk = GetNearestChunkItem(data.AllChunks, data.AllMicrobes, random);
             if (targetChunk != null && targetChunk.PhagocytosisStep == PhagocytosisPhase.None)
@@ -266,7 +266,7 @@ public class MicrobeAI
         }
 
         // There is no reason to be engulfing at this stage
-        microbe.State = Microbe.MicrobeState.Normal;
+        microbe.State = MicrobeState.Normal;
 
         // Otherwise just wander around and look for compounds
         if (!IsSessile)
@@ -285,7 +285,7 @@ public class MicrobeAI
         FloatingChunk? chosenChunk = null;
 
         // If the microbe cannot absorb, no need for this
-        if (microbe.Membrane.Type.CellWall)
+        if (!microbe.CheckEngulfCapability())
         {
             return null;
         }
@@ -476,7 +476,7 @@ public class MicrobeAI
 
     private void FleeFromPredators(Random random, Vector3 predatorLocation)
     {
-        microbe.State = Microbe.MicrobeState.Normal;
+        microbe.State = MicrobeState.Normal;
 
         targetPosition = (2 * (microbe.Translation - predatorLocation)) + microbe.Translation;
 
@@ -511,7 +511,7 @@ public class MicrobeAI
 
     private void EngagePrey(Vector3 target, Random random, bool engulf)
     {
-        microbe.State = engulf ? Microbe.MicrobeState.Engulf : Microbe.MicrobeState.Normal;
+        microbe.State = engulf ? MicrobeState.Engulf : MicrobeState.Normal;
         targetPosition = target;
         microbe.LookAtPoint = targetPosition;
         if (CanShootToxin())
@@ -721,11 +721,11 @@ public class MicrobeAI
         // Sometimes "close" is hard to discern since microbes can range from straight lines to circles
         if ((microbe.Translation - targetPosition).LengthSquared() <= microbe.EngulfSize * 2.0f)
         {
-            microbe.State = Microbe.MicrobeState.Engulf;
+            microbe.State = MicrobeState.Engulf;
         }
         else
         {
-            microbe.State = Microbe.MicrobeState.Normal;
+            microbe.State = MicrobeState.Normal;
         }
     }
 
@@ -771,7 +771,7 @@ public class MicrobeAI
 
     private void MoveToLocation(Vector3 location)
     {
-        microbe.State = Microbe.MicrobeState.Normal;
+        microbe.State = MicrobeState.Normal;
         targetPosition = location;
         microbe.LookAtPoint = targetPosition;
         SetMoveSpeed(Constants.AI_BASE_MOVEMENT);

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -243,6 +243,7 @@ public class MicrobeAI
         }
 
         // If there are no threats, look for a chunk to eat
+        // TODO: still consider engulfing things if we're in a colony that can engulf (has engulfer cells)
         if (microbe.CanEngulf)
         {
             var targetChunk = GetNearestChunkItem(data.AllChunks, data.AllMicrobes, random);
@@ -285,6 +286,7 @@ public class MicrobeAI
         FloatingChunk? chosenChunk = null;
 
         // If the microbe cannot absorb, no need for this
+        // TODO: still consider engulfing things if we're in a colony that can engulf (has engulfer cells)
         if (!microbe.CanEngulf)
         {
             return null;

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -243,7 +243,7 @@ public class MicrobeAI
         }
 
         // If there are no threats, look for a chunk to eat
-        if (microbe.CheckEngulfCapability())
+        if (microbe.CanEngulf)
         {
             var targetChunk = GetNearestChunkItem(data.AllChunks, data.AllMicrobes, random);
             if (targetChunk != null && targetChunk.PhagocytosisStep == PhagocytosisPhase.None)
@@ -257,7 +257,7 @@ public class MicrobeAI
         var possiblePrey = GetNearestPreyItem(data.AllMicrobes);
         if (possiblePrey != null && possiblePrey.PhagocytosisStep == PhagocytosisPhase.None)
         {
-            bool engulfPrey = microbe.CanEngulf(possiblePrey) &&
+            bool engulfPrey = microbe.CanEngulfObject(possiblePrey) &&
                 DistanceFromMe(possiblePrey.GlobalTransform.origin) < 10.0f * microbe.EngulfSize;
             Vector3? prey = possiblePrey.GlobalTransform.origin;
 
@@ -285,7 +285,7 @@ public class MicrobeAI
         FloatingChunk? chosenChunk = null;
 
         // If the microbe cannot absorb, no need for this
-        if (!microbe.CheckEngulfCapability())
+        if (!microbe.CanEngulf)
         {
             return null;
         }

--- a/src/microbe_stage/MicrobeColony.cs
+++ b/src/microbe_stage/MicrobeColony.cs
@@ -10,9 +10,9 @@ public class MicrobeColony
 {
     private MicrobeState state;
 
-    private bool memberDirty = true;
+    private bool membersDirty = true;
     private float hexCount;
-    private bool hasEngulfCapability;
+    private bool canEngulf;
 
     [JsonConstructor]
     private MicrobeColony(Microbe master)
@@ -64,23 +64,23 @@ public class MicrobeColony
     {
         get
         {
-            if (memberDirty)
+            if (membersDirty)
                 UpdateHexCount();
             return hexCount;
         }
     }
 
     /// <summary>
-    ///   Whether one or more member of this colony has the capability to engulf.
+    ///   Whether one or more member of this colony is allowed to enter engulf mode.
     /// </summary>
     [JsonIgnore]
-    public bool HasEngulfCapability
+    public bool CanEngulf
     {
         get
         {
-            if (memberDirty)
-                UpdateEngulfCapability();
-            return hasEngulfCapability;
+            if (membersDirty)
+                UpdateCanEngulf();
+            return canEngulf;
         }
     }
 
@@ -157,7 +157,7 @@ public class MicrobeColony
         if (microbe != Master)
             Master.Mass -= microbe.Mass;
 
-        memberDirty = true;
+        membersDirty = true;
     }
 
     public void AddToColony(Microbe microbe, Microbe master)
@@ -175,7 +175,7 @@ public class MicrobeColony
 
         ColonyMembers.ForEach(m => m.OnColonyMemberAdded(microbe));
 
-        memberDirty = true;
+        membersDirty = true;
     }
 
     private void UpdateHexCount()
@@ -188,17 +188,16 @@ public class MicrobeColony
         }
     }
 
-    private void UpdateEngulfCapability()
+    private void UpdateCanEngulf()
     {
-        hasEngulfCapability = false;
+        canEngulf = false;
 
         foreach (var member in ColonyMembers)
         {
-            if (member.CheckEngulfCapability())
-            {
-                hasEngulfCapability = true;
+            canEngulf = member.CanEngulf;
+
+            if (canEngulf)
                 break;
-            }
         }
     }
 }

--- a/src/microbe_stage/MicrobeColony.cs
+++ b/src/microbe_stage/MicrobeColony.cs
@@ -64,7 +64,8 @@ public class MicrobeColony
     {
         get
         {
-            UpdateDerivedProperties();
+            if (membersDirty)
+                UpdateDerivedProperties();
             return hexCount;
         }
     }
@@ -77,7 +78,8 @@ public class MicrobeColony
     {
         get
         {
-            UpdateDerivedProperties();
+            if (membersDirty)
+                UpdateDerivedProperties();
             return canEngulf;
         }
     }
@@ -178,9 +180,6 @@ public class MicrobeColony
 
     private void UpdateDerivedProperties()
     {
-        if (!membersDirty)
-            return;
-
         UpdateHexCount();
         UpdateCanEngulf();
 

--- a/src/microbe_stage/MicrobeColony.cs
+++ b/src/microbe_stage/MicrobeColony.cs
@@ -64,8 +64,7 @@ public class MicrobeColony
     {
         get
         {
-            if (membersDirty)
-                UpdateHexCount();
+            UpdateDerivedProperties();
             return hexCount;
         }
     }
@@ -78,8 +77,7 @@ public class MicrobeColony
     {
         get
         {
-            if (membersDirty)
-                UpdateCanEngulf();
+            UpdateDerivedProperties();
             return canEngulf;
         }
     }
@@ -178,6 +176,17 @@ public class MicrobeColony
         membersDirty = true;
     }
 
+    private void UpdateDerivedProperties()
+    {
+        if (!membersDirty)
+            return;
+
+        UpdateHexCount();
+        UpdateCanEngulf();
+
+        membersDirty = false;
+    }
+
     private void UpdateHexCount()
     {
         hexCount = 0;
@@ -194,10 +203,11 @@ public class MicrobeColony
 
         foreach (var member in ColonyMembers)
         {
-            canEngulf = member.CanEngulf;
+            if (!member.CanEngulf)
+                continue;
 
-            if (canEngulf)
-                break;
+            canEngulf = true;
+            break;
         }
     }
 }

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -344,13 +344,13 @@ public class MicrobeHUD : StageHUDBase<MicrobeStage>
             showSlime = player.SlimeJets.Count > 0;
         }
 
-        UpdateBaseAbilitiesBar(!player.CellTypeProperties.MembraneType.CellWall, showToxin, showSlime,
-            player.HasSignalingAgent, player.State == Microbe.MicrobeState.Engulf);
+        UpdateBaseAbilitiesBar(player.HasEngulfCapability, showToxin, showSlime,
+            player.HasSignalingAgent, player.State == MicrobeState.Engulf);
 
         bindingModeHotkey.Visible = player.CanBind;
         unbindAllHotkey.Visible = player.CanUnbind;
 
-        bindingModeHotkey.Pressed = player.State == Microbe.MicrobeState.Binding;
+        bindingModeHotkey.Pressed = player.State == MicrobeState.Binding;
         unbindAllHotkey.Pressed = Input.IsActionPressed(unbindAllHotkey.ActionName);
     }
 

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -344,7 +344,7 @@ public class MicrobeHUD : StageHUDBase<MicrobeStage>
             showSlime = player.SlimeJets.Count > 0;
         }
 
-        UpdateBaseAbilitiesBar(player.HasEngulfCapability, showToxin, showSlime,
+        UpdateBaseAbilitiesBar(player.CanEngulfInColony(), showToxin, showSlime,
             player.HasSignalingAgent, player.State == MicrobeState.Engulf);
 
         bindingModeHotkey.Visible = player.CanBind;

--- a/src/microbe_stage/MicrobeSpecies.cs
+++ b/src/microbe_stage/MicrobeSpecies.cs
@@ -77,6 +77,9 @@ public class MicrobeSpecies : Species, ICellProperties, IPhotographable
     public float StorageCapacity => MicrobeInternalCalculations.CalculateCapacity(Organelles);
 
     [JsonIgnore]
+    public bool CanEngulf => !MembraneType.CellWall;
+
+    [JsonIgnore]
     public string SceneToPhotographPath => "res://src/microbe_stage/Microbe.tscn";
 
     public override void OnEdited()

--- a/src/microbe_stage/MicrobeState.cs
+++ b/src/microbe_stage/MicrobeState.cs
@@ -1,4 +1,4 @@
-public enum MicrobeState
+﻿public enum MicrobeState
 {
     /// <summary>
     ///   Not in any special state

--- a/src/microbe_stage/MicrobeState.cs
+++ b/src/microbe_stage/MicrobeState.cs
@@ -1,0 +1,22 @@
+public enum MicrobeState
+{
+    /// <summary>
+    ///   Not in any special state
+    /// </summary>
+    Normal,
+
+    /// <summary>
+    ///   The microbe is currently in binding mode
+    /// </summary>
+    Binding,
+
+    /// <summary>
+    ///   The microbe is currently in unbinding mode and cannot move
+    /// </summary>
+    Unbinding,
+
+    /// <summary>
+    ///   The microbe is currently in engulf mode
+    /// </summary>
+    Engulf,
+}

--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -126,7 +126,7 @@ public class PlayerMicrobeInput : NodeWithInput
         {
             stage.Player.State = MicrobeState.Normal;
         }
-        else if (stage.Player.HasEngulfCapability)
+        else if (stage.Player.CanEngulfInColony())
         {
             stage.Player.State = MicrobeState.Engulf;
         }

--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -52,7 +52,7 @@ public class PlayerMicrobeInput : NodeWithInput
         var player = stage.Player;
         if (player != null)
         {
-            if (player.State == Microbe.MicrobeState.Unbinding)
+            if (player.State == MicrobeState.Unbinding)
             {
                 // It's probably fine to not update the tutorial state here with events as this state doesn't last
                 // that long and the player needs a pretty long time to get so far in the game as to get here
@@ -122,13 +122,13 @@ public class PlayerMicrobeInput : NodeWithInput
         if (stage.Player == null)
             return;
 
-        if (stage.Player.State == Microbe.MicrobeState.Engulf)
+        if (stage.Player.State == MicrobeState.Engulf)
         {
-            stage.Player.State = Microbe.MicrobeState.Normal;
+            stage.Player.State = MicrobeState.Normal;
         }
-        else if (!stage.Player.Membrane.Type.CellWall)
+        else if (stage.Player.HasEngulfCapability)
         {
-            stage.Player.State = Microbe.MicrobeState.Engulf;
+            stage.Player.State = MicrobeState.Engulf;
         }
     }
 
@@ -138,13 +138,13 @@ public class PlayerMicrobeInput : NodeWithInput
         if (stage.Player == null)
             return;
 
-        if (stage.Player.State == Microbe.MicrobeState.Binding)
+        if (stage.Player.State == MicrobeState.Binding)
         {
-            stage.Player.State = Microbe.MicrobeState.Normal;
+            stage.Player.State = MicrobeState.Normal;
         }
         else if (stage.Player.CanBind)
         {
-            stage.Player.State = Microbe.MicrobeState.Binding;
+            stage.Player.State = MicrobeState.Binding;
         }
     }
 
@@ -154,15 +154,15 @@ public class PlayerMicrobeInput : NodeWithInput
         if (stage.Player == null)
             return;
 
-        if (stage.Player.State == Microbe.MicrobeState.Unbinding)
+        if (stage.Player.State == MicrobeState.Unbinding)
         {
             stage.HUD.HintText = string.Empty;
-            stage.Player.State = Microbe.MicrobeState.Normal;
+            stage.Player.State = MicrobeState.Normal;
         }
         else if (stage.Player.Colony != null && !stage.Player.IsMulticellular)
         {
             stage.HUD.HintText = TranslationServer.Translate("UNBIND_HELP_TEXT");
-            stage.Player.State = Microbe.MicrobeState.Unbinding;
+            stage.Player.State = MicrobeState.Unbinding;
         }
     }
 
@@ -175,7 +175,7 @@ public class PlayerMicrobeInput : NodeWithInput
     [RunOnKeyDown("g_perform_unbinding", Priority = 1)]
     public bool AcceptUnbind()
     {
-        if (stage.Player?.State != Microbe.MicrobeState.Unbinding)
+        if (stage.Player?.State != MicrobeState.Unbinding)
             return false;
 
         if (stage.HoverInfo.HoveredMicrobes.Count == 0)

--- a/src/microbe_stage/organelle_components/CiliaComponent.cs
+++ b/src/microbe_stage/organelle_components/CiliaComponent.cs
@@ -54,7 +54,7 @@ public class CiliaComponent : ExternallyPositionedComponent
         var rawRotation = previousCellRotation.Value.AngleTo(currentCellRotation);
         var rotationSpeed = rawRotation * Constants.CILIA_ROTATION_ANIMATION_SPEED_MULTIPLIER;
 
-        if (microbe.State == Microbe.MicrobeState.Engulf && attractorArea != null)
+        if (microbe.State == MicrobeState.Engulf && attractorArea != null)
         {
             // We are using cilia pulling, play animation at fixed rate
             targetSpeed = Constants.CILIA_CURRENT_GENERATION_ANIMATION_SPEED;
@@ -101,7 +101,7 @@ public class CiliaComponent : ExternallyPositionedComponent
         if (attractorArea != null)
         {
             // Enable cilia pulling force if parent cell is not in engulf mode and is not being engulfed
-            var enable = organelle!.ParentMicrobe!.State == Microbe.MicrobeState.Engulf &&
+            var enable = organelle!.ParentMicrobe!.State == MicrobeState.Engulf &&
                 organelle.ParentMicrobe.PhagocytosisStep == PhagocytosisPhase.None;
 
             // The approach of disabling the underlying collision shape or the Area's Monitoring property makes the


### PR DESCRIPTION
**Brief Description of What This PR Does**

Walled cells can now be in engulf state but can't act on it, this is to allow specialized engulfing in a colony.

I had to make two ways of checking whether a cell is capable to engulf, one is through `ICellProperties` and the other through `Microbe` itself, decoupled from species. The reason for this is because `ICellProperties` sometimes may not reflect the actual properties visible in a cell.

I hadn't yet tested in multicellular but this should work fine for colony.

**Related Issues**

Fixes #3549 

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
