### PR TITLE
Rebalanced the system run costs after memory alloc changes

### DIFF
--- a/src/engine/common_systems/CountLimitedDespawnSystem.cs
+++ b/src/engine/common_systems/CountLimitedDespawnSystem.cs
@@ -15,7 +15,7 @@
     [With(typeof(WorldPosition))]
     [ReadsComponent(typeof(CountLimited))]
     [ReadsComponent(typeof(WorldPosition))]
-    [RuntimeCost(2)]
+    [RuntimeCost(1.5f)]
     public sealed class CountLimitedDespawnSystem : AEntitySetSystem<float>
     {
         private readonly IEntityContainer entityContainer;

--- a/src/engine/common_systems/PhysicsCollisionManagementSystem.cs
+++ b/src/engine/common_systems/PhysicsCollisionManagementSystem.cs
@@ -13,7 +13,7 @@
     [With(typeof(Physics))]
     [With(typeof(CollisionManagement))]
     [RunsAfter(typeof(PhysicsBodyCreationSystem))]
-    [RuntimeCost(0.5f)]
+    [RuntimeCost(1)]
     public sealed class PhysicsCollisionManagementSystem : AEntitySetSystem<float>
     {
         private readonly PhysicalWorld physicalWorld;

--- a/src/engine/common_systems/SoundEffectSystem.cs
+++ b/src/engine/common_systems/SoundEffectSystem.cs
@@ -15,7 +15,7 @@
     [With(typeof(WorldPosition))]
     [ReadsComponent(typeof(WorldPosition))]
     [WritesToComponent(typeof(SoundEffectPlayer))]
-    [RuntimeCost(29)]
+    [RuntimeCost(25)]
     [RunsOnMainThread]
     public sealed class SoundEffectSystem : AEntitySetSystem<float>
     {

--- a/src/gui_common/KeyPrompt.cs
+++ b/src/gui_common/KeyPrompt.cs
@@ -71,6 +71,12 @@ public class KeyPrompt : CenterContainer
 
     public override void _Process(float delta)
     {
+        // Skip processing when not visible to save quite a bit of processing time from any existing prompts
+        // Note this doesn't use IsVisibleInTree as that is also a processing intensive method. Instead this relies on
+        // the tutorial etc. to set this hidden itself.
+        if (!Visible)
+            return;
+
         if (!ShowPress)
         {
             // TODO: reset the pressed status colour if it was previously pressed?

--- a/src/microbe_stage/CompoundCloudSystem.cs
+++ b/src/microbe_stage/CompoundCloudSystem.cs
@@ -9,6 +9,7 @@ using Systems;
 /// <summary>
 ///   Manages spawning and processing compound clouds
 /// </summary>
+[RuntimeCost(35)]
 public class CompoundCloudSystem : Node, IReadonlyCompoundClouds, ISaveLoadedTracked
 {
     [JsonProperty]

--- a/src/microbe_stage/MicrobeWorldSimulation.generated.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.generated.cs
@@ -16,27 +16,21 @@ public partial class MicrobeWorldSimulation
         var background1 = new Task(() =>
             {
                 // Timeslot 1 on thread 2
-                simpleShapeCreatorSystem.Update(delta);
                 countLimitedDespawnSystem.Update(delta);
-                entitySignalingSystem.Update(delta);
+                damageCooldownSystem.Update(delta);
+                fluidCurrentsSystem.Update(delta);
                 compoundAbsorptionSystem.Update(delta);
                 barrier1.SignalAndWait();
 
                 // Timeslot 2 on thread 2
                 ProcessSystem.Update(delta);
                 barrier1.SignalAndWait();
-
-                // Timeslot 3 on thread 2
-                osmoregulationAndHealingSystem.Update(delta);
-                barrier1.SignalAndWait();
                 barrier1.SignalAndWait();
 
-                // Timeslot 5 on thread 2
-                unneededCompoundVentingSystem.Update(delta);
+                // Timeslot 4 on thread 2
                 multicellularGrowthSystem.Update(delta);
-                organelleComponentFetchSystem.Update(delta);
-                slimeSlowdownSystem.Update(delta);
                 engulfedDigestionSystem.Update(delta);
+                organelleComponentFetchSystem.Update(delta);
                 if (RunAI)
                 {
                     microbeAI.ReportPotentialPlayerPosition(reportedPlayerPosition);
@@ -44,30 +38,30 @@ public partial class MicrobeWorldSimulation
                 }
 
                 microbeEmissionSystem.Update(delta);
+                slimeSlowdownSystem.Update(delta);
                 microbeMovementSystem.Update(delta);
+                physicsBodyControlSystem.Update(delta);
+                microbeMovementSoundSystem.Update(delta);
+                colonyBindingSystem.Update(delta);
+                barrier1.SignalAndWait();
+
+                // Timeslot 5 on thread 2
+                SpawnSystem.Update(delta);
+                colonyStatsUpdateSystem.Update(delta);
+                microbeFlashingSystem.Update(delta);
                 barrier1.SignalAndWait();
 
                 // Timeslot 6 on thread 2
-                microbeMovementSoundSystem.Update(delta);
-                colonyStatsUpdateSystem.Update(delta);
+                engulfedHandlingSystem.Update(delta);
+                microbeDeathSystem.Update(delta);
                 barrier1.SignalAndWait();
 
                 // Timeslot 7 on thread 2
                 microbeEventCallbackSystem.Update(delta);
-                physicsBodyControlSystem.Update(delta);
-                barrier1.SignalAndWait();
-
-                // Timeslot 8 on thread 2
-                microbeDeathSystem.Update(delta);
-                colonyBindingSystem.Update(delta);
-                barrier1.SignalAndWait();
-
-                // Timeslot 9 on thread 2
-                microbeFlashingSystem.Update(delta);
                 damageSoundSystem.Update(delta);
                 barrier1.SignalAndWait();
 
-                // Timeslot 10 on thread 2
+                // Timeslot 8 on thread 2
                 delayedColonyOperationSystem.Update(delta);
 
                 barrier1.SignalAndWait();
@@ -77,67 +71,61 @@ public partial class MicrobeWorldSimulation
 
         // Timeslot 1 on thread 1
         pathBasedSceneLoader.Update(delta);
-        fluidCurrentsSystem.Update(delta);
         predefinedVisualLoaderSystem.Update(delta);
         microbeVisualsSystem.Update(delta);
         animationControlSystem.Update(delta);
         entityMaterialFetchSystem.Update(delta);
+        collisionShapeLoaderSystem.Update(delta);
+        entitySignalingSystem.Update(delta);
+        simpleShapeCreatorSystem.Update(delta);
         cellBurstEffectSystem.Update(delta);
+        microbeRenderPrioritySystem.Update(delta);
         TimedLifeSystem.Update(delta);
-        damageCooldownSystem.Update(delta);
         barrier1.SignalAndWait();
 
         // Timeslot 2 on thread 1
-        collisionShapeLoaderSystem.Update(delta);
-        microbeRenderPrioritySystem.Update(delta);
         microbePhysicsCreationAndSizeSystem.Update(delta);
         physicsBodyCreationSystem.Update(delta);
-        physicsBodyDisablingSystem.Update(delta);
-        physicsCollisionManagementSystem.Update(delta);
-        pilusDamageSystem.Update(delta);
-        damageOnTouchSystem.Update(delta);
-        microbeCollisionSoundSystem.Update(delta);
-        disallowPlayerBodySleepSystem.Update(delta);
         physicsUpdateAndPositionSystem.Update(delta);
-        toxinCollisionSystem.Update(delta);
+        physicsBodyDisablingSystem.Update(delta);
         attachedEntityPositionSystem.Update(delta);
+        soundListenerSystem.Update(delta);
+        physicsCollisionManagementSystem.Update(delta);
+        microbeCollisionSoundSystem.Update(delta);
+        pilusDamageSystem.Update(delta);
+        toxinCollisionSystem.Update(delta);
+        disallowPlayerBodySleepSystem.Update(delta);
+        CameraFollowSystem.Update(delta);
+        damageOnTouchSystem.Update(delta);
         barrier1.SignalAndWait();
 
         // Timeslot 3 on thread 1
-        soundListenerSystem.Update(delta);
-        CameraFollowSystem.Update(delta);
-        barrier1.SignalAndWait();
-
-        // Timeslot 4 on thread 1
+        allCompoundsVentingSystem.Update(delta);
+        unneededCompoundVentingSystem.Update(delta);
+        osmoregulationAndHealingSystem.Update(delta);
         microbeReproductionSystem.Update(delta);
         colonyCompoundDistributionSystem.Update(delta);
         engulfingSystem.Update(delta);
         barrier1.SignalAndWait();
 
-        // Timeslot 5 on thread 1
+        // Timeslot 4 on thread 1
         spatialAttachSystem.Update(delta);
         spatialPositionSystem.Update(delta);
-        SpawnSystem.Update(delta);
         barrier1.SignalAndWait();
 
-        // Timeslot 6 on thread 1
+        // Timeslot 5 on thread 1
         organelleTickSystem.Update(delta);
         barrier1.SignalAndWait();
 
-        // Timeslot 7 on thread 1
-        engulfedHandlingSystem.Update(delta);
-        barrier1.SignalAndWait();
-
-        // Timeslot 8 on thread 1
+        // Timeslot 6 on thread 1
         physicsSensorSystem.Update(delta);
         barrier1.SignalAndWait();
 
-        // Timeslot 9 on thread 1
+        // Timeslot 7 on thread 1
         fadeOutActionSystem.Update(delta);
-        allCompoundsVentingSystem.Update(delta);
         barrier1.SignalAndWait();
 
-        // Timeslot 10 on thread 1
+        // Timeslot 8 on thread 1
         soundEffectSystem.Update(delta);
 
         barrier1.SignalAndWait();

--- a/src/microbe_stage/systems/AllCompoundsVentingSystem.cs
+++ b/src/microbe_stage/systems/AllCompoundsVentingSystem.cs
@@ -15,7 +15,7 @@
     [WritesToComponent(typeof(Physics))]
     [ReadsComponent(typeof(WorldPosition))]
     [RunsAfter(typeof(PhysicsUpdateAndPositionSystem))]
-    [RuntimeCost(10)]
+    [RuntimeCost(9)]
     public sealed class AllCompoundsVentingSystem : AEntitySetSystem<float>
     {
         private readonly CompoundCloudSystem compoundCloudSystem;

--- a/src/microbe_stage/systems/CompoundAbsorptionSystem.cs
+++ b/src/microbe_stage/systems/CompoundAbsorptionSystem.cs
@@ -14,7 +14,7 @@
     [With(typeof(CompoundStorage))]
     [With(typeof(WorldPosition))]
     [ReadsComponent(typeof(WorldPosition))]
-    [RuntimeCost(45)]
+    [RuntimeCost(50)]
     public sealed class CompoundAbsorptionSystem : AEntitySetSystem<float>
     {
         private readonly CompoundCloudSystem compoundCloudSystem;

--- a/src/microbe_stage/systems/FluidCurrentsSystem.cs
+++ b/src/microbe_stage/systems/FluidCurrentsSystem.cs
@@ -20,7 +20,7 @@
     [ReadsComponent(typeof(CurrentAffected))]
     [ReadsComponent(typeof(Physics))]
     [ReadsComponent(typeof(WorldPosition))]
-    [RuntimeCost(7)]
+    [RuntimeCost(8)]
     [JsonObject(MemberSerialization.OptIn)]
     public sealed class FluidCurrentsSystem : AEntitySetSystem<float>
     {

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -41,7 +41,7 @@
     [RunsBefore(typeof(MicrobeEmissionSystem))]
     [RunsConditionally("RunAI")]
     [RunsWithCustomCode("{0}.ReportPotentialPlayerPosition(reportedPlayerPosition);\n{0}.Update(delta);")]
-    [RuntimeCost(6)]
+    [RuntimeCost(9)]
     public sealed class MicrobeAISystem : AEntitySetSystem<float>, ISpeciesMemberLocationData
     {
         private readonly Compound atp;

--- a/src/microbe_stage/systems/MicrobeDeathSystem.cs
+++ b/src/microbe_stage/systems/MicrobeDeathSystem.cs
@@ -43,7 +43,7 @@
     [RunsAfter(typeof(ColonyStatsUpdateSystem))]
     [RunsAfter(typeof(EngulfingSystem))]
     [RunsBefore(typeof(FadeOutActionSystem))]
-    [RuntimeCost(0.5f)]
+    [RuntimeCost(1)]
     public sealed class MicrobeDeathSystem : AEntitySetSystem<float>
     {
         private readonly IWorldSimulation worldSimulation;

--- a/src/microbe_stage/systems/MicrobeEmissionSystem.cs
+++ b/src/microbe_stage/systems/MicrobeEmissionSystem.cs
@@ -32,7 +32,7 @@
     [WritesToComponent(typeof(OrganelleContainer))]
     [RunsBefore(typeof(MicrobeMovementSystem))]
     [RunsAfter(typeof(ProcessSystem))]
-    [RuntimeCost(0.5f)]
+    [RuntimeCost(1)]
     public sealed class MicrobeEmissionSystem : AEntitySetSystem<float>
     {
         private readonly IWorldSimulation worldSimulation;

--- a/src/microbe_stage/systems/MicrobeMovementSoundSystem.cs
+++ b/src/microbe_stage/systems/MicrobeMovementSoundSystem.cs
@@ -21,7 +21,7 @@
     [RunsAfter(typeof(PhysicsUpdateAndPositionSystem))]
     [RunsAfter(typeof(MicrobeMovementSystem))]
     [RunsBefore(typeof(SoundEffectSystem))]
-    [RuntimeCost(2)]
+    [RuntimeCost(3)]
     public sealed class MicrobeMovementSoundSystem : AEntitySetSystem<float>
     {
         public MicrobeMovementSoundSystem(World world, IParallelRunner parallelRunner) :

--- a/src/microbe_stage/systems/MicrobeMovementSystem.cs
+++ b/src/microbe_stage/systems/MicrobeMovementSystem.cs
@@ -30,7 +30,7 @@
     [RunsAfter(typeof(PhysicsBodyCreationSystem))]
     [RunsAfter(typeof(PhysicsBodyDisablingSystem))]
     [RunsBefore(typeof(PhysicsBodyControlSystem))]
-    [RuntimeCost(13)]
+    [RuntimeCost(14)]
     public sealed class MicrobeMovementSystem : AEntitySetSystem<float>
     {
         private readonly PhysicalWorld physicalWorld;

--- a/src/microbe_stage/systems/MicrobeReproductionSystem.cs
+++ b/src/microbe_stage/systems/MicrobeReproductionSystem.cs
@@ -44,7 +44,7 @@
     [ReadsComponent(typeof(MicrobeColony))]
     [RunsAfter(typeof(OsmoregulationAndHealingSystem))]
     [RunsAfter(typeof(ProcessSystem))]
-    [RuntimeCost(9)]
+    [RuntimeCost(14)]
     [RunsOnMainThread]
     public sealed class MicrobeReproductionSystem : AEntitySetSystem<float>
     {

--- a/src/microbe_stage/systems/MicrobeShaderSystem.cs
+++ b/src/microbe_stage/systems/MicrobeShaderSystem.cs
@@ -18,7 +18,7 @@
     [With(typeof(MicrobeShaderParameters))]
     [With(typeof(EntityMaterial))]
     [ReadsComponent(typeof(EntityMaterial))]
-    [RuntimeCost(13)]
+    [RuntimeCost(8)]
     [RunsOnFrame]
     [RunsOnMainThread]
     public sealed class MicrobeShaderSystem : AEntitySetSystem<float>

--- a/src/microbe_stage/systems/MicrobeVisualsSystem.cs
+++ b/src/microbe_stage/systems/MicrobeVisualsSystem.cs
@@ -25,7 +25,7 @@
     [RunsBefore(typeof(SpatialAttachSystem))]
     [RunsBefore(typeof(EntityMaterialFetchSystem))]
     [RunsBefore(typeof(SpatialPositionSystem))]
-    [RuntimeCost(5)]
+    [RuntimeCost(6)]
     [RunsOnMainThread]
     public sealed class MicrobeVisualsSystem : AEntitySetSystem<float>
     {

--- a/src/microbe_stage/systems/OrganelleTickSystem.cs
+++ b/src/microbe_stage/systems/OrganelleTickSystem.cs
@@ -35,7 +35,7 @@
     [RunsAfter(typeof(MicrobeMovementSystem))]
     [RunsAfter(typeof(OrganelleComponentFetchSystem))]
     [RunsBefore(typeof(PhysicsSensorSystem))]
-    [RuntimeCost(13)]
+    [RuntimeCost(14)]
     [RunsOnMainThread]
     public sealed class OrganelleTickSystem : AEntitySetSystem<float>
     {

--- a/src/microbe_stage/systems/PilusDamageSystem.cs
+++ b/src/microbe_stage/systems/PilusDamageSystem.cs
@@ -18,7 +18,7 @@
     [ReadsComponent(typeof(Health))]
     [WritesToComponent(typeof(DamageCooldown))]
     [RunsAfter(typeof(PhysicsCollisionManagementSystem))]
-    [RuntimeCost(0.25f)]
+    [RuntimeCost(1)]
     public sealed class PilusDamageSystem : AEntitySetSystem<float>
     {
         public PilusDamageSystem(World world, IParallelRunner parallelRunner) : base(world, parallelRunner)

--- a/src/microbe_stage/systems/ProcessSystem.cs
+++ b/src/microbe_stage/systems/ProcessSystem.cs
@@ -24,7 +24,7 @@
     [RunsAfter(typeof(CompoundAbsorptionSystem))]
     [RunsBefore(typeof(OsmoregulationAndHealingSystem))]
     [RunsBefore(typeof(MicrobeMovementSystem))]
-    [RuntimeCost(50)]
+    [RuntimeCost(55)]
     public sealed class ProcessSystem : AEntitySetSystem<float>
     {
         private static readonly Compound ATP = SimulationParameters.Instance.GetCompound("atp");

--- a/src/microbe_stage/systems/TintColourApplyingSystem.cs
+++ b/src/microbe_stage/systems/TintColourApplyingSystem.cs
@@ -18,7 +18,7 @@
     [With(typeof(EntityMaterial))]
     [ReadsComponent(typeof(EntityMaterial))]
     [RunsAfter(typeof(ColourAnimationSystem))]
-    [RuntimeCost(9)]
+    [RuntimeCost(8)]
     [RunsOnFrame]
     [RunsOnMainThread]
     public sealed class TintColourApplyingSystem : AEntitySetSystem<float>

--- a/src/microbe_stage/systems/UnneededCompoundVentingSystem.cs
+++ b/src/microbe_stage/systems/UnneededCompoundVentingSystem.cs
@@ -21,7 +21,7 @@
     [ReadsComponent(typeof(WorldPosition))]
     [Without(typeof(AttachedToEntity))]
     [RunsAfter(typeof(ProcessSystem))]
-    [RuntimeCost(10)]
+    [RuntimeCost(9)]
     public sealed class UnneededCompoundVentingSystem : AEntitySetSystem<float>
     {
         private readonly CompoundCloudSystem compoundCloudSystem;

--- a/src/tutorial/microbe_stage/MicrobeTutorialGUI.cs
+++ b/src/tutorial/microbe_stage/MicrobeTutorialGUI.cs
@@ -136,7 +136,19 @@ public class MicrobeTutorialGUI : Control, ITutorialGUI
     public bool MicrobeMovementPromptsVisible
     {
         get => microbeMovementKeyPrompts.Visible;
-        set => microbeMovementKeyPrompts.Visible = value;
+        set
+        {
+            if (value == microbeMovementKeyPrompts.Visible)
+                return;
+
+            microbeMovementKeyPrompts.Visible = value;
+
+            // Apply visible to children to make the key prompts visible. This saves a lot of processing time overall
+            foreach (Control child in microbeMovementKeyPrompts.GetChildren())
+            {
+                child.Visible = value;
+            }
+        }
     }
 
     public bool MicrobeMovementPopupVisible

--- a/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
+++ b/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
@@ -167,6 +167,7 @@ __meta__ = {
 }
 
 [node name="Forward" parent="MicrobeMovementTutorial/KeyPrompts" instance=ExtResource( 3 )]
+visible = false
 margin_left = 620.0
 margin_top = 280.0
 margin_right = -628.0
@@ -175,6 +176,7 @@ rect_min_size = Vector2( 40, 40 )
 ActionName = "g_move_forward"
 
 [node name="Backwards" parent="MicrobeMovementTutorial/KeyPrompts" instance=ExtResource( 3 )]
+visible = false
 margin_left = 620.0
 margin_top = 400.0
 margin_right = -628.0
@@ -183,6 +185,7 @@ rect_min_size = Vector2( 40, 40 )
 ActionName = "g_move_backwards"
 
 [node name="Left" parent="MicrobeMovementTutorial/KeyPrompts" instance=ExtResource( 3 )]
+visible = false
 margin_left = 560.0
 margin_top = 340.0
 margin_right = -688.0
@@ -191,6 +194,7 @@ rect_min_size = Vector2( 40, 40 )
 ActionName = "g_move_left"
 
 [node name="Right" parent="MicrobeMovementTutorial/KeyPrompts" instance=ExtResource( 3 )]
+visible = false
 margin_left = 680.0
 margin_top = 340.0
 margin_right = -568.0


### PR DESCRIPTION
**Brief Description of What This PR Does**

Gets performance hopefully pretty close to what it was before the memory allocation reductions (this impacted the relative performance cost of quite many systems).

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
