### PR TITLE
Executor task slight safety tweak and other few minor changes

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 Thrive Game
-Copyright (C) 2013-2023  Revolutionary Games
+Copyright (C) 2013-2024  Revolutionary Games
 
 Thrive is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/doc/steam_license_readme.txt
+++ b/doc/steam_license_readme.txt
@@ -1,5 +1,5 @@
 ﻿Thrive Game
-Copyright (C) 2013-2023  Revolutionary Games
+Copyright (C) 2013-2024  Revolutionary Games
 
 This version of Thrive is distributed through Valve's digital distribution
 service Steam by Revolutionary Games Studio and licensed only for use as

--- a/src/native/physics/PhysicalWorld.cpp
+++ b/src/native/physics/PhysicalWorld.cpp
@@ -445,7 +445,8 @@ Ref<PhysicsBody> PhysicalWorld::CreateSensor(const JPH::RefConst<JPH::Shape>& sh
         auto underlyingBody = physicsSystem->GetBodyLockInterface().TryGetBody(body->GetId());
         if (underlyingBody != nullptr)
         {
-            underlyingBody->SetSensorDetectsStatic(true);
+            // TODO: test that this works (the documentation says the body needs to be kinematic)
+            underlyingBody->SetCollideKinematicVsNonDynamic(true);
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**
Based on a bug I tried to add some extra safety to the task executor, also bumped the copyright year for 2024-

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
