### PR TITLE
Fixed the panorama background compression mode artifacts

### DIFF
--- a/CIConfiguration.yml
+++ b/CIConfiguration.yml
@@ -5,12 +5,12 @@ jobs:
     image: thrive/godot-ci:v21
     cache:
       loadFrom:
-        - v5-{Branch}-build
-        - v5-master-build
-      writeTo: v5-{Branch}-build
+        - v6-{Branch}-build
+        - v6-master-build
+      writeTo: v6-{Branch}-build
       shared:
         .git/lfs: v3-lfs
-        .import: v6-import
+        .import: v7-import
         builds: v2-builds
       system:
         /root/.nuget: v2-nuget
@@ -41,7 +41,7 @@ jobs:
       writeTo: v3-{Branch}-jetbrains
       shared:
         .git/lfs: v3-lfs
-        .import: v6-import
+        .import: v7-import
         builds: v2-jetbrains-dummy-builds
       system:
         /root/.nuget: v2-nuget

--- a/assets/textures/background/panoramas/Abyssopelagic.png.import
+++ b/assets/textures/background/panoramas/Abyssopelagic.png.import
@@ -2,21 +2,19 @@
 
 importer="texture"
 type="StreamTexture"
-path.s3tc="res://.import/Abyssopelagic.png-e84069760bf0a7f29be5e5b5f42f9ff3.s3tc.stex"
-path.etc2="res://.import/Abyssopelagic.png-e84069760bf0a7f29be5e5b5f42f9ff3.etc2.stex"
+path="res://.import/Abyssopelagic.png-e84069760bf0a7f29be5e5b5f42f9ff3.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://assets/textures/background/panoramas/Abyssopelagic.png"
-dest_files=[ "res://.import/Abyssopelagic.png-e84069760bf0a7f29be5e5b5f42f9ff3.s3tc.stex", "res://.import/Abyssopelagic.png-e84069760bf0a7f29be5e5b5f42f9ff3.etc2.stex" ]
+dest_files=[ "res://.import/Abyssopelagic.png-e84069760bf0a7f29be5e5b5f42f9ff3.stex" ]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/lossy_quality=0.7
 compress/hdr_mode=0
 compress/bptc_ldr=0

--- a/assets/textures/background/panoramas/Bathypelagic.png.import
+++ b/assets/textures/background/panoramas/Bathypelagic.png.import
@@ -2,21 +2,19 @@
 
 importer="texture"
 type="StreamTexture"
-path.s3tc="res://.import/Bathypelagic.png-a34fbd82cd266a4ece0e0dcf02de403d.s3tc.stex"
-path.etc2="res://.import/Bathypelagic.png-a34fbd82cd266a4ece0e0dcf02de403d.etc2.stex"
+path="res://.import/Bathypelagic.png-a34fbd82cd266a4ece0e0dcf02de403d.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://assets/textures/background/panoramas/Bathypelagic.png"
-dest_files=[ "res://.import/Bathypelagic.png-a34fbd82cd266a4ece0e0dcf02de403d.s3tc.stex", "res://.import/Bathypelagic.png-a34fbd82cd266a4ece0e0dcf02de403d.etc2.stex" ]
+dest_files=[ "res://.import/Bathypelagic.png-a34fbd82cd266a4ece0e0dcf02de403d.stex" ]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/lossy_quality=0.7
 compress/hdr_mode=0
 compress/bptc_ldr=0

--- a/assets/textures/background/panoramas/Cave.png.import
+++ b/assets/textures/background/panoramas/Cave.png.import
@@ -2,21 +2,19 @@
 
 importer="texture"
 type="StreamTexture"
-path.s3tc="res://.import/Cave.png-6b58736ad3f4502a90a15958f4b4f33c.s3tc.stex"
-path.etc2="res://.import/Cave.png-6b58736ad3f4502a90a15958f4b4f33c.etc2.stex"
+path="res://.import/Cave.png-6b58736ad3f4502a90a15958f4b4f33c.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://assets/textures/background/panoramas/Cave.png"
-dest_files=[ "res://.import/Cave.png-6b58736ad3f4502a90a15958f4b4f33c.s3tc.stex", "res://.import/Cave.png-6b58736ad3f4502a90a15958f4b4f33c.etc2.stex" ]
+dest_files=[ "res://.import/Cave.png-6b58736ad3f4502a90a15958f4b4f33c.stex" ]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/lossy_quality=0.7
 compress/hdr_mode=0
 compress/bptc_ldr=0

--- a/assets/textures/background/panoramas/Epipelagic.png.import
+++ b/assets/textures/background/panoramas/Epipelagic.png.import
@@ -2,21 +2,19 @@
 
 importer="texture"
 type="StreamTexture"
-path.s3tc="res://.import/Epipelagic.png-859c8c0d5a2f212486ce2cc69bab7388.s3tc.stex"
-path.etc2="res://.import/Epipelagic.png-859c8c0d5a2f212486ce2cc69bab7388.etc2.stex"
+path="res://.import/Epipelagic.png-859c8c0d5a2f212486ce2cc69bab7388.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://assets/textures/background/panoramas/Epipelagic.png"
-dest_files=[ "res://.import/Epipelagic.png-859c8c0d5a2f212486ce2cc69bab7388.s3tc.stex", "res://.import/Epipelagic.png-859c8c0d5a2f212486ce2cc69bab7388.etc2.stex" ]
+dest_files=[ "res://.import/Epipelagic.png-859c8c0d5a2f212486ce2cc69bab7388.stex" ]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/lossy_quality=0.7
 compress/hdr_mode=0
 compress/bptc_ldr=0

