### PR TITLE
Couldn't find tooltip with node name: protoplasm in group organelleSelection

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -105,6 +105,10 @@ public partial class CellEditorComponent
 
         foreach (var organelle in organelles)
         {
+            // Don't bother updating the tooltips for organelles that aren't even shown
+            if (organelle.Unimplemented || organelle.EditorButtonGroup == OrganelleDefinition.OrganelleGroup.Hidden)
+                continue;
+
             float osmoregulationCost = organelle.HexCount * osmoregulationCostPerHex;
 
             var tooltip = GetSelectionTooltip(organelle.InternalName, "organelleSelection");


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR fixes the "Couldn't find tooltip with node name: protoplasm in group organelleSelection" error that started showing up in the Godot editor after entering the cell editor, which was caused by PR #4480.

**Related Issues**

No issue was made for this.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
