### PR TITLE
Reimplemented pilus stab damage cooldown when dealing much damage

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -786,9 +786,19 @@ public static class Constants
 
     /// <summary>
     ///   How much time (in seconds) an injectisome applies invulnerability upon damage. Note the invulnerability is
-    ///   not against all other damage types.
+    ///   not against all other damage types, but just the pilus.
     /// </summary>
-    public const float PILUS_INVULNERABLE_TIME = 0.35f;
+    public const float INJECTISOME_INVULNERABLE_TIME = 0.35f;
+
+    /// <summary>
+    ///   How long the shortest pilus cooldown is after dealing damage. This is applied if the damage just barely
+    ///   crosses <see cref="PILUS_MIN_DAMAGE_TRIGGER_COOLDOWN"/>
+    /// </summary>
+    public const float PILUS_MIN_COOLDOWN = 0.2f;
+
+    public const float PILUS_MAX_COOLDOWN = 0.45f;
+
+    public const float PILUS_MIN_DAMAGE_TRIGGER_COOLDOWN = PILUS_MAX_DAMAGE * 0.6f;
 
     /// <summary>
     ///   Osmoregulation ATP cost per second per hex

--- a/src/engine/common_components/DamageCooldown.cs
+++ b/src/engine/common_components/DamageCooldown.cs
@@ -1,5 +1,7 @@
 ﻿namespace Components
 {
+    using Godot;
+
     /// <summary>
     ///   Entity keeps track of damage cooldown
     /// </summary>
@@ -21,9 +23,34 @@
             damageCooldown.CooldownRemaining = cooldownTime;
         }
 
+        /// <summary>
+        ///   Starts a cooldown time if <see cref="damage"/> is above <see cref="minCooldownTime"/> and scales the
+        ///   cooldown time based on how close the damage is to <see cref="maxDamage"/>
+        /// </summary>
+        /// <returns>True when cooldown was started</returns>
+        public static bool StartDamageScaledCooldown(this ref DamageCooldown damageCooldown, float damage,
+            float minDamageToCooldown, float maxDamage, float minCooldownTime, float maxCooldownTime)
+        {
+            if (damage < minDamageToCooldown)
+                return false;
+
+            // Scale the cooldown from the damage range to the cooldown time range
+            float cooldown = minCooldownTime + (maxCooldownTime - minCooldownTime) *
+                (damage - minDamageToCooldown) / (maxDamage - minDamageToCooldown);
+
+            if (float.IsNaN(cooldown))
+            {
+                GD.PrintErr("Calculated damage cooldown is NaN");
+                return false;
+            }
+
+            damageCooldown.StartCooldown(cooldown);
+            return true;
+        }
+
         public static void StartInjectisomeCooldown(this ref DamageCooldown damageCooldown)
         {
-            damageCooldown.StartCooldown(Constants.PILUS_INVULNERABLE_TIME);
+            damageCooldown.StartCooldown(Constants.INJECTISOME_INVULNERABLE_TIME);
         }
     }
 }


### PR DESCRIPTION
to ensure that overlapping cells won't kill something super fast when otherwise it would deal maximum pilus damage many times per second

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
ejecting indigestible cells with a pilus can very easily lead to death

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
