### PR TITLE
simplify and improve rotation speed calculation

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -197,8 +197,9 @@ public static class Constants
     // Note that the speed is reversed, i.e. lower values mean faster
     public const float CELL_MAX_ROTATION = 10.0f;
     public const float CELL_MIN_ROTATION = 0.02f;
-    public const float CELL_ROTATION_INFLECTION_MASS = 200000.0f;
-    public const float CILIA_ROTATION_FACTOR = 80000.0f;
+    public const float CELL_ROTATION_INFLECTION_MASS = 300000.0f;
+    public const float CELL_ROTATION_RADIUS_FACTOR = 500.0f;
+    public const float CILIA_ROTATION_FACTOR = 120000.0f;
     public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 20000.0f;
 
     // These speed values are also reversed like the above

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -214,8 +214,8 @@ public static class Constants
     public const float CELL_MIN_ROTATION = 0.1f;
     public const float CELL_ROTATION_INFLECTION_INERTIA = 25000000.0f;
     public const float CELL_ROTATION_RADIUS_FACTOR = 200.0f;
-    public const float CILIA_ROTATION_FACTOR = 720000.0f;
-    public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 200000.0f;
+    public const float CILIA_ROTATION_FACTOR = 32000000.0f;
+    public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 8000000.0f;
 
     // These speed values are also reversed like the above
     public const float CELL_COLONY_MAX_ROTATION_MULTIPLIER = 2.5f;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -179,7 +179,7 @@ public static class Constants
 
     public const float FLAGELLA_ENERGY_COST = 4.0f;
 
-    public const float FLAGELLA_BASE_FORCE = 35.0f;
+    public const float FLAGELLA_BASE_FORCE = 250.7f;
 
     public const float BASE_MOVEMENT_FORCE = 1400.0f;
 

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -205,7 +205,7 @@ public static class Constants
 
     // Note that the speed is reversed, i.e. lower values mean faster
     public const float CELL_MAX_ROTATION = 10.0f;
-    public const float CELL_MIN_ROTATION = 0.02f;
+    public const float CELL_MIN_ROTATION = 0.5f;
     public const float CELL_ROTATION_INFLECTION_MASS = 300000.0f;
     public const float CELL_ROTATION_RADIUS_FACTOR = 500.0f;
     public const float CILIA_ROTATION_FACTOR = 120000.0f;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -209,13 +209,13 @@ public static class Constants
 
     public const float MICROBE_MOVEMENT_SOUND_EMIT_COOLDOWN = 1.3f;
 
-    // Note that the speed is reversed, i.e. lower values mean faster
+    // Note that the rotation speed is reversed, i.e. lower values mean faster
     public const float CELL_MAX_ROTATION = 10.0f;
     public const float CELL_MIN_ROTATION = 0.1f;
-    public const float CELL_ROTATION_INFLECTION_INERTIA = 65.0f;
-    public const float CELL_ROTATION_RADIUS_FACTOR = 0.4f;
-    public const float CILIA_ROTATION_FACTOR = 320.0f;
-    public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 20.0f;
+    public const float CELL_ROTATION_INFLECTION_INERTIA = 25000000.0f;
+    public const float CELL_ROTATION_RADIUS_FACTOR = 200.0f;
+    public const float CILIA_ROTATION_FACTOR = 720000.0f;
+    public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 200000.0f;
 
     // These speed values are also reversed like the above
     public const float CELL_COLONY_MAX_ROTATION_MULTIPLIER = 2.5f;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -205,9 +205,9 @@ public static class Constants
 
     // Note that the speed is reversed, i.e. lower values mean faster
     public const float CELL_MAX_ROTATION = 10.0f;
-    public const float CELL_MIN_ROTATION = 0.5f;
-    public const float CELL_ROTATION_INFLECTION_MASS = 30.0f;
-    public const float CELL_ROTATION_RADIUS_FACTOR = 0.5f;
+    public const float CELL_MIN_ROTATION = 0.1f;
+    public const float CELL_ROTATION_INFLECTION_MASS = 65.0f;
+    public const float CELL_ROTATION_RADIUS_FACTOR = 0.4f;
     public const float CILIA_ROTATION_FACTOR = 320.0f;
     public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 20.0f;
 

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -206,10 +206,10 @@ public static class Constants
     // Note that the speed is reversed, i.e. lower values mean faster
     public const float CELL_MAX_ROTATION = 10.0f;
     public const float CELL_MIN_ROTATION = 0.5f;
