### PR TITLE
Fixed the ESC icon not being used even though it existed

### DIFF
--- a/src/gui_common/KeyPromptHelper.cs
+++ b/src/gui_common/KeyPromptHelper.cs
@@ -208,6 +208,14 @@ public static class KeyPromptHelper
     /// </summary>
     public static string GetPathForKeyboardKey(string name)
     {
+        // Map some key names to match the icon set used key names
+        switch (name)
+        {
+            case "Escape":
+                name = "Esc";
+                break;
+        }
+
         if (!AvailableKeys.Contains(name))
             return GetPathForInvalidKey();
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes sure the esc icon is found when the game is looking for the "Escape" icon

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://github.com/Revolutionary-Games/Thrive/issues/4374

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
