### PR TITLE
Fix resolution label update

### DIFF
--- a/src/general/OptionsMenu.cs
+++ b/src/general/OptionsMenu.cs
@@ -488,6 +488,8 @@ public class OptionsMenu : ControlWithInput
 
         deadzoneConfigurationPopup.OnDeadzonesConfirmed += OnDeadzoneConfigurationChanged;
 
+        GetViewport().Connect("size_changed", this, nameof(DisplayResolution));
+
         selectedOptionsTab = OptionsTab.Graphics;
     }
 
@@ -543,7 +545,6 @@ public class OptionsMenu : ControlWithInput
         gpuName = GetNode<Label>(GpuNamePath);
         usedRendererName = GetNode<Label>(UsedRendererNamePath);
         videoMemory = GetNode<Label>(VideoMemoryPath);
-        GetViewport().Connect("size_changed", this, nameof(DisplayResolution));
 
         // Sound
         soundTab = GetNode<Control>(SoundTabPath);

--- a/src/general/OptionsMenu.cs
+++ b/src/general/OptionsMenu.cs
@@ -509,6 +509,7 @@ public class OptionsMenu : ControlWithInput
         gpuName = GetNode<Label>(GpuNamePath);
         usedRendererName = GetNode<Label>(UsedRendererNamePath);
         videoMemory = GetNode<Label>(VideoMemoryPath);
+        GetViewport().Connect("size_changed", this, nameof(DisplayResolution));
 
         // Sound
         soundTab = GetNode<Control>(SoundTabPath);
@@ -615,10 +616,6 @@ public class OptionsMenu : ControlWithInput
             UpdateDefaultAudioOutputDeviceText();
             DisplayResolution();
             DisplayGpuInfo();
-        }
-        else if (what == NotificationResized)
-        {
-            DisplayResolution();
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes a bug where resolution isn't updated. The issue was caused by using NotificationResized notification that gets called only when the node changes its size which doesn't happen when viewport size changes while maintaining same aspect ratio.
So instead I have used a signal from viewport to react to the change properly.

**Related Issues**

fixes #4061 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
