### PR TITLE
Do not show glucose as reducing by NaN

### DIFF
--- a/src/general/IWorldEffect.cs
+++ b/src/general/IWorldEffect.cs
@@ -77,6 +77,11 @@ public class GlucoseReductionEffect : IWorldEffect
         }
 
         var initialTotalGlucose = Math.Round(initialTotalDensity * totalAmount + totalChunkAmount, 3);
+
+        // Prevent a division by zero
+        if (initialTotalGlucose == 0)
+            return;
+
         var finalTotalGlucose = Math.Round(finalTotalDensity * totalAmount + totalChunkAmount, 3);
         var globalReduction = Math.Round((initialTotalGlucose - finalTotalGlucose) / initialTotalGlucose * 100, 1);
 
@@ -85,7 +90,7 @@ public class GlucoseReductionEffect : IWorldEffect
             targetWorld.LogEvent(new LocalizedString("GLUCOSE_CONCENTRATIONS_DRASTICALLY_DROPPED"),
                 false, "glucoseDown.png");
         }
-        else
+        else if (globalReduction > 0)
         {
             targetWorld.LogEvent(new LocalizedString("COMPOUND_CONCENTRATIONS_DECREASED",
                     glucose.Name, new LocalizedString("PERCENTAGE_VALUE", globalReduction)), false,


### PR DESCRIPTION
**Brief Description of What This PR Does**
- Early return from `GlucoseReductionEffect.OnTimePassed` to avoid division by zero.
- If the decrease in glucose is 0% then do not show any message.

**Related Issues**
Closes #4418

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
