### PR TITLE
Fix current light level in editor not working correctly

### DIFF
--- a/src/general/GameWorld.cs
+++ b/src/general/GameWorld.cs
@@ -97,8 +97,7 @@ public class GameWorld : ISaveLoadable
         if (WorldSettings.DayNightCycleEnabled)
         {
             // Make sure average light levels are computed already
-            foreach (var patch in Map.Patches)
-                patch.Value.UpdateAverageSunlight(LightCycle);
+            UpdateGlobalAverageSunlight();
         }
     }
 
@@ -190,6 +189,14 @@ public class GameWorld : ISaveLoadable
             SimulationParameters.Instance.GetOrganelleType("cytoplasm"), new Hex(0, 0), 0));
 
         species.OnEdited();
+    }
+
+    /// <summary>
+    ///   Takes care of processing everything in the world.
+    /// </summary>
+    public void Process(float delta)
+    {
+        LightCycle.Process(delta);
     }
 
     /// <summary>
@@ -606,6 +613,28 @@ public class GameWorld : ISaveLoadable
         }
 
         eventsLog[TotalPassedTime].Add(new GameEventDescription(description, iconPath, highlight));
+    }
+
+    /// <summary>
+    ///   Updates the light level in all patches according to <see cref="LightCycle"/> data.
+    /// </summary>
+    public void UpdateGlobalLightLevels()
+    {
+        foreach (var patch in Map.Patches.Values)
+        {
+            patch.UpdateCurrentSunlight(LightCycle.DayLightFraction);
+        }
+    }
+
+    /// <summary>
+    ///   Updates/sets the average light level of all patches according to <see cref="LightCycle"/> data.
+    /// </summary>
+    public void UpdateGlobalAverageSunlight()
+    {
+        foreach (var patch in Map.Patches.Values)
+        {
+            patch.UpdateAverageSunlight(LightCycle.AverageSunlight);
+        }
     }
 
     public void FinishLoading(ISaveContext? context)

--- a/src/general/base_stage/CreatureStageBase.cs
+++ b/src/general/base_stage/CreatureStageBase.cs
@@ -17,10 +17,6 @@ public abstract class CreatureStageBase<TPlayer> : StageBase, ICreatureStage
     protected DirectionalLight worldLight = null!;
 #pragma warning restore CA2213
 
-    [JsonProperty]
-    [AssignOnlyChildItemsOnDeserialize]
-    protected DayNightCycle lightCycle = null!;
-
     /// <summary>
     ///   Used to differentiate between spawning the player the first time and respawning
     /// </summary>
@@ -122,7 +118,6 @@ public abstract class CreatureStageBase<TPlayer> : StageBase, ICreatureStage
         base.ResolveNodeReferences();
 
         worldLight = world.GetNode<DirectionalLight>("WorldLight");
-        lightCycle = new DayNightCycle();
     }
 
     public override void _ExitTree()
@@ -140,8 +135,6 @@ public abstract class CreatureStageBase<TPlayer> : StageBase, ICreatureStage
     public override void _Process(float delta)
     {
         base._Process(delta);
-
-        lightCycle.Process(delta);
 
         if (gameOver)
         {
@@ -270,16 +263,6 @@ public abstract class CreatureStageBase<TPlayer> : StageBase, ICreatureStage
         UpdatePatchSettings();
         PatchExtinctionResolved();
         SpawnPlayer();
-    }
-
-    protected override void SetupStage()
-    {
-        if (IsLoadedFromSave)
-        {
-            lightCycle.CalculateDependentLightData(GameWorld.WorldSettings);
-        }
-
-        base.SetupStage();
     }
 
     protected override void StartGUIStageTransition(bool longDuration, bool returnFromEditor)

--- a/src/general/base_stage/EditorBase.cs
+++ b/src/general/base_stage/EditorBase.cs
@@ -665,8 +665,7 @@ public abstract class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoa
         ApplyAutoEvoResults();
 
         // Recompute average sunlight in case auto-evo modifies things
-        foreach (var patch in CurrentGame.GameWorld.Map.Patches.Values)
-            patch.UpdateAverageSunlight(CurrentGame.GameWorld.LightCycle);
+        CurrentGame.GameWorld.UpdateGlobalAverageSunlight();
 
         FadeIn();
     }

--- a/src/general/base_stage/EditorBase.cs
+++ b/src/general/base_stage/EditorBase.cs
@@ -84,10 +84,10 @@ public abstract class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoa
     private int? mutationPointsCache;
 
     /// <summary>
