### PR TITLE
Double click on organelle move crashes the game

### DIFF
--- a/src/microbe_stage/editor/HexPopupMenu.cs
+++ b/src/microbe_stage/editor/HexPopupMenu.cs
@@ -108,7 +108,7 @@ public abstract class HexPopupMenu : CustomPopupMenu
         }
     }
 
-    private bool CanModifyHex => Visible && !Closing;
+    private bool IsInteractable => Visible && !Closing;
 
     public override void _Ready()
     {
@@ -132,7 +132,7 @@ public abstract class HexPopupMenu : CustomPopupMenu
     [RunOnKeyDown("e_delete", Priority = 1)]
     public bool OnDeleteKeyPressed()
     {
-        if (CanModifyHex)
+        if (IsInteractable)
         {
             EmitSignal(nameof(DeletePressed));
 
@@ -148,7 +148,7 @@ public abstract class HexPopupMenu : CustomPopupMenu
     [RunOnKeyDown("e_move", Priority = 1)]
     public bool OnMoveKeyPressed()
     {
-        if (CanModifyHex)
+        if (IsInteractable)
         {
             EmitSignal(nameof(MovePressed));
 
@@ -222,7 +222,7 @@ public abstract class HexPopupMenu : CustomPopupMenu
 
     private void OnDeletePressed()
     {
-        if (!CanModifyHex)
+        if (!IsInteractable)
             return;
 
         GUICommon.Instance.PlayButtonPressSound();
@@ -234,7 +234,7 @@ public abstract class HexPopupMenu : CustomPopupMenu
 
     private void OnMovePressed()
     {
-        if (!CanModifyHex)
+        if (!IsInteractable)
             return;
 
         GUICommon.Instance.PlayButtonPressSound();
@@ -246,7 +246,7 @@ public abstract class HexPopupMenu : CustomPopupMenu
 
     private void OnModifyPressed()
     {
-        if (!CanModifyHex)
+        if (!IsInteractable)
             return;
 
         GUICommon.Instance.PlayButtonPressSound();

--- a/src/microbe_stage/editor/HexPopupMenu.cs
+++ b/src/microbe_stage/editor/HexPopupMenu.cs
@@ -108,6 +108,8 @@ public abstract class HexPopupMenu : CustomPopupMenu
         }
     }
 
+    private bool CanModifyHex => Visible && !Closing;
+
     public override void _Ready()
     {
         base._Ready();
@@ -130,7 +132,7 @@ public abstract class HexPopupMenu : CustomPopupMenu
     [RunOnKeyDown("e_delete", Priority = 1)]
     public bool OnDeleteKeyPressed()
     {
-        if (Visible)
+        if (CanModifyHex)
         {
             EmitSignal(nameof(DeletePressed));
 
@@ -146,7 +148,7 @@ public abstract class HexPopupMenu : CustomPopupMenu
     [RunOnKeyDown("e_move", Priority = 1)]
     public bool OnMoveKeyPressed()
     {
-        if (Visible)
+        if (CanModifyHex)
         {
             EmitSignal(nameof(MovePressed));
 
@@ -220,6 +222,9 @@ public abstract class HexPopupMenu : CustomPopupMenu
 
     private void OnDeletePressed()
     {
+        if (!CanModifyHex)
+            return;
+
         GUICommon.Instance.PlayButtonPressSound();
 
         EmitSignal(nameof(DeletePressed));
@@ -229,6 +234,9 @@ public abstract class HexPopupMenu : CustomPopupMenu
 
     private void OnMovePressed()
     {
+        if (!CanModifyHex)
+            return;
+
         GUICommon.Instance.PlayButtonPressSound();
 
         EmitSignal(nameof(MovePressed));
@@ -238,6 +246,9 @@ public abstract class HexPopupMenu : CustomPopupMenu
 
     private void OnModifyPressed()
     {
+        if (!CanModifyHex)
+            return;
+
         GUICommon.Instance.PlayButtonPressSound();
 
         EmitSignal(nameof(ModifyPressed));


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR adds some extra checks before making changes to organelles in the editor. Before, we were only checking that the HexPopupMenu was still visible, but it takes a few frames to fully close, so multiple clicks or key presses could come through in that time. I started checking the Closing property in addition to the Visible property because Closing gets set immediately. I also added the check to a few extra places.

**Related Issues**

closes #4442 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