-    public const float CELL_ROTATION_INFLECTION_MASS = 300000.0f;
-    public const float CELL_ROTATION_RADIUS_FACTOR = 500.0f;
-    public const float CILIA_ROTATION_FACTOR = 120000.0f;
-    public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 20000.0f;
+    public const float CELL_ROTATION_INFLECTION_MASS = 30.0f;
+    public const float CELL_ROTATION_RADIUS_FACTOR = 0.5f;
+    public const float CILIA_ROTATION_FACTOR = 320.0f;
+    public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 20.0f;
 
     // These speed values are also reversed like the above
     public const float CELL_COLONY_MAX_ROTATION_MULTIPLIER = 2.5f;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -197,14 +197,9 @@ public static class Constants
     // Note that the speed is reversed, i.e. lower values mean faster
     public const float CELL_MAX_ROTATION = 10.0f;
     public const float CELL_MIN_ROTATION = 0.02f;
-<<<<<<< HEAD
     public const float CELL_ROTATION_INFLECTION_MASS = 300000.0f;
     public const float CELL_ROTATION_RADIUS_FACTOR = 500.0f;
     public const float CILIA_ROTATION_FACTOR = 120000.0f;
-=======
-    public const float CELL_ROTATION_INFLECTION_MASS = 200000.0f;
-    public const float CILIA_ROTATION_FACTOR = 80000.0f;
->>>>>>> be847e12c (simplify and improve rotation speed calculation)
     public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 20000.0f;
 
     // These speed values are also reversed like the above

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -206,7 +206,7 @@ public static class Constants
     // Note that the speed is reversed, i.e. lower values mean faster
     public const float CELL_MAX_ROTATION = 10.0f;
     public const float CELL_MIN_ROTATION = 0.1f;
-    public const float CELL_ROTATION_INFLECTION_MASS = 65.0f;
+    public const float CELL_ROTATION_INFLECTION_INERTIA = 65.0f;
     public const float CELL_ROTATION_RADIUS_FACTOR = 0.4f;
     public const float CILIA_ROTATION_FACTOR = 320.0f;
     public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 20.0f;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -195,10 +195,11 @@ public static class Constants
     public const float MICROBE_MOVEMENT_SOUND_EMIT_COOLDOWN = 1.3f;
 
     // Note that the speed is reversed, i.e. lower values mean faster
-    public const float CELL_MAX_ROTATION = 3.0f;
-    public const float CELL_MIN_ROTATION = 0.2f;
-    public const float CILIA_ROTATION_FACTOR = 0.08f;
-    public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 0.8f;
+    public const float CELL_MAX_ROTATION = 10.0f;
+    public const float CELL_MIN_ROTATION = 0.02f;
+    public const float CELL_ROTATION_INFLECTION_MASS = 200000.0f;
+    public const float CILIA_ROTATION_FACTOR = 80000.0f;
+    public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 20000.0f;
 
     // These speed values are also reversed like the above
     public const float CELL_COLONY_MAX_ROTATION_MULTIPLIER = 2.5f;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -179,7 +179,7 @@ public static class Constants
 
     public const float FLAGELLA_ENERGY_COST = 4.0f;
 
-    public const float FLAGELLA_BASE_FORCE = 55.0f;
+    public const float FLAGELLA_BASE_FORCE = 35.0f;
 
     public const float BASE_MOVEMENT_FORCE = 1400.0f;
 
@@ -197,9 +197,14 @@ public static class Constants
     // Note that the speed is reversed, i.e. lower values mean faster
     public const float CELL_MAX_ROTATION = 10.0f;
     public const float CELL_MIN_ROTATION = 0.02f;
+<<<<<<< HEAD
     public const float CELL_ROTATION_INFLECTION_MASS = 300000.0f;
     public const float CELL_ROTATION_RADIUS_FACTOR = 500.0f;
     public const float CILIA_ROTATION_FACTOR = 120000.0f;
+=======
+    public const float CELL_ROTATION_INFLECTION_MASS = 200000.0f;
+    public const float CILIA_ROTATION_FACTOR = 80000.0f;
+>>>>>>> be847e12c (simplify and improve rotation speed calculation)
     public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 20000.0f;
 
     // These speed values are also reversed like the above

