### PR TITLE
Fix 3D environment for cell editor

### DIFF
--- a/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
+++ b/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Godot;
 using Newtonsoft.Json;
+using Environment = Godot.Environment;
 
 [JsonObject(IsReference = true)]
 [SceneLoadedClass("res://src/late_multicellular_stage/editor/LateMulticellularEditor.tscn")]
@@ -63,7 +64,7 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
     private Light bodyEditorLight = null!;
 
     private WorldEnvironment worldEnvironmentNode = null!;
-    private Godot.Environment? environment = null;
+    private Environment? environment;
 
     private Control noCellTypeSelected = null!;
 #pragma warning restore CA2213

--- a/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
+++ b/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
@@ -443,10 +443,7 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
                 BodyEditorLightPath.Dispose();
             }
 
-            if (environment != null)
-            {
-                environment.Dispose();
-            }
+            environment?.Dispose();
         }
 
         base.Dispose(disposing);

--- a/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
+++ b/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
@@ -335,7 +335,6 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
         cellEditorTab.Hide();
         noCellTypeSelected.Hide();
 
-        // Remember environment
         RememberEnvironment();
 
         // Show selected
@@ -442,6 +441,11 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
                 WorldEnvironmentNodePath.Dispose();
                 Body3DEditorCameraPath.Dispose();
                 BodyEditorLightPath.Dispose();
+            }
+
+            if (environment != null)
+            {
+                environment.Dispose();
             }
         }
 

--- a/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
+++ b/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
@@ -63,6 +63,7 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
     private Light bodyEditorLight = null!;
 
     private WorldEnvironment worldEnvironmentNode = null!;
+    private Godot.Environment? environment = null;
 
     private Control noCellTypeSelected = null!;
 #pragma warning restore CA2213
@@ -333,6 +334,9 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
         cellEditorTab.Hide();
         noCellTypeSelected.Hide();
 
+        // Remember environment
+        RememberEnvironment();
+
         // Show selected
         switch (selectedEditorTab)
         {
@@ -371,6 +375,8 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
 
                 SetWorldSceneObjectVisibilityWeControl();
 
+                ResetEnvironment();
+
                 break;
             }
 
@@ -392,6 +398,8 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
 
                     SetWorldSceneObjectVisibilityWeControl();
                 }
+
+                worldEnvironmentNode.Environment = null;
 
                 break;
             }
@@ -607,5 +615,21 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
         // This fixes complex cases where multiple types are undoing and redoing actions
         selectedCellTypeToEdit = newCell;
         cellEditorTab.OnEditorSpeciesSetup(EditedBaseSpecies);
+    }
+
+    private void RememberEnvironment()
+    {
+        if (worldEnvironmentNode.Environment != null)
+        {
+            environment = worldEnvironmentNode.Environment;
+        }
+    }
+
+    private void ResetEnvironment()
+    {
+        if (environment != null)
+        {
+            worldEnvironmentNode.Environment = environment;
+        }
     }
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR makes game disable 3D environment when entering cell editor and brings it back when going back to body plan editor.

**Related Issues**

https://community.revolutionarygamesstudio.com/t/ambient-color-applies-in-late-multicellular-editor/7150

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
