### PR TITLE
Fix editor storage statistic not taking specialized vacuole into account

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -591,6 +591,11 @@ public static class Constants
     public const string VACUOLE_DEFAULT_COMPOUND_NAME = "glucose";
 
     /// <summary>
+    ///   How much the capacity of a specialized vacuole should be multiplied
+    /// </summary>
+    public const float VACUOLE_SPECIALIZED_MULTIPLIER = 2.0f;
+
+    /// <summary>
     ///   How much ATP does binding mode cost per second
     /// </summary>
     public const float BINDING_ATP_COST_PER_SECOND = 2.0f;

--- a/src/gui_common/tooltip/ToolTipManager.tscn
+++ b/src/gui_common/tooltip/ToolTipManager.tscn
@@ -270,6 +270,14 @@ Positioning = 2
 DescriptionLabelPath = NodePath("../timeIndicator/MarginContainer/VBoxContainer/Description")
 
 [node name="digestionEfficiencyDetails" parent="GroupHolder/editor" instance=ExtResource( 1 )]
+visible = false
+DisplayDelay = 0.0
+Positioning = 1
+HideOnMouseAction = false
+DescriptionLabelPath = NodePath("MarginContainer/VBoxContainer/Description")
+
+[node name="storageDetails" parent="GroupHolder/editor" instance=ExtResource( 1 )]
+visible = false
 DisplayDelay = 0.0
 Positioning = 1
 HideOnMouseAction = false

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -1364,10 +1364,10 @@ public partial class Microbe
         int sign = negative ? -1 : 1;
 
         organellesCapacity += MicrobeInternalCalculations
-            .GetNominalCapacityForOrganelle(organelle.Upgrades, organelle.Definition) * sign;
+            .GetNominalCapacityForOrganelle(organelle.Definition, organelle.Upgrades) * sign;
 
         var capacityTuple = MicrobeInternalCalculations
-            .GetAdditionalCapacityForOrganelle(organelle.Upgrades, organelle.Definition);
+            .GetAdditionalCapacityForOrganelle(organelle.Definition, organelle.Upgrades);
 
         if (capacityTuple.Compound == null)
             return;

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -1363,17 +1363,17 @@ public partial class Microbe
     {
         int sign = negative ? -1 : 1;
 
-        if (organelle.Upgrades?.CustomUpgradeData is StorageComponentUpgrades storage &&
-            storage.SpecializedFor != null)
-        {
-            Compound specialization = storage.SpecializedFor;
-            additionalCompoundCapacities.TryGetValue(specialization, out var existing);
-            additionalCompoundCapacities[specialization] = existing + organelle.StorageCapacity * 2 * sign;
-        }
-        else
-        {
-            organellesCapacity += organelle.StorageCapacity * sign;
-        }
+        organellesCapacity += MicrobeInternalCalculations
+            .GetNominalCapacityForOrganelle(organelle.Upgrades, organelle.Definition) * sign;
+
+        var capacityTuple = MicrobeInternalCalculations
+            .GetAdditionalCapacityForOrganelle(organelle.Upgrades, organelle.Definition);
+
+        if (capacityTuple.Compound == null)
+            return;
+
+        additionalCompoundCapacities.TryGetValue(capacityTuple.Compound, out var existing);
+        additionalCompoundCapacities[capacityTuple.Compound] = existing + capacityTuple.Capacity * sign;
     }
 
     /// <summary>

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -36,6 +36,38 @@ public static class MicrobeInternalCalculations
         return (Hex.AxialToCartesian(new Hex(0, 0)) - Hex.AxialToCartesian(organelle.Position)).Normalized();
     }
 
+    public static float GetNominalCapacityForOrganelle(OrganelleUpgrades? upgrades, OrganelleDefinition definition)
+    {
+        if (upgrades?.CustomUpgradeData is StorageComponentUpgrades storage &&
+            storage.SpecializedFor != null)
+        {
+            return 0;
+        }
+
+        if (definition.Components.Storage == null)
+            return 0;
+
+        return definition.Components.Storage!.Capacity;
+    }
+
+    public static (Compound? Compound, float Capacity)
+        GetAdditionalCapacityForOrganelle(OrganelleUpgrades? upgrades, OrganelleDefinition definition)
+    {
+        if (definition.Components.Storage == null)
+            return (null, 0);
+
+        if (upgrades?.CustomUpgradeData is StorageComponentUpgrades storage &&
+            storage.SpecializedFor != null)
+        {
+            var specialization = storage.SpecializedFor;
+            var capacity = definition.Components.Storage!.Capacity;
+            var extraCapacity = capacity * Constants.VACUOLE_SPECIALIZED_MULTIPLIER;
+            return (specialization, extraCapacity);
+        }
+
+        return (null, 0);
+    }
+
     public static float CalculateCapacity(IEnumerable<OrganelleTemplate> organelles)
     {
         return organelles.Where(

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -44,12 +44,12 @@ public static class MicrobeInternalCalculations
     public static Dictionary<Compound, float> GetTotalSpecificCapacity(IEnumerable<OrganelleTemplate> organelles)
     {
         var capacities = new Dictionary<Compound, float>();
-        var nominalCap = GetTotalNominalCapacity(organelles);
+        var totalNominalCap = 0.0f;
 
         foreach (var organelle in organelles)
         {
-            var capacity = MicrobeInternalCalculations
-                .GetAdditionalCapacityForOrganelle(organelle.Definition, organelle.Upgrades);
+            var capacity = GetAdditionalCapacityForOrganelle(organelle.Definition, organelle.Upgrades);
+            totalNominalCap += GetNominalCapacityForOrganelle(organelle.Definition, organelle.Upgrades);
 
             if (capacity.Compound == null)
                 continue;
@@ -60,9 +60,12 @@ public static class MicrobeInternalCalculations
             }
             else
             {
-                capacities.Add(capacity.Compound, capacity.Capacity + nominalCap);
+                capacities.Add(capacity.Compound, capacity.Capacity);
             }
         }
+
+        foreach (var compound in capacities.Keys.ToList())
+            capacities[compound] += totalNominalCap;
 
         return capacities;
     }

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -56,6 +56,7 @@ public partial class CellEditorComponent
 
         rigiditySlider.RegisterToolTipForControl("rigiditySlider", "editor");
         digestionEfficiencyLabel.RegisterToolTipForControl("digestionEfficiencyDetails", "editor");
+        storageLabel.RegisterToolTipForControl("storageDetails", "editor");
     }
 
     protected override void OnTranslationsChanged()