--- a/src/early_multicellular_stage/CellType.cs
+++ b/src/early_multicellular_stage/CellType.cs
@@ -145,7 +145,6 @@ public class CellType : ICellProperties, ICloneable
 
     private void CalculateRotationSpeed()
     {
-        BaseRotationSpeed =
-            MicrobeInternalCalculations.CalculateRotationSpeed(Organelles.Organelles, MembraneType, IsBacteria);
+        BaseRotationSpeed = MicrobeInternalCalculations.CalculateRotationSpeed(Organelles.Organelles);
     }
 }

--- a/src/engine/physics/PhysicsShape.cs
+++ b/src/engine/physics/PhysicsShape.cs
@@ -221,7 +221,6 @@ public class PhysicsShape : IDisposable
         return NativeMethods.ShapeCalculateResultingAngularVelocity(AccessShapeInternal(), new JVecF3(torque));
     }
 
-    // TODO: check if this is used sensibly by the rotation rate calculations
     /// <summary>
     ///   Calculates how much of a rotation around the y-axis is kept if applied to this shape
     /// </summary>

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -265,7 +265,8 @@ public static class MicrobeInternalCalculations
             if (organelle.Definition.HasCiliaComponent)
             {
                 cilliaFactor += Constants.CILIA_ROTATION_FACTOR +
-                    Hex.AxialToCartesian(organelle.Position).LengthSquared() * Constants.CILIA_RADIUS_FACTOR_MULTIPLIER;
+                    Hex.AxialToCartesian(organelle.Position).LengthSquared() *
+                    Constants.CILIA_RADIUS_FACTOR_MULTIPLIER;
             }
         }
 

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -274,8 +274,7 @@ public static class MicrobeInternalCalculations
 
             if (organelle.Definition.HasCiliaComponent)
             {
-                cilliaFactor += Constants.CILIA_ROTATION_FACTOR +
-                     distance * Constants.CILIA_RADIUS_FACTOR_MULTIPLIER;
+                cilliaFactor += Constants.CILIA_ROTATION_FACTOR + distance * Constants.CILIA_RADIUS_FACTOR_MULTIPLIER;
             }
         }
 

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -282,9 +282,12 @@ public static class MicrobeInternalCalculations
     {
         float cilliaFactor = 0;
         float maxRadius = 0;
+        float totalMass = 0;
 
         foreach (var organelle in organelles)
         {
+            totalMass += organelle.Definition.HexCount;
+
             var distance = Hex.AxialToCartesian(organelle.Position).LengthSquared();
 
             if (distance > maxRadius)
@@ -298,8 +301,7 @@ public static class MicrobeInternalCalculations
             }
         }
 
-        var effectiveMass = organelles.Sum(x => x.Definition.HexCount)
-            + (maxRadius * Constants.CELL_ROTATION_RADIUS_FACTOR);
+        var effectiveMass = totalMass + (maxRadius * Constants.CELL_ROTATION_RADIUS_FACTOR);
 
         return effectiveMass / (Constants.CELL_ROTATION_INFLECTION_MASS + cilliaFactor + effectiveMass)
             * Constants.CELL_MAX_ROTATION + Constants.CELL_MIN_ROTATION;

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -241,24 +241,26 @@ public static class MicrobeInternalCalculations
     /// <param name="organelles">The organelles the cell has with their positions for the calculations</param>
     /// <param name="membraneType">
     ///   The membrane type. This must be known as it affects the membrane size (and thus radius of the cell and
-    ///   inertia)
+    ///   inertia) NOT CURRENTLY USED
     /// </param>
-    /// <param name="isBacteria">True when the species is bacteria</param>
+    /// <param name="isBacteria">True when the species is bacteria NOT CURRENTLY USED</param>
     /// <returns>
     ///   The rotation speed value for putting in <see cref="Components.OrganelleContainer.RotationSpeed"/>
     /// </returns>
     public static float CalculateRotationSpeed(IReadOnlyList<IPositionedOrganelle> organelles,
         MembraneType membraneType, bool isBacteria)
     {
-        var membraneShape = MembraneComputationHelpers.GetOrComputeMembraneShape(organelles, membraneType);
+        // this ignores shape for now
+        //var membraneShape = MembraneComputationHelpers.GetOrComputeMembraneShape(organelles, membraneType);
 
-        var shape = PhysicsShape.GetOrCreateMicrobeShape(membraneShape.Vertices2D, membraneShape.VertexCount,
-            CalculateAverageDensity(organelles), isBacteria);
+        // this ignores shape for now
+        //var shape = PhysicsShape.GetOrCreateMicrobeShape(membraneShape.Vertices2D, membraneShape.VertexCount,
+        //    CalculateAverageDensity(organelles), isBacteria);
 
         // This ignores pili right now, only the base microbe shape is calculated for inertia. If this is changed
         // the way the variant taking directly in the collision shape needs to be adjusted
 
-        return CalculateRotationSpeed(shape, organelles);
+        return CalculateRotationSpeed(organelles);
     }
 
     /// <summary>
