### PR TITLE
Added various safety checks for negative engulfed compound amounts

### DIFF
--- a/src/microbe_stage/CompoundBag.cs
+++ b/src/microbe_stage/CompoundBag.cs
@@ -27,6 +27,8 @@ public class CompoundBag : ICompoundStorage
     [JsonProperty]
     private Dictionary<Compound, float>? compoundCapacities;
 
+    private float nominalCapacity;
+
     public CompoundBag(float nominalCapacity)
     {
         NominalCapacity = nominalCapacity;
@@ -37,7 +39,17 @@ public class CompoundBag : ICompoundStorage
     ///   not have a specific capacity set in <see cref="compoundCapacities"/>
     /// </summary>
     [JsonProperty]
-    public float NominalCapacity { get; set; }
+    public float NominalCapacity
+    {
+        get => nominalCapacity;
+        set
+        {
+            nominalCapacity = value;
+
+            if (nominalCapacity < 0)
+                throw new ArgumentException("Capacity can't be negative", nameof(NominalCapacity));
+        }
+    }
 
     /// <summary>
     ///   Returns all compounds. Don't modify the returned value!
@@ -78,6 +90,9 @@ public class CompoundBag : ICompoundStorage
     /// </remarks>
     public void AddSpecificCapacityForCompound(Compound compound, float capacityToAdd)
     {
+        if (capacityToAdd < 0)
+            throw new ArgumentException("Capacity to set can't be negative", nameof(capacityToAdd));
+
         compoundCapacities ??= new Dictionary<Compound, float>();
 
         if (!compoundCapacities.TryGetValue(compound, out var existing))

--- a/src/microbe_stage/OrganelleDefinition.cs
+++ b/src/microbe_stage/OrganelleDefinition.cs
@@ -364,6 +364,21 @@ public class OrganelleDefinition : IRegistryType
             throw new InvalidRegistryDataException(name, GetType().Name, "InitialComposition is not set");
         }
 
+        foreach (var entry in InitialComposition)
+        {
+            if (entry.Value <= MathUtils.EPSILON)
+            {
+                throw new InvalidRegistryDataException(name, GetType().Name,
+                    "InitialComposition has negative or really small value");
+            }
+
+            if (!entry.Key.IsCloud)
+            {
+                throw new InvalidRegistryDataException(name, GetType().Name,
+                    "InitialComposition has a compound that can't be a cloud");
+            }
+        }
+
         if (Hexes == null || Hexes.Count < 1)
         {
             throw new InvalidRegistryDataException(name, GetType().Name, "Hexes is empty");

--- a/src/microbe_stage/components/Engulfable.cs
+++ b/src/microbe_stage/components/Engulfable.cs
@@ -370,6 +370,13 @@
             glucose ??= SimulationParameters.Instance.GetCompound("glucose");
 
             result.TryGetValue(glucose, out float existingGlucose);
+
+            if (existingGlucose < 0)
+            {
+                GD.PrintErr("Stored glucose was negative for bonus digestible glucose calculation");
+                existingGlucose = 0;
+            }
+
             result[glucose] = existingGlucose + compoundCapacityInfo.GetCapacityForCompound(glucose) *
                 Constants.ADDITIONAL_DIGESTIBLE_GLUCOSE_AMOUNT_MULTIPLIER;
         }

--- a/src/microbe_stage/systems/EngulfedDigestionSystem.cs
+++ b/src/microbe_stage/systems/EngulfedDigestionSystem.cs
@@ -166,7 +166,6 @@
                     var additionalAmount = 0.0f;
                     additionalCompounds?.TryGetValue(compound, out additionalAmount);
 
-
                     if (additionalAmount < 0)
                     {
 #if DEBUG
@@ -177,7 +176,6 @@
                         additionalAmount = 0;
                         GD.PrintErr("Additional compound amount is negative");
                     }
-
 
                     var totalAvailable = storageAmount + additionalAmount;
                     totalAmountLeft += totalAvailable;

--- a/src/microbe_stage/systems/EngulfedDigestionSystem.cs
+++ b/src/microbe_stage/systems/EngulfedDigestionSystem.cs
@@ -166,15 +166,18 @@
                     var additionalAmount = 0.0f;
                     additionalCompounds?.TryGetValue(compound, out additionalAmount);
 
-#if DEBUG
+
                     if (additionalAmount < 0)
                     {
+#if DEBUG
                         if (Debugger.IsAttached)
                             Debugger.Break();
+#endif
 
+                        additionalAmount = 0;
                         GD.PrintErr("Additional compound amount is negative");
                     }
-#endif
+
 
                     var totalAvailable = storageAmount + additionalAmount;
                     totalAmountLeft += totalAvailable;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Hopefully this fixes an actual bug. If nothing else this should at least make it so

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
