### PR TITLE
Gallery Filter Translation Fix

### DIFF
--- a/src/gui_common/art_gallery/GalleryViewer.cs
+++ b/src/gui_common/art_gallery/GalleryViewer.cs
@@ -392,12 +392,7 @@ public class GalleryViewer : CustomWindow
     {
         var selected = button.Name;
 
-        if (selected == currentGallery)
-            return;
-
         var gallery = SimulationParameters.Instance.GetGallery(selected);
-
-        currentGallery = selected;
         assetsCategoryDropdown.Clear();
 
         foreach (var entry in galleries[selected])
@@ -411,6 +406,11 @@ public class GalleryViewer : CustomWindow
             if (gallery.AssetCategories.TryGetValue(entry.Value, out AssetCategory category))
                 assetsCategoryDropdown.AddItem(category.Name, entry.Key);
         }
+
+        if (selected == currentGallery)
+            return;
+
+        currentGallery = selected;
 
         UpdateGalleryTile();
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Made change to repopulate assetsCategoryDropdown every time OnGallerySelected is called in case of language change. Gallery is still only fully refreshed on a tab change, only the filter is repopulated.

**Related Issues**

fixes #4333 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