@@ -267,17 +269,10 @@ public static class MicrobeInternalCalculations
     /// <remarks>
     ///   <para>
     ///     Microbe colonies help or hinder rotation. That calculation is in
-    ///     <see cref="Components.MicrobeColonyHelpers.CalculateRotationMultiplier"/>
+    ///     <see cref="Components.MicrobeColonyHelpers.CalculateRotationSpeed"/>
     ///   </para>
     /// </remarks>
     /// <returns>The rotation speed</returns>
-    public static float CalculateRotationSpeed(PhysicsShape shape, IEnumerable<IPositionedOrganelle> organelles)
-    {
-        shape.TestYRotationInertiaFactor();
-
-        return CalculateRotationSpeed(organelles);
-    }
-
     public static float CalculateRotationSpeed(IEnumerable<IPositionedOrganelle> organelles)
     {
         float cilliaFactor = 0;
@@ -309,7 +304,7 @@ public static class MicrobeInternalCalculations
 
     /// <summary>
     ///   Converts the speed from
-    ///   <see cref="CalculateRotationSpeed(PhysicsShape,IEnumerable{IPositionedOrganelle})"/> to a user displayable
+    ///   <see cref="CalculateRotationSpeed(IEnumerable{IPositionedOrganelle})"/> to a user displayable
     ///   form
     /// </summary>
     /// <param name="rawSpeed">The raw speed value</param>

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -258,19 +258,28 @@ public static class MicrobeInternalCalculations
     /// <returns>The rotation speed</returns>
     public static float CalculateRotationSpeed(PhysicsShape shape, IEnumerable<IPositionedOrganelle> organelles)
     {
+        shape.TestYRotationInertiaFactor();
+
         float cilliaFactor = 0;
+        float maxRadius = 0;
 
         foreach (var organelle in organelles)
         {
+            var distance = Hex.AxialToCartesian(organelle.Position).LengthSquared();
+
+            if (distance > maxRadius)
+            {
+                maxRadius = distance;
+            }
+
             if (organelle.Definition.HasCiliaComponent)
             {
                 cilliaFactor += Constants.CILIA_ROTATION_FACTOR +
-                    Hex.AxialToCartesian(organelle.Position).LengthSquared() *
-                    Constants.CILIA_RADIUS_FACTOR_MULTIPLIER;
+                     distance * Constants.CILIA_RADIUS_FACTOR_MULTIPLIER;
             }
         }
 
-        var effectiveMass = shape.GetMass();
+        var effectiveMass = shape.GetMass() + (maxRadius * Constants.CELL_ROTATION_RADIUS_FACTOR);
 
         return effectiveMass / (Constants.CELL_ROTATION_INFLECTION_MASS + cilliaFactor + effectiveMass)
             * Constants.CELL_MAX_ROTATION + Constants.CELL_MIN_ROTATION;

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -251,10 +251,10 @@ public static class MicrobeInternalCalculations
         MembraneType membraneType, bool isBacteria)
     {
         // this ignores shape for now
-        //var membraneShape = MembraneComputationHelpers.GetOrComputeMembraneShape(organelles, membraneType);
+        // var membraneShape = MembraneComputationHelpers.GetOrComputeMembraneShape(organelles, membraneType);
 
         // this ignores shape for now
-        //var shape = PhysicsShape.GetOrCreateMicrobeShape(membraneShape.Vertices2D, membraneShape.VertexCount,
+        // var shape = PhysicsShape.GetOrCreateMicrobeShape(membraneShape.Vertices2D, membraneShape.VertexCount,
         //    CalculateAverageDensity(organelles), isBacteria);
 
         // This ignores pili right now, only the base microbe shape is calculated for inertia. If this is changed

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -274,7 +274,9 @@ public static class MicrobeInternalCalculations
 
             if (organelle.Definition.HasCiliaComponent)
             {
-                cilliaFactor += Constants.CILIA_ROTATION_FACTOR + distance * Constants.CILIA_RADIUS_FACTOR_MULTIPLIER;
+                cilliaFactor += Constants.CILIA_ROTATION_FACTOR +
+                    Hex.AxialToCartesian(organelle.Position).LengthSquared() *
+                    Constants.CILIA_RADIUS_FACTOR_MULTIPLIER;
             }
         }
 

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -275,8 +275,7 @@ public static class MicrobeInternalCalculations
             if (organelle.Definition.HasCiliaComponent)
             {
                 cilliaFactor += Constants.CILIA_ROTATION_FACTOR +
-                    Hex.AxialToCartesian(organelle.Position).LengthSquared() *
-                    Constants.CILIA_RADIUS_FACTOR_MULTIPLIER;
+                     distance * Constants.CILIA_RADIUS_FACTOR_MULTIPLIER;
             }
         }
 

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -275,6 +275,11 @@ public static class MicrobeInternalCalculations
     {
         shape.TestYRotationInertiaFactor();
 
+        return CalculateRotationSpeed(organelles);
+    }
+
+    public static float CalculateRotationSpeed(IEnumerable<IPositionedOrganelle> organelles)
+    {
         float cilliaFactor = 0;
         float maxRadius = 0;
 
@@ -293,7 +298,7 @@ public static class MicrobeInternalCalculations
             }
         }
 
