### PR TITLE
Made options menu lazily load languages list and some other options

### DIFF
--- a/src/general/OptionsMenu.cs
+++ b/src/general/OptionsMenu.cs
@@ -317,10 +317,10 @@ public class OptionsMenu : ControlWithInput
     [Export]
     public NodePath PatchNotesDisplayerPath = null!;
 
-    private static readonly List<string> LanguagesCache = TranslationServer.GetLoadedLocales().Cast<string>()
-        .OrderBy(i => i, StringComparer.InvariantCulture)
-        .ToList();
+    private static readonly Lazy<List<string>> LanguagesCache = new(() => TranslationServer.GetLoadedLocales()
+        .Cast<string>().OrderBy(i => i, StringComparer.InvariantCulture).ToList());
 
+    // TODO: this should be refreshed periodically to support user plugging in new devices
     private static readonly List<string> AudioOutputDevicesCache = AudioServer
         .GetDeviceList().OfType<string>().Where(d => d != Constants.DEFAULT_AUDIO_OUTPUT_DEVICE_NAME)
         .Prepend(Constants.DEFAULT_AUDIO_OUTPUT_DEVICE_NAME).ToList();
@@ -464,6 +464,8 @@ public class OptionsMenu : ControlWithInput
 
     private bool nodeReferencesResolved;
 
+    private bool elementItemSelectionsInitialized;
+
     // Signals
 
     [Signal]
@@ -484,16 +486,18 @@ public class OptionsMenu : ControlWithInput
         Miscellaneous,
     }
 
-    private static List<string> Languages => LanguagesCache;
+    private static List<string> Languages => LanguagesCache.Value;
     private static List<string> AudioOutputDevices => AudioOutputDevicesCache;
 
     public override void _Ready()
     {
         ResolveNodeReferences(true);
 
-        LoadLanguages();
-        LoadAudioOutputDevices();
-        LoadScreenEffects();
+        if (IsVisibleInTree())
+        {
+            GD.Print("Immediately loading options menu items as it is visible in _Ready");
+            InitializeOptionsSelections();
+        }
 
         inputGroupList.OnControlsChanged += OnControlsChanged;
 
@@ -687,6 +691,8 @@ public class OptionsMenu : ControlWithInput
         if (Visible)
             return;
 
+        InitializeOptionsSelections();
+
         // Copy the live game settings so we can check against them for changes.
         savedSettings = Settings.Instance.Clone();
 
@@ -708,6 +714,8 @@ public class OptionsMenu : ControlWithInput
         // Shouldn't do anything if options is already open.
         if (Visible)
             return;
+
+        InitializeOptionsSelections();
 
         // Copy the live game settings so we can check against them for changes.
         savedSettings = Settings.Instance.Clone();
@@ -979,6 +987,18 @@ public class OptionsMenu : ControlWithInput
         }
 
         base.Dispose(disposing);
+    }
+
+    private void InitializeOptionsSelections()
+    {
+        if (elementItemSelectionsInitialized)
+            return;
+
+        elementItemSelectionsInitialized = true;
+
+        LoadLanguages();
+        LoadAudioOutputDevices();
+        LoadScreenEffects();
     }
 
     private void SwitchMode(OptionsMode mode)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Just a bit of saving of performance when the options menu isn't actually ever opened.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #2368

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
