### PR TITLE
Infinite MP achieved by abusing Duplicate and Delete to cell types

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -109,6 +109,7 @@
     <Compile Include="src\early_multicellular_stage\editor\action_data\CellMoveActionData.cs" />
     <Compile Include="src\early_multicellular_stage\editor\action_data\CellPlacementActionData.cs" />
     <Compile Include="src\early_multicellular_stage\editor\action_data\CellRemoveActionData.cs" />
+    <Compile Include="src\early_multicellular_stage\editor\action_data\DuplicateDeleteCellTypeData.cs" />
     <Compile Include="src\early_multicellular_stage\editor\CellBodyPlanEditorComponent.Callbacks.cs" />
     <Compile Include="src\early_multicellular_stage\editor\CellBodyPlanEditorComponent.cs" />
     <Compile Include="src\early_multicellular_stage\editor\CellPopupMenu.cs" />

--- a/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.Callbacks.cs
+++ b/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.Callbacks.cs
@@ -1,4 +1,6 @@
-﻿/// <summary>
+﻿using Godot;
+
+/// <summary>
 ///   Callbacks of the cell body plan editor
 /// </summary>
 [DeserializedCallbackTarget]
@@ -38,6 +40,38 @@ public partial class CellBodyPlanEditorComponent
     private void UndoCellPlaceAction(CellPlacementActionData data)
     {
         editedMicrobeCells.Remove(data.PlacedHex);
+    }
+
+    [DeserializedCallbackAllowed]
+    private void DuplicateCellType(DuplicateDeleteCellTypeData data)
+    {
+        var originalName = data.CellType.TypeName;
+        var count = 1;
+
+        // Renaming a cell doesn't create an editor action, so it's possible for someone to duplicate a cell type, undo
+        // the duplication, change another cell type's name to the old duplicate's name, then redo the duplication,
+        // which would lead to duplicate names, so this loop ensures the duplicated cell's name will be unique
+        while (!IsNewCellTypeNameValid(data.CellType.TypeName))
+        {
+            data.CellType.TypeName = $"{originalName} {count++}";
+        }
+
+        Editor.EditedSpecies.CellTypes.Add(data.CellType);
+        GD.Print("New cell type created: ", data.CellType.TypeName);
+
+        EmitSignal(nameof(OnCellTypeToEditSelected), data.CellType.TypeName, false);
+
+        UpdateCellTypeSelections();
+
+        OnCellToPlaceSelected(data.CellType.TypeName);
+    }
+
+    private void DeleteCellType(DuplicateDeleteCellTypeData data)
+    {
+        if (!Editor.EditedSpecies.CellTypes.Remove(data.CellType))
+            GD.PrintErr("Failed to delete cell type from species");
+
+        UpdateCellTypeSelections();
     }
 
     [DeserializedCallbackAllowed]

--- a/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -946,7 +946,7 @@ public partial class CellBodyPlanEditorComponent :
         OnCurrentActionChanged();
 
         // After clearing the selected cell, emit a signal to let the editor know
-        EmitSignal(nameof(OnCellTypeToEditSelected), string.Empty, false);
+        EmitSignal(nameof(OnCellTypeToEditSelected), null, false);
     }
 
     private void OnCellsChanged()

--- a/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -917,32 +917,26 @@ public partial class CellBodyPlanEditorComponent :
 
     private void OnCurrentActionChanged()
     {
-        // Enable the duplicate, delete, edit buttons for the cell type
-        if (!string.IsNullOrEmpty(activeActionName))
+        var isActionNull = string.IsNullOrEmpty(activeActionName);
+
+        // These buttons should only be enabled if a cell type is selected
+        modifyTypeButton.Disabled = isActionNull;
+        deleteTypeButton.Disabled = isActionNull;
+        duplicateTypeButton.Disabled = isActionNull;
+
+        CellTypeSelection? cellTypeButton = null;
+
+        if (!isActionNull &&
+            !cellTypeSelectionButtons.TryGetValue(activeActionName!, out cellTypeButton))
         {
-            modifyTypeButton.Disabled = false;
-            deleteTypeButton.Disabled = false;
-            duplicateTypeButton.Disabled = false;
-
-            if (!cellTypeSelectionButtons.TryGetValue(activeActionName!, out var cellTypeButton))
-            {
-                GD.PrintErr("Invalid active action for highlight update");
-                return;
-            }
-
-            // Update the icon highlightings
-            foreach (var element in cellTypeSelectionButtons.Values)
-            {
-                element.Selected = element == cellTypeButton;
-            }
+            GD.PrintErr("Invalid active action for highlight update");
+            return;
         }
-        else
+
+        // Update the icon highlightings
+        foreach (var element in cellTypeSelectionButtons.Values)
         {
-            // Clear all highlights
-            foreach (var element in cellTypeSelectionButtons.Values)
-            {
-                element.Selected = false;
-            }
+            element.Selected = element == cellTypeButton;
         }
     }
 
@@ -950,6 +944,9 @@ public partial class CellBodyPlanEditorComponent :
     {
         activeActionName = null;
         OnCurrentActionChanged();
+
+        // After clearing the selected cell, emit a signal to let the editor know
+        EmitSignal(nameof(OnCellTypeToEditSelected), string.Empty, false);
     }
 
     private void OnCellsChanged()
@@ -1126,14 +1123,9 @@ public partial class CellBodyPlanEditorComponent :
         var newType = (CellType)type.Clone();
         newType.TypeName = newTypeName;
 
