### PR TITLE
Switched initial microbe compounds to only account consumption

### DIFF
--- a/Thrive.sln.DotSettings
+++ b/Thrive.sln.DotSettings
@@ -642,6 +642,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=phagosome/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=phagosomes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Photographable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=photosynthesizers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pili/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pilus/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=playthrough/@EntryIndexedValue">True</s:Boolean>

--- a/src/microbe_stage/MicrobeSpecies.cs
+++ b/src/microbe_stage/MicrobeSpecies.cs
@@ -106,11 +106,15 @@ public class MicrobeSpecies : Species, ICellProperties, IPhotographable
     {
         // Since the initial compounds are only set once per species they can't be calculated for each Biome.
         // So, the compound balance calculation uses the default biome.
+        // Also we should not overtly punish photosynthesizers so we just use the consumption here (instead of
+        // balance where the generated glucose would offset things and spawn photosynthesizers with no glucose,
+        // which could basically make them die instantly in certain situations)
         var biomeConditions = SimulationParameters.Instance.GetBiome("default").Conditions;
         var compoundBalances = ProcessSystem.ComputeCompoundBalance(Organelles,
             biomeConditions, CompoundAmountType.Biome);
 
         var glucose = SimulationParameters.Instance.GetCompound("glucose");
+        var atp = SimulationParameters.Instance.GetCompound("atp");
         bool giveBonusGlucose = Organelles.Count <= Constants.FULL_INITIAL_GLUCOSE_SMALL_SIZE_LIMIT && IsBacteria;
 
         var cachedCapacity = StorageCapacity;
@@ -119,17 +123,26 @@ public class MicrobeSpecies : Species, ICellProperties, IPhotographable
 
         foreach (var compoundBalance in compoundBalances)
         {
+            // Skip ATP as it we don't want to give any initial ATP
+            if (compoundBalance.Key == atp)
+                continue;
+
             if (compoundBalance.Key == glucose && giveBonusGlucose)
             {
                 InitialCompounds.Add(compoundBalance.Key, cachedCapacity);
                 continue;
             }
 
-            if (compoundBalance.Value.Balance >= 0)
+            var balanceValue = compoundBalance.Value;
+
+            // Skip compounds there's no consumption for (from processes)
+            if (balanceValue.Consumption.Count < 1)
                 continue;
 
-            // Initial compounds should suffice for a fixed amount of time.
-            var compoundInitialAmount = Math.Abs(compoundBalance.Value.Balance) * Constants.INITIAL_COMPOUND_TIME;
+            // Initial compounds should suffice for a fixed amount of time of consumption.
+            var compoundInitialAmount =
+                Math.Abs(balanceValue.Consumption.SumValues()) * Constants.INITIAL_COMPOUND_TIME;
+
             if (compoundInitialAmount > cachedCapacity)
                 compoundInitialAmount = cachedCapacity;
 


### PR DESCRIPTION
instead of using the balance as that ended up with photosynthesizers not spawning with any stored glucose, which was bad in quite many situations

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #4313

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
