### PR TITLE
Added parameter to keep initial compounds on Multicells

### DIFF
--- a/src/early_multicellular_stage/Microbe.Multicellular.cs
+++ b/src/early_multicellular_stage/Microbe.Multicellular.cs
@@ -65,7 +65,7 @@ public partial class Microbe
     /// <summary>
     ///   Adds the next cell missing from this multicellular species' body plan to this microbe's colony
     /// </summary>
-    public void AddMulticellularGrowthCell()
+    public void AddMulticellularGrowthCell(bool keepCompounds = false)
     {
         if (Colony == null)
         {
@@ -77,7 +77,7 @@ public partial class Microbe
 
         var template = CastedMulticellularSpecies.Cells[nextBodyPlanCellToGrowIndex];
 
-        var cell = CreateMulticellularColonyMemberCell(template.CellType);
+        var cell = CreateMulticellularColonyMemberCell(template.CellType, keepCompounds);
         cell.MulticellularBodyPlanPartIndex = nextBodyPlanCellToGrowIndex;
 
         // We don't reset our state here in case we want to be in engulf mode
@@ -127,7 +127,7 @@ public partial class Microbe
     {
         while (!IsFullyGrownMulticellular)
         {
-            AddMulticellularGrowthCell();
+            AddMulticellularGrowthCell(true);
         }
     }
 
@@ -291,7 +291,7 @@ public partial class Microbe
         }
     }
 
-    private Microbe CreateMulticellularColonyMemberCell(CellType cellType)
+    private Microbe CreateMulticellularColonyMemberCell(CellType cellType, bool keepCompounds)
     {
         var newCell = SpawnHelpers.SpawnMicrobe(Species, Translation,
             GetParent(), SpawnHelpers.LoadMicrobeScene(), true, cloudSystem!, spawnSystem!, CurrentGame, cellType);
@@ -299,8 +299,11 @@ public partial class Microbe
         // Make it despawn like normal (if our colony is accidentally somehow disbanded)
         spawnSystem!.AddEntityToTrack(newCell);
 
-        // Remove the compounds from the created cell
-        newCell.Compounds.ClearCompounds();
+        if (!keepCompounds)
+        {
+            // Remove the compounds from the created cell
+            newCell.Compounds.ClearCompounds();
+        }
 
         // TODO: different sound effect?
         PlaySoundEffect("res://assets/sounds/soundeffects/reproduction.ogg");

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -93,7 +93,7 @@ public static class SpawnHelpers
         {
             while (!microbe.IsFullyGrownMulticellular)
             {
-                microbe.AddMulticellularGrowthCell();
+                microbe.AddMulticellularGrowthCell(true);
 
                 if (random.NextDouble() > Constants.CHANCE_MULTICELLULAR_PARTLY_GROWN_CELL_CHANCE)
                     break;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds a parameter to keep initial compounds when spawning new colonies.

Issue: #4237 

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