-        var effectiveMass = shape.GetMass() + (maxRadius * Constants.CELL_ROTATION_RADIUS_FACTOR);
+        var effectiveMass = organelles.Sum(x => x.Definition.HexCount) + (maxRadius * Constants.CELL_ROTATION_RADIUS_FACTOR);
 
         return effectiveMass / (Constants.CELL_ROTATION_INFLECTION_MASS + cilliaFactor + effectiveMass)
             * Constants.CELL_MAX_ROTATION + Constants.CELL_MIN_ROTATION;

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -298,7 +298,8 @@ public static class MicrobeInternalCalculations
             }
         }
 
-        var effectiveMass = organelles.Sum(x => x.Definition.HexCount) + (maxRadius * Constants.CELL_ROTATION_RADIUS_FACTOR);
+        var effectiveMass = organelles.Sum(x => x.Definition.HexCount)
+            + (maxRadius * Constants.CELL_ROTATION_RADIUS_FACTOR);
 
         return effectiveMass / (Constants.CELL_ROTATION_INFLECTION_MASS + cilliaFactor + effectiveMass)
             * Constants.CELL_MAX_ROTATION + Constants.CELL_MIN_ROTATION;

--- a/src/microbe_stage/MicrobeSpecies.cs
+++ b/src/microbe_stage/MicrobeSpecies.cs
@@ -238,7 +238,6 @@ public class MicrobeSpecies : Species, ICellProperties
 
     private void CalculateRotationSpeed()
     {
-        BaseRotationSpeed =
-            MicrobeInternalCalculations.CalculateRotationSpeed(Organelles.Organelles, MembraneType, IsBacteria);
+        BaseRotationSpeed = MicrobeInternalCalculations.CalculateRotationSpeed(Organelles.Organelles);
     }
 }

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -869,7 +869,7 @@
         }
 
         /// <summary>
-        ///   Calculates the total rotation rate of a colony. Physics shape is not currently used
+        ///   Calculates the total rotation rate of a colony. Physics shape is not currently used.
         /// </summary>
         public static void CalculateRotationSpeed(this ref MicrobeColony colony)
         {
@@ -900,7 +900,7 @@
                 colonyRotation += memberRotation;
             }
 
