### PR TITLE
switch to cell type editor upon duplicating

### DIFF
--- a/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Godot;
@@ -1126,6 +1126,11 @@ public partial class CellBodyPlanEditorComponent :
 
         Editor.EditedSpecies.CellTypes.Add(newType);
         GD.Print("New cell type created: ", newType.TypeName);
+
+        activeActionName = newType.TypeName;
+        OnCurrentActionChanged();
+        
+        EmitSignal(nameof(OnCellTypeToEditSelected), newType.TypeName);
 
         UpdateCellTypeSelections();
 


### PR DESCRIPTION
automatically switch to cell type editor right after creating (duplicating) new cell type

**Brief Description of What This PR Does**

After duplicating cell type in multicellular editor, editor will switch to cell type editor with new cell type being edited.

**Related Issues**
- can close issue https://github.com/Revolutionary-Games/Thrive/issues/3167 (i bet there is better way to close this)
<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
