### PR TITLE
Added separate native module to check CPU features first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,13 @@ if(NOT NATIVE_LIBRARY_VERSION)
   message(FATAL_ERROR "Failed to parse native library version")
 endif()
 
+string(REGEX MATCH "EarlyCheck = ([0-9]+);" _ "${versionFile}")
+set(EARLY_CHECK_LIBRARY_VERSION ${CMAKE_MATCH_1})
+
+if(NOT EARLY_CHECK_LIBRARY_VERSION)
+  message(FATAL_ERROR "Failed to parse native (early check) library version")
+endif()
+
 message(STATUS "Configured native library version ${NATIVE_LIBRARY_VERSION}")
 
 # Configure include file
@@ -135,4 +142,5 @@ include_directories(${PROJECT_BINARY_DIR})
 # Add the subfolders that define the actual things to build
 add_subdirectory(third_party)
 
+add_subdirectory(src/native/early_checks)
 add_subdirectory(src/native)

--- a/Scripts/NativeLibs.cs
+++ b/Scripts/NativeLibs.cs
@@ -43,11 +43,13 @@ public class NativeLibs
     private readonly SymbolHandler symbolHandler = new(null, null);
 
     private readonly Lazy<Task<long>> thriveNativePrecompiledId;
+    private readonly Lazy<Task<long>> earlyCheckPrecompiledId;
 
     public NativeLibs(Program.NativeLibOptions options)
     {
         this.options = options;
         thriveNativePrecompiledId = new Lazy<Task<long>>(GetThriveNativeLibraryId);
+        earlyCheckPrecompiledId = new Lazy<Task<long>>(GetEarlyCheckLibraryId);
 
         if (options.Libraries is { Count: < 1 })
         {
@@ -105,6 +107,11 @@ public class NativeLibs
         ///   The main native side library that is pure C++ and doesn't depend on Godot
         /// </summary>
         ThriveNative,
+
+        /// <summary>
+        ///   Library for early checking that everything is fine before loading <see cref="ThriveNative"/>
+        /// </summary>
+        EarlyCheck,
     }
 
     public async Task<bool> Run(CancellationToken cancellationToken)
@@ -172,6 +179,8 @@ public class NativeLibs
         {
             case Library.ThriveNative:
                 return NativeConstants.Version.ToString();
+            case Library.EarlyCheck:
+                return NativeConstants.EarlyCheck.ToString();
             default:
                 throw new ArgumentOutOfRangeException(nameof(library), library, null);
         }
@@ -188,6 +197,21 @@ public class NativeLibs
                         return "libthrive_native.so";
                     case PackagePlatform.Windows:
                         return "libthrive_native.dll";
+                    case PackagePlatform.Windows32:
+                        throw new NotSupportedException("32-bit support is not done currently");
+                    case PackagePlatform.Mac:
+                        throw new NotImplementedException("TODO: name for this");
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(platform), platform, null);
+                }
+
+            case Library.EarlyCheck:
+                switch (platform)
+                {
+                    case PackagePlatform.Linux:
+                        return "libearly_checks.so";
+                    case PackagePlatform.Windows:
+                        return "libearly_checks.dll";
                     case PackagePlatform.Windows32:
                         throw new NotSupportedException("32-bit support is not done currently");
                     case PackagePlatform.Mac:
@@ -617,6 +641,34 @@ public class NativeLibs
             return false;
         }
 
+        // When building Thrive native and the early check, those will conflict with each other and install each other
+        // as well to their version files. This tries to remove the extra files.
+        foreach (var file in Directory.EnumerateFiles(installPath, "*.*", SearchOption.AllDirectories))
+        {
+            foreach (var otherLibrary in Enum.GetValues<Library>())
+            {
+                if (otherLibrary == library)
+                    continue;
+
+                // TODO: skip libraries not compiled at the same time if any are added in the future
+
+                var name = GetLibraryDllName(otherLibrary, platform);
+
+                if (file.Contains(name))
+                {
+                    // Don't delete unrelated type
+                    if (!options.DebugLibrary && file.Contains("debug"))
+                        continue;
+
+                    if (options.DebugLibrary && file.Contains("release"))
+                        continue;
+
+                    File.Delete(file);
+                    ColourConsole.WriteNormalLine($"Deleting likely duplicate install of a different library: {file}");
+                }
+            }
+        }
+
         ColourConsole.WriteSuccessLine($"Successfully compiled library {library}");
         return true;
     }
