### PR TITLE
Add context support for Jukebox and add new ambient tracks

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -236,6 +236,7 @@
     <Compile Include="src\general\IDifficulty.cs" />
     <Compile Include="src\general\IInspectableEntity.cs" />
     <Compile Include="src\general\IPlayerReadableName.cs" />
+    <Compile Include="src\general\MusicContext.cs" />
     <Compile Include="src\general\PlayerInspectInfo.cs" />
     <Compile Include="src\general\ThriveNewsFeed.cs" />
     <Compile Include="src\general\utils\ColorUtils.cs" />

--- a/assets/sounds/soundeffects/ice-groans-ambience.ogg
+++ b/assets/sounds/soundeffects/ice-groans-ambience.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ffe2676217109e62cad49943f7b42ffd1a8700f7dfbdf656b5cf3c43691c133
+size 824207

--- a/assets/sounds/soundeffects/ice-groans-ambience.ogg.import
+++ b/assets/sounds/soundeffects/ice-groans-ambience.ogg.import
@@ -1,0 +1,15 @@
+[remap]
+
+importer="ogg_vorbis"
+type="AudioStreamOGGVorbis"
+path="res://.import/ice-groans-ambience.ogg-e8c2bb5b07e093d79bcf384e53be0a0b.oggstr"
+
+[deps]
+
+source_file="res://assets/sounds/soundeffects/ice-groans-ambience.ogg"
+dest_files=[ "res://.import/ice-groans-ambience.ogg-e8c2bb5b07e093d79bcf384e53be0a0b.oggstr" ]
+
+[params]
+
+loop=false
+loop_offset=0

--- a/assets/sounds/soundeffects/underwater-explosions-ambience.ogg
+++ b/assets/sounds/soundeffects/underwater-explosions-ambience.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf73592908761d195797d7d8dd49acef8c54cbb33a20f1e9410c155e08863d93
+size 620029

--- a/assets/sounds/soundeffects/underwater-explosions-ambience.ogg.import
+++ b/assets/sounds/soundeffects/underwater-explosions-ambience.ogg.import
@@ -1,0 +1,15 @@
+[remap]
+
+importer="ogg_vorbis"
+type="AudioStreamOGGVorbis"
+path="res://.import/underwater-explosions-ambience.ogg-36e65abc2bb918ee4f7cb6c3603889de.oggstr"
+
+[deps]
+
+source_file="res://assets/sounds/soundeffects/underwater-explosions-ambience.ogg"
+dest_files=[ "res://.import/underwater-explosions-ambience.ogg-36e65abc2bb918ee4f7cb6c3603889de.oggstr" ]
+
+[params]
+
+loop=false
+loop_offset=0

--- a/simulation_parameters/common/music_tracks.json
+++ b/simulation_parameters/common/music_tracks.json
@@ -69,6 +69,18 @@
           {
             "Volume": 0.6,
             "ResourcePath": "res://assets/sounds/soundeffects/microbe-ambience-3.ogg"
+          },
+          {
+            "ResourcePath": "res://assets/sounds/soundeffects/ice-groans-ambience.ogg",
+            "ExclusiveToContexts": [
+              "PatchIceShelf"
+            ]
+          },
+          {
+            "ResourcePath": "res://assets/sounds/soundeffects/underwater-explosions-ambience.ogg",
+            "ExclusiveToContexts": [
+              "PatchVents"
+            ]
           }
         ]
       }

--- a/src/general/Jukebox.cs
+++ b/src/general/Jukebox.cs
@@ -38,6 +38,8 @@ public class Jukebox : Node
     /// </summary>
     private MusicCategory? previouslyPlayedCategory;
 
+    private MusicContext[] activeContexts = null!;
+
     /// <summary>
     ///   Loads the music categories and prepares to play them
     /// </summary>
@@ -108,8 +110,9 @@ public class Jukebox : Node
     ///   Starts playing tracks from the provided category
     /// </summary>
     /// <param name="category">category from music_tracks.json</param>
-    public void PlayCategory(string category)
+    public void PlayCategory(string category, MusicContext[]? contexts = null)
     {
+        activeContexts = contexts ?? new MusicContext[] { MusicContext.General };
         PlayingCategory = category;
         Resume();
     }

--- a/src/general/Jukebox.cs
+++ b/src/general/Jukebox.cs
@@ -66,6 +66,15 @@ public class Jukebox : Node
                 throw new ArgumentException("Playing category can't be set to null");
 
             GD.Print("Jukebox now playing from: ", value);
+            GD.Print("Active Music Contexts: ");
+
+            var contexts = string.Empty;
+
+            foreach (var ctx in activeContexts)
+                contexts += ctx.ToString() + ", ";
+
+            GD.Print(contexts);
+
             playingCategory = value;
             OnCategoryChanged();
         }

