### PR TITLE
Applied single letter lambda variable style for LINQ

### DIFF
--- a/Scripts/WikiUpdater.cs
+++ b/Scripts/WikiUpdater.cs
@@ -106,7 +106,7 @@ public class WikiUpdater
     private TranslationPair ProcessOrganellesRootPage(IHtmlElement page)
     {
         var sections = GetMainBodySections(page);
-        var untranslatedSections = sections.Select(section => UntranslateSection(section, "ORGANELLES_ROOT")).ToList();
+        var untranslatedSections = sections.Select(s => UntranslateSection(s, "ORGANELLES_ROOT")).ToList();
 
         var untranslatedPage = new Wiki.Page("WIKI_PAGE_ORGANELLES_ROOT", "OrganellesRoot", ORGANELLE_CATEGORY,
             untranslatedSections);
@@ -132,8 +132,7 @@ public class WikiUpdater
             var internalName = page.QuerySelector("#info-box-internal-name")!.TextContent.Trim();
 
             var sections = GetMainBodySections(page);
-            var untranslatedSections = sections.Select(
-                section => UntranslateSection(section, untranslatedOrganelleName)).ToList();
+            var untranslatedSections = sections.Select(s => UntranslateSection(s, untranslatedOrganelleName)).ToList();
 
             var untranslatedPage = new Wiki.Page($"WIKI_PAGE_{untranslatedOrganelleName}",
                 internalName,
@@ -182,7 +181,7 @@ public class WikiUpdater
                     // Godot 3 does not support lists in BBCode, so use custom formatting
                     text = child.Children
                         .Where(c => c.TagName == "LI")
-                        .Select(li => $"[indent]—   {ConvertParagraphToBbcode(li)}[/indent]")
+                        .Select(l => $"[indent]—   {ConvertParagraphToBbcode(l)}[/indent]")
                         .Aggregate((a, b) => a + "\n" + b) + "\n\n";
                     break;
                 default:

--- a/simulation_parameters/GameWiki.cs
+++ b/simulation_parameters/GameWiki.cs
@@ -22,7 +22,9 @@ public class GameWiki : IRegistryType
     public void Check(string name)
     {
         OrganellesRoot.Check(name);
-        Organelles.ForEach(page => page.Check(name));
+
+        foreach (var page in Organelles)
+            page.Check(name);
     }
 
     public class Page

--- a/src/auto-evo/AutoEvoExploringTool.Export.cs
+++ b/src/auto-evo/AutoEvoExploringTool.Export.cs
@@ -98,7 +98,7 @@ public partial class AutoEvoExploringTool
                     });
 
                     data.AddRange(allOrganelles
-                        .Select(o => microbeSpecies.Organelles.Count(ot => ot.Definition == o).ToString()));
+                        .Select(d => microbeSpecies.Organelles.Count(t => t.Definition == d).ToString()));
                 }
                 else
                 {

--- a/src/auto-evo/AutoEvoExploringTool.cs
+++ b/src/auto-evo/AutoEvoExploringTool.cs
@@ -765,10 +765,10 @@ public partial class AutoEvoExploringTool : NodeWithInput
         gameWorld.GenerationHistory.Add(gameWorld.PlayerSpecies.Generation - 1,
             new GenerationRecord(gameWorld.TotalPassedTime, results.GetSpeciesRecords()));
         gameWorld.BuildEvolutionaryTree(evolutionaryTree);
-        world.SpeciesHistoryList.Add(gameWorld.Species.ToDictionary(pair => pair.Key,
-            pair => (Species)pair.Value.Clone()));
-        world.PatchHistoryList.Add(gameWorld.Map.Patches.ToDictionary(pair => pair.Key,
-            pair => (PatchSnapshot)pair.Value.CurrentSnapshot.Clone()));
+        world.SpeciesHistoryList.Add(gameWorld.Species.ToDictionary(s => s.Key,
+            s => (Species)s.Value.Clone()));
+        world.PatchHistoryList.Add(gameWorld.Map.Patches.ToDictionary(s => s.Key,
+            s => (PatchSnapshot)s.Value.CurrentSnapshot.Clone()));
 
         // Add checkbox to history container
         historyListMenu.AddItem(world.CurrentGeneration.ToString(CultureInfo.CurrentCulture), false, Colors.White);
@@ -1087,8 +1087,8 @@ public partial class AutoEvoExploringTool : NodeWithInput
                 },
             });
 
-            PatchHistoryList.Add(GameProperties.GameWorld.Map.Patches.ToDictionary(pair => pair.Key,
-                pair => (PatchSnapshot)pair.Value.CurrentSnapshot.Clone()));
+            PatchHistoryList.Add(GameProperties.GameWorld.Map.Patches.ToDictionary(p => p.Key,
+                p => (PatchSnapshot)p.Value.CurrentSnapshot.Clone()));
 
             PatchesCount = GameProperties.GameWorld.Map.Patches.Count;
 

--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -549,7 +549,7 @@ public class AutoEvoRun
                 GatherInfo(runSteps);
 
                 // +2 is for this step and the result apply step
-                totalSteps = runSteps.Sum(step => step.TotalSteps) + 2;
+                totalSteps = runSteps.Sum(s => s.TotalSteps) + 2;
 
                 Interlocked.Increment(ref completeSteps);
                 state = RunStage.Stepping;

