### PR TITLE
Fixed engulfing not taking being pulled in object sizes into account

### DIFF
--- a/src/microbe_stage/components/Engulfer.cs
+++ b/src/microbe_stage/components/Engulfer.cs
@@ -45,7 +45,8 @@
         public float UsedIngestionCapacity;
 
         /// <summary>
-        ///   Total size that all engulfed objects need to fit in
+        ///   Total size that all engulfed objects need to fit in (the max value <see cref="UsedIngestionCapacity"/>
+        ///   should have)
         /// </summary>
         public float EngulfStorageSize;
     }

--- a/src/microbe_stage/systems/EngulfedDigestionSystem.cs
+++ b/src/microbe_stage/systems/EngulfedDigestionSystem.cs
@@ -118,13 +118,21 @@
                             new SimpleHUDMessage(TranslationServer.Translate("NOTICE_ENGULF_STORAGE_FULL")));
                     }
 
+                    // As ejecting is delayed, we need to temporarily adjust the size here so that we don't
+                    // accidentally eject *everything* if we go slightly over the limit
+                    engulfer.UsedIngestionCapacity -= engulfable.AdjustedEngulfSize;
                     continue;
                 }
 
                 // Doesn't make sense to digest non ingested objects, i.e. objects that are being engulfed,
                 // being ejected, etc. So skip them.
                 if (engulfable.PhagocytosisStep != PhagocytosisPhase.Ingested)
+                {
+                    // Still need to consider the size of this thing for the engulf storage, otherwise cells can start
+                    // pulling in too much
+                    usedCapacity += engulfable.AdjustedEngulfSize;
                     continue;
+                }
 
                 Enzyme usedEnzyme;
 


### PR DESCRIPTION
and also fixed ejecting not immediately seeing the new size and potentially ejecting everything

I have not tested this locally, so testing before merging is needed

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

closes #4824
closes #4823

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