-            colony.ColonyRotationSpeed = colonyRotation / colony.ColonyMembers.ToArray().Length;
+            colony.ColonyRotationSpeed = colonyRotation / colony.ColonyMembers.Length;
         }
 
         /// <summary>

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -877,6 +877,10 @@
 
             foreach (var colonyMember in colony.ColonyMembers)
             {
+                // this needs to be skipped here
+                if (colonyMember == colony.Leader)
+                    continue;
+
                 ref var memberPosition = ref colonyMember.Get<AttachedToEntity>();
 
                 var distanceSquared = memberPosition.RelativePosition.LengthSquared();

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -873,11 +873,12 @@
         /// </summary>
         public static void CalculateRotationMultiplier(this ref MicrobeColony colony, PhysicsShape entireColonyShape)
         {
-            float colonyRotation = 0;
+            float colonyRotation = MicrobeInternalCalculations
+                        .CalculateRotationSpeed(colony.Leader.Get<OrganelleContainer>().Organelles!);
 
             foreach (var colonyMember in colony.ColonyMembers)
             {
-                // this needs to be skipped here
+                // colony leader is set before the loop
                 if (colonyMember == colony.Leader)
                     continue;
 
@@ -890,7 +891,7 @@
                 // fastest cell inside it
                 var memberRotation = MicrobeInternalCalculations
                         .CalculateRotationSpeed(colonyMember.Get<OrganelleContainer>().Organelles!)
-                    * (1 + 0.05f * distanceSquared);
+                    * (1 + 0.03f * distanceSquared);
 
                 colonyRotation += memberRotation;
             }

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -890,7 +890,7 @@
                 // fastest cell inside it
                 var memberRotation = MicrobeInternalCalculations
                         .CalculateRotationSpeed(colonyMember.Get<OrganelleContainer>().Organelles!)
-                        * (1 + 0.05f * distanceSquared);
+                    * (1 + 0.05f * distanceSquared);
 
                 colonyRotation += memberRotation;
             }

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -871,14 +871,18 @@
         /// <summary>
         ///   Calculates the total rotation rate of a colony. Physics shape is not currently used
         /// </summary>
-        public static void CalculateRotationSpeed(this ref MicrobeColony colony, PhysicsShape entireColonyShape)
+        public static void CalculateRotationSpeed(this ref MicrobeColony colony)
         {
+            // TODO: see the comment in MicrobeInternalCalculations.CalculateRotationSpeed about:
+            // shape.TestYRotationInertiaFactor() how to make this take the colony shape into account in rotation to
+            // be more physically accurate
+
             float colonyRotation = MicrobeInternalCalculations
-                        .CalculateRotationSpeed(colony.Leader.Get<OrganelleContainer>().Organelles!);
+                .CalculateRotationSpeed(colony.Leader.Get<OrganelleContainer>().Organelles!);
 
             foreach (var colonyMember in colony.ColonyMembers)
             {
-                // colony leader is set before the loop
+                // Colony leader is set before the loop
                 if (colonyMember == colony.Leader)
                     continue;
 

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -890,7 +890,7 @@
                 // fastest cell inside it
                 var memberRotation = MicrobeInternalCalculations
                     .CalculateRotationSpeed(colonyMember.Get<OrganelleContainer>().Organelles!)
-                    * (1 + 0.05f * distanceSquared);
+                        * (1 + 0.05f * distanceSquared);
 
                 colonyRotation += memberRotation;
             }

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -889,7 +889,7 @@
                 // This relies on the bounding of the cell rotation, as a colony can never be faster than the
                 // fastest cell inside it
                 var memberRotation = MicrobeInternalCalculations
-                    .CalculateRotationSpeed(colonyMember.Get<OrganelleContainer>().Organelles!)
+                        .CalculateRotationSpeed(colonyMember.Get<OrganelleContainer>().Organelles!)
                         * (1 + 0.05f * distanceSquared);
 
                 colonyRotation += memberRotation;

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -888,7 +888,8 @@
                 // Multiply both the propulsion and mass by the distance from center to simulate leverage
                 // This relies on the bounding of the cell rotation, as a colony can never be faster than the
                 // fastest cell inside it
-                var memberRotation = colonyMember.Get<OrganelleContainer>().RotationSpeed
+                var memberRotation = MicrobeInternalCalculations
+                    .CalculateRotationSpeed(colonyMember.Get<OrganelleContainer>().Organelles)
                     * (1 + 0.05f * distanceSquared);
 
                 colonyRotation += memberRotation;

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -901,9 +901,7 @@
                 colonyRotation += memberRotation;
             }
 
-            var biasedAverageRotation = colonyRotation / colony.ColonyMembers.Count();
-
-            colony.ColonyRotationSpeed = biasedAverageRotation;
+            colony.ColonyRotationSpeed = colonyRotation / colony.ColonyMembers.Count();
         }
 
         /// <summary>

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -901,7 +901,7 @@
                 colonyRotation += memberRotation;
             }
 
