### PR TITLE
Reversed so that the global tools json now doesn't have BOM

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,9 +1,9 @@
-﻿{
+{
   "version": 1,
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2023.1.1",
+      "version": "2023.1.2",
       "commands": [
         "jb"
       ]

--- a/Scripts/CodeChecks.cs
+++ b/Scripts/CodeChecks.cs
@@ -12,6 +12,8 @@ using ScriptsBase.Utilities;
 
 public class CodeChecks : CodeChecksBase<Program.CheckOptions>
 {
+    private static readonly string[] FilesNotAllowedToHaveBom = { "global.json", "dotnet-tools.json" };
+
     public CodeChecks(Program.CheckOptions opts,
         Func<LocalizationOptionsBase, CancellationToken, Task<bool>> runLocalizationTool) :
         base(opts)
@@ -23,9 +25,9 @@ public class CodeChecks : CodeChecksBase<Program.CheckOptions>
                 new FileChecks(true,
                     new BomChecker(BomChecker.Mode.Required, ".cs", ".json")
                     {
-                        IgnoredFiles = new List<string> { "global.json" },
+                        IgnoredFiles = new List<string>(FilesNotAllowedToHaveBom),
                     },
-                    new BomChecker(BomChecker.Mode.Disallowed, "global.json"),
+                    new BomChecker(BomChecker.Mode.Disallowed, FilesNotAllowedToHaveBom),
                     new CfgCheck(AssemblyInfoReader.ReadVersionFromAssemblyInfo()),
                     new DisallowedFileType(".gd", ".mo"))
             },


### PR DESCRIPTION
**Brief Description of What This PR Does**
Also updated the jetbrains tools. This is needed to make dependabot work better

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Example of how badly it goes: https://github.com/Revolutionary-Games/Thrive/pull/4364

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
