### PR TITLE
Duplicating a cell type selects the new type

### DIFF
--- a/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -120,10 +120,7 @@ public partial class CellBodyPlanEditorComponent :
     private bool forceUpdateCellGraphics;
 
     [Signal]
-    public delegate void OnCellTypeToEditSelected(string name);
-
-    [Signal]
-    public delegate void OnSelectCellType(string typeName);
+    public delegate void OnCellTypeToEditSelected(string name, bool switchTab);
 
     public enum SelectionMenuTab
     {
@@ -852,7 +849,7 @@ public partial class CellBodyPlanEditorComponent :
 
     private void OnModifyPressed()
     {
-        EmitSignal(nameof(OnCellTypeToEditSelected), cellPopupMenu.SelectedCells.First().Data!.CellType.TypeName);
+        EmitSignal(nameof(OnCellTypeToEditSelected), cellPopupMenu.SelectedCells.First().Data!.CellType.TypeName, true);
     }
 
     /// <summary>
@@ -1132,7 +1129,7 @@ public partial class CellBodyPlanEditorComponent :
         Editor.EditedSpecies.CellTypes.Add(newType);
         GD.Print("New cell type created: ", newType.TypeName);
 
-        EmitSignal(nameof(OnSelectCellType), newType.TypeName);
+        EmitSignal(nameof(OnCellTypeToEditSelected), newType.TypeName, false);
 
         UpdateCellTypeSelections();
 
@@ -1174,7 +1171,7 @@ public partial class CellBodyPlanEditorComponent :
 
         GUICommon.Instance.PlayButtonPressSound();
 
-        EmitSignal(nameof(OnCellTypeToEditSelected), activeActionName);
+        EmitSignal(nameof(OnCellTypeToEditSelected), activeActionName, true);
     }
 
     private void RegenerateCellTypeIcon(CellType type)

--- a/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -122,6 +122,9 @@ public partial class CellBodyPlanEditorComponent :
     [Signal]
     public delegate void OnCellTypeToEditSelected(string name);
 
+    [Signal]
+    public delegate void OnSelectCellType(string typeName);
+
     public enum SelectionMenuTab
     {
         Structure,
@@ -1129,7 +1132,11 @@ public partial class CellBodyPlanEditorComponent :
         Editor.EditedSpecies.CellTypes.Add(newType);
         GD.Print("New cell type created: ", newType.TypeName);
 
+        EmitSignal(nameof(OnSelectCellType), newType.TypeName);
+
         UpdateCellTypeSelections();
+
+        OnCellToPlaceSelected(newType.TypeName);
 
         duplicateCellTypeDialog.Hide();
     }

--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
@@ -426,19 +426,7 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
         reportTab.UpdatePatchDetails(patch, patch);
     }
 
-    private void OnSelectCellType(string typeName)
-    {
-        var newTypeToSelect = EditedSpecies.CellTypes.First(c => c.TypeName == typeName);
-
-        if (selectedCellTypeToEdit == null || selectedCellTypeToEdit != newTypeToSelect)
-        {
-            selectedCellTypeToEdit = newTypeToSelect;
-
-            cellEditorTab.OnEditorSpeciesSetup(EditedBaseSpecies);
-        }
-    }
-
-    private void OnStartEditingCellType(string name)
+    private void OnStartEditingCellType(string name, bool switchTab)
     {
         if (CanCancelAction)
         {
@@ -460,7 +448,8 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
             cellEditorTab.OnEditorSpeciesSetup(EditedBaseSpecies);
         }
 
-        SetEditorTab(EditorTab.CellTypeEditor);
+        if (switchTab)
+            SetEditorTab(EditorTab.CellTypeEditor);
     }
 
     private void CheckAndApplyCellTypeEdit()

--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
@@ -418,6 +418,18 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
         reportTab.UpdatePatchDetails(patch, patch);
     }
 
+    private void OnSelectCellType(string typeName)
+    {
+        var newTypeToSelect = EditedSpecies.CellTypes.First(c => c.TypeName == typeName);
+
+        if (selectedCellTypeToEdit == null || selectedCellTypeToEdit != newTypeToSelect)
+        {
+            selectedCellTypeToEdit = newTypeToSelect;
+
+            cellEditorTab.OnEditorSpeciesSetup(EditedBaseSpecies);
+        }
+    }
+
     private void OnStartEditingCellType(string name)
     {
         if (CanCancelAction)

--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.tscn
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.tscn
@@ -79,7 +79,6 @@ align = 1
 HelpCategory = "MicrobeEditor"
 
 [connection signal="OnCellTypeToEditSelected" from="EarlyMulticellularEditorGUI/CellBodyPlanEditorComponent" to="." method="OnStartEditingCellType"]
-[connection signal="OnSelectCellType" from="EarlyMulticellularEditorGUI/CellBodyPlanEditorComponent" to="." method="OnSelectCellType"]
 [connection signal="OnTabSelected" from="EarlyMulticellularEditorGUI/MicrobeEditorTabButtons" to="." method="SetEditorTab"]
 [connection signal="OnOpenHelp" from="EarlyMulticellularEditorGUI/EditorCommonBottomLeftButtons" to="PauseMenu" method="OpenToHelp"]
 [connection signal="OnOpenMenu" from="EarlyMulticellularEditorGUI/EditorCommonBottomLeftButtons" to="PauseMenu" method="Open"]

--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.tscn
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.tscn
@@ -79,6 +79,7 @@ align = 1
 HelpCategory = "MicrobeEditor"
 
 [connection signal="OnCellTypeToEditSelected" from="EarlyMulticellularEditorGUI/CellBodyPlanEditorComponent" to="." method="OnStartEditingCellType"]
+[connection signal="OnSelectCellType" from="EarlyMulticellularEditorGUI/CellBodyPlanEditorComponent" to="." method="OnSelectCellType"]
 [connection signal="OnTabSelected" from="EarlyMulticellularEditorGUI/MicrobeEditorTabButtons" to="." method="SetEditorTab"]
 [connection signal="OnOpenHelp" from="EarlyMulticellularEditorGUI/EditorCommonBottomLeftButtons" to="PauseMenu" method="OpenToHelp"]
 [connection signal="OnOpenMenu" from="EarlyMulticellularEditorGUI/EditorCommonBottomLeftButtons" to="PauseMenu" method="Open"]


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR makes it so that after duplicating a cell type, it is selected. Code has been adapted from the previous PR for this issue.

**Related Issues**

Closes #3167

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
