### PR TITLE
Window fixes

### DIFF
--- a/src/gui_common/AddWindowReorderingSupportToSiblings.cs
+++ b/src/gui_common/AddWindowReorderingSupportToSiblings.cs
@@ -84,7 +84,7 @@ public class AddWindowReorderingSupportToSiblings : Control
     /// <summary>
     ///   Used to save windows that ore opened at once to preserve their order.
     /// </summary>
-    private readonly List<CustomDialog> openedWindows = new();
+    private readonly List<CustomDialog> justOpenedWindows = new();
 
 #pragma warning disable CA2213
 
@@ -402,27 +402,27 @@ public class AddWindowReorderingSupportToSiblings : Control
     private void OnWindowOpen(CustomDialog window)
     {
         // Tell the system that there is an opened window and wait in case more windows will be opened at once.
-        if (openedWindows.Count == 0)
-            CallDeferred(nameof(ReorderOpenedWindows));
+        if (justOpenedWindows.Count == 0)
+            Invoke.Instance.QueueForObject(ReorderOpenedWindows, this);
 
-        openedWindows.Add(window);
+        justOpenedWindows.Add(window);
     }
 
     private void ReorderOpenedWindows()
     {
         // Sort the windows to make sure they are updated in the right order.
-        openedWindows.Sort(delegate(CustomDialog first, CustomDialog second)
+        justOpenedWindows.Sort((first, second) =>
         {
             return connectedWindows[first].GetIndex().CompareTo(connectedWindows[second].GetIndex());
         });
 
         // Reorder the windows.
-        foreach (CustomDialog window in openedWindows)
+        foreach (CustomDialog window in justOpenedWindows)
         {
             OnWindowReorder(window);
         }
 
-        openedWindows.Clear();
+        justOpenedWindows.Clear();
     }
 
     /// <summary>

--- a/src/gui_common/AddWindowReorderingSupportToSiblings.cs
+++ b/src/gui_common/AddWindowReorderingSupportToSiblings.cs
@@ -433,7 +433,7 @@ public class AddWindowReorderingSupportToSiblings : Control
         }
         catch (Exception e)
         {
-            GD.PrintErr(e);
+            GD.PrintErr($"Exception occurred in {Name} ({this}) in {nameof(ReorderOpenedWindows)}:\n{e}");
 
             // Remove invalid windows
             justOpenedWindows.RemoveAll(window => !IsInstanceValid(window) || !connectedWindows.ContainsKey(window));

--- a/src/gui_common/AddWindowReorderingSupportToSiblings.cs
+++ b/src/gui_common/AddWindowReorderingSupportToSiblings.cs
@@ -411,7 +411,7 @@ public class AddWindowReorderingSupportToSiblings : Control
     private void ReorderOpenedWindows()
     {
         // Sort the windows to make sure they are updated in the right order.
-        openedWindows.Sort(delegate (CustomDialog first, CustomDialog second)
+        openedWindows.Sort(delegate(CustomDialog first, CustomDialog second)
         {
             return connectedWindows[first].GetIndex().CompareTo(connectedWindows[second].GetIndex());
         });

--- a/src/gui_common/AddWindowReorderingSupportToSiblings.cs
+++ b/src/gui_common/AddWindowReorderingSupportToSiblings.cs
@@ -431,15 +431,12 @@ public class AddWindowReorderingSupportToSiblings : Control
                 return connectedWindows[first].GetIndex().CompareTo(connectedWindows[second].GetIndex());
             });
         }
-        catch (InvalidOperationException)
+        catch (Exception e)
         {
-            int oldCount = justOpenedWindows.Count;
+            GD.PrintErr(e);
 
             // Remove invalid windows
-            justOpenedWindows.RemoveAll(window => !IsInstanceValid(window));
-
-            GD.PrintErr($"{Name} ({this}) attempted to reorder a window that was destroyed" +
-                $" ({oldCount - justOpenedWindows.Count}x)");
+            justOpenedWindows.RemoveAll(window => !IsInstanceValid(window) || !connectedWindows.ContainsKey(window));
         }
 
         // Reorder the windows

--- a/src/gui_common/dialogs/CustomDialog.cs
+++ b/src/gui_common/dialogs/CustomDialog.cs
@@ -318,6 +318,8 @@ public class CustomDialog : CustomWindow
         var closeButtonRect = closeButton!.GetRect();
 
         // Draw close button
