### PR TITLE
Reimplemented photostudio for microbes

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -204,7 +204,9 @@
     <Compile Include="src\engine\input\RunOnRelativeMouseAttribute.cs" />
     <Compile Include="src\engine\input\ThreeDimensionalMovementMode.cs" />
     <Compile Include="src\engine\input\TwoDimensionalMovementMode.cs" />
+    <Compile Include="src\engine\IPhotographable.cs" />
     <Compile Include="src\engine\IResource.cs" />
+    <Compile Include="src\engine\ISimulationPhotographable.cs" />
     <Compile Include="src\engine\ITextureResource.cs" />
     <Compile Include="src\engine\LastPlayedVersion.cs" />
     <Compile Include="src\engine\MissingExportVariableValueException.cs" />
@@ -225,7 +227,7 @@
     <Compile Include="src\engine\ImageTask.cs" />
     <Compile Include="src\engine\input\IgnoreNoMethodsTakingInputAttribute.cs" />
     <Compile Include="src\engine\InstanceNotLoadedYetException.cs" />
-    <Compile Include="src\engine\IPhotographable.cs" />
+    <Compile Include="src\engine\IScenePhotographable.cs" />
     <Compile Include="src\engine\LaunchOptions.cs" />
     <Compile Include="src\engine\LocalizedString.cs" />
     <Compile Include="src\engine\LocalizedStringBuilder.cs" />

--- a/src/early_multicellular_stage/CellType.cs
+++ b/src/early_multicellular_stage/CellType.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 ///   Type of a cell in a multicellular species. There can be multiple instances of a cell type placed at once
 /// </summary>
 [JsonObject(IsReference = true)]
-public class CellType : ICellProperties, IPhotographable, ICloneable
+public class CellType : ICellProperties, ISimulationPhotographable, ICloneable
 {
     [JsonConstructor]
     public CellType(OrganelleLayout<OrganelleTemplate> organelles, MembraneType membraneType)
@@ -56,7 +56,8 @@ public class CellType : ICellProperties, IPhotographable, ICloneable
     public string FormattedName => TypeName;
 
     [JsonIgnore]
-    public string SceneToPhotographPath => "res://src/microbe_stage/Microbe.tscn";
+    public ISimulationPhotographable.SimulationType SimulationToPhotograph =>
+        ISimulationPhotographable.SimulationType.MicrobeGraphics;
 
     public void RepositionToOrigin()
     {
@@ -92,18 +93,20 @@ public class CellType : ICellProperties, IPhotographable, ICloneable
         return false;
     }
 
-    public void ApplySceneParameters(Spatial instancedScene)
+    public void SetupWorldEntities(IWorldSimulation worldSimulation)
     {
-        new MicrobeSpecies(new MicrobeSpecies(int.MaxValue, string.Empty, string.Empty), this)
-            .ApplySceneParameters(instancedScene);
+        new MicrobeSpecies(new MicrobeSpecies(int.MaxValue, string.Empty, string.Empty), this).SetupWorldEntities(
+            worldSimulation);
     }
 
-    public float CalculatePhotographDistance(Spatial instancedScene)
+    public float CalculatePhotographDistance(IWorldSimulation worldSimulation)
     {
-        throw new NotImplementedException();
+        return ((MicrobeVisualOnlySimulation)worldSimulation).CalculateMicrobePhotographDistance();
+    }
 
-        // return PhotoStudio.CameraDistanceFromRadiusOfObject(((Microbe)instancedScene).Radius *
-        //     Constants.PHOTO_STUDIO_CELL_RADIUS_MULTIPLIER);
+    public bool StateHasStabilized(IWorldSimulation worldSimulation)
+    {
+        return true;
     }
 
     public object Clone()

--- a/src/engine/IPhotographable.cs
+++ b/src/engine/IPhotographable.cs
@@ -1,9 +1,7 @@
-﻿using Godot;
-
-public interface IPhotographable
+﻿/// <summary>
+///   Base photographable type for things that can be photographed. See <see cref="IScenePhotographable"/> for example.
+/// </summary>
+public interface IPhotographable<T>
 {
-    public string SceneToPhotographPath { get; }
-
-    public void ApplySceneParameters(Spatial instancedScene);
-    public float CalculatePhotographDistance(Spatial instancedScene);
+    public float CalculatePhotographDistance(T photographableObjectState);
 }

--- a/src/engine/IScenePhotographable.cs
+++ b/src/engine/IScenePhotographable.cs
@@ -1,0 +1,11 @@
+﻿using Godot;
+
+/// <summary>
+///   A thing that can be photographed by instantiating a Godot scene that has visuals for this
+/// </summary>
+public interface IScenePhotographable : IPhotographable<Spatial>
+{
+    public string SceneToPhotographPath { get; }
+
+    public void ApplySceneParameters(Spatial instancedScene);
+}

--- a/src/engine/ISimulationPhotographable.cs
+++ b/src/engine/ISimulationPhotographable.cs
@@ -1,0 +1,15 @@
+﻿/// <summary>
+///   A photographable that requires an <see cref="IWorldSimulation"/> to create photographable graphics for an object
+/// </summary>
+public interface ISimulationPhotographable : IPhotographable<IWorldSimulation>
+{
+    public enum SimulationType
+    {
+        MicrobeGraphics,
+    }
+
+    public SimulationType SimulationToPhotograph { get; }
+
+    public void SetupWorldEntities(IWorldSimulation worldSimulation);
+    public bool StateHasStabilized(IWorldSimulation worldSimulation);
+}

--- a/src/engine/ImageTask.cs
+++ b/src/engine/ImageTask.cs
@@ -11,13 +11,17 @@ public class ImageTask
     private ImageTexture? finalImage;
     private Image? plainImage;
 
-    public ImageTask(IPhotographable photographable, bool storePlainImage = false)
+    public ImageTask(IScenePhotographable photographable, bool storePlainImage = false)
     {
         this.storePlainImage = storePlainImage;
-        Photographable = photographable;
+        ScenePhotographable = photographable;
     }
 
-    public IPhotographable Photographable { get; }
+    public ImageTask(ISimulationPhotographable photographable, bool storePlainImage = false)
+    {
+        this.storePlainImage = storePlainImage;
+        SimulationPhotographable = photographable;
+    }
 
     public bool Finished { get; private set; }
 
@@ -36,6 +40,9 @@ public class ImageTask
         get => plainImage ?? throw new InvalidOperationException("Not finished yet or not configured to be saved");
         private set => plainImage = value;
     }
