### PR TITLE
Apply organelle reposition before cell layout finalize to fix a crash

### DIFF
--- a/src/early_multicellular_stage/CellTemplate.cs
+++ b/src/early_multicellular_stage/CellTemplate.cs
@@ -61,9 +61,9 @@ public class CellTemplate : IPositionedCell, ICloneable, IActionHex
     public ISimulationPhotographable.SimulationType SimulationToPhotograph =>
         ISimulationPhotographable.SimulationType.MicrobeGraphics;
 
-    public void RepositionToOrigin()
+    public bool RepositionToOrigin()
     {
-        CellType.RepositionToOrigin();
+        return CellType.RepositionToOrigin();
     }
 
     public void UpdateNameIfValid(string newName)

--- a/src/early_multicellular_stage/CellType.cs
+++ b/src/early_multicellular_stage/CellType.cs
@@ -59,10 +59,11 @@ public class CellType : ICellProperties, ICloneable
     public ISimulationPhotographable.SimulationType SimulationToPhotograph =>
         ISimulationPhotographable.SimulationType.MicrobeGraphics;
 
-    public void RepositionToOrigin()
+    public bool RepositionToOrigin()
     {
-        Organelles.RepositionToOrigin();
+        var changes = Organelles.RepositionToOrigin();
         CalculateRotationSpeed();
+        return changes;
     }
 
     public void UpdateNameIfValid(string newName)

--- a/src/early_multicellular_stage/EarlyMulticellularSpecies.cs
+++ b/src/early_multicellular_stage/EarlyMulticellularSpecies.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using Godot;
 using Newtonsoft.Json;
 using Systems;
 
@@ -48,11 +49,17 @@ public class EarlyMulticellularSpecies : Species
         // Make certain these are all up to date
         foreach (var cellType in CellTypes)
         {
-            cellType.RepositionToOrigin();
+            // See the comment in CellBodyPlanEditorComponent.OnFinishEditing
+            if (cellType.RepositionToOrigin())
+            {
+                GD.Print(
+                    "Repositioned an early multicellular species' cell type. This might break / crash the " +
+                    "body plan layout.");
+            }
         }
     }
 
-    public override void RepositionToOrigin()
+    public override bool RepositionToOrigin()
     {
         // TODO: should this actually reposition things as the cell at index 0 is always the colony leader so if it
         // isn't centered, that'll cause issues?
@@ -60,11 +67,16 @@ public class EarlyMulticellularSpecies : Species
 
         var centerOfMass = Cells[0].Position;
 
+        if (centerOfMass.Q == 0 && centerOfMass.R == 0)
+            return false;
+
         foreach (var cell in Cells)
         {
             // This calculation aligns the center of mass with the origin by moving every organelle of the microbe.
             cell.Position -= centerOfMass;
         }
+
+        return true;
     }
 
     public override void UpdateInitialCompounds()

