### PR TITLE
Save load signal can trigger while loading a save leading to a crash

### DIFF
--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -166,7 +166,8 @@ public class SaveList : ScrollContainer
                 item.Connect(nameof(SaveListItem.OnKnownIncompatibleLoaded), this, nameof(OnKnownIncompatibleLoaded));
                 item.Connect(nameof(SaveListItem.OnDifferentVersionPrototypeLoaded), this,
                     nameof(OnDifferentVersionPrototypeLoaded));
-                item.Connect(nameof(SaveListItem.OnProblemFreeSaveLoaded), this, nameof(OnProblemFreeLoaded), new Array { save });
+                item.Connect(nameof(SaveListItem.OnProblemFreeSaveLoaded), this, nameof(OnProblemFreeLoaded),
+                    new Array { save });
 
                 item.SaveName = save;
                 savesList.AddChild(item);

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -82,6 +82,8 @@ public class SaveList : ScrollContainer
     private bool wasVisible;
     private bool incompatibleIfNotUpgraded;
 
+    private bool isLoadingSave;
+
     [Signal]
     public delegate void OnSelectedChanged();
 
@@ -164,7 +166,7 @@ public class SaveList : ScrollContainer
                 item.Connect(nameof(SaveListItem.OnKnownIncompatibleLoaded), this, nameof(OnKnownIncompatibleLoaded));
                 item.Connect(nameof(SaveListItem.OnDifferentVersionPrototypeLoaded), this,
                     nameof(OnDifferentVersionPrototypeLoaded));
-                item.Connect(nameof(SaveListItem.OnProblemFreeSaveLoaded), this, nameof(OnSaveLoadedWithoutProblems));
+                item.Connect(nameof(SaveListItem.OnProblemFreeSaveLoaded), this, nameof(OnProblemFreeLoaded), new Array { save });
 
                 item.SaveName = save;
                 savesList.AddChild(item);
@@ -286,6 +288,12 @@ public class SaveList : ScrollContainer
         loadInvalidConfirmDialog.PopupCenteredShrink();
     }
 
+    private void OnProblemFreeLoaded(string saveName)
+    {
+        saveToBeLoaded = saveName;
+        StartLoadTransition();
+    }
+
     private void OnKnownIncompatibleLoaded()
     {
         loadIncompatibleDialog.PopupCenteredShrink();
@@ -393,6 +401,17 @@ public class SaveList : ScrollContainer
     {
         GUICommon.Instance.PlayButtonPressSound();
 
+        StartLoadTransition();
+    }
+
+    private void StartLoadTransition()
+    {
+        // If a load is already queued, don't queue another one
+        if (isLoadingSave)
+            return;
+
+        isLoadingSave = true;
+
         TransitionManager.Instance.AddSequence(ScreenFade.FadeType.FadeOut, 0.3f, LoadSave, true);
     }
 
@@ -410,12 +429,9 @@ public class SaveList : ScrollContainer
         }
 
         SaveHelper.LoadSave(saveToBeLoaded);
+
         EmitSignal(nameof(OnSaveLoaded), saveToBeLoaded);
         saveToBeLoaded = null;
-    }
-
-    private void OnSaveLoadedWithoutProblems(string saveName)
-    {
-        EmitSignal(nameof(OnSaveLoaded), saveName);
+        isLoadingSave = false;
     }
 }

--- a/src/saving/SaveListItem.cs
+++ b/src/saving/SaveListItem.cs
@@ -294,7 +294,7 @@ public class SaveListItem : PanelContainer
             return;
         }
 
-        TransitionManager.Instance.AddSequence(ScreenFade.FadeType.FadeOut, 0.3f, LoadSave, true);
+        EmitSignal(nameof(OnProblemFreeSaveLoaded));
     }
 
     protected override void Dispose(bool disposing)
@@ -318,12 +318,6 @@ public class SaveListItem : PanelContainer
         }
 
         base.Dispose(disposing);
-    }
-
-    private void LoadSave()
-    {
-        SaveHelper.LoadSave(SaveName);
-        EmitSignal(nameof(OnProblemFreeSaveLoaded), saveName);
     }
 
     private void LoadSaveData()


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR makes SaveListItem use the same load method used by SaveList because SaveList already had plenty of guards against loading, saving, or deleting multiple times at once. It also stops SaveList from queuing multiple load transitions at once.

The multiple transition queuing was the real cause of the crash. SaveListItem would queue two transitions that loaded a save when they were finished. When the first load finished, it disposed of the scene the transitions were triggered from. Then, when the second load started, it tried to emit a signal from the disposed scene, which caused the exception found in the issue.

**Related Issues**

closes #3981 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
