### PR TITLE
Fix oversized editor tab buttons

### DIFF
--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.tscn
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.tscn
@@ -53,6 +53,8 @@ IsMulticellularEditor = true
 visible = false
 
 [node name="MicrobeEditorTabButtons" parent="EarlyMulticellularEditorGUI" instance=ExtResource( 3 )]
+margin_right = 350.0
+margin_bottom = 45.0
 IsForMulticellular = true
 
 [node name="EditorCommonBottomLeftButtons" parent="EarlyMulticellularEditorGUI" instance=ExtResource( 4 )]

--- a/src/gui_common/TabButtons.tscn
+++ b/src/gui_common/TabButtons.tscn
@@ -18,10 +18,12 @@ RightContainerPath = NodePath("RightIndicatorContainer")
 RightPaddingPath = NodePath("RightAlternativePadding")
 RightButtonIndicatorPath = NodePath("RightIndicatorContainer/KeyPrompt")
 TabButtonsContainerPath = NodePath("ButtonsContainer")
+TabButtonsContainerNoWrapPath = NodePath("ButtonsContainerNoWrap")
 
 [node name="LeftAlternativePadding" type="Control" parent="."]
 visible = false
 margin_right = 63.0
+margin_bottom = 42.0
 rect_min_size = Vector2( 63, 42 )
 
 [node name="LeftIndicatorContainer" type="HBoxContainer" parent="."]
@@ -52,6 +54,12 @@ visible = false
 size_flags_horizontal = 3
 size_flags_vertical = 4
 
+[node name="ButtonsContainerNoWrap" type="HBoxContainer" parent="."]
+visible = false
+size_flags_horizontal = 3
+size_flags_vertical = 4
+alignment = 1
+
 [node name="RightIndicatorContainer" type="HBoxContainer" parent="."]
 visible = false
 margin_left = 67.0
@@ -78,6 +86,7 @@ __meta__ = {
 
 [node name="RightAlternativePadding" type="Control" parent="."]
 visible = false
-margin_left = 56.0
-margin_right = 119.0
+margin_left = 134.0
+margin_right = 197.0
+margin_bottom = 42.0
 rect_min_size = Vector2( 63, 42 )

--- a/src/late_multicellular_stage/editor/LateMulticellularEditor.tscn
+++ b/src/late_multicellular_stage/editor/LateMulticellularEditor.tscn
@@ -62,6 +62,8 @@ IsMulticellularEditor = true
 visible = false
 
 [node name="MicrobeEditorTabButtons" parent="LateMulticellularEditorGUI" instance=ExtResource( 3 )]
+margin_right = 350.0
+margin_bottom = 45.0
 IsForMulticellular = true
 
 [node name="EditorCommonBottomLeftButtons" parent="LateMulticellularEditorGUI" instance=ExtResource( 4 )]

--- a/src/microbe_stage/editor/MicrobeEditor.tscn
+++ b/src/microbe_stage/editor/MicrobeEditor.tscn
@@ -44,11 +44,14 @@ EditorGridPath = NodePath("../../EditorWorld/Grid")
 CameraFollowPath = NodePath("../../EditorWorld/CameraLookAt")
 
 [node name="Report" parent="MicrobeEditorGUI" instance=ExtResource( 6 )]
+margin_top = 0.0
 
 [node name="PatchMap" parent="MicrobeEditorGUI" instance=ExtResource( 7 )]
 visible = false
 
 [node name="MicrobeEditorTabButtons" parent="MicrobeEditorGUI" instance=ExtResource( 5 )]
+margin_right = 350.0
+margin_bottom = 45.0
 
 [node name="EditorCommonBottomLeftButtons" parent="MicrobeEditorGUI" instance=ExtResource( 4 )]
 

--- a/src/microbe_stage/editor/MicrobeEditorTabButtons.tscn
+++ b/src/microbe_stage/editor/MicrobeEditorTabButtons.tscn
@@ -71,11 +71,10 @@ corner_radius_bottom_left = 5
 [sub_resource type="ButtonGroup" id=35]
 
 [node name="MicrobeEditorTabButtons" type="MarginContainer"]
-margin_top = -5.0
-margin_right = 511.0
-margin_bottom = 44.0
+margin_right = 278.0
+margin_bottom = 38.0
 custom_constants/margin_right = 5
-custom_constants/margin_top = 10
+custom_constants/margin_top = 5
 custom_constants/margin_left = 15
 custom_constants/margin_bottom = 5
 script = ExtResource( 2 )
@@ -89,13 +88,14 @@ CellTypeTabPath = NodePath("TabButtons/CellTypeEditorButton")
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_left = 15.0
-margin_top = 10.0
-margin_right = 506.0
-margin_bottom = 44.0
+margin_top = 5.0
+margin_right = 273.0
+margin_bottom = 33.0
+NoWrap = true
 
 [node name="ReportButton" type="Button" parent="TabButtons"]
-margin_right = 119.0
-margin_bottom = 34.0
+margin_right = 60.0
+margin_bottom = 28.0
 focus_mode = 0
 mouse_filter = 1
 size_flags_horizontal = 3
@@ -115,9 +115,9 @@ __meta__ = {
 }
 
 [node name="PatchMapButton" type="Button" parent="TabButtons"]
-margin_left = 123.0
-margin_right = 243.0
-margin_bottom = 34.0
+margin_left = 64.0
+margin_right = 152.0
+margin_bottom = 28.0
 focus_mode = 0
 mouse_filter = 1
 size_flags_horizontal = 3
@@ -136,9 +136,9 @@ __meta__ = {
 }
 
 [node name="CellEditorButton" type="Button" parent="TabButtons"]
-margin_left = 247.0
-margin_right = 367.0
-margin_bottom = 34.0
+margin_left = 156.0
+margin_right = 213.0
+margin_bottom = 28.0
 focus_mode = 0
 mouse_filter = 1
 size_flags_horizontal = 3
@@ -157,9 +157,9 @@ __meta__ = {
 }
 
 [node name="CellTypeEditorButton" type="Button" parent="TabButtons"]
-margin_left = 371.0
-margin_right = 491.0
-margin_bottom = 34.0
+margin_left = 217.0
+margin_right = 258.0
+margin_bottom = 28.0
 focus_mode = 0
 mouse_filter = 1
 size_flags_horizontal = 3


### PR DESCRIPTION
**Brief Description of What This PR Does**

To normal width in English and letting it overflow in any other case. Supersedes #4070.

Added a `HBox` version of the tab buttons container in `TabButtons` which will be used instead of `HFlow` when `NoWrap` property is true, so that they don't wrap like when in `HFlow`.

**Related Issues**

Fixes #4067.
Closes #4070.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