+        // We render this in a custom way because rendering it in a child node causes a bug where render order
+        // breaks in some cases: https://github.com/Revolutionary-Games/Thrive/issues/4365
         DrawTextureRect(closeButtonTexture, closeButtonRect, false, closeButtonColor);
 
         // Draw close button highlight

--- a/src/gui_common/dialogs/CustomDialog.cs
+++ b/src/gui_common/dialogs/CustomDialog.cs
@@ -108,6 +108,7 @@ public class CustomDialog : CustomWindow
 
 #pragma warning disable CA2213
     private TextureButton? closeButton;
+    private Texture closeButtonTexture = null!;
 
     private StyleBox customPanel = null!;
     private StyleBox titleBarPanel = null!;
@@ -116,6 +117,7 @@ public class CustomDialog : CustomWindow
     private Font? titleFont;
 #pragma warning restore CA2213
     private Color titleColor;
+    private Color closeButtonColor;
 
     private DragType dragType = DragType.None;
 
@@ -231,7 +233,9 @@ public class CustomDialog : CustomWindow
         titleFont = GetFont("custom_title_font", "WindowDialog");
         titleHeight = GetConstant("custom_title_height", "WindowDialog");
         titleColor = GetColor("custom_title_color", "WindowDialog");
+        closeButtonColor = GetColor("custom_close_color", "WindowDialog");
         closeButtonHighlight = GetStylebox("custom_close_highlight", "WindowDialog");
+        closeButtonTexture = GetIcon("custom_close", "WindowDialog");
         scaleBorderSize = GetConstant("custom_scaleBorder_size", "WindowDialog");
         customMargin = decorate ? GetConstant("custom_margin", "Dialogs") : 0;
 
@@ -311,14 +315,19 @@ public class CustomDialog : CustomWindow
         DrawString(titleFont, titlePosition, translatedWindowTitle, titleColor,
             (int)(RectSize.x - customPanel.GetMinimumSize().x));
 
+        var closeButtonRect = closeButton!.GetRect();
+
+        // Draw close button
+        DrawTextureRect(closeButtonTexture, closeButtonRect, false, closeButtonColor);
+
         // Draw close button highlight
         if (closeHovered)
         {
-            DrawStyleBox(closeButtonHighlight, closeButton!.GetRect());
+            DrawStyleBox(closeButtonHighlight, closeButtonRect);
         }
         else if (closeFocused)
         {
-            DrawStyleBox(CloseButtonFocus.Value, closeButton!.GetRect());
+            DrawStyleBox(CloseButtonFocus.Value, closeButtonRect);
         }
     }
 
