### PR TITLE
Made editor compound balance assume ATP equilibrium

### DIFF
--- a/src/microbe_stage/IProcessDisplayInfo.cs
+++ b/src/microbe_stage/IProcessDisplayInfo.cs
@@ -35,7 +35,7 @@ public interface IProcessDisplayInfo : IEquatable<IProcessDisplayInfo>
     /// <summary>
     ///   All of the output compounds
     /// </summary>
-    public IEnumerable<KeyValuePair<Compound, float>> Outputs { get; }
+    public IReadOnlyDictionary<Compound, float> Outputs { get; }
 
     /// <summary>
     ///   The current speed of the process (if known)

--- a/src/microbe_stage/ProcessSpeedInformation.cs
+++ b/src/microbe_stage/ProcessSpeedInformation.cs
@@ -36,7 +36,7 @@ public class ProcessSpeedInformation : IProcessDisplayInfo
     public IReadOnlyDictionary<Compound, float> FullSpeedRequiredEnvironmentalInputs =>
         WritableFullSpeedRequiredEnvironmentalInputs;
 
-    public IEnumerable<KeyValuePair<Compound, float>> Outputs => WritableOutputs;
+    public IReadOnlyDictionary<Compound, float> Outputs => WritableOutputs;
 
     public float CurrentSpeed { get; set; }
 

--- a/src/microbe_stage/ProcessStatistics.cs
+++ b/src/microbe_stage/ProcessStatistics.cs
@@ -96,7 +96,7 @@ public class SingleProcessStatistics : IProcessDisplayInfo
             .Where(p => p.Key.IsEnvironmental)
             .ToDictionary(p => p.Key, p => p.Value);
 
-    public IEnumerable<KeyValuePair<Compound, float>> Outputs =>
+    public IReadOnlyDictionary<Compound, float> Outputs =>
         LatestSnapshot?.Outputs ?? throw new InvalidOperationException("No snapshot set");
 
     public float CurrentSpeed
@@ -342,7 +342,7 @@ public class AverageProcessStatistics : IProcessDisplayInfo
     public IReadOnlyDictionary<Compound, float> FullSpeedRequiredEnvironmentalInputs =>
         owner.FullSpeedRequiredEnvironmentalInputs;
 
-    public IEnumerable<KeyValuePair<Compound, float>> Outputs => WritableOutputs;
+    public IReadOnlyDictionary<Compound, float> Outputs => WritableOutputs;
     public float CurrentSpeed { get; set; }
     public IReadOnlyList<Compound> LimitingCompounds => WritableLimitingCompounds;
 

--- a/src/microbe_stage/ProcessSystem.cs
+++ b/src/microbe_stage/ProcessSystem.cs
@@ -167,7 +167,7 @@ public class ProcessSystem
     /// </summary>
     /// <remarks>
     ///   <para>