@@ -928,6 +980,13 @@ public class NativeLibs
                 return new Uri(new Uri(options.Url), $"api/v1/PrecompiledObject/{nativeId}/versions/");
             }
 
+            case Library.EarlyCheck:
+            {
+                var nativeId = await earlyCheckPrecompiledId.Value;
+
+                return new Uri(new Uri(options.Url), $"api/v1/PrecompiledObject/{nativeId}/versions/");
+            }
+
             default:
                 throw new ArgumentOutOfRangeException(nameof(library), library, null);
         }
@@ -944,6 +1003,21 @@ public class NativeLibs
             throw new NullDecodedJsonException();
 
         ColourConsole.WriteDebugLine($"Determined that ThriveNative's precompiled ID is {data.Id}");
+
+        return data.Id;
+    }
+
+    private async Task<long> GetEarlyCheckLibraryId()
+    {
+        using var httpClient = GetDevCenterClient();
+
+        var data = await httpClient.GetFromJsonAsync<PrecompiledObjectDTO>(
+            "api/v1/PrecompiledObject/byName/ThriveEarlyCheck");
+
+        if (data == null)
+            throw new NullDecodedJsonException();
+
+        ColourConsole.WriteDebugLine($"Determined that Early Check's precompiled ID is {data.Id}");
 
         return data.Id;
     }

--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -26,6 +26,7 @@
     <Compile Include="src\microbe_stage\organelle_unlocks\IUnlockCondition.cs" />
     <Compile Include="src\microbe_stage\organelle_unlocks\WorldBasedUnlockCondition.cs" />
     <Compile Include="src\general\statistics_tracking\IStatistic.cs" />
+    <Compile Include="src\native\interop\CPUCheckResult.cs" />
     <Compile Include="src\saving\serializers\ConditionSetConverter.cs" />
     <Compile Include="src\tutorial\microbe_editor\AtpBalanceIntroduction.cs" />
     <Compile Include="src\tutorial\microbe_editor\ChemoreceptorPlacementTutorial.cs" />

--- a/Thrive.sln.DotSettings
+++ b/Thrive.sln.DotSettings
@@ -679,6 +679,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lerping/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lethargicness/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=libc/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=libearly/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=libthrive/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=libunwind/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=limitor/@EntryIndexedValue">True</s:Boolean>

--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(thrive_native SHARED
   core/Spinlock.hpp
   core/TaskSystem.cpp core/TaskSystem.hpp
   core/Time.hpp
-  core/CPUCheck.hpp
+  helpers/CPUCheck.hpp
   physics/BodyActivationListener.cpp physics/BodyActivationListener.hpp
   physics/BodyControlState.hpp
   physics/ContactListener.cpp physics/ContactListener.hpp

--- a/src/native/Include.h.in
+++ b/src/native/Include.h.in
@@ -12,20 +12,29 @@
 
 // clang-format off
 #define THRIVE_LIBRARY_VERSION @NATIVE_LIBRARY_VERSION@
+#define EARLY_CHECK_LIBRARY_VERSION @EARLY_CHECK_LIBRARY_VERSION@
 // clang-format on
 
+#ifdef WIN32
+#define API_EXPORT __declspec(dllexport)
+#define API_IMPORT __declspec(dllimport)
+#else
+#define API_EXPORT __attribute__((visibility("default")))
+// TODO: is the following necessary?
+#define API_IMPORT __attribute__((visibility("default")))
+#endif // WIN32
+
 #ifdef THRIVE_NATIVE_BUILD
-#ifdef WIN32
-#define THRIVE_NATIVE_API __declspec(dllexport)
+#define THRIVE_NATIVE_API API_EXPORT
 #else
-#define THRIVE_NATIVE_API __attribute__((visibility("default")))
-#endif // WIN32
+#define THRIVE_NATIVE_API API_IMPORT
+#endif // THRIVE_NATIVE_BUILD
+
+// Equivalent of the above macro block for the early check library
+#ifdef EARLY_CHECK_BUILD
+#define EARLY_NATIVE_API API_EXPORT
 #else
-#ifdef WIN32
-#define THRIVE_NATIVE_API __declspec(dllimport)
-#else
-#define THRIVE_NATIVE_API __attribute__((visibility("default")))
-#endif // WIN32
+#define EARLY_NATIVE_API API_IMPORT
 #endif // THRIVE_NATIVE_BUILD
 
 #cmakedefine USE_OBJECT_POOLS
@@ -106,7 +115,7 @@
 #include <csignal>
 #else
 #include <signal.h>
-#endif
+#endif // __cplusplus
 
 #ifndef DEBUG_BREAK
 #ifdef __cplusplus
@@ -116,14 +125,14 @@
         LOG_WRITE(__FILE__ ":" + std::to_string(__LINE__));       \
         std::raise(SIGINT);                                       \
     }
