### PR TITLE
Some emergency partial prototypes quick fix

### DIFF
--- a/src/awakening_stage/gui/InteractablePopup.tscn
+++ b/src/awakening_stage/gui/InteractablePopup.tscn
@@ -19,7 +19,7 @@ InteractionButtonFont = ExtResource( 3 )
 [node name="CustomDialog" parent="." instance=ExtResource( 1 )]
 margin_right = 0.0
 margin_bottom = 0.0
-popup_exclusive = true
+Exclusive = true
 Resizable = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="CustomDialog"]

--- a/src/awakening_stage/gui/InventoryScreen.tscn
+++ b/src/awakening_stage/gui/InventoryScreen.tscn
@@ -293,12 +293,12 @@ text = "CRAFTING_TAKE_ALL"
 anims/Flash = SubResource( 1 )
 anims/RESET = SubResource( 2 )
 
-[connection signal="Closed" from="GroundPanel" to="." method="OnGroundPanelClosed"]
+[connection signal="Cancelled" from="GroundPanel" to="." method="OnGroundPanelClosed"]
 [connection signal="Closed" from="MainInventory" to="." method="OnInventoryPanelClosed"]
 [connection signal="resized" from="MainInventory/BaseInventoryContainer/VBoxContainer/EquipmentSlots" to="." method="UpdateEquipmentSlotPositions"]
 [connection signal="toggled" from="MainInventory/BaseInventoryContainer/VBoxContainer/HBoxContainer/Ground" to="." method="ToggleGroundPanel"]
 [connection signal="toggled" from="MainInventory/BaseInventoryContainer/VBoxContainer/HBoxContainer/Crafting" to="." method="ToggleCraftingPanel"]
-[connection signal="Closed" from="CraftingPanel" to="." method="OnCraftingPanelClosed"]
+[connection signal="Cancelled" from="CraftingPanel" to="." method="OnCraftingPanelClosed"]
 [connection signal="pressed" from="CraftingPanel/VBoxContainer/CraftingItemsSection/LeftSide/ClearInputs" to="." method="ClearCraftingInputs"]
 [connection signal="pressed" from="CraftingPanel/VBoxContainer/CraftingItemsSection/CraftButton" to="." method="TryToCraft"]
 [connection signal="pressed" from="CraftingPanel/VBoxContainer/CraftingItemsSection/RightSide/Take" to="." method="TakeAllCraftingResults"]

--- a/src/awakening_stage/gui/SelectBuildingPopup.tscn
+++ b/src/awakening_stage/gui/SelectBuildingPopup.tscn
@@ -16,7 +16,7 @@ CancelButtonPath = NodePath("CustomDialog/VBoxContainer/Cancel")
 [node name="CustomDialog" parent="." instance=ExtResource( 1 )]
 margin_right = 0.0
 margin_bottom = 0.0
-popup_exclusive = true
+Exclusive = true
 WindowTitle = "SELECT_STRUCTURE_POPUP_TITLE"
 Resizable = true
 

--- a/src/late_multicellular_stage/MulticellularCamera.tscn
+++ b/src/late_multicellular_stage/MulticellularCamera.tscn
@@ -10,6 +10,7 @@ __meta__ = {
 "_editor_description_": "Base rotation of the camera
 "
 }
+Current = true
 
 [node name="CameraPosition" type="Spatial" parent="."]
 __meta__ = {


### PR DESCRIPTION
**Brief Description of What This PR Does**

This at least gets the prototypes somewhat working but apparently the interaction and structure selection popup focus is completely broken right now. Likely related to: https://github.com/Revolutionary-Games/Thrive/pull/4284

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
prototypes being inaccessible due to at least awakening prototype (probably aware as well), being totally broken.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
