### PR TITLE
Fixed organelle place refunding regression

### DIFF
--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
@@ -112,25 +112,18 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
         cellEditorTab.UpdateBackgroundImage(patch.BiomeTemplate);
     }
 
-    public override int WhatWouldActionsCost(IEnumerable<EditorCombinableActionData> actions)
-    {
-        return history.WhatWouldActionsCost(actions);
-    }
-
-    public override bool EnqueueAction(EditorAction action)
+    public override void AddContextToActions(IEnumerable<CombinableActionData> actions)
     {
         // If a cell type is being edited, add its type to each action data
         // so we can use it for undoing and redoing later
         if (selectedEditorTab == EditorTab.CellTypeEditor && selectedCellTypeToEdit != null)
         {
-            foreach (var actionData in action.Data)
+            foreach (var actionData in actions)
             {
-                if (actionData is EditorCombinableActionData<CellType> cellTypeData)
+                if (actionData is EditorCombinableActionData<CellType> cellTypeData && cellTypeData.Context == null)
                     cellTypeData.Context = selectedCellTypeToEdit;
             }
         }
-
-        return base.EnqueueAction(action);
     }
 
     public override bool CancelCurrentAction()

--- a/src/general/base_stage/IEditor.cs
+++ b/src/general/base_stage/IEditor.cs
@@ -74,6 +74,14 @@ public interface IEditor : ISaveLoadedTracked
     /// </remarks>
     public bool EnqueueAction(ReversibleAction action);
 
+    /// <summary>
+    ///   Adds editor state specific context to given sequence of actions. <see cref="EnqueueAction"/> and
+    ///   <see cref="WhatWouldActionsCost"/> perform this automatically. Only adds the context if not missing to give
+    ///   flexibility for editor components to add their custom action context that is not overridden.
+    /// </summary>
+    /// <param name="actions">The action data to add the context to</param>
+    public void AddContextToActions(IEnumerable<CombinableActionData> actions);
+
     public void NotifyUndoRedoStateChanged();
 
     public bool CheckEnoughMPForAction(int cost);

--- a/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
+++ b/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
@@ -130,25 +130,18 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
         UpdateBackgrounds(patch);
     }
 
-    public override int WhatWouldActionsCost(IEnumerable<EditorCombinableActionData> actions)
-    {
-        return history.WhatWouldActionsCost(actions);
-    }
-
-    public override bool EnqueueAction(EditorAction action)
+    public override void AddContextToActions(IEnumerable<CombinableActionData> actions)
     {
         // If a cell type is being edited, add its type to each action data
         // so we can use it for undoing and redoing later
         if (selectedEditorTab == EditorTab.CellTypeEditor && selectedCellTypeToEdit != null)
         {
-            foreach (var actionData in action.Data)
+            foreach (var actionData in actions)
             {
-                if (actionData is EditorCombinableActionData<CellType> cellTypeData)
+                if (actionData is EditorCombinableActionData<CellType> cellTypeData && cellTypeData.Context == null)
                     cellTypeData.Context = selectedCellTypeToEdit;
             }
         }
-
-        return base.EnqueueAction(action);
     }
 
     public override bool CancelCurrentAction()

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -102,9 +102,9 @@ public class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEditorRepo
         return cellEditorTab.CancelCurrentAction();
     }
 
-    public override int WhatWouldActionsCost(IEnumerable<EditorCombinableActionData> actions)
+    public override void AddContextToActions(IEnumerable<CombinableActionData> editorActions)
     {
-        return history.WhatWouldActionsCost(actions);
+        // Microbe editor doesn't require any context data in actions
     }
 
     protected override void ResolveDerivedTypeNodeReferences()

--- a/src/microbe_stage/editor/action_data/OrganelleRemoveActionData.cs
+++ b/src/microbe_stage/editor/action_data/OrganelleRemoveActionData.cs
@@ -10,8 +10,7 @@ public class OrganelleRemoveActionData : HexRemoveActionData<OrganelleTemplate, 
 
     [JsonConstructor]
     public OrganelleRemoveActionData(OrganelleTemplate organelle, Hex location, int orientation) : base(organelle,
-        location,
-        orientation)
+        location, orientation)
     {
     }
 


### PR DESCRIPTION
and made the editor action context system more reliably set the context data in, hopefully, all cases now

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #4519

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
