### PR TITLE
Fixed entering engulf mode for early multicellular where only other cells could engulf

### DIFF
--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -398,6 +398,8 @@ public class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
         bool showToxin;
         bool showSlime;
 
+        bool engulfing;
+
         // Multicellularity is not checked here (only colony membership) as that is also not checked when firing toxins
         if (player.Has<MicrobeColony>())
         {
@@ -408,17 +410,21 @@ public class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
 
             showToxin = vacuoles > 0;
             showSlime = slimeJets > 0;
+
+            engulfing = colony.ColonyState == MicrobeState.Engulf;
         }
         else
         {
             showToxin = organelles.AgentVacuoleCount > 0;
             showSlime = organelles.SlimeJets is { Count: > 0 };
+
+            engulfing = control.State == MicrobeState.Engulf;
         }
 
-        // TODO: should this read the engulf state from colony as the player cell might be unable to engulf but some
+        // Read the engulf state from the colony as the player cell might be unable to engulf but some
         // member might be able to
         UpdateBaseAbilitiesBar(cellProperties.CanEngulfInColony(player), showToxin, showSlime,
-            organelles.HasSignalingAgent, control.State == MicrobeState.Engulf);
+            organelles.HasSignalingAgent, engulfing);
 
         bindingModeHotkey.Visible = organelles.CanBind(ref species);
         unbindAllHotkey.Visible = organelles.CanUnbind(ref species, player);

--- a/src/microbe_stage/MicrobeWorldSimulation.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.cs
@@ -328,6 +328,8 @@ public class MicrobeWorldSimulation : WorldSimulationWithPhysics
 
         fluidCurrentsSystem.Update(delta);
 
+        colonyCompoundDistributionSystem.Update(delta);
+
         engulfingSystem.Update(delta);
         engulfedDigestionSystem.Update(delta);
         engulfedHandlingSystem.Update(delta);
@@ -346,8 +348,6 @@ public class MicrobeWorldSimulation : WorldSimulationWithPhysics
         pilusDamageSystem.Update(delta);
 
         ProcessSystem.Update(delta);
-
-        colonyCompoundDistributionSystem.Update(delta);
 
         osmoregulationAndHealingSystem.Update(delta);
 

--- a/src/microbe_stage/components/CellProperties.cs
+++ b/src/microbe_stage/components/CellProperties.cs
@@ -85,7 +85,7 @@
             {
                 ref var colony = ref entity.Get<MicrobeColony>();
 
-                colony.CanEngulf();
+                return colony.CanEngulf();
             }
 
             return cellProperties.MembraneType.CanEngulf;

--- a/src/microbe_stage/systems/ColonyCompoundDistributionSystem.cs
+++ b/src/microbe_stage/systems/ColonyCompoundDistributionSystem.cs
@@ -9,6 +9,13 @@
     ///   Evenly distributes compounds (except ones that can't be shared between cells like ATP) between cells in a
     ///   colony
     /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     This runs before the engulfing system to allow newly spawned multicellular members to stay in engulf mode
+    ///     when growing as otherwise the cell would have no compounds and get immediately kicked out of engulf mode
+    ///     due to missing ATP.
+    ///   </para>
+    /// </remarks>
     [With(typeof(MicrobeColony))]
     [Without(typeof(AttachedToEntity))]
     public sealed class ColonyCompoundDistributionSystem : AEntitySetSystem<float>

--- a/src/microbe_stage/systems/EngulfingSystem.cs
+++ b/src/microbe_stage/systems/EngulfingSystem.cs
@@ -43,6 +43,7 @@
     [ReadsComponent(typeof(SpeciesMember))]
     [ReadsComponent(typeof(MicrobeEventCallbacks))]
     [ReadsComponent(typeof(MicrobeColony))]
+    [RunsAfter(typeof(ColonyCompoundDistributionSystem))]
     [RunsAfter(typeof(PilusDamageSystem))]
     [RunsAfter(typeof(MicrobeVisualsSystem))]
     [RunsOnMainThread]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes a regression in the previous release that caused cell colonies where the lead cell couldn't engulf (but other cells could) to not be able to enter engulf mode.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

https://community.revolutionarygamesstudio.com/t/0-6-4-general-feedback-thread/7052/12?u=hhyyrylainen

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
