### PR TITLE
Fix Godot error when shutting down caused by the PhotoStudio

### DIFF
--- a/src/engine/PhotoStudio.cs
+++ b/src/engine/PhotoStudio.cs
@@ -360,7 +360,10 @@ public class PhotoStudio : Viewport
 
             foreach (var entry in simulationWorldRoots)
             {
-                entry.Value.QueueFree();
+                // This is needed to not cause warnings when shutting down the game as apparently the worlds have been
+                // destroyed already by Godot
+                if (IsInstanceValid(entry.Value))
+                    entry.Value.QueueFree();
             }
 
             simulationWorldRoots.Clear();


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixed an error print on shutdown coming from the PhotoStudio

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