--- a/src/general/Jukebox.cs
+++ b/src/general/Jukebox.cs
@@ -478,7 +478,7 @@ public class Jukebox : Node
         {
             foreach (var list in target.TrackLists)
             {
-                foreach (var track in list.Tracks)
+                foreach (var track in list.GetTracksForContexts(activeContexts))
                 {
                     // Resume track (but only one per list)
                     if (track.WasPlaying)
@@ -503,7 +503,7 @@ public class Jukebox : Node
 
         foreach (var list in target.TrackLists)
         {
-            var trackResources = list.Tracks.Select(track => track.ResourcePath);
+            var trackResources = list.GetTracksForContexts(activeContexts).Select(track => track.ResourcePath);
             if (activeTracks.Any(track => trackResources.Contains(track)))
                 continue;
 
@@ -514,7 +514,7 @@ public class Jukebox : Node
 
         foreach (var list in needToStartFrom)
         {
-            if (!list.Repeat && list.Tracks.All(track => track.PlayedOnce))
+            if (!list.Repeat && list.GetTracksForContexts(activeContexts).All(track => track.PlayedOnce))
                 continue;
 
             PlayNextTrackFromList(list, index =>
@@ -538,9 +538,9 @@ public class Jukebox : Node
 
         if (mode == TrackList.Order.Sequential)
         {
-            list.LastPlayedIndex = (list.LastPlayedIndex + 1) % list.Tracks.Count;
+            list.LastPlayedIndex = (list.LastPlayedIndex + 1) % list.GetTracksForContexts(activeContexts).Length;
 
-            PlayTrack(getPlayer(playerToUse), list.Tracks[list.LastPlayedIndex], list.TrackBus);
+            PlayTrack(getPlayer(playerToUse), list.GetTracksForContexts(activeContexts)[list.LastPlayedIndex], list.TrackBus);
         }
         else
         {
@@ -552,20 +552,20 @@ public class Jukebox : Node
                 // Make sure same random track is not played twice in a row
                 do
                 {
-                    nextIndex = random.Next(0, list.Tracks.Count);
+                    nextIndex = random.Next(0, list.GetTracksForContexts(activeContexts).Length);
                 }
-                while (nextIndex == list.LastPlayedIndex && list.Tracks.Count > 1);
+                while (nextIndex == list.LastPlayedIndex && list.GetTracksForContexts(activeContexts).Length > 1);
             }
             else if (mode == TrackList.Order.EntirelyRandom)
             {
-                nextIndex = random.Next(0, list.Tracks.Count);
+                nextIndex = random.Next(0, list.GetTracksForContexts(activeContexts).Length);
             }
             else
             {
                 throw new InvalidOperationException("Unknown track list order type");
             }
 
-            PlayTrack(getPlayer(playerToUse), list.Tracks[nextIndex], list.TrackBus);
+            PlayTrack(getPlayer(playerToUse), list.GetTracksForContexts(activeContexts)[nextIndex], list.TrackBus);
             list.LastPlayedIndex = nextIndex;
         }
     }
@@ -579,7 +579,7 @@ public class Jukebox : Node
             // Reset PlayedOnce flag in all tracks
             foreach (var list in category.TrackLists)
             {
-                foreach (var track in list.Tracks)
+                foreach (var track in list.GetTracksForContexts(activeContexts))
                 {
                     track.PlayedOnce = false;
                 }
@@ -595,7 +595,7 @@ public class Jukebox : Node
 
             foreach (var list in category.TrackLists)
             {
-                foreach (var track in list.Tracks)
+                foreach (var track in list.GetTracksForContexts(activeContexts))
                 {
                     if (activeTracks.Contains(track.ResourcePath))
                     {

--- a/src/general/MusicCategory.cs
+++ b/src/general/MusicCategory.cs
@@ -134,6 +134,8 @@ public class TrackList
 
         public string ResourcePath { get; set; } = null!;
 
+        public MusicContext[] ExclusiveToContexts { get; set; } = null!;
+
         [JsonIgnore]
         public bool WasPlaying { get; set; } = false;
 

--- a/src/general/MusicCategory.cs
+++ b/src/general/MusicCategory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 
 /// <summary>
@@ -108,10 +109,11 @@ public class TrackList
     /// </summary>
     public bool Repeat { get; set; } = true;
 
-    public List<Track> Tracks { get; set; } = null!;
-
     [JsonIgnore]
     public int LastPlayedIndex { get; set; } = -1;
+
+    [JsonProperty]
+    private List<Track> Tracks { get; set; } = null!;
 
     public void Check()
     {
@@ -120,6 +122,11 @@ public class TrackList
 
         foreach (var track in Tracks)
             track.Check();
+    }
+
+    public Track[] GetTracksForContexts(MusicContext[] contexts)
+    {
+        return Tracks.Where(t => t.ExclusiveToContexts == null || t.ExclusiveToContexts.Any(ctx => contexts.Contains(ctx))).ToArray();
     }
 
     /// <summary>

--- a/src/general/MusicContext.cs
+++ b/src/general/MusicContext.cs
@@ -1,0 +1,8 @@
+﻿public enum MusicContext
+{
+    General,
+
+    PatchVents,
+
+    PatchIceShelf,
+}

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -279,9 +279,19 @@ public class MicrobeStage : CreatureStageBase<Microbe>
 
     public override void StartMusic()
     {
+        var biome = CurrentGame!.GameWorld.Map.CurrentPatch!.BiomeTemplate;
+
+        var context = new MusicContext[] { MusicContext.General };
+
+        if (biome.InternalName == "aavolcanic_vent")
+            context[0] = MusicContext.PatchVents;
+
+        if (biome.InternalName == "ice_shelf")
+            context[0] = MusicContext.PatchIceShelf;
+
         Jukebox.Instance.PlayCategory(GameWorld.PlayerSpecies is EarlyMulticellularSpecies ?
             "EarlyMulticellularStage" :
-            "MicrobeStage");
+            "MicrobeStage", context);
     }
 
     [RunOnKeyDown("g_pause")]


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR does adds functionality to the Jukebox to play only specific tracks based on context provided when selecting categories as well as adding two new ambient tracks to the microbe stage to the vents and ice shelves using this new functionality.

**Related Issues**

Closes #3586 
Closes #4218

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
