### PR TITLE
Ambient light updates along with panorama background

### DIFF
--- a/src/late_multicellular_stage/MulticellularStage.cs
+++ b/src/late_multicellular_stage/MulticellularStage.cs
@@ -27,6 +27,9 @@ public class MulticellularStage : CreatureStageBase<MulticellularCreature, Dummy
     [Export]
     public NodePath WorldEnvironmentNodePath = null!;
 
+    [Export]
+    public NodePath WorldLightNodePath = null!;
+
     private const string STAGE_TRANSITION_MOUSE_LOCK = "toSocietyStage";
 
     [JsonProperty]
@@ -42,6 +45,8 @@ public class MulticellularStage : CreatureStageBase<MulticellularCreature, Dummy
     private SelectBuildingPopup selectBuildingPopup = null!;
 
     private WorldEnvironment worldEnvironmentNode = null!;
+
+    private DirectionalLight worldLightNode = null!;
 
     private Camera? animationCamera;
 #pragma warning restore CA2213
@@ -125,6 +130,7 @@ public class MulticellularStage : CreatureStageBase<MulticellularCreature, Dummy
         progressBarSystem = GetNode<ProgressBarSystem>(ProgressBarSystemPath);
         selectBuildingPopup = GetNode<SelectBuildingPopup>(SelectBuildingPopupPath);
         worldEnvironmentNode = GetNode<WorldEnvironment>(WorldEnvironmentNodePath);
+        worldLightNode = GetNode<DirectionalLight>(WorldLightNodePath);
 
         // TODO: implement late multicellular specific look at info, for now it's disabled by removing it
         HoverInfo.Free();
@@ -643,6 +649,16 @@ public class MulticellularStage : CreatureStageBase<MulticellularCreature, Dummy
 
             worldPanoramaSky.Panorama = GD.Load<Texture>(CurrentGame.GameWorld.Map.CurrentPatch.BiomeTemplate.Panorama);
         }
+
+        UpdateAmbientLight();
+    }
+
+    public void UpdateAmbientLight()
+    {
+        if (CurrentGame?.GameWorld.Map.CurrentPatch != null)
+        {
+            worldLightNode.LightColor = CurrentGame.GameWorld.Map.CurrentPatch.BiomeTemplate.Sunlight.Colour;
+        }
     }
 
     protected override void SetupStage()
@@ -787,6 +803,7 @@ public class MulticellularStage : CreatureStageBase<MulticellularCreature, Dummy
                 ProgressBarSystemPath.Dispose();
                 SelectBuildingPopupPath.Dispose();
                 WorldEnvironmentNodePath.Dispose();
+                WorldLightNodePath.Dispose();
 
                 interactionPopup.OnInteractionSelectedHandler -= ForwardInteractionSelectionToPlayer;
             }

--- a/src/late_multicellular_stage/MulticellularStage.tscn
+++ b/src/late_multicellular_stage/MulticellularStage.tscn
@@ -37,6 +37,7 @@ InteractionPopupPath = NodePath("InteractablePopup")
 ProgressBarSystemPath = NodePath("ProgressBarSystem")
 SelectBuildingPopupPath = NodePath("SelectBuildingPopup")
 WorldEnvironmentNodePath = NodePath("World/WorldEnvironment")
+WorldLightNodePath = NodePath("World/WorldLight")
 
 [node name="World" type="Node" parent="."]
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Ambient light now updates along with panorama background.

Some patches, for example cave, have white light color in JSON file, so they could be adjusted by someone a bit, but it probably isn't priority.

**Related Issues**

Closes #4608

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
