### PR TITLE
Fixed art gallery causing tooltip retrieve errors and not unregistering them

### DIFF
--- a/src/gui_common/tooltip/ToolTipManager.cs
+++ b/src/gui_common/tooltip/ToolTipManager.cs
@@ -306,12 +306,38 @@ public class ToolTipManager : CanvasLayer
     }
 
     /// <summary>
+    ///   Tries to find a tooltip but doesn't consider it an error if one is not found. Useful when caching tooltips
+    ///   and checking if one already exists is needed.
+    /// </summary>
+    /// <param name="name">The name of the tooltip's node (not display name)</param>
+    /// <param name="group">The name of the group the tooltip belongs to</param>
+    public ICustomToolTip? GetToolTipIfExists(string name, string group = DEFAULT_GROUP_NAME)
+    {
+        var retrievedGroup = GetGroup(group, false);
+        if (retrievedGroup == null)
+            return null;
+
+        var tooltip = tooltips[retrievedGroup].Find(found => found.ToolTipNode.Name == name);
+
+        return tooltip;
+    }
+
+    /// <summary>
     ///   Generic version of <see cref="GetToolTip"/> method.
     /// </summary>
     public T? GetToolTip<T>(string name, string group = DEFAULT_GROUP_NAME)
         where T : ICustomToolTip
     {
         return (T?)GetToolTip(name, group);
+    }
+
+    /// <summary>
+    ///   Generic version of <see cref="GetToolTipIfExists"/> method.
+    /// </summary>
+    public T? GetToolTipIfExists<T>(string name, string group = DEFAULT_GROUP_NAME)
+        where T : ICustomToolTip
+    {
+        return (T?)GetToolTipIfExists(name, group);
     }
 
     /// <summary>


### PR DESCRIPTION
properly leading also to error prints

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
leftover problems from ome of the recent tooltip registering changes

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
