### PR TITLE
Prevent symmetry from creating multiple copies of unique organelle

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -530,6 +530,7 @@ public partial class CellEditorComponent
 
         // Reset to cytoplasm if nothing is selected
         OnOrganelleToPlaceSelected(ActiveActionName ?? "cytoplasm");
+        ApplySymmetryForCurrentOrganelle();
 
         SetSpeciesInfo(newName, Membrane, Colour, Rigidity, behaviourEditor.Behaviour);
         UpdateGeneration(species.Generation);

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1661,9 +1661,6 @@ public partial class CellEditorComponent :
                 }
             }, overrideSymmetry);
 
-        if (GetOrganelleDefinition(organelleType).Unique)
-            componentBottomLeftButtons.SymmetryEnabled = true;
-
         if (placementActions.Count < 1)
             return false;
 
@@ -1818,9 +1815,7 @@ public partial class CellEditorComponent :
             return;
 
         var organelleDefinition = SimulationParameters.Instance.GetOrganelleType(organelle);
-
-        if (organelleDefinition.Unique)
-            componentBottomLeftButtons.SymmetryEnabled = false;
+        componentBottomLeftButtons.SymmetryEnabled = !organelleDefinition.Unique;
 
         ActiveActionName = organelle;
         UpdateOrganelleButtons(organelle);

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1625,8 +1625,6 @@ public partial class CellEditorComponent :
         // For multi hex organelles we keep track of positions that got filled in
         var usedHexes = new HashSet<Hex>();
 
-        var first = true;
-
         RunWithSymmetry(q, r,
             (attemptQ, attemptR, rotation) =>
             {
@@ -1643,11 +1641,6 @@ public partial class CellEditorComponent :
                         return;
                     }
                 }
-
-                if (GetOrganelleDefinition(organelleType).Unique && !first)
-                    return;
-
-                first = false;
 
                 var placed = CreatePlaceActionIfPossible(organelle);
 
@@ -1814,6 +1807,14 @@ public partial class CellEditorComponent :
     {
         if (ActiveActionName == organelle)
             return;
+
+        var organelleDefinition = SimulationParameters.Instance.GetOrganelleType(organelle);
+
+        if (organelleDefinition.Unique)
+        {
+            Symmetry = HexEditorSymmetry.None;
+            ResetSymmetryButton();
+        }
 
         ActiveActionName = organelle;
         UpdateOrganelleButtons(organelle);

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1625,6 +1625,8 @@ public partial class CellEditorComponent :
         // For multi hex organelles we keep track of positions that got filled in
         var usedHexes = new HashSet<Hex>();
 
+        var first = true;
+
         RunWithSymmetry(q, r,
             (attemptQ, attemptR, rotation) =>
             {
@@ -1641,6 +1643,11 @@ public partial class CellEditorComponent :
                         return;
                     }
                 }
+
+                if (GetOrganelleDefinition(organelleType).Unique && !first)
+                    return;
+
+                first = false;
 
                 var placed = CreatePlaceActionIfPossible(organelle);
 

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -669,6 +669,8 @@ public partial class CellEditorComponent :
 
         topPanel.Visible = Editor.CurrentGame.GameWorld.WorldSettings.DayNightCycleEnabled &&
             Editor.CurrentPatch.GetCompoundAmount(sunlight, CompoundAmountType.Maximum) > 0.0f;
+
+        ApplySymmetryForCurrentOrganelle();
     }
 
     public override void _Process(float delta)
@@ -1814,10 +1816,9 @@ public partial class CellEditorComponent :
         if (ActiveActionName == organelle)
             return;
 
-        var organelleDefinition = SimulationParameters.Instance.GetOrganelleType(organelle);
-        componentBottomLeftButtons.SymmetryEnabled = !organelleDefinition.Unique;
-
         ActiveActionName = organelle;
+
+        ApplySymmetryForCurrentOrganelle();
         UpdateOrganelleButtons(organelle);
     }
 
@@ -2443,6 +2444,15 @@ public partial class CellEditorComponent :
     private OrganelleDefinition GetOrganelleDefinition(string name)
     {
         return SimulationParameters.Instance.GetOrganelleType(name);
+    }
+
+    private void ApplySymmetryForCurrentOrganelle()
+    {
+        if (ActiveActionName == null)
+            return;
+
+        var organelle = GetOrganelleDefinition(ActiveActionName);
+        componentBottomLeftButtons.SymmetryEnabled = !organelle.Unique;
     }
 
     private class PendingAutoEvoPrediction

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1628,7 +1628,7 @@ public partial class CellEditorComponent :
         // For multi hex organelles we keep track of positions that got filled in
         var usedHexes = new HashSet<Hex>();
 
