### PR TITLE
Added despawning after player reproduction to stay roughly in entity limit

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -159,6 +159,23 @@ public static class Constants
     public const float REPRODUCTION_ALLOW_EXCEED_ENTITY_LIMIT_MULTIPLIER = 1.15f;
 
     /// <summary>
+    ///   If the entity limit is over this once the player has reproduced, force despawning will happen
+    /// </summary>
+    public const float REPRODUCTION_PLAYER_ALLOWED_ENTITY_LIMIT_EXCEED = 1.25f;
+
+    /// <summary>
+    ///   Once reproduced player copies take this much or more of the overall entity limit, they are preferred to
+    ///   despawn first.
+    /// </summary>
+    public const float PREFER_DESPAWN_PLAYER_REPRODUCED_COPY_AFTER = 0.30f;
+
+    /// <summary>
+    ///   Multiplier for how much cells in a colony contribute to the entity limit. Actually colonies seem quite a bit
+    ///   heavier than normal microbes, as such this is set pretty high.
+    /// </summary>
+    public const float MICROBE_COLONY_MEMBER_ENTITY_WEIGHT_MULTIPLIER = 1.15f;
+
+    /// <summary>
     ///   Extra radius added to the spawn radius of things to allow them to move in the "wrong" direction a bit
     ///   without causing them to despawn instantly. Things despawn outside the despawn radius.
     /// </summary>
@@ -936,6 +953,8 @@ public static class Constants
     public const string AI_TAG_CHUNK = "chunk";
 
     public const string PLAYER_GROUP = "player";
+
+    public const string PLAYER_REPRODUCED_GROUP = "player_offspring";
 
     public const string DELETION_HOLD_LOAD = "load";
     public const string DELETION_HOLD_MICROBE_EDITOR = "microbe_editor";

--- a/src/general/StageHUDBase.cs
+++ b/src/general/StageHUDBase.cs
@@ -294,8 +294,7 @@ public abstract class StageHUDBase<TStage> : Control, IStageHUD
     protected TStage? stage;
 
     /// <summary>
-    ///   Show mouse coordinates data in the mouse
-    ///   hover box, useful during develop.
+    ///   Show mouse coordinates data in the mouse hover box, useful during develop.
     /// </summary>
 #pragma warning disable 649 // ignored until we get some GUI or something to change this
     protected bool showMouseCoordinates;

--- a/src/microbe_stage/Microbe.cs
+++ b/src/microbe_stage/Microbe.cs
@@ -218,8 +218,24 @@ public partial class Microbe : RigidBody, ISpawned, IProcessable, IMicrobeAI, IS
     ///   Entity weight for microbes counts all organelles with a scaling factor.
     /// </summary>
     [JsonIgnore]
-    public float EntityWeight => organelles?.Count * Constants.ORGANELLE_ENTITY_WEIGHT ??
-        throw new InvalidOperationException("Organelles not initialised on microbe spawn");
+    public float EntityWeight
+    {
+        get
+        {
+            var weight = organelles?.Count * Constants.ORGANELLE_ENTITY_WEIGHT ??
+                throw new InvalidOperationException("Organelles not initialised on microbe spawn");
+
+            if (Colony != null)
+            {
+                // Only colony lead cells have the extra entity weight from the colony added
+                // As the colony reads this property on the other members, we do not throw here
+                if (Colony.Master == this)
+                    weight += Colony.EntityWeight;
+            }
+
+            return weight;
+        }
+    }
 
     /// <summary>
     ///   If true this shifts the purpose of this cell for visualizations-only

--- a/src/microbe_stage/MicrobeColony.cs
+++ b/src/microbe_stage/MicrobeColony.cs
@@ -13,6 +13,7 @@ public class MicrobeColony
     private bool membersDirty = true;
     private float hexCount;
     private bool canEngulf;
+    private float entityWeight;
 
     [JsonConstructor]
     private MicrobeColony(Microbe master)
@@ -81,6 +82,27 @@ public class MicrobeColony
             if (membersDirty)
                 UpdateDerivedProperties();
             return canEngulf;
+        }
+    }
+
+    /// <summary>
+    ///   Total entity weight of the colony. Colony member weights are modified with a multiplier to end up with
+    ///   this number;
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     Note that this doesn't include the <see cref="Master"/> weight as the intended use for this property is
+    ///     to be read through <see cref="Microbe.EntityWeight"/> where this is added on top for the colony lead cell.
+    ///   </para>
+    /// </remarks>
+    [JsonIgnore]
+    public float EntityWeight
+    {
+        get
+        {
+            if (membersDirty)
+                UpdateDerivedProperties();
+            return entityWeight;
         }
     }
 
@@ -180,19 +202,23 @@ public class MicrobeColony
 
     private void UpdateDerivedProperties()
     {
-        UpdateHexCount();
+        UpdateHexCountAndWeight();
         UpdateCanEngulf();
 
         membersDirty = false;
     }
 
-    private void UpdateHexCount()
+    private void UpdateHexCountAndWeight()
     {
         hexCount = 0;
+        entityWeight = 0;
 
         foreach (var member in ColonyMembers)
         {
             hexCount += member.EngulfSize;
+
+            if (member != Master)
+                entityWeight += member.EntityWeight * Constants.MICROBE_COLONY_MEMBER_ENTITY_WEIGHT_MULTIPLIER;
         }
     }
 

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -505,6 +505,8 @@ public class MicrobeStage : StageBase<Microbe>
         // This is done first to ensure that the player colony is still intact for spawn separation calculation
         var daughter = Player!.Divide();
 
+        daughter.AddToGroup(Constants.PLAYER_REPRODUCED_GROUP);
+
         // If multicellular, we want that other cell colony to be fully grown to show budding in action
         if (Player.IsMulticellular)
         {
@@ -518,6 +520,14 @@ public class MicrobeStage : StageBase<Microbe>
 
         // Reset all the duplicates organelles of the player
         Player.ResetOrganelleLayout();
+
+        var playerPosition = Player.GlobalTranslation;
+
+        // This is queued to run to reduce the massive lag spike that anyway happens on this frame
+        // The dynamically spawned is used here as the object to detect if the entire stage is getting disposed this
+        // frame and won't be available on the next one
+        Invoke.Instance.QueueForObject(() => spawner.EnsureEntityLimitAfterPlayerReproduction(playerPosition, daughter),
+            rootOfDynamicallySpawned);
 
         if (!CurrentGame.TutorialState.Enabled)
         {

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -513,6 +513,7 @@ public class MicrobeStage : StageBase<Microbe>
             daughter.BecomeFullyGrownMulticellularColony();
 
             // TODO: add more extra offset between the player and the divided cell
+            // See: https://github.com/Revolutionary-Games/Thrive/issues/3653
         }
 
         // Update the player's cell

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -536,9 +536,8 @@ public class SpawnSystem : ISpawnSystem
                 continue;
 
             // Global position must be used here as otherwise colony members are despawned
-            // TODO: check if it would be better to remove the spawned group tag from colony members (and add it back
-            // when leaving the colony) or this could only get direct descendants of the world root and ignore nested
-            // nodes in the spawned group
+            // This should now just process the colony lead cells as this now uses GetChildrenToProcess, but
+            // GlobalTransform is kept here just for good measure to make sure the distances are accurate.
             var entityPosition = ((Spatial)spawned).GlobalTransform.origin;
             var squaredDistance = (playerPosition - entityPosition).LengthSquared();
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

this should limit how badly the early multicellular prototype especially runs. In microbe stage I had to try really hard to get this to trigger.

also colony members now contribute to the entity limit

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #3812
closes #3208

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
