### PR TITLE
Fixed cell editor displaying simultaneously for late multicell as well

### DIFF
--- a/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
+++ b/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
@@ -175,6 +175,9 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
         // save our changes to the current cell type, then switch to the other one
         SwapEditingCellIfNeeded(cellType);
 
+        // If the action we're redoing should be done on another editor tab, switch to that tab
+        SwapEditorTabIfNeeded(history.ActionToRedo());
+
         base.Redo();
     }
 
@@ -185,6 +188,9 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
         // If the action we're undoing should be done on another cell type,
         // save our changes to the current cell type, then switch to the other one
         SwapEditingCellIfNeeded(cellType);
+
+        // If the action we're undoing should be done on another editor tab, switch to that tab
+        SwapEditorTabIfNeeded(history.ActionToUndo());
 
         base.Undo();
     }
@@ -617,6 +623,36 @@ public class LateMulticellularEditor : EditorBase<EditorAction, MulticellularSta
         // This fixes complex cases where multiple types are undoing and redoing actions
         selectedCellTypeToEdit = newCell;
         cellEditorTab.OnEditorSpeciesSetup(EditedBaseSpecies);
+    }
+
+    private void SwapEditorTabIfNeeded(EditorAction? editorAction)
+    {
+        if (editorAction == null)
+            return;
+
+        var actionData = editorAction.Data.FirstOrDefault();
+
+        EditorTab targetTab;
+
+        // If the action was performed on a single Cell Type, target the Cell Type Editor tab
+        if (actionData is EditorCombinableActionData<CellType>)
+        {
+            targetTab = EditorTab.CellTypeEditor;
+        }
+        else if (actionData != null && bodyPlanEditorTab.IsMetaballAction(actionData))
+        {
+            targetTab = EditorTab.CellEditor;
+        }
+        else
+        {
+            return;
+        }
+
+        // If we're already on the selected tab, there's no need to do anything
+        if (targetTab == selectedEditorTab)
+            return;
+
+        SetEditorTab(targetTab);
     }
 
     private void RememberEnvironment()

--- a/src/late_multicellular_stage/editor/MetaballBodyEditorComponent.tscn
+++ b/src/late_multicellular_stage/editor/MetaballBodyEditorComponent.tscn
@@ -808,10 +808,8 @@ custom_constants/margin_bottom = 0
 
 [node name="WarningBadge" type="TextureRect" parent="BottomRight/HBoxContainer/ConfirmButton/MarginContainer"]
 visible = false
-margin_left = 134.0
-margin_top = -8.58575
-margin_right = 155.0
-margin_bottom = 12.4143
+margin_right = 21.0
+margin_bottom = 21.0
 rect_min_size = Vector2( 21, 21 )
 rect_pivot_offset = Vector2( 0, 10 )
 size_flags_horizontal = 0
@@ -907,6 +905,7 @@ mouse_filter = 2
 [connection signal="OnUndo" from="EditorComponentBottomLeftButtons" to="." method="Undo"]
 [connection signal="pressed" from="BottomRight/HBoxContainer/CancelButton" to="." method="OnCancelActionClicked"]
 [connection signal="pressed" from="BottomRight/HBoxContainer/ConfirmButton" to="." method="NextOrFinishClicked"]
+[connection signal="animation_finished" from="BottomRight/HBoxContainer/ConfirmButton/MarginContainer/WarningBadge/AnimationPlayer" to="." method="HideFinishButtonWarningAfterAnimation"]
 [connection signal="Confirmed" from="NewTissueTypeSetup" to="." method="OnNewCellTypeConfirmed"]
 [connection signal="text_changed" from="NewTissueTypeSetup/VBoxContainer2/NewName" to="." method="OnNewCellTypeNameChanged"]
 [connection signal="text_entered" from="NewTissueTypeSetup/VBoxContainer2/NewName" to="." method="OnNewCellTextAccepted"]

--- a/src/late_multicellular_stage/editor/MetaballEditorComponentBase.cs
+++ b/src/late_multicellular_stage/editor/MetaballEditorComponentBase.cs
@@ -436,6 +436,22 @@ public abstract class MetaballEditorComponentBase<TEditor, TCombinedAction, TAct
         GUICommon.Instance.PlayCustomSound(hexPlacementSound, 0.7f);
     }
 
+    public bool IsMetaballAction(EditorCombinableActionData actionData)
+    {
+        // TODO: add a metaball action base class if that would be easier to handle?
+        switch (actionData)
+        {
+            case MetaballMoveActionData<TMetaball>:
+            case MetaballPlacementActionData<TMetaball>:
+            case MetaballRemoveActionData<TMetaball>:
+            case MetaballResizeActionData<TMetaball>:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
     public void OnNoPropertiesLoaded()
     {
         // Something is wrong if this is called


### PR DESCRIPTION
as #4515 only applied to the early multicellular

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

applied the fix for #3910 also to the late multicellular editor (the previous PR only added the fix for early multicellular).

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
