### PR TITLE
Reimplemented organelle render order adjusting

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -156,7 +156,7 @@
     <Compile Include="src\engine\common_components\PlayerMarker.cs" />
     <Compile Include="src\engine\common_components\PredefinedVisuals.cs" />
     <Compile Include="src\engine\common_components\ReadableName.cs" />
-    <Compile Include="src\engine\common_components\RenderOrderOverride.cs" />
+    <Compile Include="src\engine\common_components\RenderPriorityOverride.cs" />
     <Compile Include="src\engine\common_components\ReproductionStatus.cs" />
     <Compile Include="src\engine\common_components\Selectable.cs" />
     <Compile Include="src\engine\common_components\SimpleShapeCreator.cs" />
@@ -186,7 +186,7 @@
     <Compile Include="src\engine\common_systems\PhysicsCollisionManagementSystem.cs" />
     <Compile Include="src\engine\common_systems\PhysicsUpdateAndPositionSystem.cs" />
     <Compile Include="src\engine\common_systems\PredefinedVisualLoaderSystem.cs" />
-    <Compile Include="src\engine\common_systems\RenderOrderSystem.cs" />
+    <Compile Include="src\engine\common_systems\RenderPrioritySystem.cs" />
     <Compile Include="src\engine\common_systems\SimpleShapeCreatorSystem.cs" />
     <Compile Include="src\engine\common_systems\SoundEffectSystem.cs" />
     <Compile Include="src\engine\common_systems\SoundListenerSystem.cs" />
@@ -670,6 +670,7 @@
     <Compile Include="src\microbe_stage\systems\MicrobeMovementSoundSystem.cs" />
     <Compile Include="src\microbe_stage\systems\MicrobeMovementSystem.cs" />
     <Compile Include="src\microbe_stage\systems\MicrobePhysicsCreationAndSizeSystem.cs" />
+    <Compile Include="src\microbe_stage\systems\MicrobeRenderPrioritySystem.cs" />
     <Compile Include="src\microbe_stage\systems\MicrobeReproductionSystem.cs" />
     <Compile Include="src\microbe_stage\systems\MicrobeShaderSystem.cs" />
     <Compile Include="src\microbe_stage\systems\MicrobeVisualsSystem.cs" />

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1291,6 +1291,13 @@ public static class Constants
     /// </summary>
     public const int HEX_RENDER_PRIORITY_DISTANCE = 4;
 
+    public const int HEX_MAX_RENDER_PRIORITY = HEX_RENDER_PRIORITY_DISTANCE * HEX_RENDER_PRIORITY_DISTANCE;
+
+    /// <summary>
+    ///   If membrane scene is updated this should be updated as well
+    /// </summary>
+    public const int MICROBE_DEFAULT_RENDER_PRIORITY = 18;
+
     public const float COLOUR_PICKER_PICK_INTERVAL = 0.2f;
 
     // TODO: combine to a common module with launcher as these are there as well

--- a/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -1009,9 +1009,8 @@ public partial class CellBodyPlanEditorComponent :
 
         modelHolder.LoadFromAlreadyLoadedNode(billboard);
 
-        // TODO: render order setting for the cells? (similarly to how organelles are handled in the cell editor)
-        // This is probably not needed but when converted to quads, maybe 0.01 of randomness in y-position would be
-        // fine?
+        // TODO: render priority setting for the cells? (similarly to how organelles are handled in the cell editor)
+        // Alternatively maybe 0.01 of randomness in y-position would be fine?
     }
 
     private void OnSpeciesNameChanged(string newText)

