### PR TITLE
Slightly buff base movement for large cells

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -184,6 +184,15 @@ public static class Constants
     public const float BASE_MOVEMENT_FORCE = 1400.0f;
 
     /// <summary>
+    ///   How much extra base movement is given per hex. Only applies between
+    ///   <see cref="BASE_MOVEMENT_EXTRA_HEX_START"/> and <see cref="BASE_MOVEMENT_EXTRA_HEX_END"/>
+    /// </summary>
+    public const float BASE_MOVEMENT_PER_HEX = 50;
+
+    public const int BASE_MOVEMENT_EXTRA_HEX_START = 2;
+    public const int BASE_MOVEMENT_EXTRA_HEX_END = 30;
+
+    /// <summary>
     ///   How much the default <see cref="BASE_CELL_DENSITY"/> has volume in a cell. This determines how much
     ///   additional organelles impact the cell. A normal organelle has a weight of 1 so if this value is 4 then the
     ///   base density has as much impact on the average density as 4 organelles.

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -179,7 +179,7 @@ public static class Constants
 
     public const float FLAGELLA_ENERGY_COST = 4.0f;
 
-    public const float FLAGELLA_BASE_FORCE = 55.0f;
+    public const float FLAGELLA_BASE_FORCE = 60.0f;
 
     public const float BASE_MOVEMENT_FORCE = 1400.0f;
 
@@ -187,7 +187,7 @@ public static class Constants
     ///   How much extra base movement is given per hex. Only applies between
     ///   <see cref="BASE_MOVEMENT_EXTRA_HEX_START"/> and <see cref="BASE_MOVEMENT_EXTRA_HEX_END"/>
     /// </summary>
-    public const float BASE_MOVEMENT_PER_HEX = 50;
+    public const float BASE_MOVEMENT_PER_HEX = 45;
 
     public const int BASE_MOVEMENT_EXTRA_HEX_START = 2;
     public const int BASE_MOVEMENT_EXTRA_HEX_END = 30;

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -173,8 +173,8 @@ public static class MicrobeInternalCalculations
                 rightDirectionFactor = organelleDirection.Dot(Vector3.Right);
                 leftDirectionFactor = -rightDirectionFactor;
 
-                float movementConstant = Constants.FLAGELLA_BASE_FORCE
-                    * organelle.Definition.Components.Movement!.Momentum / 100.0f;
+                float movementConstant =
+                    Constants.FLAGELLA_BASE_FORCE * organelle.Definition.Components.Movement!.Momentum;
 
                 // We get the movement force for every direction as well
                 forwardsDirectionMovementForce += MovementForce(movementConstant, forwardDirectionFactor);

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -201,12 +201,27 @@ public static class MicrobeInternalCalculations
         organelleMovementForce += MovementForce(rightwardDirectionMovementForce, rightDirectionFactor);
         organelleMovementForce += MovementForce(leftwardDirectionMovementForce, leftDirectionFactor);
 
-        float baseMovementForce = Constants.BASE_MOVEMENT_FORCE *
-            (membraneType.MovementFactor - membraneRigidity * Constants.MEMBRANE_RIGIDITY_BASE_MOBILITY_MODIFIER);
+        float baseMovementForce =
+            CalculateBaseMovement(membraneType, membraneRigidity, organelles.Sum(o => o.Definition.HexCount));
 
         float finalSpeed = (baseMovementForce + organelleMovementForce) / shape.GetMass();
 
         return finalSpeed;
+    }
+
+    public static float CalculateBaseMovement(MembraneType membraneType, float membraneRigidity, int hexCount)
+    {
+        var movement = Constants.BASE_MOVEMENT_FORCE;
+
+        // Extra movement from organelles
+        movement += Mathf.Clamp(hexCount - Constants.BASE_MOVEMENT_EXTRA_HEX_START, 0,
+                Constants.BASE_MOVEMENT_EXTRA_HEX_END - Constants.BASE_MOVEMENT_EXTRA_HEX_START) *
+            Constants.BASE_MOVEMENT_PER_HEX;
+
+        // Apply membrane adjustment
+        movement *= membraneType.MovementFactor - membraneRigidity * Constants.MEMBRANE_RIGIDITY_BASE_MOBILITY_MODIFIER;
+
+        return movement;
     }
 
     public static float SpeedToUserReadableNumber(float rawSpeed)

--- a/src/microbe_stage/components/Engulfable.cs
+++ b/src/microbe_stage/components/Engulfable.cs
@@ -276,6 +276,10 @@
                             position.Position, new Random(), customizeCallback, null);
 
                         SpawnHelpers.FinalizeEntitySpawn(recorder, worldSimulation);
+
+                        // Don't need to do the normal entity state restore as the entity was killed and will be
+                        // shortly destroyed
+                        return;
                     }
                 }
             }

--- a/src/microbe_stage/systems/MicrobeMovementSystem.cs
+++ b/src/microbe_stage/systems/MicrobeMovementSystem.cs
@@ -154,7 +154,8 @@
             }
 
             // Base movement force
-            float force = Constants.BASE_MOVEMENT_FORCE;
+            float force = MicrobeInternalCalculations.CalculateBaseMovement(cellProperties.MembraneType,
+                cellProperties.MembraneRigidity, organelles.HexCount);
 
             // Length is multiplied here so that cells that set very slow movement speed don't need to pay the entire
             // movement cost


### PR DESCRIPTION
**Brief Description of What This PR Does**

buffs base movement between 2-30 hexes size to make cells that don't have any flagellum be able to at least move a tiny bit

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
