### PR TITLE
Improved the threaded run generator

### DIFF
--- a/src/microbe_stage/MicrobeWorldSimulation.generated.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.generated.cs
@@ -16,8 +16,9 @@ public partial class MicrobeWorldSimulation
         var background1 = new Task(() =>
             {
                 // Timeslot 1 on thread 2
+                countLimitedDespawnSystem.Update(delta);
+                damageCooldownSystem.Update(delta);
                 simpleShapeCreatorSystem.Update(delta);
-                entitySignalingSystem.Update(delta);
                 compoundAbsorptionSystem.Update(delta);
                 barrier1.SignalAndWait();
 
@@ -27,7 +28,6 @@ public partial class MicrobeWorldSimulation
                 barrier1.SignalAndWait();
 
                 // Timeslot 4 on thread 2
-                engulfedDigestionSystem.Update(delta);
                 multicellularGrowthSystem.Update(delta);
                 organelleComponentFetchSystem.Update(delta);
                 slimeSlowdownSystem.Update(delta);
@@ -39,28 +39,31 @@ public partial class MicrobeWorldSimulation
 
                 microbeEmissionSystem.Update(delta);
                 microbeMovementSystem.Update(delta);
-                microbeMovementSoundSystem.Update(delta);
                 physicsBodyControlSystem.Update(delta);
                 colonyBindingSystem.Update(delta);
+                microbeFlashingSystem.Update(delta);
+                delayedColonyOperationSystem.Update(delta);
+                engulfedDigestionSystem.Update(delta);
+                microbeMovementSoundSystem.Update(delta);
                 barrier1.SignalAndWait();
 
                 // Timeslot 5 on thread 2
-                microbeFlashingSystem.Update(delta);
                 SpawnSystem.Update(delta);
                 colonyStatsUpdateSystem.Update(delta);
                 barrier1.SignalAndWait();
 
                 // Timeslot 6 on thread 2
                 microbeDeathSystem.Update(delta);
-                delayedColonyOperationSystem.Update(delta);
+                engulfedHandlingSystem.Update(delta);
                 barrier1.SignalAndWait();
 
                 // Timeslot 7 on thread 2
                 microbeEventCallbackSystem.Update(delta);
+                damageSoundSystem.Update(delta);
                 barrier1.SignalAndWait();
 
                 // Timeslot 8 on thread 2
-                unneededCompoundVentingSystem.Update(delta);
+                allCompoundsVentingSystem.Update(delta);
 
                 barrier1.SignalAndWait();
             });
@@ -70,37 +73,35 @@ public partial class MicrobeWorldSimulation
         // Timeslot 1 on thread 1
         pathBasedSceneLoader.Update(delta);
         predefinedVisualLoaderSystem.Update(delta);
+        entitySignalingSystem.Update(delta);
+        fluidCurrentsSystem.Update(delta);
         microbeVisualsSystem.Update(delta);
         animationControlSystem.Update(delta);
-        TimedLifeSystem.Update(delta);
         entityMaterialFetchSystem.Update(delta);
         cellBurstEffectSystem.Update(delta);
-        countLimitedDespawnSystem.Update(delta);
+        TimedLifeSystem.Update(delta);
         microbeRenderPrioritySystem.Update(delta);
-        fluidCurrentsSystem.Update(delta);
-        damageCooldownSystem.Update(delta);
         barrier1.SignalAndWait();
 
         // Timeslot 2 on thread 1
         collisionShapeLoaderSystem.Update(delta);
         microbePhysicsCreationAndSizeSystem.Update(delta);
         physicsBodyCreationSystem.Update(delta);
+        physicsCollisionManagementSystem.Update(delta);
         physicsBodyDisablingSystem.Update(delta);
+        microbeCollisionSoundSystem.Update(delta);
         physicsUpdateAndPositionSystem.Update(delta);
         attachedEntityPositionSystem.Update(delta);
         soundListenerSystem.Update(delta);
         CameraFollowSystem.Update(delta);
-        disallowPlayerBodySleepSystem.Update(delta);
-        physicsCollisionManagementSystem.Update(delta);
-        microbeCollisionSoundSystem.Update(delta);
+        toxinCollisionSystem.Update(delta);
         pilusDamageSystem.Update(delta);
         damageOnTouchSystem.Update(delta);
-        toxinCollisionSystem.Update(delta);
+        disallowPlayerBodySleepSystem.Update(delta);
         barrier1.SignalAndWait();
 
         // Timeslot 3 on thread 1
         osmoregulationAndHealingSystem.Update(delta);
