### PR TITLE
Fix PilusDamageSystem not triggering

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -697,9 +697,14 @@ public static class Constants
     public const float BINDING_ATP_COST_PER_SECOND = 2.0f;
 
     /// <summary>
-    ///   Damage a single pilus stab does
+    ///   Damage a single pilus stab does. Scaled by penetration depth so this is now much higher than before.
     /// </summary>
-    public const float PILUS_BASE_DAMAGE = 20.0f;
+    public const float PILUS_BASE_DAMAGE = 240.0f;
+
+    /// <summary>
+    ///   Maximum damage a single pilus hit does, even if the penetration depth is very high
+    /// </summary>
+    public const float PILUS_MAX_DAMAGE = 45;
 
     public const float PILUS_PHYSICS_SIZE = 4.6f;
 

--- a/src/microbe_stage/components/MicrobeEventCallbacks.cs
+++ b/src/microbe_stage/components/MicrobeEventCallbacks.cs
@@ -13,7 +13,7 @@
     public struct MicrobeEventCallbacks
     {
         /// <summary>
-        ///   Triggers whenevery the player enters unbind mode
+        ///   Triggers whenever the player enters unbind mode
         ///   <remarks>
         ///     <para>
         ///       Only works for the player

--- a/src/microbe_stage/systems/PilusDamageSystem.cs
+++ b/src/microbe_stage/systems/PilusDamageSystem.cs
@@ -11,7 +11,6 @@
     [With(typeof(OrganelleContainer))]
     [With(typeof(CollisionManagement))]
     [With(typeof(MicrobePhysicsExtraData))]
-    [With(typeof(Species))]
     public sealed class PilusDamageSystem : AEntitySetSystem<float>
     {
         public PilusDamageSystem(World world, IParallelRunner parallelRunner) : base(world, parallelRunner)

--- a/src/microbe_stage/systems/PilusDamageSystem.cs
+++ b/src/microbe_stage/systems/PilusDamageSystem.cs
@@ -78,7 +78,6 @@
                     continue;
                 }
 
-                // TODO: readjust the pilus damage now that this takes penetration depth into account
                 float damage = Constants.PILUS_BASE_DAMAGE * collision.PenetrationAmount;
 
                 // TODO: as this will be done differently ensure game balance still works
@@ -87,8 +86,11 @@
                 // MakeInvulnerable(Constants.PILUS_INVULNERABLE_TIME);
 
                 // Skip too small damage
-                if (damage < 0.0001f)
+                if (damage < 0.01f)
                     continue;
+
+                if (damage > Constants.PILUS_MAX_DAMAGE)
+                    damage = Constants.PILUS_MAX_DAMAGE;
 
                 targetHealth.DealMicrobeDamage(ref collision.SecondEntity.Get<CellProperties>(), damage, "pilus");
             }

--- a/src/microbe_stage/systems/PilusDamageSystem.cs
+++ b/src/microbe_stage/systems/PilusDamageSystem.cs
@@ -11,6 +11,7 @@
     [With(typeof(OrganelleContainer))]
     [With(typeof(CollisionManagement))]
     [With(typeof(MicrobePhysicsExtraData))]
+    [With(typeof(SpeciesMember))]
     public sealed class PilusDamageSystem : AEntitySetSystem<float>
     {
         public PilusDamageSystem(World world, IParallelRunner parallelRunner) : base(world, parallelRunner)


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR makes one very small change that stopped `PilusDamageSystem` from triggering.
I'm guessing this was because `Species` is not actually a component so when used in the `With` attribute, it blocked the system from running properly.

**Related Issues**

- https://github.com/orgs/Revolutionary-Games/projects/5/views/1?pane=issue&itemId=44922458
- This appears to also work as intended now: https://github.com/orgs/Revolutionary-Games/projects/5/views/1?pane=issue&itemId=44922694

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