+
+    internal IScenePhotographable? ScenePhotographable { get; }
+    internal ISimulationPhotographable? SimulationPhotographable { get; }
 
     public void OnFinished(ImageTexture texture, Image rawImage)
     {

--- a/src/engine/PhotoStudio.tscn
+++ b/src/engine/PhotoStudio.tscn
@@ -21,6 +21,7 @@ shadow_atlas_size = 512
 script = ExtResource( 1 )
 CameraPath = NodePath("Camera")
 RenderedObjectHolderPath = NodePath("RenderedObjectHolder")
+SimulationWorldsParentPath = NodePath("SimulationWorldsParent")
 UseBackgroundSceneLoad = true
 UseBackgroundSceneInstance = true
 
@@ -28,3 +29,5 @@ UseBackgroundSceneInstance = true
 transform = Transform( 1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 10, 0 )
 
 [node name="RenderedObjectHolder" type="Spatial" parent="."]
+
+[node name="SimulationWorldsParent" type="Node" parent="."]

--- a/src/general/base_stage/DummyWorldSimulation.cs
+++ b/src/general/base_stage/DummyWorldSimulation.cs
@@ -63,6 +63,21 @@ public class DummyWorldSimulation : IWorldSimulation
     {
     }
 
+    public bool ProcessAll(float delta)
+    {
+        return true;
+    }
+
+    public bool ProcessLogic(float delta)
+    {
+        return true;
+    }
+
+    public bool HasSystemsWithPendingOperations()
+    {
+        return false;
+    }
+
     public void Dispose()
     {
         Dispose(true);

--- a/src/general/base_stage/IWorldSimulation.cs
+++ b/src/general/base_stage/IWorldSimulation.cs
@@ -61,4 +61,13 @@ public interface IWorldSimulation : IEntityContainer, IDisposable
     /// </summary>
     /// <param name="recorder">The recorder to return</param>
     public void FinishRecordingEntityCommands(EntityCommandRecorder recorder);
+
+    public bool ProcessAll(float delta);
+    public bool ProcessLogic(float delta);
+
+    /// <summary>
+    ///   Returns true when this simulation has pending
+    /// </summary>
+    /// <returns>True when pending operations exit</returns>
+    public bool HasSystemsWithPendingOperations();
 }

--- a/src/general/base_stage/WorldSimulation.cs
+++ b/src/general/base_stage/WorldSimulation.cs
@@ -389,6 +389,8 @@ public abstract class WorldSimulation : IWorldSimulation, IGodotEarlyNodeResolve
         minimumTimeBetweenLogicUpdates = 1 / logicFPS;
     }
 
+    public abstract bool HasSystemsWithPendingOperations();
+
     public virtual void FreeNodeResources()
     {
     }

--- a/src/gui_common/PhotographablePreview.cs
+++ b/src/gui_common/PhotographablePreview.cs
@@ -101,7 +101,7 @@ public abstract class PhotographablePreview : Control
     ///   <code>
     ///     protected override ImageTask? SetupImageTask()
     ///     {
-    ///         return conditionValid ? new ImageTask(new IPhotographable()) : null;
+    ///         return conditionValid ? new ImageTask(new IScenePhotographable()) : null;
     ///     }
     ///   </code>
     /// </example>

--- a/src/gui_common/art_gallery/GalleryCardModel.cs
+++ b/src/gui_common/art_gallery/GalleryCardModel.cs
@@ -42,7 +42,7 @@ public class GalleryCardModel : GalleryCard
         Thumbnail = imageLoadingIcon;
     }
 
