### PR TITLE
Fixed engulf animation playing twice and eject animation not working

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -681,7 +681,7 @@ public static class Constants
     /// <summary>
     ///   The duration for which an engulfable object can't be engulfed after being expelled.
     /// </summary>
-    public const float ENGULF_EJECTED_COOLDOWN = 2.0f;
+    public const float ENGULF_EJECTED_COOLDOWN = 2.5f;
 
     public const float ENGULF_EJECTION_VELOCITY = 3.0f;
 

--- a/src/microbe_stage/components/Engulfer.cs
+++ b/src/microbe_stage/components/Engulfer.cs
@@ -206,16 +206,16 @@
             // Cannot start ejecting a thing that is not in a valid state for that
             switch (engulfable.PhagocytosisStep)
             {
+                case PhagocytosisPhase.None:
                 case PhagocytosisPhase.Ingestion:
-                case PhagocytosisPhase.Ingested:
-                    break;
+                case PhagocytosisPhase.Digested:
+                    return false;
 
                 case PhagocytosisPhase.RequestExocytosis:
-                    // Already requested
+                case PhagocytosisPhase.Exocytosis:
+                case PhagocytosisPhase.Ejection:
+                    // Already requested / happening
                     return true;
-
-                default:
-                    return false;
             }
 
             engulfable.PhagocytosisStep = PhagocytosisPhase.RequestExocytosis;

--- a/src/microbe_stage/systems/EngulfedDigestionSystem.cs
+++ b/src/microbe_stage/systems/EngulfedDigestionSystem.cs
@@ -94,7 +94,12 @@
                 // is overloaded
                 if (engulfer.UsedIngestionCapacity > engulfer.EngulfStorageSize)
                 {
-                    engulfer.EjectEngulfable(ref engulfable);
+                    if (engulfer.EjectEngulfable(ref engulfable))
+                    {
+                        entity.SendNoticeIfPossible(
+                            new SimpleHUDMessage(TranslationServer.Translate("NOTICE_ENGULF_STORAGE_FULL")));
+                    }
+
                     continue;
                 }
 
@@ -121,10 +126,12 @@
 
                     case DigestCheckResult.MissingEnzyme:
                     {
-                        engulfer.EjectEngulfable(ref engulfable);
+                        if (engulfer.EjectEngulfable(ref engulfable))
+                        {
+                            entity.SendNoticeIfPossible(new LocalizedString("NOTICE_ENGULF_MISSING_ENZYME",
+                                engulfable.RequisiteEnzymeToDigest!.Name));
+                        }
 
-                        entity.SendNoticeIfPossible(new LocalizedString("NOTICE_ENGULF_MISSING_ENZYME",
-                            engulfable.RequisiteEnzymeToDigest!.Name));
                         continue;
                     }
 

--- a/src/microbe_stage/systems/EngulfingSystem.cs
+++ b/src/microbe_stage/systems/EngulfingSystem.cs
@@ -924,7 +924,15 @@
                 // binding system
                 lock (AttachedToEntityHelpers.EntityAttachRelationshipModifyLock)
                 {
-                    return IngestEngulfable(ref engulfer, ref cellProperties, entity, ref engulfable.Get<Engulfable>(),
+                    ref var engulfableComponent = ref engulfable.Get<Engulfable>();
+
+                    if (engulfableComponent.PhagocytosisStep != PhagocytosisPhase.None)
+                    {
+                        throw new InvalidOperationException(
+                            "Detected something that is currently engulfed as being engulfable");
+                    }
+
+                    return IngestEngulfable(ref engulfer, ref cellProperties, entity, ref engulfableComponent,
                         engulfable);
                 }
             }
@@ -1112,7 +1120,10 @@
             // TODO: being dead should probably override the following two if checks
             // Need to skip until the engulfer's membrane is ready
             if (engulferCellProperties.CreatedMembrane == null)
+            {
+                GD.PrintErr("Skipping ejecting engulfable as the engulfer doesn't have membrane ready yet");
                 return;
+            }
 
             if (engulfable.PhagocytosisStep is PhagocytosisPhase.Exocytosis or PhagocytosisPhase.None
                 or PhagocytosisPhase.Ejection)
@@ -1121,10 +1132,16 @@
             }
 
             if (engulfer.EngulfedObjects == null)
+            {
+                GD.PrintErr("Engulfer has no list of engulfed objects, it cannot expel anything");
                 return;
+            }
 
             if (!engulfer.EngulfedObjects.Contains(engulfedObject))
+            {
+                GD.PrintErr("Tried to eject something from engulfer that it hasn't engulfed");
                 return;
+            }
 
             engulfable.PhagocytosisStep = PhagocytosisPhase.Exocytosis;
 
@@ -1140,12 +1157,9 @@
             // If the animation is missing then for simplicity we just eject immediately or if the attached to
             // component is missing even though it should be always there
 
