### PR TITLE
Only update compound bars while player is alive

### DIFF
--- a/Thrive.sln.DotSettings
+++ b/Thrive.sln.DotSettings
@@ -596,6 +596,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Inspectable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=inspectables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=inspectable_0027s/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Interactable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Interactables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=interprocedural/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=janky/@EntryIndexedValue">True</s:Boolean>

--- a/src/general/base_stage/CreatureStageBase.cs
+++ b/src/general/base_stage/CreatureStageBase.cs
@@ -59,6 +59,9 @@ public abstract class CreatureStageBase<TPlayer, TSimulation> : StageBase, ICrea
     [JsonIgnore]
     public abstract bool HasPlayer { get; }
 
+    [JsonIgnore]
+    public abstract bool HasAlivePlayer { get; }
+
     [JsonProperty]
     public TSimulation WorldSimulation { get; private set; } = null!;
 

--- a/src/general/base_stage/CreatureStageHUDBase.cs
+++ b/src/general/base_stage/CreatureStageHUDBase.cs
@@ -449,7 +449,7 @@ public abstract class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSt
         if (stage == null)
             return;
 
-        if (stage.HasPlayer)
+        if (stage.HasAlivePlayer)
         {
             UpdateNeededBars();
             UpdateCompoundBars(delta);
@@ -1004,7 +1004,7 @@ public abstract class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSt
         if (!processPanel.Visible)
             return;
 
-        processPanel.ShownData = stage is { HasPlayer: true } ? GetPlayerProcessStatistics() : null;
+        processPanel.ShownData = stage is { HasAlivePlayer: true } ? GetPlayerProcessStatistics() : null;
     }
 
     protected abstract ProcessStatistics? GetPlayerProcessStatistics();

--- a/src/general/base_stage/ICreatureStage.cs
+++ b/src/general/base_stage/ICreatureStage.cs
@@ -8,6 +8,12 @@ public interface ICreatureStage : IStageBase, IReturnableGameState
     [JsonIgnore]
     public bool HasPlayer { get; }
 
+    /// <summary>
+    ///   True when <see cref="HasPlayer"/> and the player is alive.
+    /// </summary>
+    [JsonIgnore]
+    public bool HasAlivePlayer { get; }
+
     [JsonIgnore]
     public bool MovingToEditor { get; set; }
 

--- a/src/late_multicellular_stage/MulticellularStage.cs
+++ b/src/late_multicellular_stage/MulticellularStage.cs
@@ -91,6 +91,10 @@ public class MulticellularStage : CreatureStageBase<MulticellularCreature, Dummy
     [JsonIgnore]
     public override bool HasPlayer => Player != null;
 
+    // TODO: change when there is dying implemented
+    [JsonIgnore]
+    public override bool HasAlivePlayer => HasPlayer;
+
     [JsonIgnore]
     protected override ICreatureStageHUD BaseHUD => HUD;
 

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -95,6 +95,9 @@ public class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimulation>
     [JsonIgnore]
     public override bool HasPlayer => Player.IsAlive;
 
+    [JsonIgnore]
+    public override bool HasAlivePlayer => HasPlayer && IsPlayerAlive();
+
     [JsonProperty]
     public Patch? SavedPatchManagerPatch
     {
@@ -192,7 +195,7 @@ public class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimulation>
             }
         }
 
-        bool playerAlive = IsPlayerAlive();
+        bool playerAlive = HasAlivePlayer;
 
         if (WorldSimulation.ProcessAll(delta))
         {
@@ -203,7 +206,7 @@ public class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimulation>
         if (gameOver || playerExtinctInCurrentPatch)
             return;
 
-        if (playerAlive != IsPlayerAlive())
+        if (playerAlive != HasAlivePlayer)
         {
             // Player just became dead
             GD.Print("Detected player is no longer alive after last simulation update");
@@ -805,7 +808,7 @@ public class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimulation>
 
         Player = WorldSimulation.FindFirstEntityWithComponent<PlayerMarker>();
 
-        if (!IsPlayerAlive())
+        if (!HasAlivePlayer)
             throw new InvalidOperationException("Player spawn didn't create player entity correctly");
 
         // We despawn everything here as either the player just spawned for the first time or died and is being spawned
@@ -1003,7 +1006,7 @@ public class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimulation>
 
     private void OnDuplicatePlayerCheatUsed(object sender, EventArgs e)
     {
-        if (!IsPlayerAlive())
+        if (!HasAlivePlayer)
         {
             GD.PrintErr("Can't use duplicate player cheat as player is dead");
             return;
@@ -1237,9 +1240,6 @@ public class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimulation>
 
     private bool IsPlayerAlive()
     {
-        if (!HasPlayer)
-            return false;
-
         try
         {
             return !Player.Get<Health>().Dead;


### PR DESCRIPTION
this fixes the reproduction bars staying white after respawning if dying when ready to go to the editor

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
