### PR TITLE
Add mouse pass-through filter for new organelle unlock indicator

### DIFF
--- a/src/microbe_stage/editor/MicrobePartSelection.tscn
+++ b/src/microbe_stage/editor/MicrobePartSelection.tscn
@@ -110,10 +110,12 @@ visible = false
 anchor_left = 0.5
 anchor_right = 0.5
 grow_horizontal = 2
+mouse_filter = 2
 
 [node name="Panel" type="Panel" parent="VBoxContainer/Button/RecentlyUnlocked"]
 margin_right = 189.0
 margin_bottom = 14.0
+mouse_filter = 2
 theme = ExtResource( 5 )
 custom_styles/panel = SubResource( 6 )
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes new organelle indicator blocking mouse input to the underlying organelle button while hovering over it.

**Related Issues**

N/A

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
