### PR TITLE
Fixed tutorial not working at all, made modal top focus grab happen once

### DIFF
--- a/src/gui_common/ModalManager.cs
+++ b/src/gui_common/ModalManager.cs
@@ -23,6 +23,8 @@ public class ModalManager : NodeWithInput
 #pragma warning disable CA2213 // Disposable fields should be disposed
     private CanvasLayer canvasLayer = null!;
     private Control activeModalContainer = null!;
+
+    private CustomWindow? topMostWindowGivenFocus;
 #pragma warning restore CA2213 // Disposable fields should be disposed
 
     private bool modalsDirty = true;
@@ -142,6 +144,7 @@ public class ModalManager : NodeWithInput
         if (modalStack.Count <= 0)
         {
             activeModalContainer.Hide();
+            topMostWindowGivenFocus = null;
             return;
         }
 
@@ -151,15 +154,6 @@ public class ModalManager : NodeWithInput
 
         foreach (var modal in modalStack)
         {
-            // The user expects all modal in the stack to be visible (see `MakeModal` documentation).
-            // For unexplained reasons this has to be at the top of this loop for focus to work in the popups.
-            // So don't move this code anywhere else without a ton of testing verifying things still work.
-            if (!modal.Visible)
-            {
-                modal.Open();
-                modal.Notification(Popup.NotificationPostPopup);
-            }
-
             if (modal != top)
             {
                 modal.ReParent(canvasLayer);
@@ -168,11 +162,25 @@ public class ModalManager : NodeWithInput
             else
             {
                 top.ReParent(activeModalContainer);
-
-                // Always give focus to the top-most modal in the stack
-                // We use our custom method here to prefer to not give focus to nodes that are in disabled state
-                top.FirstFocusableControl()?.GrabFocus();
             }
+
+            // The user expects all modal in the stack to be visible (see `MakeModal` documentation).
+            // For unexplained reasons this has to be after the re-parenting operation for focus to work in the popups.
+            // So don't move this code anywhere else without a ton of testing verifying things still work.
+            if (!modal.Visible)
+            {
+                modal.Open();
+                modal.Notification(Popup.NotificationPostPopup);
+            }
+        }
+
+        // Always give focus to the top-most modal in the stack (unless we already did so to avoid overriding focus
+        // after the user has had a chance to change the focus in the modal)
+        if (topMostWindowGivenFocus != top)
+        {
+            // We use our custom method here to prefer to not give focus to nodes that are in a disabled state
+            top.FirstFocusableControl()?.GrabFocus();
+            topMostWindowGivenFocus = top;
         }
     }
 


### PR DESCRIPTION
to avoid overriding manual focus changed by the player

**Brief Description of What This PR Does**

Cleaned up version of https://github.com/Revolutionary-Games/Thrive/pull/4304

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #4304 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
