### PR TITLE
Make native libs upload script auto offer symbol uploads again

### DIFF
--- a/Scripts/NativeLibs.cs
+++ b/Scripts/NativeLibs.cs
@@ -258,7 +258,7 @@ public class NativeLibs
                 throw new NotImplementedException("Creating release packages for mac is not done");
 
             case Program.NativeLibOptions.OperationMode.Upload:
-                if (await OperateOnAllLibrariesWithResult(CheckAndUpload, cancellationToken))
+                if (await OperateOnAllLibrariesWithResult(CheckAndUpload, cancellationToken) == true)
                 {
                     ColourConsole.WriteNormalLine("Checking for potential symbols to upload after library upload");
                     return await UploadMissingSymbolsToServer(cancellationToken);
@@ -890,7 +890,7 @@ public class NativeLibs
         return true;
     }
 
-    private async Task<bool> CheckAndUpload(Library library, PackagePlatform platform,
+    private async Task<bool?> CheckAndUpload(Library library, PackagePlatform platform,
         CancellationToken cancellationToken)
     {
         var version = GetLibraryVersion(library);
@@ -901,7 +901,7 @@ public class NativeLibs
             ColourConsole.WriteWarningLine($"Skip checking uploading file that is missing locally: {file}");
 
             // For now this is not considered an error
-            return true;
+            return null;
         }
 
         bool debug = options.DebugLibrary;
@@ -909,6 +909,8 @@ public class NativeLibs
         if (string.IsNullOrEmpty(options.Key))
         {
             ColourConsole.WriteErrorLine("Key to access ThriveDevCenter is a required parameter");
+
+            // Explicit fail to stop trying
             return false;
         }
 
@@ -941,8 +943,8 @@ public class NativeLibs
 
         if (response.StatusCode == HttpStatusCode.NoContent)
         {
-            ColourConsole.WriteDebugLine("Server already has this");
-            return false;
+            // No preference to change the result
+            return null;
         }
 
         if (response.StatusCode == HttpStatusCode.OK)


### PR DESCRIPTION
to fix a regression from another script change, I noticed this bug only a few weeks ago with the changes having been made much earlier

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