-    ///   The light level the editor is previewing things at
+    ///   The fraction of daylight the editor is previewing things at
     /// </summary>
     [JsonProperty]
-    private float lightLevel = 1.0f;
+    private float dayLightFraction = 1.0f;
 
     /// <summary>
     ///   Base Node where all dynamically created world Nodes in the editor should go. Optionally grouped under
@@ -147,12 +147,12 @@ public abstract class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoa
     public bool NodeReferencesResolved { get; private set; }
 
     [JsonIgnore]
-    public float LightLevel
+    public float DayLightFraction
     {
-        get => lightLevel;
+        get => dayLightFraction;
         set
         {
-            lightLevel = value;
+            dayLightFraction = value;
 
             ApplyComponentLightLevels();
         }
@@ -664,6 +664,10 @@ public abstract class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoa
 
         ApplyAutoEvoResults();
 
+        // Recompute average sunlight in case auto-evo modifies things
+        foreach (var patch in CurrentGame.GameWorld.Map.Patches.Values)
+            patch.UpdateAverageSunlight(CurrentGame.GameWorld.LightCycle);
+
         FadeIn();
     }
 
@@ -864,7 +868,7 @@ public abstract class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoa
     {
         foreach (var editorComponent in GetAllEditorComponents())
         {
-            editorComponent.OnLightLevelChanged(lightLevel);
+            editorComponent.OnLightLevelChanged(dayLightFraction);
         }
     }
 

--- a/src/general/base_stage/IEditor.cs
+++ b/src/general/base_stage/IEditor.cs
@@ -52,7 +52,7 @@ public interface IEditor : ISaveLoadedTracked
     /// </summary>
     public bool Ready { get; }
 
-    public float LightLevel { get; set; }
+    public float DayLightFraction { get; set; }
 
     /// <summary>
     ///   Cancels the current editor action if possible

--- a/src/general/base_stage/IEditorComponent.cs
+++ b/src/general/base_stage/IEditorComponent.cs
@@ -48,5 +48,9 @@ public interface IEditorComponent
 
     public void OnMutationPointsChanged(int mutationPoints);
 
-    public void OnLightLevelChanged(float lightLevel);
+    /// <summary>
+    ///   Called when <see cref="IEditor.DayLightFraction"/> is changed.
+    /// </summary>
+    /// <param name="dayLightFraction">The editor's new fraction of daylight.</param>
+    public void OnLightLevelChanged(float dayLightFraction);
 }

--- a/src/general/base_stage/StageBase.cs
+++ b/src/general/base_stage/StageBase.cs
@@ -39,9 +39,8 @@ public abstract class StageBase : NodeWithInput, IStageBase, IGodotEarlyNodeReso
     private bool transitionFinished;
 
     /// <summary>
-    ///   Used to control how often light level is updated by the day/night cycle.
+    ///   Used to control how often updated light level data is read from the day/night cycle.
     /// </summary>
-    [JsonProperty]
     private float elapsedSinceLightLevelUpdate;
 
     /// <summary>
@@ -114,7 +113,7 @@ public abstract class StageBase : NodeWithInput, IStageBase, IGodotEarlyNodeReso
             wantsToSave = false;
         }
 
-        GameWorld.LightCycle.Process(delta);
+        GameWorld.Process(delta);
 
         elapsedSinceLightLevelUpdate += delta;
         if (elapsedSinceLightLevelUpdate > Constants.LIGHT_LEVEL_UPDATE_INTERVAL)

--- a/src/general/base_stage/StageBase.cs
+++ b/src/general/base_stage/StageBase.cs
@@ -39,6 +39,12 @@ public abstract class StageBase : NodeWithInput, IStageBase, IGodotEarlyNodeReso
     private bool transitionFinished;
 
     /// <summary>
+    ///   Used to control how often light level is updated by the day/night cycle.
+    /// </summary>
+    [JsonProperty]
+    private float elapsedSinceLightLevelUpdate;
+
+    /// <summary>
     ///   The main current game object holding various details
     /// </summary>
     [JsonProperty]
@@ -106,6 +112,15 @@ public abstract class StageBase : NodeWithInput, IStageBase, IGodotEarlyNodeReso
                 AutoSave();
 
             wantsToSave = false;
+        }
+
+        GameWorld.LightCycle.Process(delta);
+
+        elapsedSinceLightLevelUpdate += delta;
+        if (elapsedSinceLightLevelUpdate > Constants.LIGHT_LEVEL_UPDATE_INTERVAL)
+        {
+            elapsedSinceLightLevelUpdate = 0;
+            OnLightLevelUpdate();
         }
     }
 
