### PR TITLE
Don't create collision shapes for preview-only cells

### DIFF
--- a/src/microbe_stage/PlacedOrganelle.cs
+++ b/src/microbe_stage/PlacedOrganelle.cs
@@ -575,7 +575,9 @@ public class PlacedOrganelle : Spatial, IPositionedOrganelle, ISaveLoadedTracked
         //     !IsLoadedFromSave)
         //     ParentMicrobe.Colony.Master.Mass += Definition.Mass;
 
-        MakeCollisionShapes(ParentMicrobe!.Colony?.Master ?? ParentMicrobe);
+        // We don't need preview cells to be collidable (as it can lag the editor if the cell is massive).
+        if (!ParentMicrobe.IsForPreviewOnly)
+            MakeCollisionShapes(ParentMicrobe!.Colony?.Master ?? ParentMicrobe);
 
         if (Definition.Enzymes != null)
         {

--- a/src/microbe_stage/PlacedOrganelle.cs
+++ b/src/microbe_stage/PlacedOrganelle.cs
@@ -577,7 +577,7 @@ public class PlacedOrganelle : Spatial, IPositionedOrganelle, ISaveLoadedTracked
 
         // We don't need preview cells to be collidable (as it can lag the editor if the cell is massive).
         if (!ParentMicrobe.IsForPreviewOnly)
-            MakeCollisionShapes(ParentMicrobe!.Colony?.Master ?? ParentMicrobe);
+            MakeCollisionShapes(ParentMicrobe.Colony?.Master ?? ParentMicrobe);
 
         if (Definition.Enzymes != null)
         {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Found this out while testing #4273.

This helps reducing lag in early multicellular editor (or perhaps microbe editor) if the cell the player currently editing is ungodly massive.

**Related Issues**

_None, I think._

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
