### PR TITLE
Fixed the big iron collision model being way off

### DIFF
--- a/assets/models/Iron5.tscn
+++ b/assets/models/Iron5.tscn
@@ -4,7 +4,6 @@
 [ext_resource path="res://assets/models/IronMaterial.material" type="Material" id=2]
 
 [node name="iron5" type="MeshInstance"]
-transform = Transform( 100, 0, 0, 0, -1.19209e-05, 100, 0, -100, -1.19209e-05, 0, 0, 0 )
+transform = Transform( 100, 0, 0, 0, 100, 0, 0, 0, 100, 0, 0, 0 )
 material_override = ExtResource( 2 )
 mesh = ExtResource( 1 )
-material/0 = null

--- a/src/engine/physics/PhysicsShape.cs
+++ b/src/engine/physics/PhysicsShape.cs
@@ -177,8 +177,8 @@ public class PhysicsShape : IDisposable
         // TODO: if different godot imports need different scales add this is a parameter (probably is the case and
         // caused by different real scales of the meshes used for collisions)
         // TODO: base rotations are also problematic here (the rock chunks are rotated differently visually compared to
-        // the physics shape)
-        float scale = 90;
+        // the physics shape, this is now fixed for the big iron)
+        float scale = 100;
 
         // This is probably similar kind of configuration thing for Jolt as the margin is in Godot Bullet integration
         float convexRadius = godotData.Margin > 0 ? godotData.Margin : 0.01f;

--- a/src/general/base_stage/EditorBase.cs
+++ b/src/general/base_stage/EditorBase.cs
@@ -841,7 +841,7 @@ public abstract class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoa
 
         if (ReturnToStage == null)
         {
-            GD.Print("Creating new stage of type", typeof(TStage).Name, " as there isn't one yet");
+            GD.Print("Creating new stage of type ", typeof(TStage).Name, " as there isn't one yet");
 
             var scene = SceneManager.Instance.LoadScene(typeof(TStage).GetCustomAttribute<SceneLoadedClassAttribute>());
 


### PR DESCRIPTION
by removing a rotation set in the Godot editor for it. Also made the automatic scale up for physics to be multiplied by 100 instead of 90 to get it now to match the visual model. Small iron still has this bug. Also fixed a typo I noticed elsewhere in the code.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
partly helps with #4682

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
