### PR TITLE
Slime jet now plays a full animation cycle always

### DIFF
--- a/assets/models/organelles/SlimeJet.anim
+++ b/assets/models/organelles/SlimeJet.anim
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9da16909e07b0a437a562d4c360dca81b21cdc8077447a7ecd17839f55658db2
-size 1584
+oid sha256:e54661eae08d5069860e928fb028e50b24fa5b5f116037c503471242f43cec31
+size 615

--- a/assets/models/organelles/SlimeJet.tscn
+++ b/assets/models/organelles/SlimeJet.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://assets/models/organelles/SlimeJet.glb" type="PackedScene" id=1]
 [ext_resource path="res://shaders/OrganelleOpaque.shader" type="Shader" id=2]
 [ext_resource path="res://assets/textures/dissolve_noise.tres" type="Texture" id=3]
 [ext_resource path="res://assets/textures/SlimeJet.png" type="Texture" id=4]
-[ext_resource path="res://assets/models/organelles/SlimeJet.anim" type="Animation" id=5]
 
 [sub_resource type="ShaderMaterial" id=1]
 resource_local_to_scene = true
@@ -23,9 +22,3 @@ transform = Transform( 0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, -0.2, 0.2 )
 [node name="Cube" parent="Armature/Skeleton" index="0"]
 material_override = SubResource( 1 )
 skin = null
-
-[node name="AnimationPlayer" parent="." index="1"]
-autoplay = "SlimeJet"
-playback_speed = 0.0
-anims/SlimeJet = ExtResource( 5 )
-loop = true

--- a/src/microbe_stage/organelle_components/SlimeJetComponent.cs
+++ b/src/microbe_stage/organelle_components/SlimeJetComponent.cs
@@ -7,6 +7,8 @@ using Godot;
 /// </summary>
 public class SlimeJetComponent : IOrganelleComponent
 {
+    private const string SlimeJetAnimationName = "SlimeJet";
+
     private bool animationActive;
     private bool animationDirty = true;
 
@@ -53,9 +55,18 @@ public class SlimeJetComponent : IOrganelleComponent
         if (parentOrganelle.OrganelleAnimation == null)
             return;
 
-        // Play the animation if active, and vice versa
-        parentOrganelle.OrganelleAnimation.PlaybackSpeed = animationActive ? 1.0f : 0.0f;
-        animationDirty = false;
+        // Start the animation if it should play and otherwise just wait for the animation to stop
+        if (!animationActive)
+        {
+            animationDirty = false;
+            return;
+        }
+
+        if (!parentOrganelle.OrganelleAnimation.IsPlaying())
+            parentOrganelle.OrganelleAnimation.Play(SlimeJetAnimationName);
+
+        // animationDirty is not set false here as otherwise we won't know when the playing stops and we need to
+        // start the animation again to keep playing if the jet is active for long
     }
 
     public void AddQueuedForce(in Entity entity, float slimeAmount)


### PR DESCRIPTION
instead of just a tiny bit of the animation as slime jet compound cost is so high it can't stay active for long

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discordapp.com/channels/228300288023461893/958598553389903913/1199502472650174567

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
