### PR TITLE
Skip processing lost cell body plan cost if out of range

### DIFF
--- a/src/early_multicellular_stage/components/MulticellularGrowth.cs
+++ b/src/early_multicellular_stage/components/MulticellularGrowth.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using DefaultEcs;
     using DefaultEcs.Command;
+    using Godot;
     using Newtonsoft.Json;
     using Systems;
 
@@ -152,6 +153,16 @@
             if (lostPartIndex == 0)
                 return;
 
+            if (species.Cells.Count > lostPartIndex)
+            {
+                GD.PrintErr(
+                    "Multicellular colony lost a cell at index that is no longer valid for the species, " +
+                    "ignoring this for regrowing");
+
+                // TODO: does this need to  adjust multicellularGrowth.CompoundsUsedForMulticellularGrowth?
+                return;
+            }
+
             // We need to reset our growth towards the next cell and instead replace the cell we just lost
             multicellularGrowth.LostPartsOfBodyPlan ??= new List<int>();
 
@@ -207,12 +218,11 @@
             }
 
             // Adjust the already used compound amount to lose the progress we made for the current cell and also
-            // towards the lost cell, this we the total progress bar should be correct
+            // towards the lost cell, this should ensure the total progress bar should be correct
             if (multicellularGrowth.CompoundsUsedForMulticellularGrowth != null)
             {
                 var totalNeededForLostCell = species.Cells[lostPartIndex]
-                    .CellType
-                    .CalculateTotalComposition();
+                    .CellType.CalculateTotalComposition();
 
                 foreach (var compound in multicellularGrowth.CompoundsUsedForMulticellularGrowth.Keys.ToArray())
                 {


### PR DESCRIPTION
this fixes a case where if a species is made smaller after spawning a colony of it, that colony might cause a crash on despawn as it has members pointing to indexes in body plan that don't exist anymore

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://community.revolutionarygamesstudio.com/t/random-crash-during-multicell-session/7072

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