--- a/assets/textures/background/panoramas/Estuary.png.import
+++ b/assets/textures/background/panoramas/Estuary.png.import
@@ -2,21 +2,19 @@
 
 importer="texture"
 type="StreamTexture"
-path.s3tc="res://.import/Estuary.png-565f3d18dbcd862b6c3ba50593340d21.s3tc.stex"
-path.etc2="res://.import/Estuary.png-565f3d18dbcd862b6c3ba50593340d21.etc2.stex"
+path="res://.import/Estuary.png-565f3d18dbcd862b6c3ba50593340d21.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://assets/textures/background/panoramas/Estuary.png"
-dest_files=[ "res://.import/Estuary.png-565f3d18dbcd862b6c3ba50593340d21.s3tc.stex", "res://.import/Estuary.png-565f3d18dbcd862b6c3ba50593340d21.etc2.stex" ]
+dest_files=[ "res://.import/Estuary.png-565f3d18dbcd862b6c3ba50593340d21.stex" ]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/lossy_quality=0.7
 compress/hdr_mode=0
 compress/bptc_ldr=0

--- a/assets/textures/background/panoramas/HydrothermalVents.png.import
+++ b/assets/textures/background/panoramas/HydrothermalVents.png.import
@@ -2,21 +2,19 @@
 
 importer="texture"
 type="StreamTexture"
-path.s3tc="res://.import/HydrothermalVents.png-7175b71f3b65732ef165a86966cc416c.s3tc.stex"
-path.etc2="res://.import/HydrothermalVents.png-7175b71f3b65732ef165a86966cc416c.etc2.stex"
+path="res://.import/HydrothermalVents.png-7175b71f3b65732ef165a86966cc416c.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://assets/textures/background/panoramas/HydrothermalVents.png"
-dest_files=[ "res://.import/HydrothermalVents.png-7175b71f3b65732ef165a86966cc416c.s3tc.stex", "res://.import/HydrothermalVents.png-7175b71f3b65732ef165a86966cc416c.etc2.stex" ]
+dest_files=[ "res://.import/HydrothermalVents.png-7175b71f3b65732ef165a86966cc416c.stex" ]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/lossy_quality=0.7
 compress/hdr_mode=0
 compress/bptc_ldr=0

--- a/assets/textures/background/panoramas/Mesopelagic.png.import
+++ b/assets/textures/background/panoramas/Mesopelagic.png.import
@@ -2,21 +2,19 @@
 
 importer="texture"
 type="StreamTexture"
-path.s3tc="res://.import/Mesopelagic.png-806c07a4177947cf81fdec2cde3cb62a.s3tc.stex"
-path.etc2="res://.import/Mesopelagic.png-806c07a4177947cf81fdec2cde3cb62a.etc2.stex"
+path="res://.import/Mesopelagic.png-806c07a4177947cf81fdec2cde3cb62a.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://assets/textures/background/panoramas/Mesopelagic.png"
-dest_files=[ "res://.import/Mesopelagic.png-806c07a4177947cf81fdec2cde3cb62a.s3tc.stex", "res://.import/Mesopelagic.png-806c07a4177947cf81fdec2cde3cb62a.etc2.stex" ]
+dest_files=[ "res://.import/Mesopelagic.png-806c07a4177947cf81fdec2cde3cb62a.stex" ]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/lossy_quality=0.7
 compress/hdr_mode=0
 compress/bptc_ldr=0

--- a/assets/textures/background/panoramas/PolarSea.png.import
+++ b/assets/textures/background/panoramas/PolarSea.png.import
@@ -2,21 +2,19 @@
 
 importer="texture"
 type="StreamTexture"
-path.s3tc="res://.import/PolarSea.png-dc700d0afbf08f1a76475fd1b9603898.s3tc.stex"
-path.etc2="res://.import/PolarSea.png-dc700d0afbf08f1a76475fd1b9603898.etc2.stex"
+path="res://.import/PolarSea.png-dc700d0afbf08f1a76475fd1b9603898.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://assets/textures/background/panoramas/PolarSea.png"
-dest_files=[ "res://.import/PolarSea.png-dc700d0afbf08f1a76475fd1b9603898.s3tc.stex", "res://.import/PolarSea.png-dc700d0afbf08f1a76475fd1b9603898.etc2.stex" ]
+dest_files=[ "res://.import/PolarSea.png-dc700d0afbf08f1a76475fd1b9603898.stex" ]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/lossy_quality=0.7
 compress/hdr_mode=0
 compress/bptc_ldr=0


### PR DESCRIPTION
**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Noticed on dev discord that there were some artifacts in the panorama backgrounds, turns out lossy vram compression introduced those problems. This switches the backgrounds to lossless compression which seems to resolve the issue

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