--- a/src/engine/common_components/RenderPriorityOverride.cs
+++ b/src/engine/common_components/RenderPriorityOverride.cs
@@ -1,13 +1,15 @@
 ﻿namespace Components
 {
     using Newtonsoft.Json;
+    using Systems;
 
     /// <summary>
     ///   Overrides rendering order for an entity with <see cref="EntityMaterial"/>. Used for some specific rendering
-    ///   effects that can't be done otherwise.
+    ///   effects that can't be done otherwise. Microbe stage specifically uses
+    ///   <see cref="MicrobeRenderPrioritySystem"/>
     /// </summary>
     [JSONDynamicTypeAllowed]
-    public struct RenderOrderOverride
+    public struct RenderPriorityOverride
     {
         /// <summary>
         ///   Overrides the render priority of this Spatial. Use
@@ -21,11 +23,17 @@
         /// </summary>
         [JsonIgnore]
         public bool RenderPriorityApplied;
+
+        public RenderPriorityOverride(int renderPriority)
+        {
+            RenderPriority = renderPriority;
+            RenderPriorityApplied = false;
+        }
     }
 
     public static class RenderOrderOverrideHelpers
     {
-        public static void SetRenderPriority(this ref RenderOrderOverride spatialInstance, int priority)
+        public static void SetRenderPriority(this ref RenderPriorityOverride spatialInstance, int priority)
         {
             spatialInstance.RenderPriorityApplied = false;
             spatialInstance.RenderPriority = priority;

--- a/src/engine/common_systems/RenderPrioritySystem.cs
+++ b/src/engine/common_systems/RenderPrioritySystem.cs
@@ -6,19 +6,19 @@
     using DefaultEcs.Threading;
 
     /// <summary>
-    ///   Applies <see cref="RenderOrderOverride"/>
+    ///   Applies <see cref="RenderPriorityOverride"/>
     /// </summary>
-    [With(typeof(RenderOrderOverride))]
+    [With(typeof(RenderPriorityOverride))]
     [With(typeof(EntityMaterial))]
-    public sealed class RenderOrderSystem : AEntitySetSystem<float>
+    public sealed class RenderPrioritySystem : AEntitySetSystem<float>
     {
-        public RenderOrderSystem(World world, IParallelRunner runner) : base(world, runner)
+        public RenderPrioritySystem(World world, IParallelRunner runner) : base(world, runner)
         {
         }
 
         protected override void Update(float delta, in Entity entity)
         {
-            ref var renderOrder = ref entity.Get<RenderOrderOverride>();
+            ref var renderOrder = ref entity.Get<RenderPriorityOverride>();
 
             if (renderOrder.RenderPriorityApplied)
                 return;

--- a/src/microbe_stage/Membrane.cs
+++ b/src/microbe_stage/Membrane.cs
@@ -237,7 +237,7 @@ public class Membrane : MeshInstance
     private void SetMesh()
     {
         Mesh = membraneData.GeneratedMesh;
-        SetSurfaceMaterial(membraneData.SurfaceIndex, MaterialToEdit);
+        MaterialOverride = MaterialToEdit;
     }
 
     private void ApplyAllMaterialParameters()

--- a/src/microbe_stage/Membrane.tscn
+++ b/src/microbe_stage/Membrane.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://src/microbe_stage/Membrane.cs" type="Script" id=1]
 [ext_resource path="res://shaders/Membrane.shader" type="Shader" id=2]
 [ext_resource path="res://assets/textures/FresnelGradient.png" type="Texture" id=3]
 [ext_resource path="res://assets/textures/FresnelGradientDamaged.png" type="Texture" id=4]
+[ext_resource path="res://assets/textures/dissolve_noise.tres" type="Texture" id=5]
 
 [sub_resource type="CubeMesh" id=1]
 size = Vector3( 2, 0.539, 2 )
@@ -14,11 +15,12 @@ render_priority = 18
 shader = ExtResource( 2 )
 shader_param/wigglyNess = 1.0
 shader_param/movementWigglyNess = 1.0
-shader_param/dissolveValue = null
+shader_param/dissolveValue = 0.0
 shader_param/healthFraction = 0.25
 shader_param/tint = Plane( 1, 1, 1, 1 )
 shader_param/albedoTexture = ExtResource( 3 )
 shader_param/damagedTexture = ExtResource( 4 )
+shader_param/dissolveTexture = ExtResource( 5 )
 
 [node name="Membrane" type="MeshInstance"]
 process_priority = 2

--- a/src/microbe_stage/MicrobeVisualOnlySimulation.cs
+++ b/src/microbe_stage/MicrobeVisualOnlySimulation.cs
@@ -19,8 +19,6 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
     private PathBasedSceneLoader pathBasedSceneLoader = null!;
     private PredefinedVisualLoaderSystem predefinedVisualLoaderSystem = null!;
 
-    // private RenderOrderSystem renderOrderSystem = null! = null!;
-
     private SpatialAttachSystem spatialAttachSystem = null!;
     private SpatialPositionSystem spatialPositionSystem = null!;
 
@@ -29,6 +27,7 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
 
     // private ColonyBindingSystem colonyBindingSystem = null!;
     private MicrobeFlashingSystem microbeFlashingSystem = null!;
+    private MicrobeRenderPrioritySystem microbeRenderPrioritySystem = null!;
     private MicrobeShaderSystem microbeShaderSystem = null!;
     private MicrobeVisualsSystem microbeVisualsSystem = null!;
     private TintColourAnimationSystem tintColourAnimationSystem = null!;
@@ -69,6 +68,7 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
         // colonyBindingSystem = new ColonyBindingSystem(this, EntitySystem, parallelRunner);
 
         microbeFlashingSystem = new MicrobeFlashingSystem(EntitySystem, runner);
+        microbeRenderPrioritySystem = new MicrobeRenderPrioritySystem(EntitySystem);
         microbeShaderSystem = new MicrobeShaderSystem(EntitySystem);
 
         microbeVisualsSystem = new MicrobeVisualsSystem(EntitySystem);
@@ -318,7 +318,7 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
 
         fadeOutActionSystem.Update(delta);
 
-        // renderOrderSystem.Update(delta);
+        microbeRenderPrioritySystem.Update(delta);
 
         cellBurstEffectSystem.Update(delta);
 
@@ -345,6 +345,7 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
             spatialPositionSystem.Dispose();
             cellBurstEffectSystem.Dispose();
             microbeFlashingSystem.Dispose();
+            microbeRenderPrioritySystem.Dispose();
             microbeShaderSystem.Dispose();
             microbeVisualsSystem.Dispose();
             tintColourAnimationSystem.Dispose();

--- a/src/microbe_stage/MicrobeWorldSimulation.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.cs
@@ -33,8 +33,6 @@ public class MicrobeWorldSimulation : WorldSimulationWithPhysics
     private PhysicsUpdateAndPositionSystem physicsUpdateAndPositionSystem = null!;
     private PredefinedVisualLoaderSystem predefinedVisualLoaderSystem = null!;
 
-    // private RenderOrderSystem renderOrderSystem = null! = null!;
-
     private SimpleShapeCreatorSystem simpleShapeCreatorSystem = null!;
     private SoundEffectSystem soundEffectSystem = null!;
     private SoundListenerSystem soundListenerSystem = null!;
@@ -77,6 +75,7 @@ public class MicrobeWorldSimulation : WorldSimulationWithPhysics
     private PilusDamageSystem pilusDamageSystem = null!;
     private SlimeSlowdownSystem slimeSlowdownSystem = null!;
     private MicrobePhysicsCreationAndSizeSystem microbePhysicsCreationAndSizeSystem = null!;
+    private MicrobeRenderPrioritySystem microbeRenderPrioritySystem = null!;
     private MicrobeReproductionSystem microbeReproductionSystem = null!;
     private TintColourAnimationSystem tintColourAnimationSystem = null!;
     private ToxinCollisionSystem toxinCollisionSystem = null!;
@@ -204,6 +203,7 @@ public class MicrobeWorldSimulation : WorldSimulationWithPhysics
         pilusDamageSystem = new PilusDamageSystem(EntitySystem, couldParallelize);
         slimeSlowdownSystem = new SlimeSlowdownSystem(cloudSystem, EntitySystem, couldParallelize);
         microbePhysicsCreationAndSizeSystem = new MicrobePhysicsCreationAndSizeSystem(EntitySystem, couldParallelize);
+        microbeRenderPrioritySystem = new MicrobeRenderPrioritySystem(EntitySystem);
         tintColourAnimationSystem = new TintColourAnimationSystem(EntitySystem);
 
         toxinCollisionSystem = new ToxinCollisionSystem(EntitySystem, couldParallelize);
@@ -311,6 +311,7 @@ public class MicrobeWorldSimulation : WorldSimulationWithPhysics
         predefinedVisualLoaderSystem.Update(delta);
         entityMaterialFetchSystem.Update(delta);
         animationControlSystem.Update(delta);
+        microbeRenderPrioritySystem.Update(delta);
 
         simpleShapeCreatorSystem.Update(delta);
         collisionShapeLoaderSystem.Update(delta);
@@ -493,6 +494,7 @@ public class MicrobeWorldSimulation : WorldSimulationWithPhysics
             pilusDamageSystem.Dispose();
             slimeSlowdownSystem.Dispose();
             microbePhysicsCreationAndSizeSystem.Dispose();
+            microbeRenderPrioritySystem.Dispose();
             microbeReproductionSystem.Dispose();
             tintColourAnimationSystem.Dispose();
             toxinCollisionSystem.Dispose();

--- a/src/microbe_stage/OrganelleLayout.cs
+++ b/src/microbe_stage/OrganelleLayout.cs
@@ -55,12 +55,6 @@ public class OrganelleLayout<T> : HexLayout<T>
         }
     }
 
-    /// <summary>
-    ///   The highest assigned render priority from all of the organelles.
-    /// </summary>
-    [JsonIgnore]
-    public int MaxRenderPriority => Organelles.Max(o => Hex.GetRenderPriority(o.Position));
-
     public override bool CanPlace(T hex)
     {
         return CanPlace(hex, false);

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -570,6 +570,8 @@ public static class SpawnHelpers
             ApplyVisualScale = true,
         });
 
+        entity.Set(new RenderPriorityOverride(Constants.MICROBE_DEFAULT_RENDER_PRIORITY));
+
         entity.Set<EntityMaterial>();
 
         entity.Set(new ColourAnimation(Membrane.MembraneTintFromSpeciesColour(usedCellProperties.Colour))

--- a/src/microbe_stage/components/Engulfable.cs
+++ b/src/microbe_stage/components/Engulfable.cs
@@ -63,7 +63,7 @@
         /// </remarks>
         public float InitialTotalEngulfableCompounds;
 
-        // public int OriginalRenderPriority;
+        public int OriginalRenderPriority;
 
         /// <summary>
         ///   The current step of phagocytosis process this engulfable is currently in. If not phagocytized,
@@ -74,7 +74,6 @@
         // This might not need a reference to the hostile engulfer as this should have AttachedToEntity to mark what
         // this is attached to
 
-        // TODO: implement this for when ejected
         /// <summary>
         ///   If this is partially digested when ejected from an engulfer, this is destroyed (with a dissolve animation
         ///   if detected to be possible)
@@ -136,7 +135,8 @@
         ///   Called when this becomes engulfed and starts to be pulled in (this may get immediately thrown out if this
         ///   is not digestible by the attacker)
         /// </summary>
-        public static void OnBecomeEngulfed(this ref Engulfable engulfable, in Entity entity)
+        public static void OnBecomeEngulfed(this ref Engulfable engulfable, in Entity entity,
+            int engulferRenderPriority)
         {
             if (entity.Has<CellProperties>())
             {
@@ -186,23 +186,21 @@
             ref var spatial = ref entity.Get<SpatialInstance>();
             engulfable.OriginalScale = spatial.ApplyVisualScale ? spatial.VisualScale : Vector3.One;
 
-            // TODO: store original render priority?
-            // bulkTransport.OriginalRenderPriority = target.RenderPriority,
+            if (entity.Has<RenderPriorityOverride>())
+            {
+                ref var renderPriority = ref entity.Get<RenderPriorityOverride>();
 
-            // TODO: render priority re-implementation (if we need this). Note that also
-            // EngulfingSystem.IngestEngulfable has code that interacts with render priorities
-            // Make the render priority of our organelles be on top of the highest possible render priority
-            // of the hostile engulfer's organelles
-            // var hostile = HostileEngulfer.Value;
-            // if (hostile != null)
-            // {
-            //     foreach (var organelle in organelles!)
-            //     {
-            //         var newPriority = Mathf.Clamp(Hex.GetRenderPriority(organelle.Position) +
-            //             hostile.OrganelleMaxRenderPriority, 0, Material.RenderPriorityMax);
-            //         organelle.UpdateRenderPriority(newPriority);
-            //     }
-            // }
+                engulfable.OriginalRenderPriority = renderPriority.RenderPriority;
+
+                // Make the render priority of our organelles be on top of the highest possible render priority
+                // of the hostile engulfer's organelles
+                // +2 is used here as the membrane also takes one render priority slot
+                renderPriority.RenderPriority = engulferRenderPriority + Constants.HEX_MAX_RENDER_PRIORITY + 2;
+                renderPriority.RenderPriorityApplied = false;
+
+                // TODO: the above doesn't take recursive engulfing into account but that's probably fine enough for now
+                // If the above is done, IngestEngulfableFromOtherEntity might also need changes
+            }
         }
 
         /// <summary>
@@ -311,8 +309,16 @@
             }
 
             // Reset render priority
-            // TODO: render priority
-            // engulfable.RenderPriority = animation.OriginalRenderPriority;
+            if (entity.Has<RenderPriorityOverride>())
+            {
+                ref var renderPriority = ref entity.Get<RenderPriorityOverride>();
+
+                renderPriority.RenderPriority = engulfable.OriginalRenderPriority;
+                renderPriority.RenderPriorityApplied = false;
+
+                // If recursive engulfing render priority is supported in the future, there might be a need to write
+                // some code here related to that
+            }
 
             // Restore scale
             ref var spatial = ref entity.Get<SpatialInstance>();
@@ -325,15 +331,6 @@
 #endif
 
             spatial.VisualScale = engulfable.OriginalScale;
-
-            // engulfable.OriginalRenderPriority
-
-            // Reset our organelles' render priority back to their original values
-            // TODO: unify this with the render priority re-apply that exists in EngulfingSystem.CompleteEjection
-            // foreach (var organelle in organelles!)
-            // {
-            //     organelle.UpdateRenderPriority(Hex.GetRenderPriority(organelle.Position));
-            // }
 
             if (entity.Has<MicrobeEventCallbacks>())
             {

--- a/src/microbe_stage/systems/MicrobeRenderPrioritySystem.cs
+++ b/src/microbe_stage/systems/MicrobeRenderPrioritySystem.cs
@@ -81,7 +81,8 @@
 
                         foreach (var extraMaterial in tempMaterialsList)
                         {
-                            extraMaterial.RenderPriority = organelleRenderOrder;
+                            // Sub-graphics have one less render priority
+                            extraMaterial.RenderPriority = organelleRenderOrder - 1;
                         }
 
                         tempMaterialsList.Clear();

--- a/src/microbe_stage/systems/MicrobeRenderPrioritySystem.cs
+++ b/src/microbe_stage/systems/MicrobeRenderPrioritySystem.cs
@@ -1,0 +1,103 @@
+﻿namespace Systems
+{
+    using System;
+    using System.Collections.Generic;
+    using Components;
+    using DefaultEcs;
+    using DefaultEcs.System;
+    using Godot;
+    using World = DefaultEcs.World;
+
+    /// <summary>
+    ///   Microbe specific render priority system that is aware of how to set render priority separately for organelles
+    ///   and membrane. Requires <see cref="RenderPriorityOverride"/>
+    /// </summary>
+    [With(typeof(RenderPriorityOverride))]
+    [With(typeof(EntityMaterial))]
+    [With(typeof(OrganelleContainer))]
+    [RunsOnMainThread]
+    [RunsAfter(typeof(MicrobeVisualsSystem))]
+    public sealed class MicrobeRenderPrioritySystem : AEntitySetSystem<float>
+    {
+        private readonly List<ShaderMaterial> tempMaterialsList = new();
+
+        public MicrobeRenderPrioritySystem(World world) : base(world, null)
+        {
+        }
+
+        protected override void Update(float state, in Entity entity)
+        {
+            ref var renderOrder = ref entity.Get<RenderPriorityOverride>();
+
+            if (renderOrder.RenderPriorityApplied)
+                return;
+
+            ref var materials = ref entity.Get<EntityMaterial>();
+
+            // Wait until materials fetched
+            if (materials.Materials == null)
+                return;
+
+            ref var container = ref entity.Get<OrganelleContainer>();
+
+            if (container.Organelles == null)
+            {
+                GD.PrintErr("Microbe to have render priority applied doesn't have organelles list");
+                renderOrder.RenderPriorityApplied = true;
+                return;
+            }
+
+            try
+            {
+                // First material is always the membrane, which gets the base value. Organelles are rendered above it.
+                var materialList = materials.Materials;
+
+                if (materialList.Length > 0)
+                {
+                    materialList[0].RenderPriority = renderOrder.RenderPriority;
+                }
+                else
+                {
+                    GD.PrintErr("Expected microbe materials to have at least one entry for membrane");
+                }
+
+                // Rest of the materials list os not used directly as multipart organelles have multiple entries and
+                // would cause the indexes to get out of sync
+
+                foreach (var placedOrganelle in container.Organelles.Organelles)
+                {
+                    // Cytoplasm doesn't have graphics so that is naturally skipped, and we can't give a good error
+                    // message
+                    if (placedOrganelle.OrganelleGraphics == null)
+                        continue;
+
+                    // Render priority can be fully calculated from the organelle position and the base render priority
+                    int organelleRenderOrder =
+                        renderOrder.RenderPriority + Hex.GetRenderPriority(placedOrganelle.Position);
+
+                    if (placedOrganelle.OrganelleGraphics is OrganelleMeshWithChildren organelleMeshWithChildren)
+                    {
+                        organelleMeshWithChildren.GetChildrenMaterials(tempMaterialsList);
+
+                        foreach (var extraMaterial in tempMaterialsList)
+                        {
+                            extraMaterial.RenderPriority = organelleRenderOrder;
+                        }
+
+                        tempMaterialsList.Clear();
+                    }
+
+                    var material =
+                        placedOrganelle.OrganelleGraphics.GetMaterial(placedOrganelle.Definition.DisplaySceneModelPath);
+                    material.RenderPriority = organelleRenderOrder;
+                }
+            }
+            catch (Exception e)
+            {
+                GD.PrintErr($"Failed to apply render priority for entity {entity}: ", e);
+            }
+
+            renderOrder.RenderPriorityApplied = true;
+        }
+    }
+}

--- a/src/microbe_stage/systems/MicrobeVisualsSystem.cs
+++ b/src/microbe_stage/systems/MicrobeVisualsSystem.cs
@@ -20,6 +20,7 @@
     [With(typeof(CellProperties))]
     [With(typeof(SpatialInstance))]
     [With(typeof(EntityMaterial))]
+    [With(typeof(RenderPriorityOverride))]
     [RunsBefore(typeof(SpatialAttachSystem))]
     [RunsOnMainThread]
     public sealed class MicrobeVisualsSystem : AEntitySetSystem<float>
@@ -162,6 +163,9 @@
             tempMaterialsList.Clear();
 
             organelleContainer.OrganelleVisualsCreated = true;
+
+            // Need to update render priority of the visuals
+            entity.Get<RenderPriorityOverride>().RenderPriorityApplied = false;
 
             // Force recreation of physics body in case organelles changed to make sure the shape matches growth status
             cellProperties.ShapeCreated = false;
@@ -335,8 +339,6 @@
                 {
                     tempMaterialsList[i].SetShaderParam("tint", organelleColour);
                 }
-
-                // TODO: render order?
             }
 
             // Delete unused visuals


### PR DESCRIPTION
**Brief Description of What This PR Does**

Reimplemented render order for microbes as it is pretty much needed to get the engulfing mechanics to look nice. As an added bonus this naturally fixed the endosome graphics not displaying problem.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
