### PR TITLE
Fixed warning caused by options sound device list when exiting the editor

### DIFF
--- a/src/general/OptionsMenu.cs
+++ b/src/general/OptionsMenu.cs
@@ -1511,7 +1511,11 @@ public class OptionsMenu : ControlWithInput
 
     private void UpdateDefaultAudioOutputDeviceText()
     {
-        audioOutputDeviceSelection.SetItemText(0, TranslationServer.Translate("DEFAULT_AUDIO_OUTPUT_DEVICE"));
+        // Only update the text when the button is populated (otherwise this triggers an error when exiting the editor)
+        if (audioOutputDeviceSelection.GetItemCount() > 0)
+        {
+            audioOutputDeviceSelection.SetItemText(0, TranslationServer.Translate("DEFAULT_AUDIO_OUTPUT_DEVICE"));
+        }
     }
 
     private void LoadAudioOutputDevices()


### PR DESCRIPTION
**Brief Description of What This PR Does**
Fixes a warning bug I've seen for quite a while now but didn't have time to fix earlier

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