-        HexEditorSymmetry? overrideSymmetry = 
+        HexEditorSymmetry? overrideSymmetry =
             componentBottomLeftButtons.SymmetryEnabled ? null : HexEditorSymmetry.None;
 
         RunWithSymmetry(q, r,

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1628,8 +1628,8 @@ public partial class CellEditorComponent :
         // For multi hex organelles we keep track of positions that got filled in
         var usedHexes = new HashSet<Hex>();
 
-        HexEditorSymmetry? overrideSymmetry = componentBottomLeftButtons.SymmetryEnabled
-            ? null : HexEditorSymmetry.None;
+        HexEditorSymmetry? overrideSymmetry = 
+            componentBottomLeftButtons.SymmetryEnabled ? null : HexEditorSymmetry.None;
 
         RunWithSymmetry(q, r,
             (attemptQ, attemptR, rotation) =>

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -291,6 +291,8 @@ public partial class CellEditorComponent :
     /// </summary>
     private MicrobeSpecies? cachedAutoEvoPredictionSpecies;
 
+    private HexEditorSymmetry previousSymmetry;
+
     /// <summary>
     ///   This is the container that has the edited organelles in
     ///   it. This is populated when entering and used to update the
@@ -1655,6 +1657,13 @@ public partial class CellEditorComponent :
                 }
             });
 
+        if (GetOrganelleDefinition(organelleType).Unique)
+        {
+            Symmetry = previousSymmetry;
+            componentBottomLeftButtons.SymmetryEnabled = true;
+            componentBottomLeftButtons.SetSymmetry(Symmetry);
+        }
+
         if (placementActions.Count < 1)
             return false;
 
@@ -1812,7 +1821,9 @@ public partial class CellEditorComponent :
 
         if (organelleDefinition.Unique)
         {
+            previousSymmetry = Symmetry;
             Symmetry = HexEditorSymmetry.None;
+            componentBottomLeftButtons.SymmetryEnabled = false;
             ResetSymmetryButton();
         }
 

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -291,8 +291,6 @@ public partial class CellEditorComponent :
     /// </summary>
     private MicrobeSpecies? cachedAutoEvoPredictionSpecies;
 
-    private HexEditorSymmetry previousSymmetry;
-
     /// <summary>
     ///   This is the container that has the edited organelles in
     ///   it. This is populated when entering and used to update the
@@ -725,6 +723,9 @@ public partial class CellEditorComponent :
             if (shownOrganelle != null)
             {
                 HashSet<(Hex Hex, int Orientation)> hoveredHexes = new();
+
+                if (!componentBottomLeftButtons.SymmetryEnabled)
+                    effectiveSymmetry = HexEditorSymmetry.None;
 
                 RunWithSymmetry(q, r,
                     (finalQ, finalR, rotation) =>
@@ -1627,6 +1628,9 @@ public partial class CellEditorComponent :
         // For multi hex organelles we keep track of positions that got filled in
         var usedHexes = new HashSet<Hex>();
 
+        HexEditorSymmetry? overrideSymmetry = componentBottomLeftButtons.SymmetryEnabled
+            ? null : HexEditorSymmetry.None;
+
         RunWithSymmetry(q, r,
             (attemptQ, attemptR, rotation) =>
             {
@@ -1655,14 +1659,10 @@ public partial class CellEditorComponent :
                         usedHexes.Add(hex);
                     }
                 }
-            });
+            }, overrideSymmetry);
 
         if (GetOrganelleDefinition(organelleType).Unique)
-        {
-            Symmetry = previousSymmetry;
             componentBottomLeftButtons.SymmetryEnabled = true;
-            componentBottomLeftButtons.SetSymmetry(Symmetry);
-        }
 
         if (placementActions.Count < 1)
             return false;
@@ -1820,12 +1820,7 @@ public partial class CellEditorComponent :
         var organelleDefinition = SimulationParameters.Instance.GetOrganelleType(organelle);
 
         if (organelleDefinition.Unique)
-        {
-            previousSymmetry = Symmetry;
-            Symmetry = HexEditorSymmetry.None;
             componentBottomLeftButtons.SymmetryEnabled = false;
-            ResetSymmetryButton();
-        }
 
         ActiveActionName = organelle;
         UpdateOrganelleButtons(organelle);

--- a/src/microbe_stage/editor/EditorComponentBottomLeftButtons.cs
+++ b/src/microbe_stage/editor/EditorComponentBottomLeftButtons.cs
@@ -101,6 +101,8 @@ public class EditorComponentBottomLeftButtons : MarginContainer
 
     public TextureButton RedoButton { get; private set; } = null!;
 
+    public bool SymmetryLocked { get; set; }
+
     public bool UndoEnabled { get => !UndoButton.Disabled; set => UndoButton.Disabled = !value; }
     public bool RedoEnabled { get => !RedoButton.Disabled; set => RedoButton.Disabled = !value; }
     public bool SymmetryEnabled { get => !symmetryButton.Disabled; set => symmetryButton.Disabled = !value; }

--- a/src/microbe_stage/editor/EditorComponentBottomLeftButtons.cs
+++ b/src/microbe_stage/editor/EditorComponentBottomLeftButtons.cs
@@ -101,8 +101,6 @@ public class EditorComponentBottomLeftButtons : MarginContainer
 
     public TextureButton RedoButton { get; private set; } = null!;
 
-    public bool SymmetryLocked { get; set; }
-
     public bool UndoEnabled { get => !UndoButton.Disabled; set => UndoButton.Disabled = !value; }
     public bool RedoEnabled { get => !RedoButton.Disabled; set => RedoButton.Disabled = !value; }
     public bool SymmetryEnabled { get => !symmetryButton.Disabled; set => symmetryButton.Disabled = !value; }


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR makes it so that when adding a unique organelle with symmetry enabled, only one of said organelle will be placed.

**Related Issues**

Closes #3530 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
