### PR TITLE
Toxins fired in a colony (or multicellular) can collide with the firing colony

### DIFF
--- a/src/microbe_stage/AgentProjectile.cs
+++ b/src/microbe_stage/AgentProjectile.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Godot;
 using Newtonsoft.Json;
 
@@ -20,6 +21,11 @@ public class AgentProjectile : RigidBody, ITimedLife, IInspectableEntity
 
     public Spatial EntityNode => this;
 
+    /// <summary>
+    ///     <see cref="IEntity"/>s that this projectile should not collide with.
+    /// </summary>
+    public IEnumerable<IEntity>? CollisionExceptions { get; set; }
+
     public AliveMarker AliveMarker { get; } = new();
 
     [JsonIgnore]
@@ -39,6 +45,17 @@ public class AgentProjectile : RigidBody, ITimedLife, IInspectableEntity
 
         if (emitterNode != null)
             AddCollisionExceptionWith(emitterNode);
+
+        if (CollisionExceptions != null)
+        {
+            foreach (var collisionException in CollisionExceptions)
+            {
+                var exceptionNode = collisionException.EntityNode;
+
+                if (exceptionNode != null)
+                    AddCollisionExceptionWith(exceptionNode);
+            }
+        }
 
         Connect("body_shape_entered", this, nameof(OnContactBegin));
     }

--- a/src/microbe_stage/AgentProjectile.cs
+++ b/src/microbe_stage/AgentProjectile.cs
@@ -50,10 +50,7 @@ public class AgentProjectile : RigidBody, ITimedLife, IInspectableEntity
         {
             foreach (var collisionException in CollisionExceptions)
             {
-                var exceptionNode = collisionException.EntityNode;
-
-                if (exceptionNode != null)
-                    AddCollisionExceptionWith(exceptionNode);
+                AddCollisionExceptionWith(collisionException.EntityNode);
             }
         }
 

--- a/src/microbe_stage/AgentProjectile.cs
+++ b/src/microbe_stage/AgentProjectile.cs
@@ -22,7 +22,7 @@ public class AgentProjectile : RigidBody, ITimedLife, IInspectableEntity
     public Spatial EntityNode => this;
 
     /// <summary>
-    ///     <see cref="IEntity"/>s that this projectile should not collide with.
+    ///   <see cref="IEntity"/>s that this projectile should not collide with.
     /// </summary>
     public IEnumerable<IEntity>? CollisionExceptions { get; set; }
 

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -817,10 +817,12 @@ public partial class Microbe
                 var direction = new Vector3(random.Next(0.0f, 1.0f) * 2 - 1,
                     0, random.Next(0.0f, 1.0f) * 2 - 1);
 
+                // If this microbe is in a colony, send each of its colony members as a collision exception
+                // so the projectile isn't blocked by the microbe's own colony
                 var agent = SpawnHelpers.SpawnAgent(props, Constants.MAXIMUM_AGENT_EMISSION_AMOUNT,
                     Constants.EMITTED_AGENT_LIFETIME,
                     Translation, direction, GetStageAsParent(),
-                    agentScene, this);
+                    agentScene, this, Colony?.ColonyMembers);
 
                 ModLoader.ModInterface.TriggerOnToxinEmitted(agent);
 

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -304,9 +304,11 @@ public partial class Microbe
 
         var position = GlobalTransform.origin + (direction * ejectionDistance);
 
+        // If this microbe is in a colony, send each of its colony members as a collision exception
+        // so the projectile isn't blocked by the microbe's own colony
         var agent = SpawnHelpers.SpawnAgent(props, amountEmitted, Constants.EMITTED_AGENT_LIFETIME,
             position, direction, GetStageAsParent(),
-            SpawnHelpers.LoadAgentScene(), this);
+            SpawnHelpers.LoadAgentScene(), this, Colony?.ColonyMembers);
 
         ModLoader.ModInterface.TriggerOnToxinEmitted(agent);
 

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -186,7 +186,7 @@ public static class SpawnHelpers
     /// </summary>
     public static AgentProjectile SpawnAgent(AgentProperties properties, float amount,
         float lifetime, Vector3 location, Vector3 direction,
-        Node worldRoot, PackedScene agentScene, IEntity emitter)
+        Node worldRoot, PackedScene agentScene, IEntity emitter, IEnumerable<IEntity>? collisionExceptions)
     {
         var normalizedDirection = direction.Normalized();
 
@@ -195,6 +195,7 @@ public static class SpawnHelpers
         agent.Amount = amount;
         agent.TimeToLiveRemaining = lifetime;
         agent.Emitter = new EntityReference<IEntity>(emitter);
+        agent.CollisionExceptions = collisionExceptions;
 
         worldRoot.AddChild(agent);
         agent.Translation = location + (direction * 1.5f);


### PR DESCRIPTION
**Brief Description of What This PR Does**

This adds a collision exception to AgentProjectiles for each microbe in the firing microbe's colony.
Previously, all microbes of the same species as the firing microbe were prevented from taking damage from the projectile, but only the firing microbe had a collision exception.

**Related Issues**

closes #4342 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
