### PR TITLE
Fixed crashing when showing a custom window with no close button

### DIFF
--- a/src/gui_common/dialogs/CustomWindow.cs
+++ b/src/gui_common/dialogs/CustomWindow.cs
@@ -315,21 +315,24 @@ public class CustomWindow : TopLevelContainer
         DrawString(titleFont, titlePosition, translatedWindowTitle, titleColor,
             (int)(RectSize.x - customPanel.GetMinimumSize().x));
 
-        var closeButtonRect = closeButton!.GetRect();
-
-        // Draw close button
-        // We render this in a custom way because rendering it in a child node causes a bug where render order
-        // breaks in some cases: https://github.com/Revolutionary-Games/Thrive/issues/4365
-        DrawTextureRect(closeButtonTexture, closeButtonRect, false, closeButtonColor);
-
-        // Draw close button highlight
-        if (closeHovered)
+        // Draw close button (if this window has a close button)
+        if (closeButton != null)
         {
-            DrawStyleBox(closeButtonHighlight, closeButtonRect);
-        }
-        else if (closeFocused)
-        {
-            DrawStyleBox(CloseButtonFocus.Value, closeButtonRect);
+            var closeButtonRect = closeButton!.GetRect();
+
+            // We render this in a custom way because rendering it in a child node causes a bug where render order
+            // breaks in some cases: https://github.com/Revolutionary-Games/Thrive/issues/4365
+            DrawTextureRect(closeButtonTexture, closeButtonRect, false, closeButtonColor);
+
+            // Draw close button highlight
+            if (closeHovered)
+            {
+                DrawStyleBox(closeButtonHighlight, closeButtonRect);
+            }
+            else if (closeFocused)
+            {
+                DrawStyleBox(CloseButtonFocus.Value, closeButtonRect);
+            }
         }
     }
 
@@ -656,7 +659,7 @@ public class CustomWindow : TopLevelContainer
         {
             if (closeButton != null)
             {
-                RemoveChild(closeButton);
+                closeButton.DetachAndQueueFree();
                 closeButton = null;
             }
 


### PR DESCRIPTION
there was a mistake in the code that assumed the close button always existed. Also fixed close button when being removed leaking the object

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
game was noticed crashing when trying to modify a chemoreceptor

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
