### PR TITLE
Update Netanalyzers to 7.0.1 Consistently

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,6 @@
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="all" />
         <AdditionalFiles Include="$(MSBuildThisFileDirectory)RevolutionaryGamesCommon/stylecop.json"
                          Link="stylecop.json" />
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1" PrivateAssets="all" />
     </ItemGroup>
 </Project>

--- a/third_party/Directory.Build.props
+++ b/third_party/Directory.Build.props
@@ -10,6 +10,6 @@
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="all" />
         <AdditionalFiles Include="$(MSBuildThisFileDirectory)../RevolutionaryGamesCommon/stylecop.json"
                          Link="stylecop.json" />
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1" PrivateAssets="all" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR updates the RevolutionaryGamesCommon submodule. This makes the Microsoft.CodeAnalysis.NetAnalyzers version consistent across the project.

**Related Issues**

This PR closes #4215  by including its commits alongside the corresponding change to the common submodule so that multiple versions of the analyzers are not used across the project.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
