### PR TITLE
Add .mo files to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,5 @@ simulation_parameters/revision.json
 out.txt
 output.png
 *.DS_Store
+
+*.mo


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR adds .mo files to the .gitignore

**Related Issues**

This makes life slightly easier as (at least for me) poedit creates .mo files automatically and they cause failing checks.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
