### PR TITLE
Prevent engulfing/binding sound effect continuing after death

### DIFF
--- a/src/engine/common_components/SoundEffectPlayer.cs
+++ b/src/engine/common_components/SoundEffectPlayer.cs
@@ -226,9 +226,9 @@
 
                     slot.InternalAppliedState = false;
                 }
-            }
 
-            soundEffectPlayer.SoundsApplied = false;
+                soundEffectPlayer.SoundsApplied = false;
+            }
         }
 
         /// <summary>

--- a/src/engine/common_components/SoundEffectPlayer.cs
+++ b/src/engine/common_components/SoundEffectPlayer.cs
@@ -190,6 +190,48 @@
         }
 
         /// <summary>
+        ///   Stops all sounds that are currently playing
+        /// </summary>
+        /// <param name="soundEffectPlayer">The player that may have sounds</param>
+        /// <param name="immediately">
+        ///   If false, any looping sounds will only stop playing after their current loop ends
+        /// </param>
+        public static void StopAllSounds(this ref SoundEffectPlayer soundEffectPlayer, bool immediately = true)
+        {
+            SoundEffectSlot[]? slots = soundEffectPlayer.SoundEffectSlots;
+
+            if (slots == null)
+                return;
+
+            lock (slots)
+            {
+                int slotCount = slots.Length;
+
+                for (int i = 0; i < slotCount; ++i)
+                {
+                    ref var slot = ref slots[i];
+
+                    if (!slot.Play)
+                        continue;
+
+                    if (slot.Loop && !immediately)
+                    {
+                        // Stop after current loop
+                        slot.Loop = false;
+                    }
+                    else
+                    {
+                        slot.Play = false;
+                    }
+
+                    slot.InternalAppliedState = false;
+                }
+            }
+
+            soundEffectPlayer.SoundsApplied = false;
+        }
+
+        /// <summary>
         ///   Handles starting and turning up a looping sound effect. Used for microbe movement sound handling,
         ///   for example.
         /// </summary>

--- a/src/microbe_stage/systems/MicrobeDeathSystem.cs
+++ b/src/microbe_stage/systems/MicrobeDeathSystem.cs
@@ -415,7 +415,7 @@
                 position.Position, random, null, glucose);
 
             ref var soundPlayer = ref entity.Get<SoundEffectPlayer>();
-
+            soundPlayer.StopAllSounds();
             soundPlayer.PlaySoundEffect("res://assets/sounds/soundeffects/microbe-death-2.ogg");
 
             return true;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Stops all sounds for a microbe on its death.

**Related Issues**

N/A

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
