### PR TITLE
Buffed eukaryotic movement force by 50%

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -190,6 +190,11 @@ public static class Constants
     public const float BASE_MOVEMENT_FORCE = 1400.0f;
 
     /// <summary>
+    ///   As eukaryotes are immediately 50% larger they get a corresponding movement force increase to offset that
+    /// </summary>
+    public const float EUKARYOTIC_MOVEMENT_FORCE_MULTIPLIER = 1.5f;
+
+    /// <summary>
     ///   How much extra base movement is given per hex. Only applies between
     ///   <see cref="BASE_MOVEMENT_EXTRA_HEX_START"/> and <see cref="BASE_MOVEMENT_EXTRA_HEX_END"/>
     /// </summary>

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -202,14 +202,16 @@ public static class MicrobeInternalCalculations
         organelleMovementForce += MovementForce(leftwardDirectionMovementForce, leftDirectionFactor);
 
         float baseMovementForce =
-            CalculateBaseMovement(membraneType, membraneRigidity, organelles.Sum(o => o.Definition.HexCount));
+            CalculateBaseMovement(membraneType, membraneRigidity, organelles.Sum(o => o.Definition.HexCount),
+                isBacteria);
 
         float finalSpeed = (baseMovementForce + organelleMovementForce) / shape.GetMass();
 
         return finalSpeed;
     }
 
-    public static float CalculateBaseMovement(MembraneType membraneType, float membraneRigidity, int hexCount)
+    public static float CalculateBaseMovement(MembraneType membraneType, float membraneRigidity, int hexCount,
+        bool isBacteria)
     {
         var movement = Constants.BASE_MOVEMENT_FORCE;
 
@@ -220,6 +222,9 @@ public static class MicrobeInternalCalculations
 
         // Apply membrane adjustment
         movement *= membraneType.MovementFactor - membraneRigidity * Constants.MEMBRANE_RIGIDITY_BASE_MOBILITY_MODIFIER;
+
+        if (!isBacteria)
+            movement *= Constants.EUKARYOTIC_MOVEMENT_FORCE_MULTIPLIER;
 
         return movement;
     }

--- a/src/microbe_stage/organelle_components/MovementComponent.cs
+++ b/src/microbe_stage/organelle_components/MovementComponent.cs
@@ -66,9 +66,9 @@ public class MovementComponent : IOrganelleComponent
     }
 
     public float UseForMovement(Vector3 wantedMovementDirection, CompoundBag compounds, Quat extraColonyRotation,
-        float delta)
+        bool isBacteria, float delta)
     {
-        return CalculateMovementForce(compounds, wantedMovementDirection, extraColonyRotation, delta);
+        return CalculateMovementForce(compounds, wantedMovementDirection, extraColonyRotation, isBacteria, delta);
     }
 
     /// <summary>
@@ -107,7 +107,7 @@ public class MovementComponent : IOrganelleComponent
     ///   </para>
     /// </remarks>
     private float CalculateMovementForce(CompoundBag compounds, Vector3 wantedMovementDirection,
-        Quat extraColonyRotation, float elapsed)
+        Quat extraColonyRotation, bool isBacteria, float elapsed)
     {
         // Real force the flagella applied to the colony (considering rotation)
         var realForce = extraColonyRotation.Xform(force);
@@ -141,8 +141,10 @@ public class MovementComponent : IOrganelleComponent
 
         SetSpeedFactor(newAnimationSpeed);
 
-        // TODO: adjust the flagella force for the new physics engine
-        return Constants.FLAGELLA_BASE_FORCE * forceMagnitude;
+        if (isBacteria)
+            return Constants.FLAGELLA_BASE_FORCE * forceMagnitude;
+
+        return Constants.FLAGELLA_BASE_FORCE * forceMagnitude * Constants.EUKARYOTIC_MOVEMENT_FORCE_MULTIPLIER;
     }
 }
 

--- a/src/microbe_stage/systems/MicrobeMovementSystem.cs
+++ b/src/microbe_stage/systems/MicrobeMovementSystem.cs
@@ -159,7 +159,7 @@
 
             // Base movement force
             float force = MicrobeInternalCalculations.CalculateBaseMovement(cellProperties.MembraneType,
-                cellProperties.MembraneRigidity, organelles.HexCount);
+                cellProperties.MembraneRigidity, organelles.HexCount, cellProperties.IsBacteria);
 
             // Length is multiplied here so that cells that set very slow movement speed don't need to pay the entire
             // movement cost
@@ -179,7 +179,8 @@
             {
                 foreach (var flagellum in organelles.ThrustComponents)
                 {
-                    force += flagellum.UseForMovement(control.MovementDirection, compounds, Quat.Identity, delta);
+                    force += flagellum.UseForMovement(control.MovementDirection, compounds, Quat.Identity,
+                        cellProperties.IsBacteria, delta);
                 }
             }
 
@@ -187,8 +188,8 @@
 
             if (control.MovementDirection != Vector3.Zero && hasColony)
             {
-                CalculateColonyImpactOnMovementForce(ref entity.Get<MicrobeColony>(), control.MovementDirection, delta,
-                    ref force);
+                CalculateColonyImpactOnMovementForce(ref entity.Get<MicrobeColony>(), control.MovementDirection,
+                    cellProperties.IsBacteria, delta, ref force);
             }
 
             if (control.SlowedBySlime)
@@ -267,7 +268,7 @@
         }
 
         private void CalculateColonyImpactOnMovementForce(ref MicrobeColony microbeColony, Vector3 movementDirection,
-            float delta, ref float force)
+            bool isBacteria, float delta, ref float force)
         {
             // Multiplies the movement factor as if the colony has the normal microbe speed
             // Then it subtracts movement speed from 100% up to 75%(soft cap),
@@ -301,7 +302,7 @@
                     foreach (var flagellum in organelles.ThrustComponents)
                     {
                         force += flagellum.UseForMovement(movementDirection, compounds,
-                            relativeRotation, delta);
+                            relativeRotation, isBacteria, delta);
                     }
                 }
             }


### PR DESCRIPTION
**Brief Description of What This PR Does**

As eukaryotes are immediately scaled up 50% their physics size is also bigger and as such they were probably a lot slower. This gives them a flat 50% movement force increase.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
