### PR TITLE
Improve auto-evo performance by caching

### DIFF
--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -127,7 +127,7 @@
             return cached;
         }
 
-        public float GetEnergyCreationScoreForOrganelle(OrganelleTemplate organelle, BiomeConditions biomeConditions, 
+        public float GetEnergyCreationScoreForOrganelle(OrganelleTemplate organelle, BiomeConditions biomeConditions,
             Compound compound)
         {
             var key = (organelle, biomeConditions, compound);
@@ -187,7 +187,7 @@
         ///   A float to represent score. Scores are only compared against other scores from the same FoodSource,
         ///   so different implementations do not need to worry about scale.
         /// </returns>
-        public float GetEnergyGenerationScoreForSpecies(MicrobeSpecies species, BiomeConditions biomeConditions, 
+        public float GetEnergyGenerationScoreForSpecies(MicrobeSpecies species, BiomeConditions biomeConditions,
             Compound compound)
         {
             var key = (species, biomeConditions, compound);

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -32,8 +32,8 @@
             new();
 
         private readonly Dictionary<MicrobeSpecies, float[]> cachedPredationToolsRawScores = new();
-        private readonly Dictionary<(OrganelleTemplate, BiomeConditions, Compound), float> cachedEnergyCreationScoreForOrganelle;
-        private readonly Dictionary<(MicrobeSpecies, BiomeConditions, Compound), float> cachedEnergyCreationScoreForSpecies;
+        private readonly Dictionary<(OrganelleTemplate, BiomeConditions, Compound), float> cachedEnergyCreationScoreForOrganelle = new();
+        private readonly Dictionary<(MicrobeSpecies, BiomeConditions, Compound), float> cachedEnergyCreationScoreForSpecies = new();
 
         public SimulationCache(WorldGenerationSettings worldSettings)
         {

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -200,7 +200,8 @@
             // We check generation from all the processes of the cell.
             foreach (var organelle in species.Organelles)
             {
-                energyCreationScore += GetEnergyCreationScoreForOrganelle(organelle.Definition, biomeConditions, compound);
+                energyCreationScore += GetEnergyCreationScoreForOrganelle(organelle.Definition, biomeConditions,
+                    compound);
             }
 
             cachedEnergyCreationScoreForSpecies.Add(key, energyCreationScore);

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -30,8 +30,10 @@
             new();
 
         private readonly Dictionary<MicrobeSpecies, float[]> cachedPredationToolsRawScores = new();
-        private readonly Dictionary<(OrganelleTemplate, BiomeConditions, Compound), float> cachedEnergyCreationScoreForOrganelle = new();
-        private readonly Dictionary<(MicrobeSpecies, BiomeConditions, Compound), float> cachedEnergyCreationScoreForSpecies = new();
+        private readonly Dictionary<(OrganelleTemplate, BiomeConditions, Compound), float>
+            cachedEnergyCreationScoreForOrganelle = new();
+        private readonly Dictionary<(MicrobeSpecies, BiomeConditions, Compound), float>
+            cachedEnergyCreationScoreForSpecies = new();
 
         public SimulationCache(WorldGenerationSettings worldSettings)
         {
@@ -123,7 +125,8 @@
             return cached;
         }
 
-        public float GetEnergyCreationScoreForOrganelle(OrganelleTemplate organelle, BiomeConditions biomeConditions, Compound compound)
+        public float GetEnergyCreationScoreForOrganelle(
+            OrganelleTemplate organelle, BiomeConditions biomeConditions, Compound compound)
         {
             var key = (organelle, biomeConditions, compound);
             if (cachedEnergyCreationScoreForOrganelle.TryGetValue(key, out var cached))
@@ -182,7 +185,8 @@
         ///   A float to represent score. Scores are only compared against other scores from the same FoodSource,
         ///   so different implementations do not need to worry about scale.
         /// </returns>
-        public float GetEnergyGenerationScoreForSpecies(MicrobeSpecies species, BiomeConditions biomeConditions, Compound compound)
+        public float GetEnergyGenerationScoreForSpecies(
+            MicrobeSpecies species, BiomeConditions biomeConditions, Compound compound)
         {
             var key = (species, biomeConditions, compound);
 

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -31,8 +31,7 @@
 
         private readonly Dictionary<MicrobeSpecies, (float, float, float)> cachedPredationToolsRawScores = new();
 
-        // TODO : investigate using the hashcode of the organelle template as well, but possibly without orientation and position)
-        private readonly Dictionary<(OrganelleTemplate, BiomeConditions, Compound), float>
+        private readonly Dictionary<(OrganelleDefinition, BiomeConditions, Compound), float>
             cachedEnergyCreationScoreForOrganelle = new();
 
         private readonly Dictionary<(MicrobeSpecies, BiomeConditions, Compound), float>
@@ -128,7 +127,7 @@
             return cached;
         }
 
-        public float GetEnergyCreationScoreForOrganelle(OrganelleTemplate organelle, BiomeConditions biomeConditions,
+        public float GetEnergyCreationScoreForOrganelle(OrganelleDefinition organelle, BiomeConditions biomeConditions,
             Compound compound)
         {
             var key = (organelle, biomeConditions, compound);
@@ -138,7 +137,7 @@
             var energyCreationScore = 0.0f;
 
             // We check generation from all processes of the cell
-            foreach (var process in organelle.Definition.RunnableProcesses)
+            foreach (var process in organelle.RunnableProcesses)
             {
                 // ... that uses the given compound...
                 if (process.Process.Inputs.TryGetValue(compound, out var inputAmount))
@@ -201,7 +200,7 @@
             // We check generation from all the processes of the cell.
             foreach (var organelle in species.Organelles)
             {
-                energyCreationScore += GetEnergyCreationScoreForOrganelle(organelle, biomeConditions, compound);
+                energyCreationScore += GetEnergyCreationScoreForOrganelle(organelle.Definition, biomeConditions, compound);
             }
 
             cachedEnergyCreationScoreForSpecies.Add(key, energyCreationScore);

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -1,9 +1,7 @@
 ﻿namespace AutoEvo
 {
-    using HarmonyLib;
     using System;
     using System.Collections.Generic;
-    using static System.Net.WebRequestMethods;
 
     /// <summary>
     ///   Caches some information in auto-evo runs to speed them up
@@ -232,7 +230,6 @@
 
         public float[] GetPredationToolsRawScores(MicrobeSpecies microbeSpecies)
         {
-
             if (cachedPredationToolsRawScores.TryGetValue(microbeSpecies, out var cached))
                 return cached;
 

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -31,6 +31,7 @@
 
         private readonly Dictionary<MicrobeSpecies, (float, float, float)> cachedPredationToolsRawScores = new();
 
+        // TODO : investigate using the hashcode of the organelle template as well, but possibly without orientation and position)
         private readonly Dictionary<(OrganelleTemplate, BiomeConditions, Compound), float>
             cachedEnergyCreationScoreForOrganelle = new();
 
@@ -234,7 +235,8 @@
             return worldSettings.Equals(checkAgainst);
         }
 
-        public (float PilusScore, float OxytoxyScore, float MucilageScore) GetPredationToolsRawScores(MicrobeSpecies microbeSpecies)
+        public (float PilusScore, float OxytoxyScore, float MucilageScore) GetPredationToolsRawScores(
+            MicrobeSpecies microbeSpecies)
         {
             if (cachedPredationToolsRawScores.TryGetValue(microbeSpecies, out var cached))
                 return cached;

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -29,7 +29,7 @@
         private readonly Dictionary<(TweakedProcess, BiomeConditions), ProcessSpeedInformation> cachedProcessSpeeds =
             new();
 
-        private readonly Dictionary<MicrobeSpecies, float[]> cachedPredationToolsRawScores = new();
+        private readonly Dictionary<MicrobeSpecies, (float, float, float)> cachedPredationToolsRawScores = new();
         private readonly Dictionary<(OrganelleTemplate, BiomeConditions, Compound), float>
             cachedEnergyCreationScoreForOrganelle = new();
         private readonly Dictionary<(MicrobeSpecies, BiomeConditions, Compound), float>
@@ -232,7 +232,7 @@
             return worldSettings.Equals(checkAgainst);
         }
 
-        public float[] GetPredationToolsRawScores(MicrobeSpecies microbeSpecies)
+        public (float PilusScore, float OxytoxyScore, float MucilageScore) GetPredationToolsRawScores(MicrobeSpecies microbeSpecies)
         {
             if (cachedPredationToolsRawScores.TryGetValue(microbeSpecies, out var cached))
                 return cached;
@@ -263,7 +263,7 @@
                 }
             }
 
-            var predationToolsRawScores = new float[3] { pilusScore, oxytoxyScore, mucilageScore };
+            var predationToolsRawScores = (pilusScore, oxytoxyScore, mucilageScore);
 
             cachedPredationToolsRawScores.Add(microbeSpecies, predationToolsRawScores);
             return predationToolsRawScores;

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -30,8 +30,10 @@
             new();
 
         private readonly Dictionary<MicrobeSpecies, (float, float, float)> cachedPredationToolsRawScores = new();
+
         private readonly Dictionary<(OrganelleTemplate, BiomeConditions, Compound), float>
             cachedEnergyCreationScoreForOrganelle = new();
+
         private readonly Dictionary<(MicrobeSpecies, BiomeConditions, Compound), float>
             cachedEnergyCreationScoreForSpecies = new();
 
@@ -125,8 +127,8 @@
             return cached;
         }
 
-        public float GetEnergyCreationScoreForOrganelle(
-            OrganelleTemplate organelle, BiomeConditions biomeConditions, Compound compound)
+        public float GetEnergyCreationScoreForOrganelle(OrganelleTemplate organelle, BiomeConditions biomeConditions, 
+            Compound compound)
         {
             var key = (organelle, biomeConditions, compound);
             if (cachedEnergyCreationScoreForOrganelle.TryGetValue(key, out var cached))
@@ -185,8 +187,8 @@
         ///   A float to represent score. Scores are only compared against other scores from the same FoodSource,
         ///   so different implementations do not need to worry about scale.
         /// </returns>
-        public float GetEnergyGenerationScoreForSpecies(
-            MicrobeSpecies species, BiomeConditions biomeConditions, Compound compound)
+        public float GetEnergyGenerationScoreForSpecies(MicrobeSpecies species, BiomeConditions biomeConditions, 
+            Compound compound)
         {
             var key = (species, biomeConditions, compound);
 

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -232,6 +232,10 @@
 
         public float[] GetPredationToolsRawScores(MicrobeSpecies microbeSpecies)
         {
+
+            if (cachedPredationToolsRawScores.TryGetValue(microbeSpecies, out var cached))
+                return cached;
+
             var pilusScore = 0.0f;
             var oxytoxyScore = 0.0f;
             var mucilageScore = 0.0f;

--- a/src/auto-evo/simulation/food_source/FoodSource.cs
+++ b/src/auto-evo/simulation/food_source/FoodSource.cs
@@ -4,9 +4,6 @@
 
     public abstract class FoodSource
     {
-        private readonly Compound glucose = SimulationParameters.Instance.GetCompound("glucose");
-        private readonly Compound atp = SimulationParameters.Instance.GetCompound("atp");
-
         public abstract float TotalEnergyAvailable();
 
         /// <summary>
@@ -56,71 +53,13 @@
         protected float CompoundUseScore(MicrobeSpecies species, Compound compound, Patch patch,
             SimulationCache simulationCache, WorldGenerationSettings worldSettings)
         {
-            var energyGenerationScore = EnergyGenerationScore(species, compound, patch, simulationCache);
+            var energyGenerationScore = simulationCache.GetEnergyGenerationScoreForSpecies(species, patch.Biome, compound);
 
             if (energyGenerationScore <= MathUtils.EPSILON)
                 return 0.0f;
 
             return energyGenerationScore * StorageScore(
                 species, compound, patch, simulationCache, worldSettings);
-        }
-
-        /// <summary>
-        ///   A measure of how good the species is for generating energy from a given compound.
-        /// </summary>
-        /// <returns>
-        ///   A float to represent score. Scores are only compared against other scores from the same FoodSource,
-        ///   so different implementations do not need to worry about scale.
-        /// </returns>
-        private float EnergyGenerationScore(MicrobeSpecies species, Compound compound, Patch patch,
-            SimulationCache simulationCache)
-        {
-            var energyCreationScore = 0.0f;
-
-            // We check generation from all the processes of the cell..
-            foreach (var organelle in species.Organelles)
-            {
-                foreach (var process in organelle.Definition.RunnableProcesses)
-                {
-                    // ... that uses the given compound...
-                    if (process.Process.Inputs.TryGetValue(compound, out var inputAmount))
-                    {
-                        var processEfficiency = simulationCache.GetProcessMaximumSpeed(process, patch.Biome).Efficiency;
-
-                        // ... and that produce glucose
-                        if (process.Process.Outputs.TryGetValue(glucose, out var glucoseAmount))
-                        {
-                            // Better ratio means that we transform stuff more efficiently and need less input
-                            var compoundRatio = glucoseAmount / inputAmount;
-
-                            // Better output is a proxy for more time dedicated to reproduction than energy production
-                            var absoluteOutput = glucoseAmount * processEfficiency;
-
-                            energyCreationScore += (float)(
-                                Math.Pow(compoundRatio, Constants.AUTO_EVO_COMPOUND_RATIO_POWER_BIAS)
-                                * Math.Pow(absoluteOutput, Constants.AUTO_EVO_ABSOLUTE_PRODUCTION_POWER_BIAS)
-                                * Constants.AUTO_EVO_GLUCOSE_USE_SCORE_MULTIPLIER);
-                        }
-
-                        // ... and that produce ATP
-                        if (process.Process.Outputs.TryGetValue(atp, out var atpAmount))
-                        {
-                            // Better ratio means that we transform stuff more efficiently and need less input
-                            var compoundRatio = atpAmount / inputAmount;
-
-                            // Better output is a proxy for more time dedicated to reproduction than energy production
-                            var absoluteOutput = atpAmount * processEfficiency;
-
-                            energyCreationScore += (float)(
-                                Math.Pow(compoundRatio, Constants.AUTO_EVO_COMPOUND_RATIO_POWER_BIAS)
-                                * Math.Pow(absoluteOutput, Constants.AUTO_EVO_ABSOLUTE_PRODUCTION_POWER_BIAS)
-                                * Constants.AUTO_EVO_ATP_USE_SCORE_MULTIPLIER);
-                        }
-                    }
-                }
-            }
-
-            return energyCreationScore;
         }
     }
 }

--- a/src/auto-evo/simulation/food_source/FoodSource.cs
+++ b/src/auto-evo/simulation/food_source/FoodSource.cs
@@ -53,7 +53,8 @@
         protected float CompoundUseScore(MicrobeSpecies species, Compound compound, Patch patch,
             SimulationCache simulationCache, WorldGenerationSettings worldSettings)
         {
-            var energyGenerationScore = simulationCache.GetEnergyGenerationScoreForSpecies(species, patch.Biome, compound);
+            var energyGenerationScore = simulationCache.GetEnergyGenerationScoreForSpecies(
+                species, patch.Biome, compound);
 
             if (energyGenerationScore <= MathUtils.EPSILON)
                 return 0.0f;

--- a/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
@@ -4,9 +4,6 @@
 
     public class HeterotrophicFoodSource : RandomEncounterFoodSource
     {
-        private readonly Compound oxytoxy = SimulationParameters.Instance.GetCompound("oxytoxy");
-        private readonly Compound mucilage = SimulationParameters.Instance.GetCompound("mucilage");
-
         private readonly MicrobeSpecies prey;
         private readonly Patch patch;
         private readonly float preyHexSize;
@@ -68,30 +65,9 @@
                 engulfScore = catchScore * Constants.AUTO_EVO_ENGULF_PREDATION_SCORE;
             }
 
-            var pilusScore = 0.0f;
-            var oxytoxyScore = 0.0f;
-            var mucilageScore = 0.0f;
-            foreach (var organelle in microbeSpecies.Organelles)
-            {
-                if (organelle.Definition.HasPilusComponent)
-                {
-                    pilusScore += Constants.AUTO_EVO_PILUS_PREDATION_SCORE;
-                    continue;
-                }
-
-                foreach (var process in organelle.Definition.RunnableProcesses)
-                {
-                    if (process.Process.Outputs.TryGetValue(oxytoxy, out var oxytoxyAmount))
-                    {
-                        oxytoxyScore += oxytoxyAmount * Constants.AUTO_EVO_TOXIN_PREDATION_SCORE;
-                    }
-
-                    if (process.Process.Outputs.TryGetValue(mucilage, out var mucilageAmount))
-                    {
-                        mucilageScore += mucilageAmount * Constants.AUTO_EVO_MUCILAGE_PREDATION_SCORE;
-                    }
-                }
-            }
+            var pilusScore = simulationCache.GetPilusScore(microbeSpecies);
+            var oxytoxyScore = simulationCache.GetOxytoxyScore(microbeSpecies);
+            var mucilageScore = simulationCache.GetMucilageScore(microbeSpecies);
 
             // Pili are much more useful if the microbe can close to melee
             pilusScore *= predatorSpeed > preySpeed ? 1.0f : Constants.AUTO_EVO_ENGULF_LUCKY_CATCH_PROBABILITY;

--- a/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
@@ -68,12 +68,10 @@
                 engulfScore = catchScore * Constants.AUTO_EVO_ENGULF_PREDATION_SCORE;
             }
 
-            // The array was used to have a time & memory efficient structure,
-            // but this could be turned into a class for more readable and less error-prone code.
             var predationToolsRawScores = simulationCache.GetPredationToolsRawScores(microbeSpecies);
-            var pilusScore = predationToolsRawScores[0];
-            var oxytoxyScore = predationToolsRawScores[1];
-            var mucilageScore = predationToolsRawScores[2];
+            var pilusScore = predationToolsRawScores.PilusScore;
+            var oxytoxyScore = predationToolsRawScores.OxytoxyScore;
+            var mucilageScore = predationToolsRawScores.MucilageScore;
 
             // Pili are much more useful if the microbe can close to melee
             pilusScore *= predatorSpeed > preySpeed ? 1.0f : Constants.AUTO_EVO_ENGULF_LUCKY_CATCH_PROBABILITY;

--- a/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/HeterotrophicFoodSource.cs
@@ -4,6 +4,9 @@
 
     public class HeterotrophicFoodSource : RandomEncounterFoodSource
     {
+        private readonly Compound oxytoxy = SimulationParameters.Instance.GetCompound("oxytoxy");
+        private readonly Compound mucilage = SimulationParameters.Instance.GetCompound("mucilage");
+
         private readonly MicrobeSpecies prey;
         private readonly Patch patch;
         private readonly float preyHexSize;
@@ -65,9 +68,12 @@
                 engulfScore = catchScore * Constants.AUTO_EVO_ENGULF_PREDATION_SCORE;
             }
 
-            var pilusScore = simulationCache.GetPilusScore(microbeSpecies);
-            var oxytoxyScore = simulationCache.GetOxytoxyScore(microbeSpecies);
-            var mucilageScore = simulationCache.GetMucilageScore(microbeSpecies);
+            // The array was used to have a time & memory efficient structure,
+            // but this could be turned into a class for more readable and less error-prone code.
+            var predationToolsRawScores = simulationCache.GetPredationToolsRawScores(microbeSpecies);
+            var pilusScore = predationToolsRawScores[0];
+            var oxytoxyScore = predationToolsRawScores[1];
+            var mucilageScore = predationToolsRawScores[2];
 
             // Pili are much more useful if the microbe can close to melee
             pilusScore *= predatorSpeed > preySpeed ? 1.0f : Constants.AUTO_EVO_ENGULF_LUCKY_CATCH_PROBABILITY;


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR adds further caching for auto-evo computations. Last checks indicated a reduction from 4m 22s to 48s to compute 20 generations.

**Related Issues**

None, but improving auto-evo performance is always good.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