-            if (engulfedObject.Has<AttachedToEntity>())
+            if (!engulfedObject.Has<AttachedToEntity>())
             {
-                if (!engulfedObject.Has<AttachedToEntity>())
-                {
-                    GD.Print($"Immediately ejecting engulfable that has no {nameof(AttachedToEntity)} component");
-                }
+                GD.Print($"Immediately ejecting engulfable that has no {nameof(AttachedToEntity)} component");
 
                 CompleteEjection(ref engulfer, entity, ref engulfable, engulfedObject);
 
@@ -1224,7 +1238,56 @@
             // Mark the object as recently expelled (0 seconds since ejection)
             engulfer.ExpelledObjects[engulfableObject] = 0;
 
-            Vector3 relativePosition = Vector3.Forward;
+            PerformEjectionForceAndAttachedRemove(entity, ref engulfable, engulfableObject);
+
+            RemoveEngulfedObject(ref engulfer, engulfableObject, ref engulfable);
+
+            // The phagosome will be deleted automatically, we just hide it here to make it disappear on the same frame
+            // as the ejection completes
+            var endosome = GetEndosomeIfExists(entity, engulfableObject);
+
+            endosome?.Hide();
+
+            if (entity.Has<Engulfable>() && canMoveToHigherLevelEngulfer)
+            {
+                ref var engulfersEngulfable = ref entity.Get<Engulfable>();
+
+                if (engulfersEngulfable.PhagocytosisStep != PhagocytosisPhase.None)
+                {
+                    if (!engulfersEngulfable.HostileEngulfer.IsAlive ||
+                        !engulfersEngulfable.HostileEngulfer.Has<Engulfer>())
+                    {
+                        GD.PrintErr("Attempt to pass ejected object to our engulfer failed because that " +
+                            "engulfer is not alive");
+                        return;
+                    }
+
+                    // Skip sending to the hostile engulfer if it is dead
+                    if (engulfersEngulfable.HostileEngulfer.Has<Health>() &&
+                        engulfersEngulfable.HostileEngulfer.Get<Health>().Dead)
+                    {
+                        GD.Print("Not sending engulfable to our engulfer as that is dead");
+                        return;
+                    }
+
+                    ref var hostileEngulfer = ref engulfersEngulfable.HostileEngulfer.Get<Engulfer>();
+
+                    // We have our own engulfer and it wants to claim this object we've just expelled
+                    if (!IngestEngulfable(ref hostileEngulfer,
+                            ref engulfersEngulfable.HostileEngulfer.Get<CellProperties>(),
+                            engulfersEngulfable.HostileEngulfer, ref engulfable,
+                            engulfableObject))
+                    {
+                        GD.PrintErr("Failed to pass ejected object from an engulfed object to its engulfer");
+                    }
+                }
+            }
+        }
+
+        private void PerformEjectionForceAndAttachedRemove(in Entity entity, ref Engulfable engulfable,
+            Entity engulfableObject)
+        {
+            var relativePosition = Vector3.Forward;
 
             // This lock is a bit useless but for symmetry on start this is also used here on eject
             lock (AttachedToEntityHelpers.EntityAttachRelationshipModifyLock)
@@ -1286,49 +1349,6 @@
             // Reset engulfable state after the ejection (but before RemoveEngulfedObject to allow this to still see
             // the hostile engulfer entity)
             engulfable.OnExpelledFromEngulfment(engulfableObject, spawnSystem, worldSimulation);
-
-            RemoveEngulfedObject(ref engulfer, engulfableObject, ref engulfable);
-
-            // The phagosome will be deleted automatically, we just hide it here to make it disappear on the same frame
-            // as the ejection completes
-            var endosome = GetEndosomeIfExists(entity, engulfableObject);
-
-            endosome?.Hide();
-
-            if (entity.Has<Engulfable>() && canMoveToHigherLevelEngulfer)
-            {
-                ref var engulfersEngulfable = ref entity.Get<Engulfable>();
-
-                if (engulfersEngulfable.PhagocytosisStep != PhagocytosisPhase.None)
-                {
-                    if (!engulfersEngulfable.HostileEngulfer.IsAlive ||
-                        !engulfersEngulfable.HostileEngulfer.Has<Engulfer>())
-                    {
-                        GD.PrintErr("Attempt to pass ejected object to our engulfer failed because that " +
-                            "engulfer is not alive");
-                        return;
-                    }
-
-                    // Skip sending to the hostile engulfer if it is dead
-                    if (engulfersEngulfable.HostileEngulfer.Has<Health>() &&
-                        engulfersEngulfable.HostileEngulfer.Get<Health>().Dead)
-                    {
-                        GD.Print("Not sending engulfable to our engulfer as that is dead");
-                        return;
-                    }
-
-                    ref var hostileEngulfer = ref engulfersEngulfable.HostileEngulfer.Get<Engulfer>();
-
-                    // We have our own engulfer and it wants to claim this object we've just expelled
-                    if (!IngestEngulfable(ref hostileEngulfer,
-                            ref engulfersEngulfable.HostileEngulfer.Get<CellProperties>(),
-                            engulfersEngulfable.HostileEngulfer, ref engulfable,
-                            engulfableObject))
-                    {
-                        GD.PrintErr("Failed to pass ejected object from an engulfed object to its engulfer");
-                    }
-                }
-            }
         }
 
         /// <summary>
@@ -1395,6 +1415,12 @@
 
                 // Some code didn't initialize the animation data
                 GD.PrintErr($"{nameof(AnimateBulkTransport)} cannot run because bulk animation data is null");
+                return true;
+            }
+
+            if (!animation.Interpolate)
+            {
+                // Animation is complete, this happens when the steps are updated for example to request exocytosis
                 return true;
             }
 
@@ -1613,6 +1639,17 @@
             }
 
             ref var engulfable = ref toEject.Get<Engulfable>();
+
+            // This shouldn't happen but here's this workaround to stop crashing
+            if (engulfer.EngulfedObjects == null)
+            {
+                GD.PrintErr(
+                    "Force ejection on engulfer that doesn't have engulfed object list setup is skipping " +
+                    "normal eject logic");
+
+                PerformEjectionForceAndAttachedRemove(entity, ref engulfable, toEject);
+                return;
+            }
 
             CompleteEjection(ref engulfer, entity, ref engulfable, toEject, false);
         }


### PR DESCRIPTION
turns out that there was a slight bug that just replayed the engulf animation before ejection could be started when indigestible things were eaten

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