--- a/src/auto-evo/EvolutionaryTree.cs
+++ b/src/auto-evo/EvolutionaryTree.cs
@@ -322,7 +322,7 @@ public class EvolutionaryTree : Control
     {
         var treeNodeSize = sizeFactor * TreeNodeSize;
 
-        foreach (var node in speciesNodes.Values.SelectMany(speciesNodeList => speciesNodeList))
+        foreach (var node in speciesNodes.Values.SelectMany(l => l))
         {
             node.RectMinSize = treeNodeSize;
 

--- a/src/auto-evo/simulation/PopulationSimulation.cs
+++ b/src/auto-evo/simulation/PopulationSimulation.cs
@@ -147,7 +147,7 @@
             {
                 // Simulate the species in each patch taking into account the already computed populations
                 SimulatePatchStep(parameters, entry.Value,
-                    species.Where(item => parameters.Results.GetPopulationInPatch(item, entry.Value) > 0),
+                    species.Where(s => parameters.Results.GetPopulationInPatch(s, entry.Value) > 0),
                     random, cache, autoEvoConfiguration, worldSettings);
             }
         }

--- a/src/auto-evo/steps/FindBestMigration.cs
+++ b/src/auto-evo/steps/FindBestMigration.cs
@@ -100,7 +100,7 @@
                 --attemptsLeft;
 
                 // Randomly select starting patch
-                var entry = map.Patches.Where(pair => pair.Value.SpeciesInPatch.ContainsKey(species))
+                var entry = map.Patches.Where(p => p.Value.SpeciesInPatch.ContainsKey(species))
                     .OrderBy(_ => random.Next()).Take(1).ToList();
 
                 if (entry.Count > 0)

--- a/src/engine/input/key_mapping/InputGroupList.cs
+++ b/src/engine/input/key_mapping/InputGroupList.cs
@@ -43,8 +43,8 @@ public class InputGroupList : VBoxContainer
     ///   Is any Input currently waiting for input
     /// </summary>
     public bool ListeningForInput => ActiveInputGroupList
-        .Any(group => group.Actions
-            .Any(action => action.Inputs.Any(singularInput => singularInput.WaitingForInput)));
+        .Any(g => g.Actions
+            .Any(a => a.Inputs.Any(i => i.WaitingForInput)));
 
     public IEnumerable<InputGroupItem> ActiveInputGroupList => activeInputGroupList ?? Array.Empty<InputGroupItem>();
 
@@ -127,11 +127,11 @@ public class InputGroupList : VBoxContainer
         // Take the ones with any interception of the environments.
         // Take the input actions.
         // Get the first action where the event collides or null if there aren't any.
-        return ActiveInputGroupList.Where(group => group.EnvironmentId.Any(x => environments.Contains(x)))
-            .SelectMany(group => group.Actions)
-            .Where(action => !Equals(inputActionItem, action))
-            .SelectMany(action => action.Inputs)
-            .FirstOrDefault(input => Equals(input, item));
+        return ActiveInputGroupList.Where(g => g.EnvironmentId.Any(e => environments.Contains(e)))
+            .SelectMany(g => g.Actions)
+            .Where(a => !Equals(inputActionItem, a))
+            .SelectMany(a => a.Inputs)
+            .FirstOrDefault(i => Equals(i, item));
     }
 
     /// <summary>

--- a/src/general/GameWorld.cs
+++ b/src/general/GameWorld.cs
@@ -642,7 +642,7 @@ public class GameWorld : ISaveLoadable
             eventsLog.Add(TotalPassedTime, new List<GameEventDescription>());
 
         // Event already logged in timeline
-        if (eventsLog[TotalPassedTime].Any(entry => entry.Description.Equals(description)))
+        if (eventsLog[TotalPassedTime].Any(e => e.Description.Equals(description)))
         {
             return;
         }

--- a/src/general/Jukebox.cs
+++ b/src/general/Jukebox.cs
@@ -72,8 +72,8 @@ public class Jukebox : Node
         }
     }
 