-    ///     Ignores how much ATP the cell needs
+    ///     Assumes that all processes run at maximum speed
     ///   </para>
     /// </remarks>
     public static Dictionary<Compound, CompoundBalance> ComputeCompoundBalance(

--- a/src/microbe_stage/ProcessSystem.cs
+++ b/src/microbe_stage/ProcessSystem.cs
@@ -165,6 +165,11 @@ public class ProcessSystem
     ///   Computes the compound balances for given organelle list in a patch and at a given time during the day (or
     ///   using longer timespan values)
     /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     Ignores how much ATP the cell needs
+    ///   </para>
+    /// </remarks>
     public static Dictionary<Compound, CompoundBalance> ComputeCompoundBalance(
         IEnumerable<OrganelleDefinition> organelles, BiomeConditions biome, CompoundAmountType amountType)
     {
@@ -205,6 +210,77 @@ public class ProcessSystem
         IEnumerable<OrganelleTemplate> organelles, BiomeConditions biome, CompoundAmountType amountType)
     {
         return ComputeCompoundBalance(organelles.Select(o => o.Definition), biome, amountType);
+    }
+
+    /// <summary>
+    ///   Computes the compound balances for given organelle list in a patch and at a given time during the day (or
+    ///   using longer timespan values)
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     Assumes that the cell produces at most as much ATP as it consumes
+    ///   </para>
+    /// </remarks>
+    public static Dictionary<Compound, CompoundBalance> ComputeCompoundBalanceAtEquilibrium(
+        IEnumerable<OrganelleTemplate> organelles, BiomeConditions biome, CompoundAmountType amountType,
+        EnergyBalanceInfo energyBalance)
+    {
+        var result = new Dictionary<Compound, CompoundBalance>();
+
+        void MakeSureResultExists(Compound compound)
+        {
+            if (!result.ContainsKey(compound))
+            {
+                result[compound] = new CompoundBalance();
+            }
+        }
+
+        float consumptionProductionRatio = energyBalance.TotalConsumption / energyBalance.TotalProduction;
+        bool useRatio;
+
+        foreach (var organelle in organelles)
+        {
+            foreach (var process in organelle.Definition.RunnableProcesses)
+            {
+                var speedAdjusted = CalculateProcessMaximumSpeed(process, biome, amountType);
+
+                useRatio = false;
+
+                // If the cell produces more ATP than it needs, its ATP producing processes need to be toned down
+                if (speedAdjusted.Outputs.Select(o => o.Key).Contains(ATP) && consumptionProductionRatio < 1.0f)
+                    useRatio = true;
+
+                foreach (var input in speedAdjusted.Inputs)
+                {
+                    if (input.Key == ATP)
+                        continue;
+
+                    float amount = input.Value;
+
+                    if (useRatio)
+                        amount *= consumptionProductionRatio;
+
+                    MakeSureResultExists(input.Key);
+                    result[input.Key].AddConsumption(organelle.Definition.InternalName, amount);
+                }
+
+                foreach (var output in speedAdjusted.Outputs)
+                {
+                    if (output.Key == ATP)
+                        continue;
+
+                    float amount = output.Value;
+
+                    if (useRatio)
+                        amount *= consumptionProductionRatio;
+
+                    MakeSureResultExists(output.Key);
+                    result[output.Key].AddProduction(organelle.Definition.InternalName, amount);
+                }
+            }
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/src/microbe_stage/ProcessSystem.cs
+++ b/src/microbe_stage/ProcessSystem.cs
@@ -222,7 +222,7 @@ public class ProcessSystem
     ///   </para>
     /// </remarks>
     public static Dictionary<Compound, CompoundBalance> ComputeCompoundBalanceAtEquilibrium(
-        IEnumerable<OrganelleTemplate> organelles, BiomeConditions biome, CompoundAmountType amountType,
+        IEnumerable<OrganelleDefinition> organelles, BiomeConditions biome, CompoundAmountType amountType,
         EnergyBalanceInfo energyBalance)
     {
         var result = new Dictionary<Compound, CompoundBalance>();
@@ -240,7 +240,7 @@ public class ProcessSystem
 
         foreach (var organelle in organelles)
         {
-            foreach (var process in organelle.Definition.RunnableProcesses)
+            foreach (var process in organelle.RunnableProcesses)
             {
                 var speedAdjusted = CalculateProcessMaximumSpeed(process, biome, amountType);
 
@@ -261,7 +261,7 @@ public class ProcessSystem
                         amount *= consumptionProductionRatio;
 
                     MakeSureResultExists(input.Key);
-                    result[input.Key].AddConsumption(organelle.Definition.InternalName, amount);
+                    result[input.Key].AddConsumption(organelle.InternalName, amount);
                 }
 
                 foreach (var output in speedAdjusted.Outputs)
@@ -275,12 +275,20 @@ public class ProcessSystem
                         amount *= consumptionProductionRatio;
 
                     MakeSureResultExists(output.Key);
-                    result[output.Key].AddProduction(organelle.Definition.InternalName, amount);
+                    result[output.Key].AddProduction(organelle.InternalName, amount);
                 }
             }
         }
 
         return result;
+    }
+
+    public static Dictionary<Compound, CompoundBalance> ComputeCompoundBalanceAtEquilibrium(
+        IEnumerable<OrganelleTemplate> organelles, BiomeConditions biome, CompoundAmountType amountType,
+        EnergyBalanceInfo energyBalance)
+    {
+        return ComputeCompoundBalanceAtEquilibrium(organelles.Select(o => o.Definition), biome, amountType,
+            energyBalance);
     }
 
     /// <summary>

--- a/src/microbe_stage/ProcessSystem.cs
+++ b/src/microbe_stage/ProcessSystem.cs
@@ -247,7 +247,7 @@ public class ProcessSystem
                 useRatio = false;
 
                 // If the cell produces more ATP than it needs, its ATP producing processes need to be toned down
-                if (speedAdjusted.Outputs.Select(o => o.Key).Contains(ATP) && consumptionProductionRatio < 1.0f)
+                if (speedAdjusted.Outputs.ContainsKey(ATP) && consumptionProductionRatio < 1.0f)
                     useRatio = true;
 
                 foreach (var input in speedAdjusted.Inputs)

--- a/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
@@ -206,7 +206,7 @@ public partial class CellEditorComponent
         UpdateMembraneButtons(Membrane.InternalName);
         UpdateSpeed(CalculateSpeed());
         UpdateHitpoints(CalculateHitpoints());
-        CalculateEnergyBalanceWithOrganellesAndMembraneType(editedMicrobeOrganelles.Organelles, Membrane);
+        CalculateEnergyAndCompoundBalance(editedMicrobeOrganelles.Organelles, Membrane);
         SetMembraneTooltips(Membrane);
 
         StartAutoEvoPrediction();
@@ -227,7 +227,7 @@ public partial class CellEditorComponent
         UpdateMembraneButtons(Membrane.InternalName);
         UpdateSpeed(CalculateSpeed());
         UpdateHitpoints(CalculateHitpoints());
-        CalculateEnergyBalanceWithOrganellesAndMembraneType(editedMicrobeOrganelles.Organelles, Membrane);
+        CalculateEnergyAndCompoundBalance(editedMicrobeOrganelles.Organelles, Membrane);
         SetMembraneTooltips(Membrane);
 
         StartAutoEvoPrediction();

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -892,10 +892,8 @@ public partial class CellEditorComponent :
         topPanel.Visible = Editor.CurrentGame.GameWorld.WorldSettings.DayNightCycleEnabled &&
             Editor.CurrentPatch.GetCompoundAmount("sunlight", CompoundAmountType.Maximum) > 0.0f;
 
-        // Calculate and send energy balance to the GUI
-        CalculateEnergyBalanceWithOrganellesAndMembraneType(editedMicrobeOrganelles.Organelles, Membrane);
-
-        CalculateCompoundBalanceInPatch(editedMicrobeOrganelles.Organelles);
+        // Calculate and send energy balance and compound balance to the GUI
+        CalculateEnergyAndCompoundBalance(editedMicrobeOrganelles.Organelles, Membrane);
     }
 
     /// <summary>