-            colony.ColonyRotationSpeed = colonyRotation / colony.ColonyMembers.Count();
+            colony.ColonyRotationSpeed = colonyRotation / colony.ColonyMembers.ToArray().Length;
         }
 
         /// <summary>

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -869,9 +869,9 @@
         }
 
         /// <summary>
-        ///   Calculates the help and extra inertia caused by the colony member cells
+        ///   Calculates the total rotation rate of a colony. Physics shape is not currently used
         /// </summary>
-        public static void CalculateRotationMultiplier(this ref MicrobeColony colony, PhysicsShape entireColonyShape)
+        public static void CalculateRotationSpeed(this ref MicrobeColony colony, PhysicsShape entireColonyShape)
         {
             float colonyRotation = MicrobeInternalCalculations
                         .CalculateRotationSpeed(colony.Leader.Get<OrganelleContainer>().Organelles!);

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -889,7 +889,7 @@
                 // This relies on the bounding of the cell rotation, as a colony can never be faster than the
                 // fastest cell inside it
                 var memberRotation = MicrobeInternalCalculations
-                    .CalculateRotationSpeed(colonyMember.Get<OrganelleContainer>().Organelles)
+                    .CalculateRotationSpeed(colonyMember.Get<OrganelleContainer>().Organelles!)
                     * (1 + 0.05f * distanceSquared);
 
                 colonyRotation += memberRotation;

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1064,8 +1064,7 @@ public partial class CellEditorComponent :
 
     public float CalculateRotationSpeed()
     {
-        return MicrobeInternalCalculations.CalculateRotationSpeed(editedMicrobeOrganelles.Organelles, Membrane,
-            !HasNucleus);
+        return MicrobeInternalCalculations.CalculateRotationSpeed(editedMicrobeOrganelles.Organelles);
     }
 
     public float CalculateHitpoints()

--- a/src/microbe_stage/systems/MicrobeMovementSystem.cs
+++ b/src/microbe_stage/systems/MicrobeMovementSystem.cs
@@ -111,14 +111,14 @@
             // Note that cilia taking ATP is actually calculated later, this is the max speed rotation calculation
             // only
 
-            // Lower value is faster rotation
-            if (CheatManager.Speed > 1 && entity.Has<PlayerMarker>())
-                rotationSpeed /= CheatManager.Speed;
-
             if (entity.Has<MicrobeColony>())
             {
                 rotationSpeed = entity.Get<MicrobeColony>().ColonyRotationSpeed;
             }
+
+            // Lower value is faster rotation
+            if (CheatManager.Speed > 1 && entity.Has<PlayerMarker>())
+                rotationSpeed /= CheatManager.Speed;
 
             return rotationSpeed;
         }

--- a/src/microbe_stage/systems/MicrobeMovementSystem.cs
+++ b/src/microbe_stage/systems/MicrobeMovementSystem.cs
@@ -117,9 +117,7 @@
 
             if (entity.Has<MicrobeColony>())
             {
-                rotationSpeed = Mathf.Clamp(rotationSpeed * entity.Get<MicrobeColony>().ColonyRotationMultiplier,
-                    Math.Max(rotationSpeed * Constants.CELL_COLONY_MAX_ROTATION_HELP, Constants.CELL_MIN_ROTATION),
-                    Constants.CELL_MAX_ROTATION);
+                rotationSpeed = entity.Get<MicrobeColony>().ColonyRotationSpeed;
             }
 
             return rotationSpeed;

--- a/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
+++ b/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
@@ -407,7 +407,8 @@
         ///   Updates the microbe movement's used rotation rate. This is here as it is more efficient to calculate this
         ///   when the physics shape is also done.
         ///
