### PR TITLE
Fixed cases of Random.Next having the wrong ceiling value

### DIFF
--- a/src/benchmark/microbe/MicrobeBenchmark.cs
+++ b/src/benchmark/microbe/MicrobeBenchmark.cs
@@ -517,7 +517,7 @@ public class MicrobeBenchmark : Node
         cloudSystem!.AddCloud(glucose, GLUCOSE_CLOUD_AMOUNT, position);
 
         // And a bit of phosphate or ammonia
-        cloudSystem!.AddCloud(random.Next(0, 1) == 1 ? phosphates : ammonia, AMMONIA_PHOSPHATE_CLOUD_AMOUNT, position);
+        cloudSystem!.AddCloud(random.Next(0, 2) == 1 ? phosphates : ammonia, AMMONIA_PHOSPHATE_CLOUD_AMOUNT, position);
     }
 
     private void PruneDeadMicrobes()

--- a/src/general/Mutations.cs
+++ b/src/general/Mutations.cs
@@ -110,7 +110,7 @@ public class Mutations
         mutated.IsBacteria = parent.IsBacteria;
 
         // Mutate the epithet
-        if (random.Next(0, 101) < Constants.MUTATION_WORD_EDIT)
+        if (random.Next(0, 100) < Constants.MUTATION_WORD_EDIT)
         {
             mutated.Epithet = MutateWord(parent.Epithet, true);
         }
@@ -127,7 +127,7 @@ public class Mutations
         if (NewGenus(mutated, parent))
         {
             // We can do more fun stuff here later
-            if (random.Next(0, 101) < Constants.MUTATION_WORD_EDIT)
+            if (random.Next(0, 100) < Constants.MUTATION_WORD_EDIT)
             {
                 mutated.Genus = MutateWord(parent.Genus);
             }
@@ -150,7 +150,7 @@ public class Mutations
 
         // Update colour and membrane
         var colour = mutated.IsBacteria ? RandomProkaryoteColour() : RandomEukaryoteColour();
-        if (random.Next(0, 101) <= 20)
+        if (random.Next(0, 100) < 20)
         {
             mutated.MembraneType = RandomMembraneType(simulation);
             if (mutated.MembraneType != simulation.GetMembrane("single"))
@@ -436,27 +436,27 @@ public class Mutations
         // Could perhaps use a weighted entry model here... the
         // earlier one is listed, the more likely currently (I
         // think). That may be an issue.
-        if (random.Next(0, 101) < 50)
+        if (random.Next(0, 100) < 50)
         {
             return simulation.GetMembrane("single");
         }
 
-        if (random.Next(0, 101) < 50)
+        if (random.Next(0, 100) < 50)
         {
             return simulation.GetMembrane("double");
         }
 
-        if (random.Next(0, 101) < 50)
+        if (random.Next(0, 100) < 50)
         {
             return simulation.GetMembrane("cellulose");
         }
 
-        if (random.Next(0, 101) < 50)
+        if (random.Next(0, 100) < 50)
         {
             return simulation.GetMembrane("chitin");
         }
 
-        if (random.Next(0, 101) < 50)
+        if (random.Next(0, 100) < 50)
         {
             return simulation.GetMembrane("calciumCarbonate");
         }
@@ -595,7 +595,7 @@ public class Mutations
                 // Are we a vowel or are we a consonant?
                 var part = newName.ToString(index, 2);
                 bool isPermute = PronounceablePermutation.Contains(part);
-                if (random.Next(0, 21) <= 10 && isPermute)
+                if (random.Next(0, 20) < 10 && isPermute)
                 {
                     newName.Erase(index, 2);
                     changes++;
@@ -607,7 +607,7 @@ public class Mutations
         // 2% chance each letter
         for (int i = 1; i < newName.Length; i++)
         {
-            if (random.Next(0, 121) <= 1 && changes <= changeLimit)
+            if (random.Next(0, 120) <= 1 && changes <= changeLimit)
             {
                 // Index we are adding or erasing chromosomes at
                 int index = newName.Length - i - 1;
@@ -661,7 +661,7 @@ public class Mutations
                 {
                     newName.Erase(index, 1);
                     changes++;
-                    if (random.Next(0, 21) <= 10)
+                    if (random.Next(0, 20) < 10)
                     {
                         newName.Insert(index, Consonants.Random(random) +
                             Vowels.Random(random) + original);
@@ -693,7 +693,7 @@ public class Mutations
             bool isVowel = Vowels.Contains(part);
 
             // 50 percent chance replace
-            if (random.Next(0, 21) <= 10 && changes <= changeLimit)
+            if (random.Next(0, 20) < 10 && changes <= changeLimit)
             {
                 if (!isVowel && newName.ToString(index, 1) != "r" && !isPermute)
                 {

--- a/src/microbe_stage/NameGenerator.cs
+++ b/src/microbe_stage/NameGenerator.cs
@@ -46,7 +46,7 @@ public class NameGenerator : IRegistryType
 
         string newName;
 
-        if (random.Next(0, 101) >= 10)
+        if (random.Next(0, 100) >= 10)
         {
             switch (random.Next(0, 4))
             {


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR increases the ceiling so that `Random.Next` can return 1. Now the code can randomly spawn phosphate clouds instead of just ammonia clouds.

This also fixes similar issues in the rest of the codebase.

**Related Issues**

Fixes #4402 

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
