### PR TITLE
Stop cells that join a colony from independently using mucilage

### DIFF
--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -807,7 +807,7 @@
             }
 
             // Clear queued slime jet force
-            addedEntity.Get<MicrobeControl>().QueuedSlimeSecretionTime = 0;
+            control.QueuedSlimeSecretionTime = 0;
 
             ReportReproductionStatusOnAddToColony(addedEntity);
         }

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -806,6 +806,9 @@
                 organelles.AllOrganellesDivided = false;
             }
 
+            // Clear queued slime jet force
+            addedEntity.Get<MicrobeControl>().QueuedSlimeSecretionTime = 0;
+
             ReportReproductionStatusOnAddToColony(addedEntity);
         }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR Clears queued slime jet force whenever attaching to cell

**Related Issues**

Closes #3844

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
