### PR TITLE
Fixed saving when chemoreceptor is set to find the species it is in

### DIFF
--- a/src/general/Species.cs
+++ b/src/general/Species.cs
@@ -43,6 +43,18 @@ public abstract class Species : ICloneable
     public IReadOnlyDictionary<Compound, float> BaseReproductionCost =>
         cachedBaseReproductionCost ??= CalculateBaseReproductionCost();
 
+    /// <summary>
+    ///   Unique id of this species, used to identify this
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     In the previous version a string name was used to identify species, but it was just the word species
+    ///     followed by a sequential number, so now this is an actual number.
+    ///   </para>
+    /// </remarks>
+    [JsonProperty]
+    public uint ID { get; private set; }
+
     public string Genus { get; set; }
     public string Epithet { get; set; }
 
@@ -86,18 +98,6 @@ public abstract class Species : ICloneable
     public long Population { get; set; } = 1;
 
     public int Generation { get; set; } = 1;
-
-    /// <summary>
-    ///   Unique id of this species, used to identify this
-    /// </summary>
-    /// <remarks>
-    ///   <para>
-    ///     In the previous version a string name was used to identify species, but it was just the word species
-    ///     followed by a sequential number, so now this is an actual number.
-    ///   </para>
-    /// </remarks>
-    [JsonProperty]
-    public uint ID { get; private set; }
 
     /// <summary>
     ///   This is the genome of the species

--- a/src/microbe_stage/MicrobeSpecies.cs
+++ b/src/microbe_stage/MicrobeSpecies.cs
@@ -53,6 +53,11 @@ public class MicrobeSpecies : Species, ICellProperties
 
     public float MembraneRigidity { get; set; }
 
+    /// <summary>
+    ///   Organelles this species consist of. This is saved last to ensure organelle data that may refer back to this
+    ///   species can be loaded (for example cell-detecting chemoreceptors).
+    /// </summary>
+    [JsonProperty(Order = 1)]
     public OrganelleLayout<OrganelleTemplate> Organelles { get; set; }
 
     [JsonIgnore]

--- a/src/saving/serializers/ThriveJsonConverter.cs
+++ b/src/saving/serializers/ThriveJsonConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -281,10 +282,18 @@ public abstract class BaseThriveConverter : JsonConverter
 
     private static readonly List<string> DefaultOnlyChildCopyIgnore = new();
 
+    private static readonly ConcurrentQueue<List<(int Order, string Name, object? Value, Type FieldType)>>
+        DelayWriteProperties = new();
+
+    private static readonly IComparer<(int Order, string Name, object? Value, Type FieldType)> PropertyOrderComparer =
+        new OrderComparer();
+
     private static readonly Type ObjectBaseType = typeof(object);
     private static readonly Type AlwaysDynamicAttribute = typeof(JSONAlwaysDynamicTypeAttribute);
     private static readonly Type SceneLoadedAttribute = typeof(SceneLoadedClassAttribute);
     private static readonly Type BaseDynamicTypeAllowedAttribute = typeof(JSONDynamicTypeAllowedAttribute);
+    private static readonly Type JsonPropertyAttribute = typeof(JsonPropertyAttribute);
+    private static readonly Type JsonIgnoreAttribute = typeof(JsonIgnoreAttribute);
 
     protected BaseThriveConverter(ISaveContext? context)
     {
@@ -311,13 +320,13 @@ public abstract class BaseThriveConverter : JsonConverter
     {
         var fields = type.GetFields(
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(p => p.CustomAttributes.All(
-            a => a.AttributeType != typeof(JsonIgnoreAttribute) &&
+            a => a.AttributeType != JsonIgnoreAttribute &&
                 a.AttributeType != typeof(CompilerGeneratedAttribute)));
 
         // Ignore fields that aren't public unless it has JsonPropertyAttribute
         fields = fields.Where(p =>
             (p.IsPublic && !p.IsInitOnly) ||
-            p.CustomAttributes.Any(a => a.AttributeType == typeof(JsonPropertyAttribute)));
+            p.CustomAttributes.Any(a => a.AttributeType == JsonPropertyAttribute));
 
         // Ignore fields that are marked export without explicit JSON property
         fields = fields.Where(p =>
@@ -331,7 +340,7 @@ public abstract class BaseThriveConverter : JsonConverter
             {
                 // Ignore all fields not opted in
                 fields = fields.Where(
-                    p => p.CustomAttributes.Any(a => a.AttributeType == typeof(JsonPropertyAttribute)));
+                    p => p.CustomAttributes.Any(a => a.AttributeType == JsonPropertyAttribute));
             }
         }
 
@@ -340,7 +349,7 @@ public abstract class BaseThriveConverter : JsonConverter
 
     public static IEnumerable<PropertyInfo> PropertiesOf(object value, bool handleClassJSONSettings = true)
     {
-        return PropertiesOf(value.GetType());
+        return PropertiesOf(value.GetType(), handleClassJSONSettings);
     }
 
     public static IEnumerable<PropertyInfo> PropertiesOf(Type type, bool handleClassJSONSettings = true)
@@ -348,11 +357,11 @@ public abstract class BaseThriveConverter : JsonConverter
         var properties = type.GetProperties(
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(
             p => p.CustomAttributes.All(
-                a => a.AttributeType != typeof(JsonIgnoreAttribute)));
+                a => a.AttributeType != JsonIgnoreAttribute));
 
         // Ignore properties that don't have a public setter unless it has JsonPropertyAttribute
         properties = properties.Where(p => p.GetSetMethod() != null ||
-            p.CustomAttributes.Any(a => a.AttributeType == typeof(JsonPropertyAttribute)));
+            p.CustomAttributes.Any(a => a.AttributeType == JsonPropertyAttribute));
 
         // Ignore properties that are marked export without explicit JSON property
         properties = properties.Where(p =>
@@ -366,7 +375,7 @@ public abstract class BaseThriveConverter : JsonConverter
             {
                 // Ignore all properties not opted in
                 properties = properties.Where(
-                    p => p.CustomAttributes.Any(a => a.AttributeType == typeof(JsonPropertyAttribute)));
+                    p => p.CustomAttributes.Any(a => a.AttributeType == JsonPropertyAttribute));
             }
         }
 