-        ///   Note that the PhysicsShape is not currently used in rotation calculations, and is retained for historical purposes
+        ///   Note that the PhysicsShape is not currently used in rotation calculations, and is retained for 
+        ///   historical purposes
         /// </summary>
         private void UpdateRotationRate(PhysicsShape baseShape, ref OrganelleContainer organelleContainer)
         {

--- a/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
+++ b/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
@@ -406,8 +406,7 @@
         /// <summary>
         ///   Updates the microbe movement's used rotation rate. This is here as it is more efficient to calculate this
         ///   when the physics shape is also done.
-        ///
-        ///   Note that the PhysicsShape is not currently used in rotation calculations, and is retained for 
+        ///   Note that the PhysicsShape is not currently used in rotation calculations, and is retained for
         ///   historical purposes
         /// </summary>
         private void UpdateRotationRate(PhysicsShape baseShape, ref OrganelleContainer organelleContainer)

--- a/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
+++ b/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
@@ -179,7 +179,7 @@
                     {
                         // Update full colony rotation properties now with the physics shape
                         ref var colony = ref entity.Get<MicrobeColony>();
-                        colony.CalculateRotationMultiplier(shapeHolder.Shape);
+                        colony.CalculateRotationSpeed(shapeHolder.Shape);
                     }
 
                     // TODO: colony rotation rate update is elsewhere but it would make quite a bit of sense to move
@@ -406,6 +406,8 @@
         /// <summary>
         ///   Updates the microbe movement's used rotation rate. This is here as it is more efficient to calculate this
         ///   when the physics shape is also done.
+        ///
+        ///   Note that the PhysicsShape is not currently used in rotation calculations, and is retained for historical purposes
         /// </summary>
         private void UpdateRotationRate(PhysicsShape baseShape, ref OrganelleContainer organelleContainer)
         {
@@ -416,7 +418,7 @@
             }
 
             organelleContainer.RotationSpeed =
-                MicrobeInternalCalculations.CalculateRotationSpeed(baseShape, organelleContainer.Organelles);
+                MicrobeInternalCalculations.CalculateRotationSpeed(organelleContainer.Organelles);
         }
 
         private PhysicsShape CreatePilusShape(float size)

--- a/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
+++ b/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
@@ -177,13 +177,11 @@
 
                     if (colonyMembranes != null)
                     {
-                        // Update full colony rotation properties now with the physics shape
+                        // Update full colony rotation properties. Note that this is here for historical reasons as
+                        // this used to use the shape of the entire colony here, which is only available easily here.
                         ref var colony = ref entity.Get<MicrobeColony>();
-                        colony.CalculateRotationSpeed(shapeHolder.Shape);
+                        colony.CalculateRotationSpeed();
                     }
-
-                    // TODO: colony rotation rate update is elsewhere but it would make quite a bit of sense to move
-                    // that logic here so that it can take advantage of the real physics shape
                 }
 
                 // Skip updating the physics body shape if we got the same cached shape as we had before
@@ -213,7 +211,7 @@
                 MicrobeInternalCalculations.CalculateAverageDensity(organelles.Organelles!),
                 cellProperties.IsBacteria);
 
-            UpdateRotationRate(shape, ref organelles);
+            UpdateRotationRate(ref organelles);
 
             ++extraData.MicrobeShapesCount;
             ++extraData.TotalShapeCount;
@@ -250,7 +248,7 @@
                 CreateSimpleMicrobeShape(ref extraData, ref organelles, ref cellProperties, membraneVertices,
                     vertexCount), Vector3.Zero, Quat.Identity));
 
-            UpdateRotationRate(combinedData[combinedData.Count - 1].Shape, ref organelles);
+            UpdateRotationRate(ref organelles);
 
             List<(OrganelleLayout<PlacedOrganelle> Organelles, Vector3 ExtraOffset, Quat ExtraRotation)>?
                 memberOrganelles = null;
@@ -404,12 +402,11 @@
         }
 
         /// <summary>
-        ///   Updates the microbe movement's used rotation rate. This is here as it is more efficient to calculate this
-        ///   when the physics shape is also done.
-        ///   Note that the PhysicsShape is not currently used in rotation calculations, and is retained for
-        ///   historical purposes
+        ///   Updates the microbe movement's used rotation rate.
+        ///   Note that the PhysicsShape is not currently used in rotation calculations, and this code is here due to
+        ///   earlier version requiring it.
         /// </summary>
-        private void UpdateRotationRate(PhysicsShape baseShape, ref OrganelleContainer organelleContainer)
+        private void UpdateRotationRate(ref OrganelleContainer organelleContainer)
         {
             if (organelleContainer.Organelles == null)
             {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Rebalances rotation rates post ECS refactor, including the effect of cillia. This simplifies the calculation somewhat, but still accounts for leverage from cillia placed further from the center.

**Related Issues**

https://github.com/orgs/Revolutionary-Games/projects/5/views/1?pane=issue&itemId=44943890

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