-#endif
 #else
 #define DEBUG_BREAK                                               \
     {                                                             \
         raise(SIGINT);                                            \
     }
 #endif
-#endif
+#endif // DEBUG_BREAK
+#endif // _WIN32
 
 // This is needed to allow including this in the C interop header
 #ifdef __cplusplus

--- a/src/native/NativeConstants.cs
+++ b/src/native/NativeConstants.cs
@@ -1,4 +1,5 @@
 ﻿public class NativeConstants
 {
     public const int Version = 10;
+    public const int EarlyCheck = 1;
 }

--- a/src/native/early_checks/CMakeLists.txt
+++ b/src/native/early_checks/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Early load library that allows checking things before loading the main library,
+# which causes global constructors to run that may already do some complex stuff
+add_library(early_checks SHARED
+  EarlyInterop.h EarlyInterop.cpp
+  ../helpers/CPUCheck.hpp
+  ../helpers/CPUCheckResult.h)
+
+# Make the library runnable on really old CPUs (and turn on extra warnings)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  # TODO: really old CPU support for MSVC
+
+  target_compile_options(early_checks PRIVATE /W4 /wd4068)
+
+  if(WARNINGS_AS_ERRORS)
+    target_compile_options(early_checks PRIVATE /WX)
+  endif()
+
+  # Probably really don't need to support debug symbols in release for MSVC
+else()
+  # Sadly this needs to specify sandy bridge to get xgetbv working, but that
+  # is only called if AVX support is already detected, so this should be fined
+  # for older CPUs
+  target_compile_options(early_checks PRIVATE -march=sandybridge)
+
+  target_compile_options(early_checks PRIVATE -Wall -Wextra -Wpedantic -Wno-unknown-pragmas)
+
+  if(WARNINGS_AS_ERRORS)
+    target_compile_options(early_checks PRIVATE -Werror)
+  endif()
+
+  # For now, no debug symbols as it should be impossible to crash in this
+  # simple library
+  # For some reason this needs to define NDEBUG explicitly to work (Thrive
+  # library gets the NDEBUG automatically from somewhere)
+  # target_compile_options(early_checks PRIVATE $<$<CONFIG:Release>:-g -O3>
+  #   $<$<CONFIG:Distribution>:-g -O3>)
+  target_compile_options(early_checks PRIVATE $<$<CONFIG:Release>:-DNDEBUG -O3>
+      $<$<CONFIG:Distribution>:-DNDEBUG -O3>)
+endif()
+
+target_compile_definitions(early_checks PRIVATE EARLY_CHECK_BUILD)
+
+set_target_properties(early_checks PROPERTIES
+  CXX_STANDARD 20
+  CXX_EXTENSIONS OFF)
+
+install(TARGETS early_checks)

--- a/src/native/early_checks/EarlyInterop.cpp
+++ b/src/native/early_checks/EarlyInterop.cpp
@@ -1,0 +1,16 @@
+// ------------------------------------ //
+#include "EarlyInterop.h"
+
+#include "../helpers/CPUCheck.hpp"
+
+// ------------------------------------ //
+int32_t CheckEarlyAPIVersion()
+{
+    return EARLY_CHECK_LIBRARY_VERSION;
+}
+
+// ------------------------------------ //
+CPU_CHECK_RESULT CheckRequiredCPUFeatures()
+{
+    return Thrive::CPUCheck::CheckCurrentCPU();
+}

--- a/src/native/early_checks/EarlyInterop.h
+++ b/src/native/early_checks/EarlyInterop.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+
+#include "Include.h"
+
+#include "../helpers/CPUCheckResult.h"
+
+/// \file Defines all of the API methods that can be called from C# for this early check library
+
+extern "C"
+{
+    /// \brief Checks that current CPU has required features to run Thrive
+    [[maybe_unused]] EARLY_NATIVE_API CPU_CHECK_RESULT CheckRequiredCPUFeatures();
+
+    /// \returns The API version the native library was compiled with
+    [[maybe_unused]] EARLY_NATIVE_API int32_t CheckEarlyAPIVersion();
+}