@@ -191,6 +206,8 @@ public abstract class StageBase : NodeWithInput, IStageBase, IGodotEarlyNodeReso
 
     protected abstract void AutoSave();
     protected abstract void PerformQuickSave();
+
+    protected abstract void OnLightLevelUpdate();
 
     protected override void Dispose(bool disposing)
     {

--- a/src/general/base_stage/StageBase.cs
+++ b/src/general/base_stage/StageBase.cs
@@ -41,7 +41,7 @@ public abstract class StageBase : NodeWithInput, IStageBase, IGodotEarlyNodeReso
     /// <summary>
     ///   Used to control how often updated light level data is read from the day/night cycle.
     /// </summary>
-    private float elapsedSinceLightLevelUpdate;
+    private float elapsedSinceLightLevelUpdate = 1;
 
     /// <summary>
     ///   The main current game object holding various details

--- a/src/late_multicellular_stage/MulticellularStage.cs
+++ b/src/late_multicellular_stage/MulticellularStage.cs
@@ -665,7 +665,6 @@ public class MulticellularStage : CreatureStageBase<MulticellularCreature>
     {
         // patchManager.CurrentGame = CurrentGame;
 
-        lightCycle.ApplyWorldSettings(GameWorld.WorldSettings);
         UpdatePatchSettings();
 
         SpawnPlayer();
@@ -721,6 +720,10 @@ public class MulticellularStage : CreatureStageBase<MulticellularCreature>
 
         spawnedPlayer = true;
         playerRespawnTimer = Constants.PLAYER_RESPAWN_TIME;
+    }
+
+    protected override void OnLightLevelUpdate()
+    {
     }
 
     protected override void AutoSave()

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -46,12 +46,6 @@ public class MicrobeStage : CreatureStageBase<Microbe>
     [JsonProperty]
     private float elapsedSinceEntityPositionCheck;
 
-    /// <summary>
-    ///   Used to control how often light level is updated by the day/night cycle.
-    /// </summary>
-    [JsonProperty]
-    private float elapsedSinceLightLevelUpdate;
-
     [JsonProperty]
     private bool wonOnce;
 
@@ -141,8 +135,7 @@ public class MicrobeStage : CreatureStageBase<Microbe>
         floatingChunkSystem = new FloatingChunkSystem(rootOfDynamicallySpawned, Clouds);
         FluidSystem = new FluidSystem(rootOfDynamicallySpawned);
         spawner = new SpawnSystem(rootOfDynamicallySpawned);
-        patchManager = new PatchManager(spawner, ProcessSystem, Clouds, TimedLifeSystem,
-            worldLight, CurrentGame, lightCycle);
+        patchManager = new PatchManager(spawner, ProcessSystem, Clouds, TimedLifeSystem, worldLight, CurrentGame);
     }
 
     public override void _EnterTree()
@@ -169,20 +162,6 @@ public class MicrobeStage : CreatureStageBase<Microbe>
         floatingChunkSystem.Process(delta, Player?.Translation);
         microbeAISystem.Process(delta);
         microbeSystem.Process(delta);
-
-        elapsedSinceLightLevelUpdate += delta;
-        if (elapsedSinceLightLevelUpdate > Constants.LIGHT_LEVEL_UPDATE_INTERVAL)
-        {
-            elapsedSinceLightLevelUpdate = 0;
-
-            if (GameWorld.Map.CurrentPatch != null)
-            {
-                patchManager.UpdatePatchBiome(GameWorld.Map.CurrentPatch);
-                patchManager.UpdateAllPatchLightLevels();
-                HUD.UpdateEnvironmentalBars(GameWorld.Map.CurrentPatch.Biome);
-                UpdateDayLightEffects();
-            }
-        }
 
         if (gameOver)
             return;
@@ -603,7 +582,6 @@ public class MicrobeStage : CreatureStageBase<Microbe>
     {
         patchManager.CurrentGame = CurrentGame;
 
-        lightCycle.ApplyWorldSettings(GameWorld.WorldSettings);
         UpdatePatchSettings(!TutorialState.Enabled);
 
         SpawnPlayer();
@@ -712,6 +690,32 @@ public class MicrobeStage : CreatureStageBase<Microbe>
         UpdatePatchLightLevelSettings();
     }
 
