### PR TITLE
Probably fixed engulfed safety eject not fully clearing state

### DIFF
--- a/src/microbe_stage/systems/EngulfedHandlingSystem.cs
+++ b/src/microbe_stage/systems/EngulfedHandlingSystem.cs
@@ -107,6 +107,8 @@
                     GD.PrintErr("Entity is stuck inside a dead engulfer, force clearing state to rescue it");
 
                     engulfable.OnExpelledFromEngulfment(entity, spawnSystem, worldSimulation);
+                    engulfable.PhagocytosisStep = PhagocytosisPhase.None;
+                    engulfable.HostileEngulfer = default;
 
                     var recorder = worldSimulation.StartRecordingEntityCommands();
 


### PR DESCRIPTION
when running the benchmark a bunch I noticed that when the entity stuck inside engulfer error is printed and safety eject done it gets repeated a ton. This should fix that by making the safety eject properly clear the state of the incorrectly engulfed object.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