-        Editor.EditedSpecies.CellTypes.Add(newType);
-        GD.Print("New cell type created: ", newType.TypeName);
-
-        EmitSignal(nameof(OnCellTypeToEditSelected), newType.TypeName, false);
-
-        UpdateCellTypeSelections();
-
-        OnCellToPlaceSelected(newType.TypeName);
+        var data = new DuplicateDeleteCellTypeData(newType);
+        var action = new SingleEditorAction<DuplicateDeleteCellTypeData>(DuplicateCellType, DeleteCellType, data);
+        EnqueueAction(new CombinedEditorAction(action));
 
         duplicateCellTypeDialog.Hide();
     }
@@ -1155,13 +1147,9 @@ public partial class CellBodyPlanEditorComponent :
             return;
         }
 
-        // TODO: make a reversible action
-        if (!Editor.EditedSpecies.CellTypes.Remove(type))
-        {
-            GD.PrintErr("Failed to delete cell type from species");
-        }
-
-        UpdateCellTypeSelections();
+        var data = new DuplicateDeleteCellTypeData(type);
+        var action = new SingleEditorAction<DuplicateDeleteCellTypeData>(DeleteCellType, DuplicateCellType, data);
+        EnqueueAction(new CombinedEditorAction(action));
     }
 
     private void OnModifyCurrentCellTypePressed()

--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
@@ -426,7 +426,7 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
         reportTab.UpdatePatchDetails(patch, patch);
     }
 
-    private void OnStartEditingCellType(string name, bool switchTab)
+    private void OnStartEditingCellType(string? name, bool switchTab)
     {
         if (CanCancelAction)
         {

--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
@@ -435,14 +435,14 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
             return;
         }
 
-        var newTypeToEdit = EditedSpecies.CellTypes.First(c => c.TypeName == name);
+        var newTypeToEdit = EditedSpecies.CellTypes.FirstOrDefault(c => c.TypeName == name);
 
         // Only reinitialize the editor when required
         if (selectedCellTypeToEdit == null || selectedCellTypeToEdit != newTypeToEdit)
         {
             selectedCellTypeToEdit = newTypeToEdit;
 
-            GD.Print("Start editing cell type: ", selectedCellTypeToEdit.TypeName);
+            GD.Print("Start editing cell type: ", selectedCellTypeToEdit?.TypeName);
 
             // Reinitialize the cell editor to be able to edit the new cell type
             cellEditorTab.OnEditorSpeciesSetup(EditedBaseSpecies);

--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
@@ -435,14 +435,23 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
             return;
         }
 
-        var newTypeToEdit = EditedSpecies.CellTypes.FirstOrDefault(c => c.TypeName == name);
+        // If there is a null name, that means there is no selected cell,
+        // so clear the selectedCellTypeToEdit and return early
+        if (name == null)
+        {
+            selectedCellTypeToEdit = null;
+            GD.Print("Cleared editing cell type");
+            return;
+        }
+
+        var newTypeToEdit = EditedSpecies.CellTypes.First(c => c.TypeName == name);
 
         // Only reinitialize the editor when required
         if (selectedCellTypeToEdit == null || selectedCellTypeToEdit != newTypeToEdit)
         {
             selectedCellTypeToEdit = newTypeToEdit;
 
-            GD.Print("Start editing cell type: ", selectedCellTypeToEdit?.TypeName);
+            GD.Print("Start editing cell type: ", selectedCellTypeToEdit.TypeName);
 
             // Reinitialize the cell editor to be able to edit the new cell type
             cellEditorTab.OnEditorSpeciesSetup(EditedBaseSpecies);

--- a/src/early_multicellular_stage/editor/action_data/DuplicateDeleteCellTypeData.cs
+++ b/src/early_multicellular_stage/editor/action_data/DuplicateDeleteCellTypeData.cs
@@ -1,0 +1,28 @@
+﻿/// <summary>
+///   Stores information for duplicating and deleting cell types.
+/// </summary>
+[JSONAlwaysDynamicType]
+public class DuplicateDeleteCellTypeData : EditorCombinableActionData<EarlyMulticellularSpecies>
+{
+    public readonly CellType CellType;
+
+    public DuplicateDeleteCellTypeData(CellType cellType)
+    {
+        CellType = cellType;
+    }
+
+    protected override ActionInterferenceMode GetInterferenceModeWithGuaranteed(CombinableActionData other)
+    {
+        return ActionInterferenceMode.NoInterference;
+    }
+
+    protected override CombinableActionData CombineGuaranteed(CombinableActionData other)
+    {
+        throw new System.NotSupportedException();
+    }
+
+    protected override int CalculateCostInternal()
+    {
+        return 0;
+    }
+}

--- a/src/early_multicellular_stage/editor/action_data/DuplicateDeleteCellTypeData.cs
+++ b/src/early_multicellular_stage/editor/action_data/DuplicateDeleteCellTypeData.cs
@@ -1,4 +1,6 @@
-﻿/// <summary>
+﻿using System;
+
+/// <summary>
 ///   Stores information for duplicating and deleting cell types.
 /// </summary>
 [JSONAlwaysDynamicType]
@@ -18,7 +20,7 @@ public class DuplicateDeleteCellTypeData : EditorCombinableActionData<EarlyMulti
 
     protected override CombinableActionData CombineGuaranteed(CombinableActionData other)
     {
-        throw new System.NotSupportedException();
+        throw new NotSupportedException();
     }
 
     protected override int CalculateCostInternal()


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR makes duplicating and deleting cell types undoable editor actions so trying to undo actions to regain MP will also undo the duplication, preventing the infinite MP exploit. This approach will also made the multicellular editor more manageable by preventing cases where the action to undo/redo exists on a cell type that's been deleted.

**Related Issues**

closes #3912

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