+    protected override void OnLightLevelUpdate()
+    {
+        if (GameWorld.Map.CurrentPatch == null)
+            return;
+
+        patchManager.UpdatePatchBiome(GameWorld.Map.CurrentPatch);
+        patchManager.UpdateAllPatchLightLevels();
+        HUD.UpdateEnvironmentalBars(GameWorld.Map.CurrentPatch.Biome);
+
+        // Updates the background lighting and does various post-effects
+        if (templateMaxLightLevel > 0.0f && maxLightLevel > 0.0f)
+        {
+            // This might need to be refactored for efficiency but, it works for now
+            var lightLevel = GameWorld.Map.CurrentPatch!.GetCompoundAmount("sunlight") *
+                GameWorld.LightCycle.DayLightFraction;
+
+            // Normalise by maximum light level in the patch
+            Camera.LightLevel = lightLevel / maxLightLevel;
+        }
+        else
+        {
+            // Don't change lighting for patches without day/night effects
+            Camera.LightLevel = 1.0f;
+        }
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)
@@ -726,26 +730,6 @@ public class MicrobeStage : CreatureStageBase<Microbe>
     {
         Camera.SetBackground(SimulationParameters.Instance.GetBackground(
             GameWorld.Map.CurrentPatch!.BiomeTemplate.Background));
-    }
-
-    /// <summary>
-    ///   Updates the background lighting and does various post-effects
-    /// </summary>
-    private void UpdateDayLightEffects()
-    {
-        if (templateMaxLightLevel > 0.0f && maxLightLevel > 0.0f)
-        {
-            // This might need to be refactored for efficiency but, it works for now
-            var lightLevel = GameWorld.Map.CurrentPatch!.GetCompoundAmount("sunlight") * lightCycle.DayLightFraction;
-
-            // Normalise by maximum light level in the patch
-            Camera.LightLevel = lightLevel / maxLightLevel;
-        }
-        else
-        {
-            // Don't change lighting for patches without day/night effects
-            Camera.LightLevel = 1.0f;
-        }
     }
 
     private void UpdatePatchLightLevelSettings()

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -695,8 +695,11 @@ public class MicrobeStage : CreatureStageBase<Microbe>
         if (GameWorld.Map.CurrentPatch == null)
             return;
 
+        // TODO: it would make more sense for the GameWorld to update its patch map data based on the
+        // light cycle in it.
         patchManager.UpdatePatchBiome(GameWorld.Map.CurrentPatch);
-        patchManager.UpdateAllPatchLightLevels();
+        GameWorld.UpdateGlobalLightLevels();
+
         HUD.UpdateEnvironmentalBars(GameWorld.Map.CurrentPatch.Biome);
 
         // Updates the background lighting and does various post-effects

--- a/src/microbe_stage/Patch.cs
+++ b/src/microbe_stage/Patch.cs
@@ -426,19 +426,19 @@ public class Patch
         // TODO: can we do something about the game log here?
     }
 
-    public void UpdateAverageSunlight(DayNightCycle lightCycle)
+    public void UpdateAverageSunlight(float multiplier)
     {
         Biome.AverageCompounds[sunlight] = new BiomeCompoundProperties
         {
-            Ambient = Biome.MaximumCompounds[sunlight].Ambient * lightCycle.AverageSunlight,
+            Ambient = Biome.MaximumCompounds[sunlight].Ambient * multiplier,
         };
     }
 
-    public void UpdateCurrentSunlight(DayNightCycle lightCycle)
+    public void UpdateCurrentSunlight(float multiplier)
     {
         Biome.CurrentCompoundAmounts[sunlight] = new BiomeCompoundProperties
         {
-            Ambient = Biome.MaximumCompounds[sunlight].Ambient * lightCycle.DayLightFraction,
+            Ambient = Biome.MaximumCompounds[sunlight].Ambient * multiplier,
         };
     }
 

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -127,18 +127,17 @@ public class PatchManager : IChildPropertiesLoadCallback
 
     public void UpdateAllPatchLightLevels()
     {
-        var gameWorld = CurrentGame!.GameWorld;
+        if (CurrentGame == null)
+            throw new InvalidOperationException($"{nameof(PatchManager)} doesn't have {nameof(CurrentGame)} set");
+
+        var gameWorld = CurrentGame.GameWorld;
 
         if (!gameWorld.WorldSettings.DayNightCycleEnabled)
             return;
 
         var multiplier = gameWorld.LightCycle.DayLightFraction;
         compoundCloudSystem.SetBrightnessModifier(multiplier * (compoundCloudBrightness - 1.0f) + 1.0f);
-
-        foreach (var patch in gameWorld.Map.Patches.Values)
-        {
-            patch.UpdateCurrentSunlight(gameWorld.LightCycle);
-        }
+        gameWorld.UpdateGlobalLightLevels();
     }
 
     private void HandleChunkSpawns(BiomeConditions biome)

