### PR TITLE
Prevent player accidentally becoming awakened when entering macroscopic

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -447,7 +447,16 @@ public class MicrobeStage : CreatureStageBase<Microbe>
 
         CurrentGame!.EnterPrototypes();
 
-        GameWorld.ChangeSpeciesToLateMulticellular(Player.Species);
+        var modifiedSpecies = GameWorld.ChangeSpeciesToLateMulticellular(Player.Species);
+
+        // Similar code as in the MetaballBodyEditorComponent to prevent the player automatically getting stuck
+        // underwater in the awakening stage
+        if (modifiedSpecies.MulticellularType == MulticellularSpeciesType.Awakened)
+        {
+            GD.Print("Preventing player from becoming awakened too soon");
+            modifiedSpecies.KeepPlayerInAwareStage();
+        }
+
         GameWorld.NotifySpeciesChangedStages();
 
         var scene = SceneManager.Instance.LoadScene(MainGameState.LateMulticellularEditor);


### PR DESCRIPTION
as that made them stuck underwater as a civ

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Problem was shown in a recent gameplay video: https://www.youtube.com/watch?v=wUNilQ31mBY&t=1s and after investigating I realized the cause

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