-    public class ModelPreview : IPhotographable
+    public class ModelPreview : IScenePhotographable
     {
         private string resourcePath;
         private string meshNodePath;

--- a/src/microbe_stage/CellHexesPhotoBuilder.cs
+++ b/src/microbe_stage/CellHexesPhotoBuilder.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Godot;
 
-public class CellHexesPhotoBuilder : Spatial, IPhotographable
+public class CellHexesPhotoBuilder : Spatial, IScenePhotographable
 {
     private float radius;
     private bool radiusDirty;

--- a/src/microbe_stage/MicrobeSpecies.cs
+++ b/src/microbe_stage/MicrobeSpecies.cs
@@ -13,7 +13,7 @@ using Systems;
 [JSONDynamicTypeAllowed]
 [UseThriveConverter]
 [UseThriveSerializer]
-public class MicrobeSpecies : Species, ICellProperties, IPhotographable
+public class MicrobeSpecies : Species, ICellProperties, ISimulationPhotographable
 {
     [JsonConstructor]
     public MicrobeSpecies(uint id, string genus, string epithet) : base(id, genus, epithet)
@@ -84,7 +84,8 @@ public class MicrobeSpecies : Species, ICellProperties, IPhotographable
     public bool CanEngulf => !MembraneType.CellWall;
 
     [JsonIgnore]
-    public string SceneToPhotographPath => "res://src/microbe_stage/Microbe.tscn";
+    public ISimulationPhotographable.SimulationType SimulationToPhotograph =>
+        ISimulationPhotographable.SimulationType.MicrobeGraphics;
 
     public override void OnEdited()
     {
@@ -166,25 +167,21 @@ public class MicrobeSpecies : Species, ICellProperties, IPhotographable
         MembraneRigidity = casted.MembraneRigidity;
     }
 
-    public void ApplySceneParameters(Spatial instancedScene)
+    public float CalculatePhotographDistance(IWorldSimulation worldSimulation)
     {
-        throw new NotImplementedException("need to reimplement photographing cells");
-
-        // var microbe = (Microbe)instancedScene;
-        // microbe.IsForPreviewOnly = true;
-        //
-        // // We need to call _Ready here as the object may not be attached to the scene yet by the photo studio
-        // microbe._Ready();
-        //
-        // microbe.ApplySpecies(this);
+        return ((MicrobeVisualOnlySimulation)worldSimulation).CalculateMicrobePhotographDistance();
     }
 
-    public float CalculatePhotographDistance(Spatial instancedScene)
+    public void SetupWorldEntities(IWorldSimulation worldSimulation)
     {
-        throw new NotImplementedException();
+        ((MicrobeVisualOnlySimulation)worldSimulation).CreateVisualisationMicrobe(this);
+    }
 
-        // return PhotoStudio.CameraDistanceFromRadiusOfObject(((Microbe)instancedScene).Radius *
-        //     Constants.PHOTO_STUDIO_CELL_RADIUS_MULTIPLIER);
+    public bool StateHasStabilized(IWorldSimulation worldSimulation)
+    {
+        // This is stabilized as long as the default no background operations check passes
+        // If this is changed CellType also needs changes
+        return true;
     }
 
     public override object Clone()

--- a/src/microbe_stage/MicrobeWorldSimulation.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.cs
@@ -257,6 +257,11 @@ public class MicrobeWorldSimulation : WorldSimulationWithPhysics
         SpawnSystem.ClearSpawnCoordinates();
     }
 
+    public override bool HasSystemsWithPendingOperations()
+    {
+        return microbeVisualsSystem.HasPendingOperations();
+    }
+
     public override void FreeNodeResources()
     {
         base.FreeNodeResources();

--- a/src/microbe_stage/systems/MicrobeVisualsSystem.cs
+++ b/src/microbe_stage/systems/MicrobeVisualsSystem.cs
@@ -47,10 +47,17 @@
         /// </summary>
         private readonly List<Task> activeGenerationTasks = new();
 
+        private bool pendingMembraneGenerations;
+
         private int runningMembraneTaskCount;
 
         public MicrobeVisualsSystem(World world) : base(world, null)
         {
+        }
+
+        public bool HasPendingOperations()
+        {
+            return pendingMembraneGenerations;
         }
 
         public override void Dispose()
@@ -73,6 +80,8 @@
         protected override void PreUpdate(float delta)
         {
             base.PreUpdate(delta);
+
+            pendingMembraneGenerations = false;
 
             activeGenerationTasks.RemoveAll(t => t.IsCompleted);
         }
@@ -117,6 +126,8 @@
 
                 // Need to wait for membrane generation. Organelle visuals aren't created yet even if they could be
                 // to avoid the organelles popping in before the membrane.
+                pendingMembraneGenerations = true;
+
                 return;
             }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

added a new mode for world simulation based things to be photographed, while still preserving the old scene type photographing for things that fit that better.

With photographing now working the fossilisation feature works again and also the auto-evo exploring tool

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
