### PR TITLE
Fixed conflicting scale set by the visual system

### DIFF
--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -591,6 +591,8 @@ public static class SpawnHelpers
         entity.Set(new SpatialInstance
         {
             VisualScale = scale,
+
+            // Microbes must always apply visual scale for them to work correctly
             ApplyVisualScale = true,
         });
 

--- a/src/microbe_stage/components/Engulfable.cs
+++ b/src/microbe_stage/components/Engulfable.cs
@@ -235,6 +235,18 @@
         public static void OnExpelledFromEngulfment(this ref Engulfable engulfable, in Entity entity,
             ISpawnSystem spawnSystem, IWorldSimulation worldSimulation)
         {
+            // Restore scale
+            ref var spatial = ref entity.Get<SpatialInstance>();
+
+#if DEBUG
+            if (engulfable.OriginalScale.Length() < MathUtils.EPSILON)
+            {
+                throw new Exception("Ejected engulfable with zero original scale");
+            }
+#endif
+
+            spatial.VisualScale = engulfable.OriginalScale;
+
             bool alreadyDeathProcessed = false;
 
             if (entity.Has<Health>())
@@ -344,18 +356,6 @@
                 // If recursive engulfing render priority is supported in the future, there might be a need to write
                 // some code here related to that
             }
-
-            // Restore scale
-            ref var spatial = ref entity.Get<SpatialInstance>();
-
-#if DEBUG
-            if (engulfable.OriginalScale.Length() < MathUtils.EPSILON)
-            {
-                throw new Exception("Ejected engulfable with zero original scale");
-            }
-#endif
-
-            spatial.VisualScale = engulfable.OriginalScale;
 
             if (entity.Has<MicrobeEventCallbacks>())
             {

--- a/src/microbe_stage/systems/MicrobeVisualsSystem.cs
+++ b/src/microbe_stage/systems/MicrobeVisualsSystem.cs
@@ -4,6 +4,7 @@
     using System.Buffers;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
     using Components;
@@ -110,9 +111,36 @@
             // Create graphics top level node if missing for entity
             spatialInstance.GraphicalInstance ??= new Spatial();
 
-            // Bacteria is 50% of the scale of other microbes
-            spatialInstance.GraphicalInstance.Scale =
-                cellProperties.IsBacteria ? new Vector3(0.5f, 0.5f, 0.5f) : Vector3.One;
+#if DEBUG
+
+            // Check scale is applied properly (but only if not attached as being attached can mean engulfment and at
+            // that time the scale can be modified)
+            if (!entity.Has<AttachedToEntity>())
+            {
+                if (cellProperties.IsBacteria)
+                {
+                    if (spatialInstance.ApplyVisualScale != true ||
+                        spatialInstance.VisualScale != new Vector3(0.5f, 0.5f, 0.5f))
+                    {
+                        GD.PrintErr("Microbe spatial component doesn't have scale correctly set for bacteria");
+
+                        if (Debugger.IsAttached)
+                            Debugger.Break();
+                    }
+                }
+                else
+                {
+                    if (spatialInstance.ApplyVisualScale &&
+                        spatialInstance.VisualScale != Vector3.One)
+                    {
+                        GD.PrintErr("Microbe spatial component doesn't have scale correctly set for eukaryote");
+
+                        if (Debugger.IsAttached)
+                            Debugger.Break();
+                    }
+                }
+            }
+#endif
 
             ref var materialStorage = ref entity.Get<EntityMaterial>();
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes a mistake in the systems where the visual system applied a separate scale compared to the real scale applied by the visual transform system

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
might do something to:  #3750

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
