### PR TITLE
Editor button confirm warning icon can get stuck on sometimes

### DIFF
--- a/src/general/base_stage/EditorComponentWithActionsBase.cs
+++ b/src/general/base_stage/EditorComponentWithActionsBase.cs
@@ -107,6 +107,10 @@ public abstract class EditorComponentWithActionsBase<TEditor, TAction> : EditorC
     {
         SetUndoButtonStatus(canUndo && !Editor.CanCancelAction);
         SetRedoButtonStatus(canRedo && !Editor.CanCancelAction);
+
+        // Update the finish badge warning visibility aftrer updating action history
+        // because undoing and redoing actions can cause or fix warnings
+        UpdateFinishButtonWarningVisibility();
     }
 
     /// <summary>
@@ -146,17 +150,11 @@ public abstract class EditorComponentWithActionsBase<TEditor, TAction> : EditorC
     protected void Undo()
     {
         Editor.Undo();
-
-        // Update the finish badge warning visibility in case undoing an action caused or fixed the warning
-        UpdateFinishButtonWarningVisibility();
     }
 
     protected void Redo()
     {
         Editor.Redo();
-
-        // Update the finish badge warning visibility in case redoing an action caused or fixed the warning
-        UpdateFinishButtonWarningVisibility();
     }
 
     protected void SetUndoButtonStatus(bool enabled)

--- a/src/general/base_stage/EditorComponentWithActionsBase.cs
+++ b/src/general/base_stage/EditorComponentWithActionsBase.cs
@@ -110,6 +110,17 @@ public abstract class EditorComponentWithActionsBase<TEditor, TAction> : EditorC
     }
 
     /// <summary>
+    ///   Hides the finish button warning badge after the hide animation plays.
+    /// </summary>
+    /// <param name="animation">The name of the animation that just finished playing.</param>
+    public void HideFinishButtonWarningAfterAnimation(string animation)
+    {
+        // Before hiding the warning badge, make sure it's still supposed to be hidden
+        if (animation == "hide" && !ShowFinishButtonWarning)
+            finishButtonWarningBadge.Hide();
+    }
+
+    /// <summary>
     ///   Updates the visibility of the finish button's warning badge based on <see cref="ShowFinishButtonWarning"/>.
     /// </summary>
     protected void UpdateFinishButtonWarningVisibility()
@@ -135,11 +146,17 @@ public abstract class EditorComponentWithActionsBase<TEditor, TAction> : EditorC
     protected void Undo()
     {
         Editor.Undo();
+
+        // Update the finish badge warning visibility in case undoing an action caused or fixed the warning
+        UpdateFinishButtonWarningVisibility();
     }
 
     protected void Redo()
     {
         Editor.Redo();
+
+        // Update the finish badge warning visibility in case redoing an action caused or fixed the warning
+        UpdateFinishButtonWarningVisibility();
     }
 
     protected void SetUndoButtonStatus(bool enabled)

--- a/src/microbe_stage/editor/CellEditorComponent.tscn
+++ b/src/microbe_stage/editor/CellEditorComponent.tscn
@@ -1575,6 +1575,7 @@ text = "CLOSE"
 [connection signal="OnUndo" from="EditorComponentBottomLeftButtons" to="." method="Undo"]
 [connection signal="pressed" from="BottomRight/HBoxContainer/CancelButton" to="." method="OnCancelActionClicked"]
 [connection signal="pressed" from="BottomRight/HBoxContainer/ConfirmButton" to="." method="NextOrFinishClicked"]
+[connection signal="animation_finished" from="BottomRight/HBoxContainer/ConfirmButton/MarginContainer/WarningBadge/AnimationPlayer" to="." method="HideFinishButtonWarningAfterAnimation"]
 [connection signal="Confirmed" from="NegativeAtpWarning" to="." method="ConfirmFinishEditingWithNegativeATPPressed"]
 [connection signal="Accepted" from="OrganelleUpgradeGUI" to="." method="UpdateStats"]
 [connection signal="DeletePressed" from="OrganellePopupMenu" to="." method="OnDeletePressed"]


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR started hiding the warning icon after the "hide" animation finishes playing. Previously, the badge was made visible before playing the "show" animation for the first time and its visibility was never set back to false after that. It relied on the "hide" animation to make it appear visible. If we don't like the approach I took, we could probably also skip to the end of the "hide"/"show" animation (whichever is appropriate at the time) whenever the editor tab is opened instead.

**Related Issues**

closes #4310 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
