### PR TITLE
Fixed toxin projectile visuals not loading after a save

### DIFF
--- a/src/engine/common_components/PredefinedVisuals.cs
+++ b/src/engine/common_components/PredefinedVisuals.cs
@@ -1,5 +1,7 @@
 ﻿namespace Components
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     ///   Entity uses a predefined visual
     /// </summary>
@@ -12,8 +14,10 @@
         public VisualResourceIdentifier VisualIdentifier;
 
         /// <summary>
-        ///   Don't touch this, used by the system for handling this
+        ///   Don't touch this, used by the system for handling this. Not saved so that after load the visual is
+        ///   properly reloaded.
         /// </summary>
+        [JsonIgnore]
         public VisualResourceIdentifier LoadedInstance;
     }
 }


### PR DESCRIPTION
turns out that this was just a case of the predefined visuals loader thinking it had already loaded the visuals

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
