### PR TITLE
Add property in `BiomeConditions` to get all compounds

### DIFF
--- a/src/microbe_stage/BiomeConditions.cs
+++ b/src/microbe_stage/BiomeConditions.cs
@@ -90,6 +90,34 @@ public class BiomeConditions : ICloneable, ISaveLoadable
     [JsonIgnore]
     public IDictionary<Compound, BiomeCompoundProperties> ChangeableCompounds => compounds;
 
+    /// <summary>
+    ///   Returns a new dictionary where <see cref="Compounds"/> is combined with compounds contained in
+    ///   <see cref="Chunks"/>.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyDictionary<Compound, BiomeCompoundProperties> CombinedCompounds
+    {
+        get
+        {
+            var result = new Dictionary<Compound, BiomeCompoundProperties>(compounds);
+
+            foreach (var chunk in Chunks.Values)
+            {
+                if (chunk.Compounds == null)
+                    continue;
+
+                foreach (var compound in chunk.Compounds)
+                {
+                    compounds.TryGetValue(compound.Key, out BiomeCompoundProperties properties);
+                    properties.Amount += compound.Value.Amount;
+                    result[compound.Key] = properties;
+                }
+            }
+
+            return result;
+        }
+    }
+
     public BiomeCompoundProperties GetCompound(Compound compound, CompoundAmountType amountType)
     {
         if (TryGetCompound(compound, amountType, out var result))

--- a/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
+++ b/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
@@ -291,7 +291,7 @@ public class MicrobeEditorReportComponent : EditorComponentBase<IEditorReportDat
 
         foreach (var snapshot in patch.History)
         {
-            foreach (var entry in snapshot.Biome.Compounds)
+            foreach (var entry in snapshot.Biome.CombinedCompounds)
             {
                 var dataset = new LineChartData
                 {
@@ -318,13 +318,13 @@ public class MicrobeEditorReportComponent : EditorComponentBase<IEditorReportDat
         for (int i = patch.History.Count - 1; i >= 0; i--)
         {
             var snapshot = patch.History.ElementAt(i);
-
             var temperature = SimulationParameters.Instance.GetCompound("temperature");
+            var combinedCompounds = snapshot.Biome.CombinedCompounds;
 
             temperatureData.AddPoint(DataPoint.GetDataPoint(snapshot.TimePeriod,
-                snapshot.Biome.Compounds[temperature].Ambient, markerColour: temperatureData.Colour));
+                combinedCompounds[temperature].Ambient, markerColour: temperatureData.Colour));
 
-            foreach (var entry in snapshot.Biome.Compounds)
+            foreach (var entry in combinedCompounds)
             {
                 var dataset = GetChartForCompound(entry.Key.InternalName)?.GetDataSet(entry.Key.Name);
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Add new `CombinedCompounds` property in `BiomeConditions` where it returns a new dictionary with entries from both cloud compounds and compounds contained in chunks.

The returned dictionary is not cached internally because `BiomeConditions.Compounds` can change anytime due to `BiomeConditions.ChangeableCompounds`.

**Related Issues**

Fixes #4213.
(I realized the branch prefix is wrong)

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