--- a/src/native/helpers/CPUCheckResult.h
+++ b/src/native/helpers/CPUCheckResult.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#ifdef __cplusplus
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
+/// \brief Return codes for the CPU check
+enum CPU_CHECK_RESULT : int32_t
+{
+    CPU_CHECK_SUCCESS = 0,
+    CPU_CHECK_MISSING_AVX = 1,
+    CPU_CHECK_MISSING_SSE41 = 2,
+    CPU_CHECK_MISSING_SSE42 = 4,
+
+    CPU_CHECK_MISSING_FEATURE = CPU_CHECK_MISSING_AVX | CPU_CHECK_MISSING_SSE41 | CPU_CHECK_MISSING_SSE42,
+};

--- a/src/native/interop/CInterop.cpp
+++ b/src/native/interop/CInterop.cpp
@@ -9,8 +9,8 @@
 #include "Jolt/Jolt.h"
 #include "Jolt/RegisterTypes.h"
 
-#include "core/CPUCheck.hpp"
 #include "core/TaskSystem.hpp"
+#include "helpers/CPUCheck.hpp"
 #include "physics/DebugDrawForwarder.hpp"
 #include "physics/PhysicalWorld.hpp"
 #include "physics/PhysicsBody.hpp"
@@ -76,33 +76,6 @@ void ShutdownThriveLibrary()
     Thrive::TaskSystem::Get().Shutdown();
 
     SetLogForwardingCallback(nullptr);
-}
-
-bool CheckRequiredCPUFeatures()
-{
-    if (!Thrive::CPUCheck::HasRequiredFeatures())
-    {
-        if (!Thrive::CPUCheck::HasAVX())
-        {
-            LOG_ERROR("Missing CPU AVX support");
-        }
-        else if (!Thrive::CPUCheck::HasSSE42())
-        {
-            LOG_ERROR("Missing CPU SSE 4.2 support");
-        }
-        else if (!Thrive::CPUCheck::HasSSE41())
-        {
-            LOG_ERROR("Missing CPU SSE 4.1 support");
-        }
-        else
-        {
-            LOG_ERROR("Unknown missing CPU feature");
-        }
-
-        return false;
-    }
-
-    return true;
 }
 
 // ------------------------------------ //

--- a/src/native/interop/CInterop.cpp
+++ b/src/native/interop/CInterop.cpp
@@ -10,7 +10,6 @@
 #include "Jolt/RegisterTypes.h"
 
 #include "core/TaskSystem.hpp"
-#include "helpers/CPUCheck.hpp"
 #include "physics/DebugDrawForwarder.hpp"
 #include "physics/PhysicalWorld.hpp"
 #include "physics/PhysicsBody.hpp"

--- a/src/native/interop/CInterop.h
+++ b/src/native/interop/CInterop.h
@@ -30,9 +30,6 @@ extern "C"
     /// other calls to the library have been performed
     [[maybe_unused]] THRIVE_NATIVE_API void ShutdownThriveLibrary();
 
-    /// \brief Checks that current CPU has required features to run Thrive
-    [[maybe_unused]] THRIVE_NATIVE_API bool CheckRequiredCPUFeatures();
-
     // ------------------------------------ //
     // Logging
 

--- a/src/native/interop/CPUCheckResult.cs
+++ b/src/native/interop/CPUCheckResult.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+/// <summary>
+///   CPU check result from the native library side. Must match CPUCheckResult.h (except the naming convention)
+/// </summary>
+[Flags]
+public enum CPUCheckResult
+{
+    CPUCheckSuccess = 0,
+    CPUCheckMissingAvx = 1,
+    CPUCheckMissingSse41 = 2,
+    CPUCheckMissingSse42 = 4,
+
+    CPUCheckMissingFeature = CPUCheckMissingAvx | CPUCheckMissingSse41 | CPUCheckMissingSse42,
+}

--- a/src/native/physics/PhysicalWorld.cpp
+++ b/src/native/physics/PhysicalWorld.cpp
@@ -198,7 +198,7 @@ public:
 #ifdef JPH_DEBUG_RENDERER
     JPH::BodyManager::DrawSettings bodyDrawSettings;
 
-    JPH::Vec3Arg debugDrawCameraLocation = {};
+    JPH::Vec3 debugDrawCameraLocation = {};
 #endif
 };
 


### PR DESCRIPTION
as the main module seems to have global constructors that already use the AVX features, which would crash. So here's the best alternative, with mono missing CPU feature checks in C#, of using a really small native library first to check things.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
I noticed in the latest Linux crash report that the crash happened while loading the native library so the previous place where the CPU check was, would have been too late.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
