### PR TITLE
Closing modal on "Next" pressed in editors

### DIFF
--- a/src/general/base_stage/EditorComponentBase.cs
+++ b/src/general/base_stage/EditorComponentBase.cs
@@ -171,6 +171,10 @@ public abstract class EditorComponentBase<TEditor> : ControlWithInput, IEditorCo
     {
         GUICommon.Instance.PlayButtonPressSound();
 
+        // If a modal won't close, don't do anything
+        if (!ModalManager.Instance.ClearModals())
+            return;
+
         if (OnFinish != null)
         {
             if (OnFinish!.Invoke(null))

--- a/src/general/base_stage/EditorComponentBase.cs
+++ b/src/general/base_stage/EditorComponentBase.cs
@@ -171,9 +171,7 @@ public abstract class EditorComponentBase<TEditor> : ControlWithInput, IEditorCo
     {
         GUICommon.Instance.PlayButtonPressSound();
 
-        // If a modal won't close, don't do anything
-        if (!ModalManager.Instance.ClearModals())
-            return;
+        ModalManager.Instance.ClearModals();
 
         if (OnFinish != null)
         {

--- a/src/gui_common/ModalManager.cs
+++ b/src/gui_common/ModalManager.cs
@@ -99,7 +99,7 @@ public class ModalManager : NodeWithInput
     }
 
     /// <summary>
-    /// Attempt to clear all open modals.
+    ///   Attempt to clear all open modals.
     /// </summary>
     /// <returns>Returns true if all modals were closed, false otherwise.</returns>
     public bool ClearModals()
@@ -133,8 +133,8 @@ public class ModalManager : NodeWithInput
     }
 
     /// <summary>
-    /// Attempts to hide the given modal.
-    /// This won't hide the modal if it's exclusive and doesn't allow closing on escape.
+    ///   Attempts to hide the given modal.
+    ///   This won't hide the modal if it's exclusive and doesn't allow closing on escape.
     /// </summary>
     /// <param name="popup">Modal to hide</param>
     /// <returns>True if the modal was hidden</returns>

--- a/src/gui_common/ModalManager.cs
+++ b/src/gui_common/ModalManager.cs
@@ -95,16 +95,23 @@ public class ModalManager : NodeWithInput
 
         var popup = modalStack.First();
 
-        if (popup.Exclusive && !popup.ExclusiveAllowCloseOnEscape)
-            return false;
+        return HideModal(popup);
+    }
 
-        // This is emitted before closing to allow window using components to differentiate between "cancel" and
-        // "any other reason for closing" in case some logic can be simplified by handling just those two situations.
-        if (popup is CustomWindow dialog)
-            dialog.EmitSignal(nameof(CustomWindow.Cancelled));
+    /// <summary>
+    /// Attempt to clear all open modals.
+    /// </summary>
+    /// <returns>Returns true if all modals were closed, false otherwise.</returns>
+    public bool ClearModals()
+    {
+        if (modalStack.Count <= 0)
+            return true;
 
-        popup.Close();
-        popup.Notification(Control.NotificationModalClose);
+        for (int i = 0; i < modalStack.Count; ++i)
+        {
+            if (!HideModal(modalStack[i]))
+                return false;
+        }
 
         return true;
     }
@@ -123,6 +130,28 @@ public class ModalManager : NodeWithInput
             return modal;
 
         return null;
+    }
+
+    /// <summary>
+    /// Attempts to hide the given modal.
+    /// This won't hide the modal if it's exclusive and doesn't allow closing on escape.
+    /// </summary>
+    /// <param name="popup">Modal to hide</param>
+    /// <returns>True if the modal was hidden</returns>
+    private static bool HideModal(TopLevelContainer popup)
+    {
+        if (popup.Exclusive && !popup.ExclusiveAllowCloseOnEscape)
+            return false;
+
+        // This is emitted before closing to allow window using components to differentiate between "cancel" and
+        // "any other reason for closing" in case some logic can be simplified by handling just those two situations.
+        if (popup is CustomWindow dialog)
+            dialog.EmitSignal(nameof(CustomWindow.Cancelled));
+
+        popup.Close();
+        popup.Notification(Control.NotificationModalClose);
+
+        return true;
     }
 
     private void UpdateModals()

--- a/src/gui_common/ModalManager.cs
+++ b/src/gui_common/ModalManager.cs
@@ -95,25 +95,23 @@ public class ModalManager : NodeWithInput
 
         var popup = modalStack.First();
 
-        return HideModal(popup);
+        if (popup.Exclusive && !popup.ExclusiveAllowCloseOnEscape)
+            return false;
+
+        HideModal(popup);
+
+        return true;
     }
 
     /// <summary>
     ///   Attempt to clear all open modals.
     /// </summary>
-    /// <returns>Returns true if all modals were closed, false otherwise.</returns>
-    public bool ClearModals()
+    public void ClearModals()
     {
-        if (modalStack.Count <= 0)
-            return true;
-
-        for (int i = 0; i < modalStack.Count; ++i)
+        foreach (var modal in modalStack)
         {
-            if (!HideModal(modalStack[i]))
-                return false;
+            HideModal(modal);
         }
-
-        return true;
     }
 
     /// <summary>
@@ -137,11 +135,10 @@ public class ModalManager : NodeWithInput
     ///   This won't hide the modal if it's exclusive and doesn't allow closing on escape.
     /// </summary>
     /// <param name="popup">Modal to hide</param>
-    /// <returns>True if the modal was hidden</returns>
-    private static bool HideModal(TopLevelContainer popup)
+    private static void HideModal(TopLevelContainer popup)
     {
-        if (popup.Exclusive && !popup.ExclusiveAllowCloseOnEscape)
-            return false;
+        if (!popup.Visible)
+            return;
 
         // This is emitted before closing to allow window using components to differentiate between "cancel" and
         // "any other reason for closing" in case some logic can be simplified by handling just those two situations.
@@ -150,8 +147,6 @@ public class ModalManager : NodeWithInput
 
         popup.Close();
         popup.Notification(Control.NotificationModalClose);
-
-        return true;
     }
 
     private void UpdateModals()


### PR DESCRIPTION
**Brief Description of What This PR Does**

Editors will now attempt to close all their open modals before continuing.
It will not let the editor continue if there is an exclusive modal open that refuses to close.

Closes #4470 

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