-        allCompoundsVentingSystem.Update(delta);
         microbeReproductionSystem.Update(delta);
         colonyCompoundDistributionSystem.Update(delta);
         engulfingSystem.Update(delta);
@@ -121,11 +122,10 @@ public partial class MicrobeWorldSimulation
 
         // Timeslot 7 on thread 1
         fadeOutActionSystem.Update(delta);
-        engulfedHandlingSystem.Update(delta);
+        unneededCompoundVentingSystem.Update(delta);
         barrier1.SignalAndWait();
 
         // Timeslot 8 on thread 1
-        damageSoundSystem.Update(delta);
         soundEffectSystem.Update(delta);
 
         barrier1.SignalAndWait();

--- a/src/tools/GenerateThreadedSystems.cs
+++ b/src/tools/GenerateThreadedSystems.cs
@@ -27,7 +27,8 @@ public class GenerateThreadedSystems : Node
     /// <summary>
     ///   When true inserts calls to mark which components systems are allowed to access. With help from
     ///   <see cref="ComponentFetchHelpers.GetChecked{T}"/> this can be used to ensure all access attributes are
-    ///   correct on systems.
+    ///   correct on systems. Disables multithreading when enabled so that the checks can pass as this mode is not made
+    ///   to run in multithreaded mode as this would be very difficult to make work with multithreading.
     /// </summary>
     public static bool UseCheckedComponentAccess = false;
 

--- a/src/tools/ThreadedRunSimulator.cs
+++ b/src/tools/ThreadedRunSimulator.cs
@@ -381,8 +381,11 @@
                 }
 
                 // Prioritize running exclusive tasks a bit
+                bool triedExclusive = false;
                 if (thread.HasUpcomingExclusiveTask && random.NextDouble() < ExclusiveTaskChance)
                 {
+                    triedExclusive = true;
+
                     foreach (var exclusiveTask in thread.GetUpcomingExclusiveTasks())
                     {
                         if (CanRunSystemInParallel(exclusiveTask, thread))
@@ -407,6 +410,19 @@
                     }
 
                     // TODO: should this have a chance here to stop checking things for more randomness?
+                }
+
+                // If skipped earlier, try an exclusive task again
+                if (thread.HasUpcomingExclusiveTask && !triedExclusive)
+                {
+                    foreach (var exclusiveTask in thread.GetUpcomingExclusiveTasks())
+                    {
+                        if (CanRunSystemInParallel(exclusiveTask, thread))
+                        {
+                            MarkConcurrentlyRunningSystem(exclusiveTask, thread);
+                            return true;
+                        }
+                    }
                 }
 
                 // Thread cannot start work

--- a/src/tools/ThreadedRunSimulator.cs
+++ b/src/tools/ThreadedRunSimulator.cs
@@ -474,8 +474,8 @@
                 // the upcoming tasks
                 foreach (var otherThread in allThreads)
                 {
-                    if (otherThread == thread)
-                        continue;
+                    // Should not skip checking self as later exclusive systems shouldn't be allowed to run on the
+                    // same thread either
 
                     foreach (var futureSystem in otherThread.GetUpcomingExclusiveTasks())
                     {

--- a/src/tools/ThreadedRunSimulator.cs
+++ b/src/tools/ThreadedRunSimulator.cs
@@ -30,7 +30,7 @@
         ///   Relative time cost of a barrier to running an average system (which is 1). For example 1.5 means that a
         ///   barrier is as expensive as running 1.5 other systems.
         /// </summary>
-        private const float TimeCostPerBarrier = 2.0f;
+        private const float TimeCostPerBarrier = 1.5f;
 
         private static readonly bool ExtraVerifySystemRun = false;
 

--- a/src/tools/ThreadedRunSimulator.cs
+++ b/src/tools/ThreadedRunSimulator.cs
@@ -29,7 +29,7 @@
         ///   Relative time cost of a barrier to running an average system (which is 1). For example 1.5 means that a
         ///   barrier is as expensive as running 1.5 other systems.
         /// </summary>
-        private const float TimeCostPerBarrier = 1.5f;
+        private const float TimeCostPerBarrier = 2.0f;
 
         private static readonly bool ExtraVerifySystemRun = false;
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Did some changes that add some more randomness and can do a few new actions to the threaded run generation to make it find more optimal runs. Fixed one bug with system ordering (same thread exclusive systems could run before other upcoming systems on the same thread).

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #4867 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
