### PR TITLE
Replaced the compound cloud noise image with a much higher resolution

### DIFF
--- a/assets/textures/PerlinNoise.jpg
+++ b/assets/textures/PerlinNoise.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81be9b1d624c7cc52309334b0abf6a22aaea6f853b32ddf1776d343be520e3b8
-size 410292
+oid sha256:118abca04d0cb19a7f903ab32b80f6cf1827f44b9af2fe57b73815e0c623ab58
+size 4566228

--- a/shaders/CompoundCloudPlane.shader
+++ b/shaders/CompoundCloudPlane.shader
@@ -16,7 +16,7 @@ uniform float BrightnessMultiplier = 1.0f;
 uniform float CloudAlpha = 0.7f;
 
 // Setting this too low makes the clouds invisible
-const float CLOUD_DISSIPATION = 0.9f;
+const float CLOUD_DISSIPATION = 0.70f;
 
 const float DENSITY_MULTIPLIER = 0.95f;
 
@@ -25,11 +25,7 @@ const float CLOUD_MAX_INTENSITY_SHOWN = 1000.f;
 
 // This needs to be less than 0.5 otherwise large cloud areas (due to the noise texture 
 // not being very high resolution) are invisible
-const float NOISE_ZERO_OFFSET = 0.35f;
-
-// Needs to match the value in CompoundCloudPlane.cs
-// TODO: implement this or increase the perlin noise texture size to give the clouds more detail
-const float NOISE_UV_SCALE = 2.5f;
+const float NOISE_ZERO_OFFSET = 0.001f;
 
 float getIntensity(float value){
     return min(DENSITY_MULTIPLIER * atan(0.006f * CLOUD_MAX_INTENSITY_SHOWN * value), 1.0f) * BrightnessMultiplier;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -108,9 +108,6 @@ public static class Constants
     // Should be the same as its counterpart in shaders/CompoundCloudPlane.shader
     public const float CLOUD_MAX_INTENSITY_SHOWN = 1000;
 
-    // Should be the same as its counterpart in shaders/CompoundCloudPlane.shader
-    public const float CLOUD_NOISE_UV_OFFSET_MULTIPLIER = 2.5f;
-
     public const float CLOUD_CHEAT_DENSITY = 16000.0f;
 
     public const int MEMBRANE_RESOLUTION = 10;


### PR DESCRIPTION
**Brief Description of What This PR Does**

this improves the visuals of the clouds

further tweaks to the shader values welcome, I tried to adjust them accordingly for the new texture.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes  #2286

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
