### PR TITLE
Fix Thriveopedia patch map not working when opened before editor

### DIFF
--- a/src/thriveopedia/pages/ThriveopediaPatchMapPage.cs
+++ b/src/thriveopedia/pages/ThriveopediaPatchMapPage.cs
@@ -120,9 +120,14 @@ public class ThriveopediaPatchMapPage : ThriveopediaPage
         playerPatchOnEntry = mapDrawer.Map?.CurrentPatch ??
             throw new InvalidOperationException("Map current patch needs to be set / SetMap needs to be called");
 
-        // Make sure the map setting of fog of war always matches the world,
-        // this needs to be called here in case this page is opened before the editor
+        // Make sure the map setting of fog of war always matches the world
+        // These need to be called here in case this page is opened before the editor
         mapDrawer.Map.FogOfWar = CurrentGame!.GameWorld.WorldSettings.FogOfWarMode;
+
+        if (mapDrawer.Map.FogOfWar == FogOfWarMode.Ignored)
+        {
+            mapDrawer.Map.RevealAllPatches();
+        }
 
         UpdatePlayerPatch(playerPatchOnEntry);
     }

--- a/src/thriveopedia/pages/ThriveopediaPatchMapPage.cs
+++ b/src/thriveopedia/pages/ThriveopediaPatchMapPage.cs
@@ -105,7 +105,10 @@ public class ThriveopediaPatchMapPage : ThriveopediaPage
     {
         mapDrawer.PlayerPatch = patch ?? playerPatchOnEntry;
 
-        if (mapDrawer.Map!.UpdatePatchVisibility(mapDrawer.PlayerPatch))
+        if (mapDrawer.Map == null)
+            throw new InvalidOperationException("This can be only called after map is set from current game");
+
+        if (mapDrawer.Map.UpdatePatchVisibility(mapDrawer.PlayerPatch))
             mapDrawer.MarkDirty();
 
         detailsPanel.CurrentPatch = mapDrawer.PlayerPatch;
@@ -122,7 +125,7 @@ public class ThriveopediaPatchMapPage : ThriveopediaPage
 
         // Make sure the map setting of fog of war always matches the world
         // These need to be called here in case this page is opened before the editor
-        mapDrawer.Map.FogOfWar = CurrentGame!.GameWorld.WorldSettings.FogOfWarMode;
+        mapDrawer.Map.FogOfWar = CurrentGame.GameWorld.WorldSettings.FogOfWarMode;
 
         if (mapDrawer.Map.FogOfWar == FogOfWarMode.Ignored)
         {

--- a/src/thriveopedia/pages/ThriveopediaPatchMapPage.cs
+++ b/src/thriveopedia/pages/ThriveopediaPatchMapPage.cs
@@ -104,6 +104,10 @@ public class ThriveopediaPatchMapPage : ThriveopediaPage
     private void UpdatePlayerPatch(Patch? patch)
     {
         mapDrawer.PlayerPatch = patch ?? playerPatchOnEntry;
+
+        if (mapDrawer.Map!.UpdatePatchVisibility(mapDrawer.PlayerPatch))
+            mapDrawer.MarkDirty();
+
         detailsPanel.CurrentPatch = mapDrawer.PlayerPatch;
 
         // Just in case this didn't get called already. Note that this may result in duplicate calls here
@@ -115,6 +119,11 @@ public class ThriveopediaPatchMapPage : ThriveopediaPage
         mapDrawer.Map = CurrentGame!.GameWorld.Map;
         playerPatchOnEntry = mapDrawer.Map?.CurrentPatch ??
             throw new InvalidOperationException("Map current patch needs to be set / SetMap needs to be called");
+
+        // Make sure the map setting of fog of war always matches the world,
+        // this needs to be called here in case this page is opened before the editor
+        mapDrawer.Map.FogOfWar = CurrentGame!.GameWorld.WorldSettings.FogOfWarMode;
+
         UpdatePlayerPatch(playerPatchOnEntry);
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR fixes a problem with opening the Thriveopedia patch map before the editor, resulting in the patch map not loading.

**Related Issues**

N/A

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