--- a/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/early_multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -339,9 +339,18 @@ public partial class CellBodyPlanEditorComponent :
     {
         var editedSpecies = Editor.EditedSpecies;
 
+        // Note that for the below calculations to work all cell types need to be positioned correctly. So we need
+        // to force that to happen here first. This also ensures that the skipped positioning to origin of the cell
+        // editor component (that is used as a special mode in multicellular) is performed.
+        foreach (var cellType in editedSpecies.CellTypes)
+        {
+            cellType.RepositionToOrigin();
+        }
+
         // Compute final cell layout positions and update the species
         // TODO: maybe in the future we want to switch to editing the full hex layout with the entire cells in this
-        // editor so this step can be skipped
+        // editor so this step can be skipped. Or another approach that keeps the shape the player worked on better
+        // than this approach that can move around the cells a lot.
         editedSpecies.Cells.Clear();
 
         foreach (var hexWithData in editedMicrobeCells)

--- a/src/general/Species.cs
+++ b/src/general/Species.cs
@@ -139,7 +139,8 @@ public abstract class Species : ICloneable
     /// <summary>
     ///   Repositions the structure of the species according to stage specific rules
     /// </summary>
-    public abstract void RepositionToOrigin();
+    /// <returns>True when repositioning happened, false if this was already positioned correctly</returns>
+    public abstract bool RepositionToOrigin();
 
     public void SetPopulationFromPatches(long population)
     {

--- a/src/late_multicellular_stage/LateMulticellularSpecies.cs
+++ b/src/late_multicellular_stage/LateMulticellularSpecies.cs
@@ -81,9 +81,9 @@ public class LateMulticellularSpecies : Species
         SetTypeFromBrainPower();
     }
 
-    public override void RepositionToOrigin()
+    public override bool RepositionToOrigin()
     {
-        BodyLayout.RepositionToGround();
+        return BodyLayout.RepositionToGround();
     }
 
     public override void UpdateInitialCompounds()

--- a/src/late_multicellular_stage/MulticellularMetaballLayout.cs
+++ b/src/late_multicellular_stage/MulticellularMetaballLayout.cs
@@ -6,7 +6,7 @@ public class MulticellularMetaballLayout : MetaballLayout<MulticellularMetaball>
     ///   Repositions the bottom-most metaballs to touch the ground, and the center of all metaballs to be aligned
     ///   above 0,0
     /// </summary>
-    public void RepositionToGround()
+    public bool RepositionToGround()
     {
         float lowestCoordinate = 0;
         var center = Vector3.Zero;
@@ -25,9 +25,15 @@ public class MulticellularMetaballLayout : MetaballLayout<MulticellularMetaball>
         var adjustment = center / Count;
         adjustment.y = lowestCoordinate;
 
+        // Should this allow slight movement?
+        if (adjustment.x == 0 && adjustment.y == 0 && adjustment.z == 0)
+            return false;
+
         foreach (var metaball in this)
         {
             metaball.Position -= adjustment;
         }
+
+        return true;
     }
 }

--- a/src/microbe_stage/ICellProperties.cs
+++ b/src/microbe_stage/ICellProperties.cs
@@ -27,7 +27,8 @@ public interface ICellProperties : ISimulationPhotographable
     /// <summary>
     ///   Repositions the cell to the origin and recalculates any properties dependant on its position.
     /// </summary>
-    public void RepositionToOrigin();
+    /// <returns>True when changes were made, false if everything was positioned well already</returns>
+    public bool RepositionToOrigin();
 
     public void UpdateNameIfValid(string newName);
 }

--- a/src/microbe_stage/MicrobeSpecies.cs
+++ b/src/microbe_stage/MicrobeSpecies.cs
@@ -107,10 +107,11 @@ public class MicrobeSpecies : Species, ICellProperties
         UpdateInitialCompounds();
     }
 
-    public override void RepositionToOrigin()
+    public override bool RepositionToOrigin()
     {
-        Organelles.RepositionToOrigin();
+        var changes = Organelles.RepositionToOrigin();
         CalculateRotationSpeed();
+        return changes;
     }
 
     public override void UpdateInitialCompounds()

--- a/src/microbe_stage/OrganelleLayout.cs
+++ b/src/microbe_stage/OrganelleLayout.cs
@@ -100,15 +100,21 @@ public class OrganelleLayout<T> : HexLayout<T>
         return IsTouchingExistingHex(organelle) || (allowReplacingLastCytoplasm && IsReplacingLast(organelle));
     }
 
-    public void RepositionToOrigin()
+    public bool RepositionToOrigin()
     {
         var centerOfMass = CenterOfMass;
+
+        // Skip if center of mass is already correct
+        if (centerOfMass.Q == 0 && centerOfMass.R == 0)
+            return false;
 
         foreach (var organelle in Organelles)
         {
             // This calculation aligns the center of mass with the origin by moving every organelle of the microbe.
             organelle.Position -= centerOfMass;
         }
+
+        return true;
     }
 
     protected override IEnumerable<Hex> GetHexComponentPositions(T hex)


### PR DESCRIPTION
with modified cell types no longer fitting in the places selected for them

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #4635
https://community.revolutionarygamesstudio.com/t/crash-upon-leaving-multicellular-freebuild-editor/7063

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
