### PR TITLE
Make engulfed tutorial not appear if player can't be digested and make it hide after some time

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -864,6 +864,7 @@ public static class Constants
     public const float MICROBE_REPRODUCTION_TUTORIAL_DELAY = 10;
     public const float HIDE_MICROBE_STAYING_ALIVE_TUTORIAL_AFTER = 60;
     public const float HIDE_MICROBE_DAY_NIGHT_TUTORIAL_AFTER = 20;
+    public const float HIDE_MICROBE_ENGULFED_TUTORIAL_AFTER = 35;
     public const float MICROBE_EDITOR_BUTTON_TUTORIAL_DELAY = 20;
 
     public const float DAY_NIGHT_TUTORIAL_LIGHT_MIN = 0.01f;

--- a/src/microbe_stage/IEngulfable.cs
+++ b/src/microbe_stage/IEngulfable.cs
@@ -41,8 +41,8 @@ public interface IEngulfable : IGraphicalEntity
     public float DigestedAmount { get; set; }
 
     /// <summary>
-    ///   Additional means bonus compounds that can be acquired from this engulfable for predating microbes
-    ///   on top of <see cref="Compounds"/>
+    ///   Additional means bonus compounds that can be acquired on top of <see cref="Compounds"/> from this engulfable
+    ///   for predating microbes.
     /// </summary>
     /// <remarks>
     ///   <para>

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -410,7 +410,7 @@ public partial class Microbe
     }
 
     /// <summary>
-    ///   Returns true when this microbe can engulf the target
+    ///   Returns the check result whether this microbe can engulf the target
     /// </summary>
     public EngulfCheckResult CanEngulfObject(IEngulfable target)
     {

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -95,6 +95,12 @@ public partial class Microbe
     private bool organelleMaxRenderPriorityDirty = true;
     private int cachedOrganelleMaxRenderPriority;
 
+    public enum DigestCheckResult
+    {
+        Ok,
+        MissingEnzyme,
+    }
+
     /// <summary>
     ///   The stored compounds in this microbe
     /// </summary>
@@ -630,6 +636,19 @@ public partial class Microbe
 
         CalculateBonusDigestibleGlucose(result);
         return result;
+    }
+
+    /// <summary>
+    ///   Returns the check result whether this microbe can digest the target (has the enzyme necessary).
+    /// </summary>
+    public DigestCheckResult CanDigestObject(IEngulfable engulfable)
+    {
+        var enzyme = engulfable.RequisiteEnzymeToDigest;
+
+        if (enzyme != null && !Enzymes.ContainsKey(enzyme))
+            return DigestCheckResult.MissingEnzyme;
+
+        return DigestCheckResult.Ok;
     }
 
     /// <summary>
@@ -1449,7 +1468,7 @@ public partial class Microbe
 
             if (engulfable.RequisiteEnzymeToDigest != null)
             {
-                if (!Enzymes.ContainsKey(engulfable.RequisiteEnzymeToDigest))
+                if (CanDigestObject(engulfable) == DigestCheckResult.MissingEnzyme)
                 {
                     EjectEngulfable(engulfable);
                     OnNoticeMessage?.Invoke(this,

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -840,7 +840,8 @@ public class MicrobeStage : CreatureStageBase<Microbe>
     [DeserializedCallbackAllowed]
     private void OnPlayerEngulfedByHostile(Microbe player, Microbe hostile)
     {
-        TutorialState.SendEvent(TutorialEventType.MicrobePlayerIsEngulfed, EventArgs.Empty, this);
+        if (hostile.CanDigestObject(player) == Microbe.DigestCheckResult.Ok)
+            TutorialState.SendEvent(TutorialEventType.MicrobePlayerIsEngulfed, EventArgs.Empty, this);
     }
 
     [DeserializedCallbackAllowed]

--- a/src/tutorial/microbe_stage/MicrobeEngulfedExplanation.cs
+++ b/src/tutorial/microbe_stage/MicrobeEngulfedExplanation.cs
@@ -27,5 +27,13 @@
 
             return false;
         }
+
+        protected override void OnProcess(TutorialState overallState, float delta)
+        {
+            if (Time > Constants.HIDE_MICROBE_ENGULFED_TUTORIAL_AFTER)
+            {
+                Hide();
+            }
+        }
     }
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Added new method similar to `CanEngulfedObject` where instead it checks for target digestibility and returns an enum. And set the tutorial's visible time to 35s.

**Related Issues**

Fixes #3649.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
