### PR TITLE
Tweak prediction GUI to get a bit more horizontal room

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.tscn
+++ b/src/microbe_stage/editor/CellEditorComponent.tscn
@@ -1326,66 +1326,64 @@ hint_tooltip = "GATHERED_ENERGY_TOOLTIP"
 Description = "TOTAL_GATHERED_ENERGY_COLON"
 InvalidIcon = ExtResource( 20 )
 
-[node name="Best" type="HBoxContainer" parent="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Best" type="VBoxContainer" parent="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer"]
 margin_top = 29.0
 margin_right = 255.0
-margin_bottom = 48.0
+margin_bottom = 69.0
 
 [node name="Label" type="Label" parent="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/Best"]
-margin_top = 1.0
-margin_right = 139.0
-margin_bottom = 18.0
+margin_right = 255.0
+margin_bottom = 17.0
 custom_fonts/font = ExtResource( 23 )
 text = "BEST_PATCH_COLON"
 
 [node name="Value" type="Label" parent="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/Best"]
-margin_left = 143.0
+margin_top = 21.0
 margin_right = 255.0
-margin_bottom = 19.0
+margin_bottom = 40.0
 size_flags_horizontal = 3
 custom_fonts/font = ExtResource( 10 )
 text = "n/a"
 autowrap = true
-max_lines_visible = 5
+max_lines_visible = 2
 __meta__ = {
 "_editor_description_": "PLACEHOLDER"
 }
 
-[node name="Worst" type="HBoxContainer" parent="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer"]
-margin_top = 52.0
+[node name="Worst" type="VBoxContainer" parent="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer"]
+margin_top = 73.0
 margin_right = 255.0
-margin_bottom = 71.0
+margin_bottom = 113.0
 
 [node name="Label" type="Label" parent="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/Worst"]
-margin_top = 1.0
-margin_right = 157.0
-margin_bottom = 18.0
+margin_right = 255.0
+margin_bottom = 17.0
 custom_fonts/font = ExtResource( 23 )
 text = "WORST_PATCH_COLON"
 
 [node name="Value" type="Label" parent="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/Worst"]
-margin_left = 161.0
+margin_top = 21.0
 margin_right = 255.0
-margin_bottom = 19.0
+margin_bottom = 40.0
 size_flags_horizontal = 3
 custom_fonts/font = ExtResource( 10 )
 text = "n/a"
 autowrap = true
-max_lines_visible = 5
+max_lines_visible = 2
 __meta__ = {
 "_editor_description_": "PLACEHOLDER"
 }
 
 [node name="Spacer" type="Control" parent="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer"]
-margin_top = 75.0
+margin_top = 117.0
 margin_right = 255.0
-margin_bottom = 79.0
+margin_bottom = 121.0
 rect_min_size = Vector2( 0, 4 )
 
 [node name="VSeparator" type="VSeparator" parent="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer"]
-margin_top = 83.0
+margin_top = 125.0
 margin_right = 255.0
-margin_bottom = 93.0
+margin_bottom = 135.0
 rect_min_size = Vector2( 0, 10 )
 mouse_filter = 1
 custom_styles/separator = SubResource( 6 )

--- a/src/microbe_stage/editor/CellStatsIndicator.cs
+++ b/src/microbe_stage/editor/CellStatsIndicator.cs
@@ -25,7 +25,7 @@ public class CellStatsIndicator : HBoxContainer
     public Texture? Icon;
 
     [Export]
-    public NodePath? ValuePath = null;
+    public NodePath? ValuePath;
 
     private Label? descriptionLabel;
     private Label? valueLabel;
@@ -111,6 +111,10 @@ public class CellStatsIndicator : HBoxContainer
         decreaseIcon = GD.Load<Texture>("res://assets/textures/gui/bevel/decrease.png");
 
         iconRect.Texture = Icon;
+
+        // Hide the icon displayer when no icon to save on some horizontal space
+        if (Icon == null)
+            iconRect.Visible = false;
 
         UpdateChangeIndicator();
         UpdateDescription();


### PR DESCRIPTION
**Brief Description of What This PR Does**

More horizontal room for the numbers:
![2024-02-19_14 44 35 2519](https://github.com/Revolutionary-Games/Thrive/assets/3796411/33291987-297e-400c-a193-0ac1f1559c04)


**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
