### PR TITLE
Fixed endosome scale blowing up a ton when engulfing specific things

### DIFF
--- a/src/microbe_stage/systems/EngulfingSystem.cs
+++ b/src/microbe_stage/systems/EngulfingSystem.cs
@@ -625,6 +625,9 @@
                 if (geometryInstance != null)
                 {
                     boundingBoxSize = geometryInstance.GetAabb().Size;
+
+                    // Apply the current visual scale as it is not included in the AABB automatically
+                    boundingBoxSize *= geometryInstance.Scale;
                 }
                 else
                 {


### PR DESCRIPTION
this general fix should fix anything else that might not work, it was pretty surprising that oxytoxy proteins was the only problematic object to trigger this hiding bug

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
