### PR TITLE
Fix crash when trying to get new population in prediction

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -2495,8 +2495,10 @@ public partial class CellEditorComponent :
 
         if (worstPatch != null)
         {
-            worstPatchPopulation = results.GetPopulationInPatches(run.PlayerSpeciesNew).First(p => p.Key == worstPatch)
-                .Value;
+            // For some reason in rare cases the population numbers cannot be found, using FirstOrDefault should ensure
+            // here that missing population numbers get assigned 0
+            worstPatchPopulation = results.GetPopulationInPatches(run.PlayerSpeciesNew)
+                .FirstOrDefault(p => p.Key == worstPatch).Value;
         }
 
         bestPatchName = bestPatch?.Name.ToString();
@@ -2504,8 +2506,8 @@ public partial class CellEditorComponent :
 
         if (bestPatch != null)
         {
-            bestPatchPopulation = results.GetPopulationInPatches(run.PlayerSpeciesNew).First(p => p.Key == bestPatch)
-                .Value;
+            bestPatchPopulation = results.GetPopulationInPatches(run.PlayerSpeciesNew)
+                .FirstOrDefault(p => p.Key == bestPatch).Value;
         }
 
         CreateAutoEvoPredictionDetailsText(results.GetPatchEnergyResults(run.PlayerSpeciesNew),


### PR DESCRIPTION
which happens for some people consistently

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
