### PR TITLE
Fix hotfix for modal windows not able to grab focus

### DIFF
--- a/src/gui_common/ModalManager.cs
+++ b/src/gui_common/ModalManager.cs
@@ -151,23 +151,32 @@ public class ModalManager : NodeWithInput
 
         foreach (var modal in modalStack)
         {
-            // The user expects all modal in the stack to be visible (see `MakeModal` documentation).
-            // For unexplained reasons this has to be at the top of this loop for focus to work in the popups.
-            // So don't move this code anywhere else without a ton of testing verifying things still work.
-            if (!modal.Visible)
-            {
-                modal.Open();
-                modal.Notification(Popup.NotificationPostPopup);
-            }
-
             if (modal != top)
             {
                 modal.ReParent(canvasLayer);
                 canvasLayer.MoveChild(modal, 0);
+
+                // The user expects all modal in the stack to be visible (see `MakeModal` documentation).
+                // For unexplained reasons this has to be at the top of this loop for focus to work in the popups.
+                // So don't move this code anywhere else without a ton of testing verifying things still work.
+                if (!modal.Visible)
+                {
+                    modal.Open();
+                    modal.Notification(Popup.NotificationPostPopup);
+                }
             }
             else
             {
                 top.ReParent(activeModalContainer);
+
+                // The user expects all modal in the stack to be visible (see `MakeModal` documentation).
+                // For unexplained reasons this has to be at the top of this loop for focus to work in the popups.
+                // So don't move this code anywhere else without a ton of testing verifying things still work.
+                if (!modal.Visible)
+                {
+                    modal.Open();
+                    modal.Notification(Popup.NotificationPostPopup);
+                }
 
                 // Always give focus to the top-most modal in the stack
                 // We use our custom method here to prefer to not give focus to nodes that are in disabled state


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes a newly created issue caused by #4300 where a tutorial pop-up didn't even show up. This fix should fix the new issue while not breaking the old issue again. This PR is tested, but not fully so further testing is needed.

Also I didn't update the code comments yet and I have a duplicate code here.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