@@ -1555,25 +1553,20 @@ public partial class CellEditorComponent :
     }
 
     /// <summary>
-    ///   Calculates the energy balance for a cell with the given organelles
+    ///   Calculates the energy balance and compound balance for a cell with the given organelles and membrane
     /// </summary>
-    private void CalculateEnergyBalanceWithOrganellesAndMembraneType(IReadOnlyCollection<OrganelleTemplate> organelles,
+    private void CalculateEnergyAndCompoundBalance(IReadOnlyCollection<OrganelleTemplate> organelles,
         MembraneType membrane, BiomeConditions? biome = null)
     {
         biome ??= Editor.CurrentPatch.Biome;
 
-        UpdateEnergyBalance(ProcessSystem.ComputeEnergyBalance(organelles, biome, membrane, true,
-            Editor.CurrentGame.GameWorld.WorldSettings, CompoundAmountType.Current));
-    }
+        var energyBalance = ProcessSystem.ComputeEnergyBalance(organelles, biome, membrane, true,
+            Editor.CurrentGame.GameWorld.WorldSettings, CompoundAmountType.Current);
 
-    private void CalculateCompoundBalanceInPatch(IReadOnlyCollection<OrganelleTemplate> organelles,
-        BiomeConditions? biome = null)
-    {
-        biome ??= Editor.CurrentPatch.Biome;
+        UpdateEnergyBalance(energyBalance);
 
-        var result = ProcessSystem.ComputeCompoundBalance(organelles, biome, CompoundAmountType.Current);
-
-        UpdateCompoundBalances(result);
+        UpdateCompoundBalances(ProcessSystem.ComputeCompoundBalanceAtEquilibrium(organelles, biome,
+            CompoundAmountType.Current, energyBalance));
     }
 
     /// <summary>


### PR DESCRIPTION
**Brief Description of What This PR Does**

This adds a new method that calculates compound balance assuming that the cell will produce at most as much ATP as it consumes. The editor uses the new method.

Notes:
-	All in-game text is kept the same, so this assumes that players will find this change intuitive.
-	Initial compounds still use the old method for compound balance. Changing them to use the new one might make sense.
-	I’m not sure, but this might be slightly different from true compound balance during gameplay if e.g. process ordering and storage capacity make different processes happen at different speeds.
-	The code of the new method `CalculateCompoundBalanceAtEquilibrium` is very similar to the old method `CalculateCompoundBalance`. If wanted, the old method could be removed, or the methods or their parts could be merged into a single method.
-	This method should be pretty simple to adapt to use different presets like not moving or lacking certain compounds. Could be useful for #2068 in the future.
-	This doesn’t show ATP. If it did, it would show either 0 or a negative value. I think it’s probably unnecessary to show ATP since the ATP balance bar exists.
-	If you consume more ATP than you produce, the method treats that as you being at equilibrium. This means that ATP consuming processes (like producing toxins) are always considered to run at full speed.


**Related Issues**

Closes [#2069](https://github.com/Revolutionary-Games/Thrive/issues/2069)
<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
