### PR TITLE
Fixed GetMicrobeFromSubShape max index off by one crash

### DIFF
--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -319,14 +319,16 @@
                     throw new InvalidOperationException("Bad calculated microbe index");
 #endif
 
+                var members = colony.ColonyMembers;
+
                 // In case the physics data is not yet up to date compared to the colony members, skip
-                if (microbeIndex > colony.ColonyMembers.Length)
+                if (microbeIndex >= members.Length)
                 {
                     microbe = default;
                     return false;
                 }
 
-                microbe = colony.ColonyMembers[microbeIndex];
+                microbe = members[microbeIndex];
                 return true;
             }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Should fix a crash caused by a typo (missing `=` in index in range check).

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://community.revolutionarygamesstudio.com/t/unhandled-exception-error-while-engulfing-and-getting-hurt-in-multicellular-stage/7161

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