@@ -174,9 +175,42 @@ public partial class CellEditorComponent
         hpLabel.Value = hp;
     }
 
-    private void UpdateStorage(float storage)
+    private void UpdateStorage(float nominalStorage, Dictionary<Compound, float> storage)
     {
-        storageLabel.Value = (float)Math.Round(storage, 1);
+        storageLabel.Value = nominalStorage;
+
+        var tooltip = ToolTipManager.Instance.GetToolTip("storageDetails", "editor");
+        var tooltipLoaded = tooltip != null;
+
+        if (storage.Count == 0)
+        {
+            storageLabel.UnRegisterFirstToolTipForControl();
+
+            return;
+        }
+
+        var description = new LocalizedStringBuilder(100);
+
+        bool first = true;
+
+        foreach (var entry in storage)
+        {
+            if (!first)
+                description.Append("\n");
+
+            first = false;
+
+            description.Append(entry.Key.Name);
+            description.Append(": ");
+            description.Append(entry.Value);
+        }
+
+        storageLabel.RegisterToolTipForControl("storageDetails", "editor");
+
+        if (tooltipLoaded)
+            tooltip!.Description = description.ToString();
+        else
+            GD.PrintErr("Can't update storage tooltip");
     }
 
     private void UpdateTotalDigestionSpeed(float speed)
@@ -499,7 +533,7 @@ public partial class CellEditorComponent
         SetSpeciesInfo(newName, Membrane, Colour, Rigidity, behaviourEditor.Behaviour);
         UpdateGeneration(species.Generation);
         UpdateHitpoints(CalculateHitpoints());
-        UpdateStorage(CalculateStorage());
+        UpdateStorage(GetNominalCapacity(), GetAdditionalCapacities());
 
         ApplyLightLevelOption();
     }

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -177,7 +177,7 @@ public partial class CellEditorComponent
 
     private void UpdateStorage(float nominalStorage, Dictionary<Compound, float> storage)
     {
-        storageLabel.Value = nominalStorage;
+        storageLabel.Value = (float)Math.Round(nominalStorage, 1);
 
         if (storage.Count == 0)
         {

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -179,15 +179,21 @@ public partial class CellEditorComponent
     {
         storageLabel.Value = nominalStorage;
 
-        var tooltip = ToolTipManager.Instance.GetToolTip("storageDetails", "editor");
-        var tooltipLoaded = tooltip != null;
-
         if (storage.Count == 0)
         {
             storageLabel.UnRegisterFirstToolTipForControl();
-
             return;
         }
+
+        var tooltip = ToolTipManager.Instance.GetToolTip("storageDetails", "editor");
+        if (tooltip == null)
+        {
+            GD.PrintErr("Can't update storage tooltip");
+            return;
+        }
+
+        if (!storageLabel.IsToolTipRegistered(tooltip))
+            storageLabel.RegisterToolTipForControl(tooltip, true);
 
         var description = new LocalizedStringBuilder(100);
 
@@ -205,12 +211,7 @@ public partial class CellEditorComponent
             description.Append(entry.Value);
         }
 
-        storageLabel.RegisterToolTipForControl("storageDetails", "editor");
-
-        if (tooltipLoaded)
-            tooltip!.Description = description.ToString();
-        else
-            GD.PrintErr("Can't update storage tooltip");
+        tooltip.Description = description.ToString();
     }
 
     private void UpdateTotalDigestionSpeed(float speed)

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1039,31 +1039,12 @@ public partial class CellEditorComponent :
 
     public float GetNominalCapacity()
     {
-        return editedMicrobeOrganelles.Sum(o => MicrobeInternalCalculations
-            .GetNominalCapacityForOrganelle(o.Upgrades, o.Definition));
+        return MicrobeInternalCalculations.GetTotalNominalCapacity(editedMicrobeOrganelles);
     }
 
     public Dictionary<Compound, float> GetAdditionalCapacities()
     {
-        var dict = new Dictionary<Compound, float>();
-
-        foreach (var organelle in editedMicrobeOrganelles)
-        {
-            var capacity = MicrobeInternalCalculations
-                .GetAdditionalCapacityForOrganelle(organelle.Upgrades, organelle.Definition);
-
-            if (capacity.Compound == null)
-                continue;
-
-            if (dict.TryGetValue(capacity.Compound, out var currentCapacity))
-                dict[capacity.Compound] = currentCapacity + capacity.Capacity;
-            else
-                dict.Add(capacity.Compound, capacity.Capacity);
-        }
-
-        var nominalCap = GetNominalCapacity();
-        return dict.Select(e => new KeyValuePair<Compound, float>(e.Key, e.Value + nominalCap))
-            .ToDictionary(x => x.Key, x => x.Value);
+        return MicrobeInternalCalculations.GetTotalSpecificCapacity(editedMicrobeOrganelles);
     }
 
     public float CalculateTotalDigestionSpeed()


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR updates the code the organism statistics panel uses to display storage to display the correct capacity

**Related Issues**

Closes #4496 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
