### PR TITLE
Made 3D menu backgrounds not render during videos

### DIFF
--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -496,13 +496,6 @@ public class MainMenu : NodeWithInput
 
     private void SetBackgroundScene(string path)
     {
-        background.Visible = false;
-        if (created3DBackground != null)
-        {
-            created3DBackground.DetachAndQueueFree();
-            created3DBackground = null;
-        }
-
         var backgroundScene = GD.Load<PackedScene>(path);
 
         if (backgroundScene == null)
@@ -515,6 +508,14 @@ public class MainMenu : NodeWithInput
         // lag spike when loading the main menu
         Invoke.Instance.Queue(() =>
         {
+            // These are done here to ensure there isn't a weird single frame with a grey menu background
+            background.Visible = false;
+            if (created3DBackground != null)
+            {
+                created3DBackground.DetachAndQueueFree();
+                created3DBackground = null;
+            }
+
             created3DBackground = backgroundScene.Instance<Spatial>();
             AddChild(created3DBackground);
         });

--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -442,8 +442,6 @@ public class MainMenu : NodeWithInput
         // Set initial menu
         SwitchMenu();
 
-        RandomizeBackground();
-
         // Easter egg message
         thriveLogo.RegisterToolTipForControl("thriveLogoEasterEgg", "mainMenu");
 
@@ -652,6 +650,10 @@ public class MainMenu : NodeWithInput
         StartMusic();
 
         introVideoPassed = true;
+
+        // Load the menu background only here as the 3D ones are performance intensive so they aren't very nice to
+        // consume power unnecessarily while showing the video
+        RandomizeBackground();
     }
 
     private void CheckStartupSuccess()

--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -991,4 +991,13 @@ public class MainMenu : NodeWithInput
         TransitionManager.Instance.AddSequence(ScreenFade.FadeType.FadeOut, 0.1f,
             () => { SceneManager.Instance.SwitchToScene("res://src/benchmark/microbe/MicrobeBenchmark.tscn"); }, false);
     }
+
+    private void OnNewGameIntroVideoStarted()
+    {
+        if (created3DBackground != null)
+        {
+            // Hide the background again when playing a video as the 3D backgrounds are performance intensive
+            created3DBackground.Visible = false;
+        }
+    }
 }

--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -102,7 +102,7 @@ public class MainMenu : NodeWithInput
 
 #pragma warning disable CA2213
     private TextureRect background = null!;
-    private Node? created3DBackground;
+    private Spatial? created3DBackground;
 
     private TextureRect thriveLogo = null!;
     private OptionsMenu options = null!;
@@ -517,7 +517,7 @@ public class MainMenu : NodeWithInput
         // lag spike when loading the main menu
         Invoke.Instance.Queue(() =>
         {
-            created3DBackground = backgroundScene.Instance();
+            created3DBackground = backgroundScene.Instance<Spatial>();
             AddChild(created3DBackground);
         });
     }
@@ -931,12 +931,24 @@ public class MainMenu : NodeWithInput
         SetCurrentMenu(uint.MaxValue, false);
         galleryViewer.OpenFullRect();
         Jukebox.Instance.PlayCategory("ArtGallery");
+
+        if (created3DBackground != null)
+        {
+            // Hide the 3D background while in the gallery as it is a fullscreen popup and rendering the expensive 3D
+            // scene underneath it is not the best
+            created3DBackground.Visible = false;
+        }
     }
 
     private void OnReturnFromArtGallery()
     {
         SetCurrentMenu(2, false);
         Jukebox.Instance.PlayCategory("Menu");
+
+        if (created3DBackground != null)
+        {
+            created3DBackground.Visible = true;
+        }
     }
 
     private void OnWebsitesButtonPressed()

--- a/src/general/MainMenu.tscn
+++ b/src/general/MainMenu.tscn
@@ -1040,6 +1040,7 @@ DialogText = "STEAM_INIT_FAILED_DESCRIPTION"
 [connection signal="OnOptionsClosed" from="OptionsMenu" to="." method="OnReturnFromOptions"]
 [connection signal="OnBackPressed" from="SaveManagerGUI" to="." method="OnReturnFromLoadGame"]
 [connection signal="OnNewGameSettingsClosed" from="NewGameSettings" to="." method="OnReturnFromNewGameSettings"]
+[connection signal="OnNewGameVideoStarted" from="NewGameSettings" to="." method="OnNewGameIntroVideoStarted"]
 [connection signal="OnWantToSwitchToOptionsMenu" from="NewGameSettings" to="." method="OnRedirectedToOptionsMenuFromNewGameSettings"]
 [connection signal="OnThriveopediaClosed" from="Thriveopedia" to="." method="OnReturnFromThriveopedia"]
 [connection signal="hide" from="LicensesDisplay" to="." method="OnReturnFromLicenses"]


### PR DESCRIPTION
**Brief Description of What This PR Does**
As the backgrounds are intensive it makes sense to save on processing power by not displaying them when they can't be seen

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #4290
closes #4289

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