@@ -385,7 +394,7 @@ public abstract class BaseThriveConverter : JsonConverter
         if (!export)
             return false;
 
-        return customAttributeData.All(attr => attr.AttributeType != typeof(JsonPropertyAttribute));
+        return customAttributeData.All(attr => attr.AttributeType != JsonPropertyAttribute);
     }
 
     public static bool IsIgnoredGodotMember(string name, Type type)
@@ -686,9 +695,30 @@ public abstract class BaseThriveConverter : JsonConverter
                 }
             }
 
+            List<(int Order, string Name, object? Value, Type FieldType)>? delayWriteProperties = null;
+
+            // TODO: does this need to support higher priority properties (i.e. negative ordering)?
+
             // First time writing, write all fields and properties
             foreach (var field in FieldsOf(value))
             {
+                var jsonCustomization = field.GetCustomAttribute<JsonPropertyAttribute>();
+                if (jsonCustomization != null && jsonCustomization.Order != 0)
+                {
+                    if (jsonCustomization.Order < 0)
+                        throw new NotSupportedException("Negative JSON priority order is not implemented");
+
+                    if (delayWriteProperties == null)
+                    {
+                        if (!DelayWriteProperties.TryDequeue(out delayWriteProperties))
+                            delayWriteProperties = new List<(int Order, string Name, object? Value, Type FieldType)>();
+                    }
+
+                    delayWriteProperties.Add((jsonCustomization.Order, field.Name, field.GetValue(value),
+                        field.FieldType));
+                    continue;
+                }
+
                 WriteMember(field.Name, field.GetValue(value), field.FieldType, type, writer, serializer);
             }
 
@@ -723,8 +753,39 @@ public abstract class BaseThriveConverter : JsonConverter
                     continue;
                 }
 
+                var jsonCustomization = property.GetCustomAttribute<JsonPropertyAttribute>();
+                if (jsonCustomization != null && jsonCustomization.Order != 0)
+                {
+                    if (jsonCustomization.Order < 0)
+                        throw new NotSupportedException("Negative JSON priority oder is not implemented");
+
+                    if (delayWriteProperties == null)
+                    {
+                        if (!DelayWriteProperties.TryDequeue(out delayWriteProperties))
+                            delayWriteProperties = new List<(int Order, string Name, object? Value, Type FieldType)>();
+                    }
+
+                    delayWriteProperties.Add((jsonCustomization.Order, property.Name, memberValue,
+                        property.PropertyType));
+                    continue;
+                }
+
                 WriteMember(property.Name, memberValue, property.PropertyType, type, writer,
                     serializer);
+            }
+
+            if (delayWriteProperties != null)
+            {
+                delayWriteProperties.Sort(PropertyOrderComparer);
+
+                foreach (var delayWrite in delayWriteProperties)
+                {
+                    WriteMember(delayWrite.Name, delayWrite.Value, delayWrite.FieldType, type, writer,
+                        serializer);
+                }
+
+                delayWriteProperties.Clear();
+                DelayWriteProperties.Enqueue(delayWriteProperties);
             }
 
             WriteCustomExtraFields(writer, value, serializer);
@@ -757,7 +818,7 @@ public abstract class BaseThriveConverter : JsonConverter
     ///   Default member writer for thrive types. Has special handling for some Thrive types,
     ///   others use default serializers
     /// </summary>
-    protected virtual void WriteMember(string name, object memberValue, Type memberType, Type objectType,
+    protected virtual void WriteMember(string name, object? memberValue, Type memberType, Type objectType,
         JsonWriter writer, JsonSerializer serializer)
     {
         if (SkipMember(name))
@@ -943,10 +1004,19 @@ public abstract class BaseThriveConverter : JsonConverter
                 serializer.ReferenceResolver.GetReference(serializer, oldReference), newReference);
         }
     }
+
+    private class OrderComparer : IComparer<(int Order, string Name, object? Value, Type FieldType)>
+    {
+        public int Compare((int Order, string Name, object? Value, Type FieldType) x,
+            (int Order, string Name, object? Value, Type FieldType) y)
+        {
+            return x.Order.CompareTo(y.Order);
+        }
+    }
 }
 
 /// <summary>
-///   When a class has this attribute DefaultThriveJSONConverter is used to serialize it
+///   When a class has this attribute <see cref="DefaultThriveJSONConverter"/> is used to serialize it
 /// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
 public class UseThriveSerializerAttribute : Attribute
@@ -955,7 +1025,7 @@ public class UseThriveSerializerAttribute : Attribute
 
 /// <summary>
 ///   Custom serializer for all Thrive types that don't need any special handling. They need to have the attribute
-///   UseThriveSerializerAttribute to be detected
+///   <see cref="UseThriveSerializerAttribute"/> to be detected
 /// </summary>
 internal class DefaultThriveJSONConverter : BaseThriveConverter
 {


### PR DESCRIPTION
**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://community.revolutionarygamesstudio.com/t/crash-when-trying-to-load-save/7068

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