--- a/src/microbe_stage/PatchMapGenerator.cs
+++ b/src/microbe_stage/PatchMapGenerator.cs
@@ -166,18 +166,6 @@ public static class PatchMapGenerator
         ConnectPatchesBetweenRegions(map, random);
         map.CreateAdjacenciesFromPatchData();
 
-        if (settings.DayNightCycleEnabled)
-        {
-            // Make sure average light levels are computed already
-            // See the TODO comments in PatchManager
-            var dummyLight = new DayNightCycle();
-            dummyLight.ApplyWorldSettings(settings);
-            foreach (var patch in map.Patches)
-            {
-                patch.Value.UpdateAverageSunlight(dummyLight);
-            }
-        }
-
         return map;
     }
 

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1071,10 +1071,7 @@ public partial class CellEditorComponent :
         // is non-zero too.
         if (maxLightLevel > 0.0f && templateMaxLightLevel > 0.0f)
         {
-            var lightLevel = maxLightLevel * dayLightFraction;
-
-            // Normalise by maximum light level in the patch
-            camera!.LightLevel = lightLevel / maxLightLevel;
+            camera!.LightLevel = dayLightFraction;
         }
         else
         {

--- a/src/microbe_stage/editor/PatchMapEditorComponent.cs
+++ b/src/microbe_stage/editor/PatchMapEditorComponent.cs
@@ -138,12 +138,11 @@ public abstract class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEd
     {
     }
 
-    public override void OnLightLevelChanged(float lightLevel)
+    public override void OnLightLevelChanged(float dayLightFraction)
     {
-        base.OnLightLevelChanged(lightLevel);
+        base.OnLightLevelChanged(dayLightFraction);
 
         var maxLightLevel = Editor.CurrentPatch.Biome.MaximumCompounds[sunlight].Ambient;
-        var minLightLevel = Editor.CurrentPatch.Biome.MinimumCompounds[sunlight].Ambient;
         var templateMaxLightLevel = Editor.CurrentPatch.GetCompoundAmount(sunlight, CompoundAmountType.Template);
 
         // We don't want the light level in other patches be changed to zero if this callback is called while
@@ -153,13 +152,11 @@ public abstract class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEd
             foreach (var patch in Editor.CurrentGame.GameWorld.Map.Patches.Values)
             {
                 var targetMaxLightLevel = patch.Biome.MaximumCompounds[sunlight].Ambient;
-                var targetMinLightLevel = patch.Biome.MinimumCompounds[sunlight].Ambient;
 
-                // Figure out the daylight in all patches relative to the player's current patch
-                var relativeLightLevel = (lightLevel - minLightLevel) / (maxLightLevel - minLightLevel) *
-                    (targetMaxLightLevel - targetMinLightLevel) + targetMinLightLevel;
-
-                var lightLevelAmount = new BiomeCompoundProperties { Ambient = relativeLightLevel };
+                var lightLevelAmount = new BiomeCompoundProperties
+                {
+                    Ambient = targetMaxLightLevel * dayLightFraction,
+                };
 
                 patch.Biome.CurrentCompoundAmounts[sunlight] = lightLevelAmount;
             }

--- a/src/society_stage/SocietyStage.cs
+++ b/src/society_stage/SocietyStage.cs
@@ -220,6 +220,10 @@ public class SocietyStage : StrategyStageBase, ISocietyStructureDataAccess, IStr
         // TODO: once possible to lose, show in the GUI
     }
 
+    protected override void OnLightLevelUpdate()
+    {
+    }
+
     protected override void AutoSave()
     {
         SaveHelper.ShowErrorAboutPrototypeSaving(this);


### PR DESCRIPTION
Fixing slightly flawed approach in #4276.

Moved `DayNightCycle` instance out of `CreatureStageBase` higher to `GameWorld` so that it's accessible to more logic that needs it. Also refactored some TODO comments regarding updating average sunlight in patches.

Editor light level is now changed to be a daylight fraction instead. This is to make it easier to apply the correct editor-specific time of day to all patches in the patch map.

DRAFT because old save needs to be loaded correctly.

**Brief Description of What This PR Does**

Fixes #4286.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