-    private List<string> PlayingTracks => audioPlayers.Where(player => player.Playing)
-        .Select(player => player.CurrentTrack).WhereNotNull().ToList();
+    private List<string> PlayingTracks => audioPlayers.Where(p => p.Playing)
+        .Select(p => p.CurrentTrack).WhereNotNull().ToList();
 
     public override void _Ready()
     {
@@ -501,15 +501,15 @@ public class Jukebox : Node
         var needToStartFrom = new List<TrackList>();
 
         var activeTracks = PlayingTracks;
-        var usablePlayers = audioPlayers.Where(player => !player.Playing).ToList();
+        var usablePlayers = audioPlayers.Where(p => !p.Playing).ToList();
 
         foreach (var list in target.TrackLists)
         {
             // Detecting playing tracks doesn't take context restrictions into account to allow context to change but
             // not then force 2 tracks to play at the same time from the same track list if the context switch didn't
             // force tracks to end
-            var trackResources = list.GetAllTracks().Select(track => track.ResourcePath);
-            if (activeTracks.Any(track => trackResources.Contains(track)))
+            var trackResources = list.GetAllTracks().Select(t => t.ResourcePath);
+            if (activeTracks.Any(t => trackResources.Contains(t)))
                 continue;
 
             needToStartFrom.Add(list);
@@ -519,7 +519,7 @@ public class Jukebox : Node
 
         foreach (var list in needToStartFrom)
         {
-            if (!list.Repeat && list.GetTracksForContexts(activeContexts).All(track => track.PlayedOnce))
+            if (!list.Repeat && list.GetTracksForContexts(activeContexts).All(t => t.PlayedOnce))
                 continue;
 
             PlayNextTrackFromList(list, index =>
@@ -615,8 +615,8 @@ public class Jukebox : Node
 
                         // Store the position to resume from
                         track.PreviousPlayedPosition = audioPlayers
-                            .Where(player => player.Playing && player.CurrentTrack == track.ResourcePath)
-                            .Select(player => player.Player.GetPlaybackPosition()).First();
+                            .Where(p => p.Playing && p.CurrentTrack == track.ResourcePath)
+                            .Select(p => p.Player.GetPlaybackPosition()).First();
                     }
                     else
                     {

--- a/src/general/Mutations.cs
+++ b/src/general/Mutations.cs
@@ -284,7 +284,7 @@ public class Mutations
                 {
                     // Duplicate an existing organelle, but only if there are any organelles where that is legal
                     var organellesThatCanBeDuplicated =
-                        parentOrganelles.Organelles.Where(organelle => !organelle.Definition.Unique).ToList();
+                        parentOrganelles.Organelles.Where(o => !o.Definition.Unique).ToList();
                     if (organellesThatCanBeDuplicated.Any())
                     {
                         AddNewOrganelle(mutatedOrganelles,
@@ -574,7 +574,7 @@ public class Mutations
                     letterPool = isVowel ? Vowels : Consonants;
 
                     // Take next letter in the pool (cycle if necessary);
-                    var nextIndex = letterPool.FindIndex(item => item == letter) + 1;
+                    var nextIndex = letterPool.FindIndex(l => l == letter) + 1;
                     nextIndex = nextIndex < letterPool.Count ? nextIndex : 0;
 
                     var nextLetterInPool = letterPool.ElementAt(nextIndex);

--- a/src/gui_common/AddWindowReorderingSupportToSiblings.cs
+++ b/src/gui_common/AddWindowReorderingSupportToSiblings.cs
@@ -436,7 +436,7 @@ public class AddWindowReorderingSupportToSiblings : Control
             GD.PrintErr($"Exception occurred in {Name} ({this}) in {nameof(ReorderOpenedWindows)}:\n{e}");
 
             // Remove invalid windows
-            justOpenedWindows.RemoveAll(window => !IsInstanceValid(window) || !connectedWindows.ContainsKey(window));
+            justOpenedWindows.RemoveAll(w => !IsInstanceValid(w) || !connectedWindows.ContainsKey(w));
         }
 
         // Reorder the windows

--- a/src/gui_common/CollapsibleList.cs
+++ b/src/gui_common/CollapsibleList.cs
@@ -110,12 +110,12 @@ public class CollapsibleList : VBoxContainer
     public T GetItem<T>(string name)
         where T : Control
     {
-        return (T)items.Find(match => match.Name == name);
+        return (T)items.Find(i => i.Name == name);
     }
 
     public void RemoveItem(string name)
     {
-        var found = items.Find(item => item.Name == name);
+        var found = items.Find(i => i.Name == name);
         found.QueueFree();
         items.Remove(found);
     }
@@ -123,7 +123,7 @@ public class CollapsibleList : VBoxContainer
     public void RemoveAllOfType<T>()
         where T : Control
     {
-        var found = items.FindAll(item => item is T);
+        var found = items.FindAll(i => i is T);
 
         foreach (var item in found)
         {

--- a/src/gui_common/GUICommon.cs
+++ b/src/gui_common/GUICommon.cs
@@ -137,7 +137,7 @@ public class GUICommon : Node
         volume = Mathf.Clamp(volume, 0.0f, 1.0f);
 
         // Find a player not in use or create a new one if none are available.
-        var player = AudioSources.Find(nextPlayer => !nextPlayer.Playing);
+        var player = AudioSources.Find(p => !p.Playing);
 
         if (player == null)
         {

--- a/src/gui_common/SegmentedBar.cs
+++ b/src/gui_common/SegmentedBar.cs
@@ -188,8 +188,8 @@ public class SegmentedBar : HBoxContainer
             if (b.Disabled && !a.Disabled)
                 return -1;
 
-            return barValues.FindIndex(pair => pair.Key == a.Name) -
-                barValues.FindIndex(pair => pair.Key == b.Name);
+            return barValues.FindIndex(v => v.Key == a.Name) -
+                barValues.FindIndex(v => v.Key == b.Name);
         });
 
         int location = 0;

--- a/src/gui_common/charts/line/LineChart.cs
+++ b/src/gui_common/charts/line/LineChart.cs
@@ -244,7 +244,7 @@ public class LineChart : VBoxContainer
     /// <summary>
     ///   Returns the number of shown datasets.
     /// </summary>
-    public int VisibleDataSets => dataSets.Count(data => data.Value.Draw);
+    public int VisibleDataSets => dataSets.Count(d => d.Value.Draw);
 
     public override void _Ready()
     {

--- a/src/gui_common/tooltip/ToolTipHelper.cs
+++ b/src/gui_common/tooltip/ToolTipHelper.cs
@@ -180,7 +180,7 @@ public static class ToolTipHelper
     /// </summary>
     public static Control? GetControlAssociatedWithToolTip(ICustomToolTip? tooltip)
     {
-        var callbackData = ToolTipCallbacks.Find(match => match.ToolTip == tooltip);
+        var callbackData = ToolTipCallbacks.Find(c => c.ToolTip == tooltip);
 
         return callbackData?.ToolTipable;
     }
@@ -217,11 +217,11 @@ public static class ToolTipHelper
 
     private static ToolTipCallbackData GetToolTipCallbackData(Control control, ICustomToolTip tooltip)
     {
-        return ToolTipCallbacks.Find(match => match.ToolTipable == control && match.ToolTip == tooltip);
+        return ToolTipCallbacks.Find(c => c.ToolTipable == control && c.ToolTip == tooltip);
     }
 
     private static IEnumerable<ToolTipCallbackData> GetAllToolTipsForControl(Control control)
     {
-        return ToolTipCallbacks.Where(match => match.ToolTipable == control);
+        return ToolTipCallbacks.Where(c => c.ToolTipable == control);
     }
 }

--- a/src/gui_common/tooltip/ToolTipManager.cs
+++ b/src/gui_common/tooltip/ToolTipManager.cs
@@ -294,7 +294,7 @@ public class ToolTipManager : CanvasLayer
             return null;
         }
 
-        var tooltip = tooltips[retrievedGroup].Find(found => found.ToolTipNode.Name == name);
+        var tooltip = tooltips[retrievedGroup].Find(t => t.ToolTipNode.Name == name);
 
         if (tooltip == null)
         {
@@ -317,7 +317,7 @@ public class ToolTipManager : CanvasLayer
         if (retrievedGroup == null)
             return null;
 
-        var tooltip = tooltips[retrievedGroup].Find(found => found.ToolTipNode.Name == name);
+        var tooltip = tooltips[retrievedGroup].Find(t => t.ToolTipNode.Name == name);
 
         return tooltip;
     }

--- a/src/late_multicellular_stage/MulticellularCreature.cs
+++ b/src/late_multicellular_stage/MulticellularCreature.cs
@@ -349,7 +349,7 @@ public class MulticellularCreature : RigidBody, ISaveLoadedTracked, ICharacterIn
         // TODO: implement sound playing, should probably create a helper method to share with Microbe
 
         /*// Find a player not in use or create a new one if none are available.
-        var player = otherAudioPlayers.Find(nextPlayer => !nextPlayer.Playing);
+        var player = otherAudioPlayers.Find(p => !p.Playing);
 
         if (player == null)
         {

--- a/src/late_multicellular_stage/editor/MetaballBodyEditorComponent.cs
+++ b/src/late_multicellular_stage/editor/MetaballBodyEditorComponent.cs
@@ -414,10 +414,10 @@ public partial class MetaballBodyEditorComponent :
 
         var positions = MouseHoverPositions.ToList();
 
-        var cellTemplates = positions.Select(tuple => new MulticellularMetaball(cellType)
+        var cellTemplates = positions.Select(p => new MulticellularMetaball(cellType)
         {
-            Position = tuple.Position,
-            Parent = tuple.Parent,
+            Position = p.Position,
+            Parent = p.Parent,
         }).ToList();
 
         // TODO: it's extremely unlikely that metaballs would overlap exactly so we can probably remove the occupancy

--- a/src/microbe_stage/MicrobeSpecies.cs
+++ b/src/microbe_stage/MicrobeSpecies.cs
@@ -82,7 +82,7 @@ public class MicrobeSpecies : Species, ICellDefinition
     ///   match between these two.
     /// </summary>
     [JsonIgnore]
-    public float BaseHexSize => Organelles.Organelles.Sum(organelle => organelle.Definition.HexCount)
+    public float BaseHexSize => Organelles.Organelles.Sum(o => o.Definition.HexCount)
         * (IsBacteria ? 0.5f : 1.0f);
 
     [JsonIgnore]

--- a/src/microbe_stage/Patch.cs
+++ b/src/microbe_stage/Patch.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using Godot;
 using Newtonsoft.Json;
 using Nito.Collections;
@@ -493,8 +492,11 @@ public class Patch
     public void LogEvent(LocalizedString description, bool highlight = false, string? iconPath = null)
     {
         // Event already logged in timeline
-        if (currentSnapshot.EventsLog.Any(entry => entry.Description.Equals(description)))
-            return;
+        foreach (var gameEvent in currentSnapshot.EventsLog)
+        {
+            if (gameEvent.Description.Equals(description))
+                return;
+        }
 
         currentSnapshot.EventsLog.Add(new GameEventDescription(description, iconPath, highlight));
     }

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -205,7 +205,7 @@ public class PatchManager : IChildPropertiesLoadCallback
 
         GD.Print("Number of species in this patch = ", patch.SpeciesInPatch.Count);
 
-        foreach (var entry in patch.SpeciesInPatch.OrderByDescending(entry => entry.Value))
+        foreach (var entry in patch.SpeciesInPatch.OrderByDescending(s => s.Value))
         {
             var species = entry.Key;
             var population = entry.Value;
@@ -327,12 +327,12 @@ public class PatchManager : IChildPropertiesLoadCallback
     /// <param name="spawners">Spawner list to act upon</param>
     private void ClearUnmarkedSingle(List<CreatedSpawner> spawners)
     {
-        spawners.RemoveAll(item =>
+        spawners.RemoveAll(spawner =>
         {
-            if (!item.Marked)
+            if (!spawner.Marked)
             {
-                GD.Print("Removed ", item.Name, " spawner.");
-                item.Spawner.DestroyQueued = true;
+                GD.Print("Removed ", spawner.Name, " spawner.");
+                spawner.Spawner.DestroyQueued = true;
                 return true;
             }
 

--- a/src/microbe_stage/components/MicrobeControl.cs
+++ b/src/microbe_stage/components/MicrobeControl.cs
@@ -124,10 +124,10 @@
             {
                 ref var colony = ref entity.Get<MicrobeColony>();
 
-                colony.PerformForOtherColonyMembersThanLeader(member =>
-                    member.Get<MicrobeControl>()
-                        .EmitToxin(ref member.Get<OrganelleContainer>(), member.Get<CompoundStorage>().Compounds,
-                            member, agentType));
+                colony.PerformForOtherColonyMembersThanLeader(m =>
+                    m.Get<MicrobeControl>()
+                        .EmitToxin(ref m.Get<OrganelleContainer>(), m.Get<CompoundStorage>().Compounds,
+                            m, agentType));
             }
 
             if (control.AgentEmissionCooldown > 0)
@@ -161,9 +161,9 @@
                 ref var colony = ref entity.Get<MicrobeColony>();
 
                 // TODO: is it a good idea to allocate a delegate here?
-                colony.PerformForOtherColonyMembersThanLeader(member =>
-                    member.Get<MicrobeControl>()
-                        .QueueSecreteSlime(ref member.Get<OrganelleContainer>(), member, duration));
+                colony.PerformForOtherColonyMembersThanLeader(m =>
+                    m.Get<MicrobeControl>()
+                        .QueueSecreteSlime(ref m.Get<OrganelleContainer>(), m, duration));
             }
 
             if (organelleInfo.SlimeJets == null || organelleInfo.SlimeJets.Count < 1)

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -439,8 +439,11 @@ public partial class CellEditorComponent :
             // Need to reapply the species as changes to it are ignored when the appearance tab is not shown
             UpdateCellVisualization();
 
-            placedHexes.ForEach(entry => entry.Visible = !MicrobePreviewMode);
-            placedModels.ForEach(entry => entry.Visible = !MicrobePreviewMode);
+            foreach (var hex in placedHexes)
+                hex.Visible = !MicrobePreviewMode;
+
+            foreach (var model in placedModels)
+                model.Visible = !MicrobePreviewMode;
         }
     }
 
@@ -1607,7 +1610,7 @@ public partial class CellEditorComponent :
     {
         foreach (var templateHex in organelles
                      .Where(o => o.Definition.InternalName != "cytoplasm")
-                     .SelectMany(o => o.RotatedHexes.Select(hex => hex + o.Position)))
+                     .SelectMany(o => o.RotatedHexes.Select(h => h + o.Position)))
         {
             var existingOrganelle = editedMicrobeOrganelles.GetElementAt(templateHex, hexTemporaryMemory);
 
@@ -2229,7 +2232,7 @@ public partial class CellEditorComponent :
         var input = newText.ToLower(CultureInfo.InvariantCulture);
 
         var organelles = SimulationParameters.Instance.GetAllOrganelles().Where(
-            organelle => organelle.Name.ToLower(CultureInfo.CurrentCulture).Contains(input)).ToList();
+            o => o.Name.ToLower(CultureInfo.CurrentCulture).Contains(input)).ToList();
 
         foreach (var node in placeablePartSelectionElements.Values)
         {

--- a/src/microbe_stage/editor/CompoundBalanceDisplay.cs
+++ b/src/microbe_stage/editor/CompoundBalanceDisplay.cs
@@ -20,7 +20,7 @@ public class CompoundBalanceDisplay : VBoxContainer
         compoundListContainer = GetNode<VBoxContainer>(CompoundListContainerPath);
 
         childCache = new ChildObjectCache<Compound, CompoundAmount>(compoundListContainer,
-            compound => new CompoundAmount { Compound = compound, PrefixPositiveWithPlus = true });
+            c => new CompoundAmount { Compound = c, PrefixPositiveWithPlus = true });
     }
 
     public void UpdateBalances(Dictionary<Compound, CompoundBalance> balances)

--- a/src/microbe_stage/editor/tooltips/SelectionMenuToolTip.cs
+++ b/src/microbe_stage/editor/tooltips/SelectionMenuToolTip.cs
@@ -220,7 +220,7 @@ public class SelectionMenuToolTip : ControlWithInput, ICustomToolTip
 
     public ModifierInfoLabel GetModifierInfo(string nodeName)
     {
-        return modifierInfos.Find(found => found.Name == nodeName);
+        return modifierInfos.Find(m => m.Name == nodeName);
     }
 
     /// <summary>

--- a/src/microbe_stage/editor/upgrades/SingleEditorAction.cs
+++ b/src/microbe_stage/editor/upgrades/SingleEditorAction.cs
@@ -30,11 +30,10 @@ public class SingleEditorAction<T> : EditorAction
     [JsonIgnore]
     public override IEnumerable<EditorCombinableActionData> Data => new[] { SingleData };
 
-    public static implicit operator SingleEditorAction<EditorCombinableActionData>(SingleEditorAction<T> x)
+    public static implicit operator SingleEditorAction<EditorCombinableActionData>(SingleEditorAction<T> action)
     {
-        return new SingleEditorAction<EditorCombinableActionData>(data => x.redo((T)data),
-            data => x.undo((T)data),
-            x.SingleData);
+        return new SingleEditorAction<EditorCombinableActionData>(d => action.redo((T)d),
+            d => action.undo((T)d), action.SingleData);
     }
 
     public override void DoAction()

--- a/src/microbe_stage/organelle_unlocks/UnlockProgress.cs
+++ b/src/microbe_stage/organelle_unlocks/UnlockProgress.cs
@@ -15,7 +15,7 @@ public class UnlockProgress
     /// </summary>
     [JsonProperty]
     private readonly HashSet<OrganelleDefinition> unlockedOrganelles =
-        SimulationParameters.Instance.GetAllOrganelles().Where(organelle => organelle.UnlockConditions == null)
+        SimulationParameters.Instance.GetAllOrganelles().Where(o => o.UnlockConditions == null)
             .ToHashSet();
 
     /// <summary>
@@ -60,10 +60,23 @@ public class UnlockProgress
         if (organelle.UnlockConditions == null || game.FreeBuild || UnlockAll)
             return true;
 
-        if (autoUnlock && organelle.UnlockConditions.Any(unlock => unlock.Satisfied(worldAndPlayerArgs)))
+        if (autoUnlock)
         {
-            UnlockOrganelle(organelle, game);
-            return true;
+            bool anyConditionSatisfied = false;
+            foreach (var condition in organelle.UnlockConditions)
+            {
+                if (condition.Satisfied(worldAndPlayerArgs))
+                {
+                    anyConditionSatisfied = true;
+                    break;
+                }
+            }
+
+            if (anyConditionSatisfied)
+            {
+                UnlockOrganelle(organelle, game);
+                return true;
+            }
         }
 
         return unlockedOrganelles.Contains(organelle);

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -824,8 +824,8 @@
 
             if (detections is { Count: > 0 })
             {
-                ai.LastSmelledCompoundPosition = detections.OrderBy(detection =>
-                    weights.TryGetValue(detection.Compound, out var weight) ?
+                ai.LastSmelledCompoundPosition = detections.OrderBy(d =>
+                    weights.TryGetValue(d.Compound, out var weight) ?
                         weight :
                         0).First().Target;
                 ai.PursuitThreshold = position.Position.DistanceSquaredTo(ai.LastSmelledCompoundPosition.Value)

--- a/src/microbe_stage/systems/SpawnSystem.cs
+++ b/src/microbe_stage/systems/SpawnSystem.cs
@@ -123,7 +123,7 @@
 
                 estimateEntityCount = DespawnEntities();
 
-                spawnTypes.RemoveAll(entity => entity.DestroyQueued);
+                spawnTypes.RemoveAll(s => s.DestroyQueued);
 
                 SpawnAllTypes(ref spawnsLeftThisFrame);
             }

--- a/src/saving/SaveHelper.cs
+++ b/src/saving/SaveHelper.cs
@@ -260,8 +260,8 @@ public static class SaveHelper
             case SaveOrder.LastModifiedFirst:
             {
                 using var file = new File();
-                result = result.OrderByDescending(item =>
-                    file.GetModifiedTime(Path.Combine(Constants.SAVE_FOLDER, item))).ToList();
+                result = result.OrderByDescending(s =>
+                    file.GetModifiedTime(Path.Combine(Constants.SAVE_FOLDER, s))).ToList();
 
                 break;
             }
@@ -269,8 +269,8 @@ public static class SaveHelper
             case SaveOrder.FirstModifiedFirst:
             {
                 using var file = new File();
-                result = result.OrderBy(item =>
-                    file.GetModifiedTime(Path.Combine(Constants.SAVE_FOLDER, item))).ToList();
+                result = result.OrderBy(s =>
+                    file.GetModifiedTime(Path.Combine(Constants.SAVE_FOLDER, s))).ToList();
 
                 break;
             }

--- a/src/saving/SaveManagerGUI.cs
+++ b/src/saving/SaveManagerGUI.cs
@@ -270,11 +270,11 @@ public class SaveManagerGUI : Control
     {
         GUICommon.Instance.PlayButtonPressSound();
 
-        GD.Print("Deleting save(s): ", string.Join(", ", Selected.Select(item => item.SaveName).ToList()));
+        GD.Print("Deleting save(s): ", string.Join(", ", Selected.Select(s => s.SaveName).ToList()));
 
         try
         {
-            Selected.ForEach(item => SaveHelper.DeleteSave(item.SaveName));
+            Selected.ForEach(s => SaveHelper.DeleteSave(s.SaveName));
         }
         catch (IOException e)
         {

--- a/src/saving/serializers/InProgressObjectDeserialization.cs
+++ b/src/saving/serializers/InProgressObjectDeserialization.cs
@@ -438,7 +438,7 @@ public class InProgressObjectDeserialization
         instanceCreationStarted = true;
 
         // Detect scene loaded type
-        bool sceneLoad = type.CustomAttributes.Any(attr => attr.AttributeType == typeof(SceneLoadedClassAttribute));
+        bool sceneLoad = type.CustomAttributes.Any(a => a.AttributeType == typeof(SceneLoadedClassAttribute));
 
         createdInstance = !sceneLoad ?
             CreateDeserializedInstance(type) :

--- a/src/saving/serializers/NodeGroupSaveHelper.cs
+++ b/src/saving/serializers/NodeGroupSaveHelper.cs
@@ -28,7 +28,7 @@ public static class NodeGroupSaveHelper
             var groups = value.GetGroups().Cast<string>().ToList();
 
             // Ignore inbuilt groups
-            groups.RemoveAll(item => item.BeginsWith("_") || IgnoredGroups.Contains(item));
+            groups.RemoveAll(g => g.BeginsWith("_") || IgnoredGroups.Contains(g));
 
             serializer.Serialize(writer, groups.Count > 0 ? groups : null);
         }

--- a/src/saving/serializers/RegistryTypeStringConverter.cs
+++ b/src/saving/serializers/RegistryTypeStringConverter.cs
@@ -18,52 +18,52 @@ public class RegistryTypeStringConverter : TypeConverter
             {
                 "compound",
                 new SupportedRegistryType(typeof(Compound), "compound",
-                    name => SimulationParameters.Instance.GetCompound(name))
+                    n => SimulationParameters.Instance.GetCompound(n))
             },
             {
                 "enzyme",
                 new SupportedRegistryType(typeof(Enzyme), "enzyme",
-                    name => SimulationParameters.Instance.GetEnzyme(name))
+                    n => SimulationParameters.Instance.GetEnzyme(n))
             },
             {
                 "worldResource",
                 new SupportedRegistryType(typeof(WorldResource), "worldResource",
-                    name => SimulationParameters.Instance.GetWorldResource(name))
+                    n => SimulationParameters.Instance.GetWorldResource(n))
             },
             {
                 "equipment",
                 new SupportedRegistryType(typeof(EquipmentDefinition), "equipment",
-                    name => SimulationParameters.Instance.GetBaseEquipmentDefinition(name))
+                    n => SimulationParameters.Instance.GetBaseEquipmentDefinition(n))
             },
             {
                 "recipe",
                 new SupportedRegistryType(typeof(CraftingRecipe), "recipe",
-                    name => SimulationParameters.Instance.GetCraftingRecipe(name))
+                    n => SimulationParameters.Instance.GetCraftingRecipe(n))
             },
             {
                 "structure",
                 new SupportedRegistryType(typeof(StructureDefinition), "structure",
-                    name => SimulationParameters.Instance.GetStructure(name))
+                    n => SimulationParameters.Instance.GetStructure(n))
             },
             {
                 "unitType",
                 new SupportedRegistryType(typeof(UnitType), "unitType",
-                    name => SimulationParameters.Instance.GetUnitType(name))
+                    n => SimulationParameters.Instance.GetUnitType(n))
             },
             {
                 "spaceStructure",
                 new SupportedRegistryType(typeof(SpaceStructureDefinition), "spaceStructure",
-                    name => SimulationParameters.Instance.GetSpaceStructure(name))
+                    n => SimulationParameters.Instance.GetSpaceStructure(n))
             },
             {
                 "biome",
                 new SupportedRegistryType(typeof(Biome), "biome",
-                    name => SimulationParameters.Instance.GetBiome(name))
+                    n => SimulationParameters.Instance.GetBiome(n))
             },
             {
                 "organelle",
                 new SupportedRegistryType(typeof(OrganelleDefinition), "organelle",
-                    name => SimulationParameters.Instance.GetOrganelleType(name))
+                    n => SimulationParameters.Instance.GetOrganelleType(n))
             },
         };
 

--- a/src/saving/serializers/SerializationBinder.cs
+++ b/src/saving/serializers/SerializationBinder.cs
@@ -25,9 +25,9 @@ public class SerializationBinder : DefaultSerializationBinder
         if (type.IsAbstract || type.IsInterface)
             throw new JsonException($"Dynamically typed JSON object is of interface or abstract type {typeName}");
 
-        if (type.CustomAttributes.Any(attr => attr.AttributeType == DynamicTypeAllowedAttribute ||
-                attr.AttributeType == AlwaysDynamicTypeAttribute || attr.AttributeType == SceneLoadedClassAttribute ||
-                attr.AttributeType == CustomizedRegistryTypeAttribute))
+        if (type.CustomAttributes.Any(a => a.AttributeType == DynamicTypeAllowedAttribute ||
+                a.AttributeType == AlwaysDynamicTypeAttribute || a.AttributeType == SceneLoadedClassAttribute ||
+                a.AttributeType == CustomizedRegistryTypeAttribute))
         {
             // Allowed type
             return originalType;

--- a/src/saving/serializers/ThriveJsonConverter.cs
+++ b/src/saving/serializers/ThriveJsonConverter.cs
@@ -83,13 +83,12 @@ public class ThriveJsonConverter : IDisposable
     /// </param>
     public string SerializeObject(object @object, Type? type = null)
     {
-        return PerformWithSettings(settings =>
-            JsonConvert.SerializeObject(@object, type, Constants.SAVE_FORMATTING, settings));
+        return PerformWithSettings(s => JsonConvert.SerializeObject(@object, type, Constants.SAVE_FORMATTING, s));
     }
 
     public T? DeserializeObject<T>(string json)
     {
-        return PerformWithSettings(settings => JsonConvert.DeserializeObject<T>(json, settings));
+        return PerformWithSettings(s => JsonConvert.DeserializeObject<T>(json, s));
     }
 
     /// <summary>
@@ -386,12 +385,12 @@ public abstract class BaseThriveConverter : JsonConverter
     {
         var customAttributeData = customAttributes.ToList();
 
-        bool export = customAttributeData.Any(attr => attr.AttributeType == typeof(ExportAttribute));
+        bool export = customAttributeData.Any(a => a.AttributeType == typeof(ExportAttribute));
 
         if (!export)
             return false;
 
-        return customAttributeData.All(attr => attr.AttributeType != JsonPropertyAttribute);
+        return customAttributeData.All(a => a.AttributeType != JsonPropertyAttribute);
     }
 
     public static bool IsIgnoredGodotMember(string name, Type type)
@@ -670,8 +669,8 @@ public abstract class BaseThriveConverter : JsonConverter
 
                 while (baseType != null && baseType != ObjectBaseType)
                 {
-                    if (baseType.CustomAttributes.Any(attr =>
-                            attr.AttributeType == BaseDynamicTypeAllowedAttribute) ||
+                    if (baseType.CustomAttributes.Any(a =>
+                            a.AttributeType == BaseDynamicTypeAllowedAttribute) ||
                         HasAlwaysJSONTypeWriteAttribute(baseType))
                     {
                         writeType = true;
@@ -864,9 +863,9 @@ public abstract class BaseThriveConverter : JsonConverter
     private static bool HasAlwaysJSONTypeWriteAttribute(Type type)
     {
         // If the current uses scene creation, dynamic type needs to be also in that case output
-        return type.CustomAttributes.Any(attr =>
-            attr.AttributeType == AlwaysDynamicAttribute ||
-            attr.AttributeType == SceneLoadedAttribute);
+        return type.CustomAttributes.Any(a =>
+            a.AttributeType == AlwaysDynamicAttribute ||
+            a.AttributeType == SceneLoadedAttribute);
     }
 
     private static bool UsesOnlyChildAssign(IEnumerable<Attribute> customAttributes,
@@ -1045,8 +1044,8 @@ internal class DefaultThriveJSONConverter : BaseThriveConverter
     public override bool CanConvert(Type objectType)
     {
         // Types with out custom attribute are supported
-        if (objectType.CustomAttributes.Any(attr =>
-                attr.AttributeType == UseSerializerAttribute || attr.AttributeType == SceneLoadedAttribute))
+        if (objectType.CustomAttributes.Any(a =>
+                a.AttributeType == UseSerializerAttribute || a.AttributeType == SceneLoadedAttribute))
         {
             return true;
         }

--- a/src/saving/serializers/ThriveTypeConverter.cs
+++ b/src/saving/serializers/ThriveTypeConverter.cs
@@ -25,7 +25,7 @@ public class ThriveTypeConverter : TypeConverter
     public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
     {
         return destinationType == StringType || destinationType.CustomAttributes.Any(
-            attr => attr.AttributeType == typeof(UseThriveConverterAttribute));
+            a => a.AttributeType == typeof(UseThriveConverterAttribute));
     }
 
     public override object? ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object? value)
@@ -44,9 +44,9 @@ public class ThriveTypeConverter : TypeConverter
         {
             var type = value.GetType();
 
-            if (type.CustomAttributes.Any(attr =>
-                    attr.AttributeType == typeof(JSONAlwaysDynamicTypeAttribute) ||
-                    attr.AttributeType == typeof(JSONDynamicTypeAllowedAttribute)))
+            if (type.CustomAttributes.Any(a =>
+                    a.AttributeType == typeof(JSONAlwaysDynamicTypeAttribute) ||
+                    a.AttributeType == typeof(JSONDynamicTypeAllowedAttribute)))
             {
                 type = type.BaseType;
             }

--- a/src/thriveopedia/Thriveopedia.cs
+++ b/src/thriveopedia/Thriveopedia.cs
@@ -477,7 +477,7 @@ public class Thriveopedia : ControlWithInput
             var children = GetAllChildren(page);
 
             if (page.TranslatedPageName.ToLower().Contains(newText.ToLower()) ||
-                children.Any(child => child.TranslatedPageName.ToLower().Contains(newText.ToLower())))
+                children.Any(c => c.TranslatedPageName.ToLower().Contains(newText.ToLower())))
             {
                 // We can assume a page is always before its children in the list of all pages
                 allPages[page] = CreateTreeItem(page, page.ParentPageName);

--- a/src/thriveopedia/fossilisation/FossilisedSpecies.cs
+++ b/src/thriveopedia/fossilisation/FossilisedSpecies.cs
@@ -94,8 +94,8 @@ public class FossilisedSpecies
         if (orderByDate)
         {
             using var file = new File();
-            result = result.OrderBy(item =>
-                file.GetModifiedTime(Path.Combine(Constants.FOSSILISED_SPECIES_FOLDER, item))).ToList();
+            result = result.OrderBy(s =>
+                file.GetModifiedTime(Path.Combine(Constants.FOSSILISED_SPECIES_FOLDER, s))).ToList();
         }
 
         return result;

--- a/src/tutorial/TutorialState.cs
+++ b/src/tutorial/TutorialState.cs
@@ -131,7 +131,7 @@ public class TutorialState : ITutorialInput
     ///   True if any of the tutorials are active that want to pause the game
     /// </summary>
     [JsonIgnore]
-    public bool WantsGamePaused => Tutorials.Any(tutorial => tutorial.WantsPaused);
+    public bool WantsGamePaused => Tutorials.Any(t => t.WantsPaused);
 
     [JsonIgnore]
     public IEnumerable<TutorialPhase> Tutorials
@@ -186,7 +186,7 @@ public class TutorialState : ITutorialInput
     /// <returns>True if any tutorial is visible</returns>
     public bool TutorialActive()
     {
-        return Tutorials.Any(tutorial => tutorial.ShownCurrently);
+        return Tutorials.Any(t => t.ShownCurrently);
     }
 
     /// <summary>


### PR DESCRIPTION
statements, and fixed a few simple places that allocated memory just for looping. Left some lambda parameters alone that were for long non-LINQ blocks to help readability a bit.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #2935

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
