### PR TITLE
Made going to the art gallery disable menu performance tracking

### DIFF
--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -180,6 +180,9 @@ public class MainMenu : NodeWithInput
 
     private float averageFrameRate;
 
+    /// <summary>
+    ///   Time tracking related to performance. Note that this is reset when performance tracking is restarted.
+    /// </summary>
     private float secondsInMenu;
 
     private bool canShowLowPerformanceWarning = true;
@@ -298,7 +301,9 @@ public class MainMenu : NodeWithInput
             {
                 secondsInMenu += delta;
 
-                if (secondsInMenu >= 1)
+                // Don't track performance when the 3D background aren't actually visible. For example when going to
+                // the art gallery
+                if (secondsInMenu >= 1 && created3DBackground?.Visible == true)
                 {
                     averageFrameRate = TrackMenuPerformance();
 
@@ -1090,6 +1095,8 @@ public class MainMenu : NodeWithInput
         {
             created3DBackground.Visible = true;
         }
+
+        ResetPerformanceTracking();
     }
 
     private void OnWebsitesButtonPressed()
@@ -1138,5 +1145,11 @@ public class MainMenu : NodeWithInput
             // Hide the background again when playing a video as the 3D backgrounds are performance intensive
             created3DBackground.Visible = false;
         }
+    }
+
+    private void ResetPerformanceTracking()
+    {
+        secondsInMenu = 0;
+        averageFrameRate = 0;
     }
 }


### PR DESCRIPTION
so that the low performance warning doesn't trigger due to the lag of loading the art gallery contents

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

I can't remember where but someone showed a screenshot with the performance warning opening while in the art gallery, this should fix that.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
