### PR TITLE
Made physics bodies being re-enabled re-apply their latest world position

### DIFF
--- a/src/engine/common_systems/PhysicsBodyDisablingSystem.cs
+++ b/src/engine/common_systems/PhysicsBodyDisablingSystem.cs
@@ -14,6 +14,7 @@
     [With(typeof(Physics))]
     [WritesToComponent(typeof(Physics))]
     [WritesToComponent(typeof(ManualPhysicsControl))]
+    [ReadsComponent(typeof(WorldPosition))]
     [RunsOnMainThread]
     public sealed class PhysicsBodyDisablingSystem : AEntitySetSystem<float>
     {
@@ -79,8 +80,15 @@
                 // from the world by us)
                 if (disabledBodies.Remove(body))
                 {
-                    // TODO: should a new position be applied first?
                     physicalWorld.AddBody(body);
+
+                    if (entity.Has<WorldPosition>())
+                    {
+                        // Set new position to update the body to be where it should be now after not tracking its
+                        // position for a while (due to it being disabled)
+                        ref var newPosition = ref entity.Get<WorldPosition>();
+                        physicalWorld.SetBodyPositionAndRotation(body, newPosition.Position, newPosition.Rotation);
+                    }
                 }
 
                 // TODO: should physics speed on the body or on the component be reset here?

--- a/src/engine/common_systems/PhysicsSensorSystem.cs
+++ b/src/engine/common_systems/PhysicsSensorSystem.cs
@@ -85,8 +85,12 @@
                     // Re-enable (not an error if body doesn't exist, it will be created brand-new soon)
                     if (detachedBodies.TryGetValue(entity, out var disabledBody))
                     {
-                        // TODO: should a new position be applied first?
                         worldSimulationWithPhysics.PhysicalWorld.AddBody(disabledBody);
+
+                        // Update position before the sensor should have any time to collide with anything
+                        // Note that rotation is not updated as it's not updated elsewhere for sensors either
+                        ref var newPosition = ref entity.Get<WorldPosition>();
+                        worldSimulationWithPhysics.PhysicalWorld.SetBodyPosition(disabledBody, newPosition.Position);
 
                         detachedBodies.Remove(entity);
 

--- a/src/engine/physics/PhysicalWorld.cs
+++ b/src/engine/physics/PhysicalWorld.cs
@@ -264,6 +264,12 @@ public class PhysicalWorld : IDisposable
         NativeMethods.SetBodyPosition(AccessWorldInternal(), body.AccessBodyInternal(), new JVec3(position));
     }
 
+    public void SetBodyPositionAndRotation(NativePhysicsBody body, Vector3 position, Quat rotation)
+    {
+        NativeMethods.SetBodyPositionAndRotation(AccessWorldInternal(), body.AccessBodyInternal(), new JVec3(position),
+            new JQuat(rotation));
+    }
+
     /// <summary>
     ///   Sets velocity for a body
     /// </summary>
@@ -613,6 +619,10 @@ internal static partial class NativeMethods
 
     [DllImport("thrive_native")]
     internal static extern void SetBodyPosition(IntPtr world, IntPtr body, JVec3 position, bool activate = true);
+
+    [DllImport("thrive_native")]
+    internal static extern void SetBodyPositionAndRotation(IntPtr world, IntPtr body, JVec3 position, JQuat rotation,
+        bool activate = true);
 
     [DllImport("thrive_native")]
     internal static extern void SetBodyVelocity(IntPtr world, IntPtr body, JVecF3 velocity);

--- a/src/native/NativeConstants.cs
+++ b/src/native/NativeConstants.cs
@@ -1,4 +1,4 @@
 ﻿public class NativeConstants
 {
-    public const int Version = 6;
+    public const int Version = 7;
 }

--- a/src/native/interop/CInterop.cpp
+++ b/src/native/interop/CInterop.cpp
@@ -316,6 +316,14 @@ void SetBodyPosition(PhysicalWorld* physicalWorld, PhysicsBody* body, JVec3 posi
             reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(), Thrive::DVec3FromCAPI(position), activate);
 }
 
+void SetBodyPositionAndRotation(
+    PhysicalWorld* physicalWorld, PhysicsBody* body, JVec3 position, JQuat rotation, bool activate)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetPositionAndRotation(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(), Thrive::DVec3FromCAPI(position),
+            Thrive::QuatFromCAPI(rotation), activate);
+}
+
 void SetBodyVelocity(PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 velocity)
 {
     reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)

--- a/src/native/interop/CInterop.h
+++ b/src/native/interop/CInterop.h
@@ -95,6 +95,9 @@ extern "C"
     [[maybe_unused]] THRIVE_NATIVE_API void SetBodyPosition(
         PhysicalWorld* physicalWorld, PhysicsBody* body, JVec3 position, bool activate);
 
+    [[maybe_unused]] THRIVE_NATIVE_API void SetBodyPositionAndRotation(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, JVec3 position, JQuat rotation, bool activate = true);
+
     [[maybe_unused]] THRIVE_NATIVE_API void SetBodyVelocity(
         PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 velocity);
 

--- a/src/native/physics/PhysicalWorld.cpp
+++ b/src/native/physics/PhysicalWorld.cpp
@@ -715,6 +715,21 @@ void PhysicalWorld::SetPosition(JPH::BodyID bodyId, JPH::DVec3Arg position, bool
         bodyId, position, activate ? JPH::EActivation::Activate : JPH::EActivation::DontActivate);
 }
 
+void PhysicalWorld::SetPositionAndRotation(
+    JPH::BodyID bodyId, JPH::DVec3Arg position, JPH::QuatArg rotation, bool activate)
+{
+    if (!activate)
+    {
+        physicsSystem->GetBodyInterface().SetPositionAndRotationWhenChanged(
+            bodyId, position, rotation, JPH::EActivation::DontActivate);
+    }
+    else
+    {
+        physicsSystem->GetBodyInterface().SetPositionAndRotation(
+            bodyId, position, rotation, JPH::EActivation::Activate);
+    }
+}
+
 void PhysicalWorld::SetBodyAllowSleep(JPH::BodyID bodyId, bool allowSleeping)
 {
     JPH::BodyLockWrite lock(physicsSystem->GetBodyLockInterface(), bodyId);

--- a/src/native/physics/PhysicalWorld.hpp
+++ b/src/native/physics/PhysicalWorld.hpp
@@ -112,6 +112,9 @@ public:
 
     void SetPosition(JPH::BodyID bodyId, JPH::DVec3Arg position, bool activate = true);
 
+    void SetPositionAndRotation(
+        JPH::BodyID bodyId, JPH::DVec3Arg position, JPH::QuatArg rotation, bool activate = true);
+
     void SetBodyAllowSleep(JPH::BodyID bodyId, bool allowSleeping);
 
     /// \brief Ensures body's Y coordinate is 0, if not moves it so that it is 0


### PR DESCRIPTION
this should prevent unbound cells or engulfing released cells from teleporting to where their physics bodies last were

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
