### PR TITLE
Balance pass 0.6.4.1

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -183,25 +183,25 @@ public static class Constants
     /// </remarks>
     public const float BASE_MOVEMENT_ATP_COST = 1.0f;
 
-    public const float FLAGELLA_ENERGY_COST = 4.0f;
+    public const float FLAGELLA_ENERGY_COST = 8.0f;
 
-    public const float FLAGELLA_BASE_FORCE = 20.0f;
+    public const float FLAGELLA_BASE_FORCE = 50.0f;
 
-    public const float BASE_MOVEMENT_FORCE = 1000.0f;
+    public const float BASE_MOVEMENT_FORCE = 650.0f;
 
     /// <summary>
     ///   As eukaryotes are immediately 50% larger they get a movement force increase to offset that
     /// </summary>
-    public const float EUKARYOTIC_MOVEMENT_FORCE_MULTIPLIER = 3.0f;
+    public const float EUKARYOTIC_MOVEMENT_FORCE_MULTIPLIER = 2.5f;
 
     /// <summary>
     ///   How much extra base movement is given per hex. Only applies between
     ///   <see cref="BASE_MOVEMENT_EXTRA_HEX_START"/> and <see cref="BASE_MOVEMENT_EXTRA_HEX_END"/>
     /// </summary>
-    public const float BASE_MOVEMENT_PER_HEX = 55;
+    public const float BASE_MOVEMENT_PER_HEX = 110;
 
-    public const int BASE_MOVEMENT_EXTRA_HEX_START = 2;
-    public const int BASE_MOVEMENT_EXTRA_HEX_END = 30;
+    public const int BASE_MOVEMENT_EXTRA_HEX_START = 1;
+    public const int BASE_MOVEMENT_EXTRA_HEX_END = 40;
 
     /// <summary>
     ///   How much the default <see cref="BASE_CELL_DENSITY"/> has volume in a cell. This determines how much
@@ -215,10 +215,10 @@ public static class Constants
     public const float MICROBE_MOVEMENT_SOUND_EMIT_COOLDOWN = 1.3f;
 
     // Note that the rotation speed is reversed, i.e. lower values mean faster
-    public const float CELL_MAX_ROTATION = 10.0f;
+    public const float CELL_MAX_ROTATION = 5.0f;
     public const float CELL_MIN_ROTATION = 0.1f;
     public const float CELL_ROTATION_INFLECTION_INERTIA = 25000000.0f;
-    public const float CELL_ROTATION_RADIUS_FACTOR = 200.0f;
+    public const float CELL_ROTATION_RADIUS_FACTOR = 150.0f;
     public const float CILIA_ROTATION_FACTOR = 32000000.0f;
     public const float CILIA_RADIUS_FACTOR_MULTIPLIER = 8000000.0f;
 
@@ -760,7 +760,7 @@ public static class Constants
     /// <summary>
     ///   Damage a single pilus stab does. Scaled by penetration depth so this is now much higher than before.
     /// </summary>
-    public const float PILUS_BASE_DAMAGE = 240.0f;
+    public const float PILUS_BASE_DAMAGE = 235.0f;
 
     /// <summary>
     ///   Maximum damage a single pilus hit does, even if the penetration depth is very high
@@ -906,7 +906,7 @@ public static class Constants
     /// <summary>
     ///   Maximum extra microbes to spawn
     /// </summary>
-    public const int MAX_BACTERIAL_COLONY_SIZE = 1;
+    public const int MAX_BACTERIAL_COLONY_SIZE = 3;
 
     // What is divided during fear and aggression calculations in the AI
     public const float AGGRESSION_DIVISOR = 25.0f;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -183,11 +183,11 @@ public static class Constants
     /// </remarks>
     public const float BASE_MOVEMENT_ATP_COST = 1.0f;
 
-    public const float FLAGELLA_ENERGY_COST = 8.0f;
+    public const float FLAGELLA_ENERGY_COST = 6.0f;
 
-    public const float FLAGELLA_BASE_FORCE = 50.0f;
+    public const float FLAGELLA_BASE_FORCE = 35.0f;
 
-    public const float BASE_MOVEMENT_FORCE = 650.0f;
+    public const float BASE_MOVEMENT_FORCE = 900.0f;
 
     /// <summary>
     ///   As eukaryotes are immediately 50% larger they get a movement force increase to offset that
@@ -198,9 +198,9 @@ public static class Constants
     ///   How much extra base movement is given per hex. Only applies between
     ///   <see cref="BASE_MOVEMENT_EXTRA_HEX_START"/> and <see cref="BASE_MOVEMENT_EXTRA_HEX_END"/>
     /// </summary>
-    public const float BASE_MOVEMENT_PER_HEX = 110;
+    public const float BASE_MOVEMENT_PER_HEX = 130;
 
-    public const int BASE_MOVEMENT_EXTRA_HEX_START = 1;
+    public const int BASE_MOVEMENT_EXTRA_HEX_START = 2;
     public const int BASE_MOVEMENT_EXTRA_HEX_END = 40;
 
     /// <summary>
@@ -215,7 +215,7 @@ public static class Constants
     public const float MICROBE_MOVEMENT_SOUND_EMIT_COOLDOWN = 1.3f;
 
     // Note that the rotation speed is reversed, i.e. lower values mean faster
-    public const float CELL_MAX_ROTATION = 5.0f;
+    public const float CELL_MAX_ROTATION = 8.0f;
     public const float CELL_MIN_ROTATION = 0.1f;
     public const float CELL_ROTATION_INFLECTION_INERTIA = 25000000.0f;
     public const float CELL_ROTATION_RADIUS_FACTOR = 150.0f;

--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -3,10 +3,10 @@
     "Name": "RESPIRATION",
     "Inputs": {
       "oxygen": 1,
-      "glucose": 0.16
+      "glucose": 0.14
     },
     "Outputs": {
-      "atp": 87
+      "atp": 91
     }
   },
   "glycolysis": {
@@ -111,7 +111,7 @@
     "Name": "RESPIRATION",
     "Inputs": {
       "oxygen": 1,
-      "glucose": 0.1
+      "glucose": 0.08
     },
     "Outputs": {
       "atp": 38

--- a/simulation_parameters/microbe_stage/organelles.json
+++ b/simulation_parameters/microbe_stage/organelles.json
@@ -394,7 +394,7 @@
     },
     "ProkaryoteChance": 2,
     "ChanceToCreate": 6,
-    "Density": 1100,
+    "Density": 1200,
     "RelativeDensityVolume": 1,
     "DisplayScene": "res://assets/models/organelles/Flagellum.tscn",
     "DisplaySceneModelPath": "Armature001/Skeleton/flagella",


### PR DESCRIPTION
**Brief Description of What This PR Does**
* Rotation speed now slows down significantly less as cells grow larger.
* Speed has been averaged across the board for size. Species will be around the same speed for the most part.
* Flagella are more significant in speed, but cost more to prevent bacteria from entering orbital exit velocity.
* Metabolosomes consume a little less glucose over time.
* Mitochondria produce slightly more ATP and consume a little less glucose over time.
* Pili deal a little bit less damage on average.
* Bacteria will now use the bacteria colony constant to spawn in clumps.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
