### PR TITLE
Hotfix for modal windows not able to grab focus

### DIFF
--- a/src/gui_common/ModalManager.cs
+++ b/src/gui_common/ModalManager.cs
@@ -151,6 +151,13 @@ public class ModalManager : NodeWithInput
 
         foreach (var modal in modalStack)
         {
+            // The user expects all modal in the stack to be visible (see `MakeModal` documentation).
+            if (!modal.Visible)
+            {
+                modal.Open();
+                modal.Notification(Popup.NotificationPostPopup);
+            }
+
             if (modal != top)
             {
                 modal.ReParent(canvasLayer);
@@ -162,13 +169,6 @@ public class ModalManager : NodeWithInput
 
                 // Always give focus to the top-most modal in the stack
                 top.FindNextValidFocus()?.GrabFocus();
-            }
-
-            // The user expects all modal in the stack to be visible (see `MakeModal` documentation).
-            if (!modal.Visible)
-            {
-                modal.Open();
-                modal.Notification(Popup.NotificationPostPopup);
             }
         }
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Modals must be shown first before they can grab any focus. This is just a simple reordering of logic in the code.

Related to #4299.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
