### PR TITLE
Fixed slow physics rotation speed

### DIFF
--- a/src/microbe_stage/systems/MicrobeMovementSystem.cs
+++ b/src/microbe_stage/systems/MicrobeMovementSystem.cs
@@ -80,7 +80,9 @@
 
             var up = Vector3.Up;
 
-            // Math loaned from Godot.Transform.SetLookAt adapted to fit here and removed one extra
+            // Math loaned from Godot.Transform.SetLookAt adapted to fit here and removed one extra operation
+            // For some reason this results in an inverse quaternion, so for simplicity this is just flipped
+            lookVector *= -1;
             var column0 = up.Cross(lookVector);
             var column1 = lookVector.Cross(column0);
             var wantedRotation = new Basis(column0.Normalized(), column1.Normalized(), lookVector).Quat();

--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(thrive_native SHARED
   interop/CInterop.cpp interop/CInterop.h
   interop/CStructures.h interop/JoltTypeConversions.hpp
   core/Logger.cpp core/Logger.hpp
+  core/Math.hpp
   core/Mutex.hpp
   core/NonCopyable.hpp core/Reference.hpp
   core/RefCounted.hpp

--- a/src/native/core/Math.hpp
+++ b/src/native/core/Math.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Jolt/Math/Quat.h"
+
+#include "Include.h"
+
+namespace Thrive
+{
+/// \brief Math helper operations
+class Math
+{
+private:
+    Math() = delete;
+
+public:
+    static JPH::Quat ShortestRotation(JPH::Quat a, JPH::Quat b)
+    {
+        if (a.Dot(b) < 0)
+        {
+            return a * (b * -1).Inversed();
+        }
+        else
+        {
+            return a * b.Inversed();
+        }
+    }
+};
+} // namespace Thrive

--- a/src/native/physics/BodyControlState.hpp
+++ b/src/native/physics/BodyControlState.hpp
@@ -9,8 +9,6 @@ class BodyControlState
 public:
     BodyControlState() = default;
 
-    JPH::Quat previousRotation = {};
-    JPH::Quat previousTarget = {};
     JPH::Quat targetRotation = {};
 
     JPH::Vec3 movement = {};
@@ -18,9 +16,6 @@ public:
     /// \brief Rotation speed divisor. Should at smallest be 1 for full speed, any higher value has chance of causing
     /// unwanted oscillation. Higher values slow down rotation.
     float rotationRate = 1;
-
-    bool justStarted = true;
-    bool targetChanged = false;
 };
 
 } // namespace Thrive::Physics


### PR DESCRIPTION
**Brief Description of What This PR Does**

I had the quaternion math wrong. Turns out the error was in the look at method that was in the C# side of things

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
