### PR TITLE
Fixes incorrect Build Tool name in setup instructions

### DIFF
--- a/doc/setup_instructions.md
+++ b/doc/setup_instructions.md
@@ -187,7 +187,7 @@ _C#_, _Mono Debug_, and _C# Tools for Godot_.
 Open up a Project in Godot. On the top toolbar, go to Editor -> Editor Settings.
 Scroll down on the left window until you find Mono. Click on Editor and set
 External Editor to Visual Studio Code. Click on Builds and set Build Tool to
-MSBuild (VS Build Tools).
+dotnet CLI.
 
 If you want to setup live debugging with Godot follow the instructions here:
 https://docs.godotengine.org/en/3.3/getting_started/scripting/c_sharp/c_sharp_basics.html#visual-studio-code


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR changes the Build Tool name when using VSC in setup instructions. With the previous 'MSBuild (VS Build Tools)' project wouldn't build and throw several errors regarding missing SDK tools somewhere, after changing to 'dotnet CLI' project built properly without any errors. The rest of the setup instruction seems fine, as far as using VSC on Windows is concerned.

**Related Issues**

I don't know of any.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