@@ -327,7 +336,7 @@ public class CustomDialog : CustomWindow
         // Handle title bar dragging
         if (@event is InputEventMouseButton { ButtonIndex: (int)ButtonList.Left } mouseButton)
         {
-            if (mouseButton.Pressed && Movable)
+            if (mouseButton.Pressed && Movable && !closeHovered)
             {
                 // Begin a possible dragging operation
                 dragType = DragHitTest(new Vector2(mouseButton.Position.x, mouseButton.Position.y));
@@ -655,15 +664,11 @@ public class CustomDialog : CustomWindow
         if (closeButton != null)
             return;
 
-        var closeColor = GetColor("custom_close_color", "WindowDialog");
-
-        closeButton = new TextureButton
+        closeButton = new TextureButton()
         {
             Expand = true,
             RectMinSize = new Vector2(14, 14),
-            SelfModulate = closeColor,
             MouseFilter = MouseFilterEnum.Pass,
-            TextureNormal = GetIcon("custom_close", "WindowDialog"),
         };
 
         closeButton.SetAnchorsPreset(LayoutPreset.TopRight);

--- a/src/gui_common/dialogs/CustomDialog.cs
+++ b/src/gui_common/dialogs/CustomDialog.cs
@@ -664,7 +664,7 @@ public class CustomDialog : CustomWindow
         if (closeButton != null)
             return;
 
-        closeButton = new TextureButton()
+        closeButton = new TextureButton
         {
             Expand = true,
             RectMinSize = new Vector2(14, 14),

--- a/test/WindowReorderingSupportTest.tscn
+++ b/test/WindowReorderingSupportTest.tscn
@@ -18,13 +18,10 @@ margin_bottom = 40.0
 [node name="AddWindowReorderingSupportToSiblings" parent="Automatic" instance=ExtResource( 3 )]
 
 [node name="Window1" parent="Automatic" instance=ExtResource( 1 )]
-visible = true
 margin_right = 200.0
 margin_bottom = 125.0
 WindowTitle = "Window1"
 WindowReorderingPaths = [  ]
-AutomaticWindowReorderingDepth = 10
-AllowWindowReorderingRecursion = true
 
 [node name="Control" type="Control" parent="Automatic/Window1"]
 margin_right = 40.0
@@ -39,79 +36,61 @@ margin_right = 40.0
 margin_bottom = 40.0
 
 [node name="Child1ReordersWindow1" parent="Automatic/Window1/Control/Control2/Control3" instance=ExtResource( 1 )]
-visible = true
 margin_right = 200.0
 margin_bottom = 125.0
 WindowTitle = "Child1ReordersWindow1"
 WindowReorderingPaths = [  ]
 AutomaticWindowReorderingDepth = 5
-AllowWindowReorderingRecursion = true
 
 [node name="Window2" parent="Automatic" instance=ExtResource( 1 )]
-visible = true
 margin_right = 200.0
 margin_bottom = 125.0
 WindowTitle = "Window2"
 WindowReorderingPaths = [  ]
-AutomaticWindowReorderingDepth = 10
-AllowWindowReorderingRecursion = true
 
 [node name="AddWindowReorderingSupportToSiblings" parent="Automatic/Window2" instance=ExtResource( 3 )]
 AutomaticWindowReorderingDepth = 1
 
 [node name="Child2AlwaysBottomReodersWindow2Manual" parent="Automatic/Window2" instance=ExtResource( 1 )]
-visible = true
 margin_right = 200.0
 margin_bottom = 125.0
 WindowTitle = "Child2AlwaysBottomReodersWindow2Manual"
 WindowReorderingPaths = [ NodePath("../../AddWindowReorderingSupportToSiblings") ]
 AutomaticWindowReorderingDepth = 0
-AllowWindowReorderingRecursion = true
 
 [node name="Child2ReordersWindow2" parent="Automatic/Window2" instance=ExtResource( 1 )]
-visible = true
 margin_right = 200.0
 margin_bottom = 125.0
 WindowTitle = "Child2ReordersWindow2"
 WindowReorderingPaths = [  ]
-AutomaticWindowReorderingDepth = 10
-AllowWindowReorderingRecursion = true
 
 [node name="Child2" parent="Automatic/Window2" instance=ExtResource( 1 )]
-visible = true
 margin_right = 200.0
 margin_bottom = 125.0
 WindowTitle = "Child2"
 WindowReorderingPaths = [  ]
-AutomaticWindowReorderingDepth = 10
 AllowWindowReorderingRecursion = false
 
 [node name="Child2AlwaysTop" parent="Automatic/Window2" instance=ExtResource( 1 )]
-visible = true
 margin_right = 200.0
 margin_bottom = 125.0
 WindowTitle = "Child2AlwaysTop"
 WindowReorderingPaths = [  ]
 AutomaticWindowReorderingDepth = 0
-AllowWindowReorderingRecursion = true
 
 [node name="Window3AlwaysTop" parent="Automatic" instance=ExtResource( 1 )]
-visible = true
 margin_right = 200.0
 margin_bottom = 125.0
 WindowTitle = "Window3AlwaysTop"
 WindowReorderingPaths = [  ]
 AutomaticWindowReorderingDepth = 0
-AllowWindowReorderingRecursion = true
 
 [node name="AutomaticWindowSet" parent="Automatic" instance=ExtResource( 1 )]
-visible = true
 margin_right = 300.0
 margin_bottom = 300.0
 WindowTitle = "AutomaticWindowSet"
 WindowReorderingPaths = [ NodePath("../../AddWindowReorderingSupportToSiblings") ]
 AutomaticWindowReorderingDepth = 0
-AllowWindowReorderingRecursion = true
 
 [node name="Manual" type="Control" parent="."]
 margin_right = 40.0
@@ -122,14 +101,12 @@ margin_left = 1800.0
 margin_right = 1800.0
 
 [node name="Window12" parent="Manual" instance=ExtResource( 1 )]
-visible = true
 margin_left = 1800.0
 margin_right = 2000.0
 margin_bottom = 125.0
 WindowTitle = "Window12"
 WindowReorderingPaths = [ NodePath("../AddWindowReorderingSupportToSiblings") ]
 AutomaticWindowReorderingDepth = 0
-AllowWindowReorderingRecursion = true
 
 [node name="Control" type="Control" parent="Manual/Window12"]
 margin_right = 40.0
@@ -144,40 +121,33 @@ margin_right = 40.0
 margin_bottom = 40.0
 
 [node name="Child1ReordersWindow12" parent="Manual/Window12/Control/Control2/Control3" instance=ExtResource( 1 )]
-visible = true
 margin_left = 900.0
 margin_right = 1100.0
 margin_bottom = 125.0
 WindowTitle = "Child1ReordersWindow12"
 WindowReorderingPaths = [ NodePath("../../../../../AddWindowReorderingSupportToSiblings") ]
 AutomaticWindowReorderingDepth = 0
-AllowWindowReorderingRecursion = true
 
 [node name="Window22" parent="Manual" instance=ExtResource( 1 )]
-visible = true
 margin_left = 1800.0
 margin_right = 2000.0
 margin_bottom = 125.0
 WindowTitle = "Window22"
 WindowReorderingPaths = [ NodePath("../AddWindowReorderingSupportToSiblings") ]
 AutomaticWindowReorderingDepth = 0
-AllowWindowReorderingRecursion = true
 
 [node name="AddWindowReorderingSupportToSiblings" parent="Manual/Window22" instance=ExtResource( 3 )]
 WindowReorderingPaths = [ NodePath("../../AddWindowReorderingSupportToSiblings") ]
 
 [node name="Child2AlwaysBottomReodersWindow22" parent="Manual/Window22" instance=ExtResource( 1 )]
-visible = true
 margin_left = 900.0
 margin_right = 1100.0
 margin_bottom = 125.0
 WindowTitle = "Child2AlwaysBottomReodersWindow22"
 WindowReorderingPaths = [ NodePath("../../AddWindowReorderingSupportToSiblings") ]
 AutomaticWindowReorderingDepth = 0
-AllowWindowReorderingRecursion = true
 
 [node name="Child2ReordersWindow22" parent="Manual/Window22" instance=ExtResource( 1 )]
-visible = true
 margin_left = 900.0
 margin_right = 1100.0
 margin_bottom = 125.0
@@ -187,7 +157,6 @@ AutomaticWindowReorderingDepth = 0
 AllowWindowReorderingRecursion = false
 
 [node name="Child22" parent="Manual/Window22" instance=ExtResource( 1 )]
-visible = true
 margin_left = 900.0
 margin_right = 1100.0
 margin_bottom = 125.0
@@ -197,31 +166,25 @@ AutomaticWindowReorderingDepth = 0
 AllowWindowReorderingRecursion = false
 
 [node name="Child2AlwaysTop2" parent="Manual/Window22" instance=ExtResource( 1 )]
-visible = true
 margin_left = 900.0
 margin_right = 1100.0
 margin_bottom = 125.0
 WindowTitle = "Child2AlwaysTop2"
 WindowReorderingPaths = [  ]
 AutomaticWindowReorderingDepth = 0
-AllowWindowReorderingRecursion = true
 
 [node name="Window3AlwaysTop2" parent="Manual" instance=ExtResource( 1 )]
-visible = true
 margin_left = 1800.0
 margin_right = 2000.0
 margin_bottom = 125.0
 WindowTitle = "Window3AlwaysTop2"
 WindowReorderingPaths = [  ]
 AutomaticWindowReorderingDepth = 0
-AllowWindowReorderingRecursion = true
 
 [node name="ManualWindowSet" parent="Manual" instance=ExtResource( 1 )]
-visible = true
 margin_left = 1800.0
 margin_right = 2100.0
 margin_bottom = 300.0
 WindowTitle = "ManualWindowSet"
 WindowReorderingPaths = [ NodePath("../../AddWindowReorderingSupportToSiblings") ]
 AutomaticWindowReorderingDepth = 0
-AllowWindowReorderingRecursion = true


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds a code in a reordering system to count with multiple windows being opened at once, instead of a suggested fix in #4350 I sort the windows by their tree order and then reorder them.
Changes rendering of a close button as suggested in #4365.
Removes some leftover mess from a WindowReorderingSupportTest scene.
I have also noticed that one can drag a window in a place where a close button is so I have added a fix for that too.

**Related Issues**

fixes #4350 
fixes #4365 
<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
