### PR TITLE
Fixed ATP low text not turning red

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -493,13 +493,13 @@ public partial class CellEditorComponent
         if (energyBalance.FinalBalance > 0)
         {
             atpBalanceLabel.Text = Localization.Translate("ATP_PRODUCTION");
-            atpBalanceLabel.AddThemeColorOverride("font_color", new Color(1.0f, 1.0f, 1.0f));
+            atpBalanceLabel.LabelSettings = ATPBalanceNormalText;
         }
         else
         {
             atpBalanceLabel.Text = Localization.Translate("ATP_PRODUCTION") + " - " +
                 Localization.Translate("ATP_PRODUCTION_TOO_LOW");
-            atpBalanceLabel.AddThemeColorOverride("font_color", new Color(1.0f, 0.2f, 0.2f));
+            atpBalanceLabel.LabelSettings = ATPBalanceNotEnoughText;
         }
 
         atpProductionLabel.Text = string.Format(CultureInfo.CurrentCulture, "{0:F1}", energyBalance.TotalProduction);

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -110,9 +110,6 @@ public partial class CellEditorComponent :
     public NodePath ATPBalancePanelPath = null!;
 
     [Export]
-    public NodePath ATPBalanceLabelPath = null!;
-
-    [Export]
     public NodePath ATPProductionLabelPath = null!;
 
     [Export]
@@ -147,6 +144,14 @@ public partial class CellEditorComponent :
 
     [Export]
     public NodePath RightPanelScrollContainerPath = null!;
+
+#pragma warning disable CA2213
+    [Export]
+    public LabelSettings ATPBalanceNormalText = null!;
+
+    [Export]
+    public LabelSettings ATPBalanceNotEnoughText = null!;
+#pragma warning restore CA2213
 
     /// <summary>
     ///   Temporary hex memory for use by the main thread in this component
@@ -220,7 +225,10 @@ public partial class CellEditorComponent :
     private TweakedColourPicker membraneColorPicker = null!;
 
     private Control atpBalancePanel = null!;
+
+    [Export]
     private Label atpBalanceLabel = null!;
+
     private Label atpProductionLabel = null!;
     private Label atpConsumptionLabel = null!;
     private SegmentedBar atpProductionBar = null!;
@@ -627,7 +635,6 @@ public partial class CellEditorComponent :
         membraneColorPicker = GetNode<TweakedColourPicker>(MembraneColorPickerPath);
 
         atpBalancePanel = GetNode<Control>(ATPBalancePanelPath);
-        atpBalanceLabel = GetNode<Label>(ATPBalanceLabelPath);
         atpProductionLabel = GetNode<Label>(ATPProductionLabelPath);
         atpConsumptionLabel = GetNode<Label>(ATPConsumptionLabelPath);
         atpProductionBar = GetNode<SegmentedBar>(ATPProductionBarPath);
@@ -1379,7 +1386,6 @@ public partial class CellEditorComponent :
                 BestPatchLabelPath.Dispose();
                 MembraneColorPickerPath.Dispose();
                 ATPBalancePanelPath.Dispose();
-                ATPBalanceLabelPath.Dispose();
                 ATPProductionLabelPath.Dispose();
                 ATPConsumptionLabelPath.Dispose();
                 ATPProductionBarPath.Dispose();

--- a/src/microbe_stage/editor/CellEditorComponent.tscn
+++ b/src/microbe_stage/editor/CellEditorComponent.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=61 format=3 uid="uid://cwot2e52r7lx0"]
+[gd_scene load_steps=62 format=3 uid="uid://cwot2e52r7lx0"]
 
 [ext_resource type="PackedScene" uid="uid://bwegwjlcioasf" path="res://src/microbe_stage/editor/EditorComponentBottomLeftButtons.tscn" id="3"]
 [ext_resource type="Script" path="res://src/microbe_stage/editor/CellEditorComponent.cs" id="4"]
+[ext_resource type="LabelSettings" uid="uid://o0tip7etc0x2" path="res://src/gui_common/fonts/Body-Bold-Small-Red.tres" id="4_fhdek"]
 [ext_resource type="Theme" uid="uid://b4cx0o110g4b6" path="res://src/gui_common/thrive_theme.tres" id="6"]
 [ext_resource type="PackedScene" uid="uid://seoiqsheiljf" path="res://src/microbe_stage/editor/MutationPointsBar.tscn" id="7"]
 [ext_resource type="FontVariation" uid="uid://cik4lxxj7fi2t" path="res://assets/fonts/variants/Jura-Regular.tres" id="8_07qd0"]
@@ -344,7 +345,7 @@ _data = {
 "show": SubResource("44")
 }
 
-[node name="CellEditorComponent" type="Control"]
+[node name="CellEditorComponent" type="Control" node_paths=PackedStringArray("atpBalanceLabel")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -386,7 +387,6 @@ WorstPatchLabelPath = NodePath("RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxCo
 BestPatchLabelPath = NodePath("RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/Best/Value")
 MembraneColorPickerPath = NodePath("LeftPanel/MainPanel/VBoxContainer/MarginContainer/EditingPanel/Membrane/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer2/TweakedColourPicker")
 ATPBalancePanelPath = NodePath("RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/ATPBalancePanel")
-ATPBalanceLabelPath = NodePath("RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/ATPBalancePanel/VBoxContainer/Label")
 ATPProductionLabelPath = NodePath("RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/ATPBalancePanel/VBoxContainer/ATPBarContainer/HBoxContainer/Label")
 ATPConsumptionLabelPath = NodePath("RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/ATPBalancePanel/VBoxContainer/ATPBarContainer/HBoxContainer2/Label")
 ATPProductionBarPath = NodePath("RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/ATPBalancePanel/VBoxContainer/ATPBarContainer/HBoxContainer/ATPProductionBar")
@@ -399,6 +399,9 @@ AutoEvoPredictionExplanationPopupPath = NodePath("PredictionExplanation")
 AutoEvoPredictionExplanationLabelPath = NodePath("PredictionExplanation/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ExplanationText")
 OrganelleUpgradeGUIPath = NodePath("OrganelleUpgradeGUI")
 RightPanelScrollContainerPath = NodePath("RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer")
+ATPBalanceNormalText = ExtResource("24_ekuel")
+ATPBalanceNotEnoughText = ExtResource("4_fhdek")
+atpBalanceLabel = NodePath("RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/ATPBalancePanel/VBoxContainer/ATPBalanceTitle")
 IslandErrorPath = NodePath("IslandError")
 MutationPointsBarPath = NodePath("LeftPanel/MainPanel/VBoxContainer/MarginContainer2/MutationPointsBar")
 ComponentBottomLeftButtonsPath = NodePath("EditorComponentBottomLeftButtons")
@@ -906,11 +909,13 @@ theme_override_constants/margin_bottom = 3
 layout_mode = 2
 theme_override_constants/separation = 0
 
-[node name="Label" type="Label" parent="RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/ATPBalancePanel/VBoxContainer"]
+[node name="ATPBalanceTitle" type="Label" parent="RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/ATPBalancePanel/VBoxContainer"]
+custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 text = "ATP_BALANCE"
 label_settings = ExtResource("24_ekuel")
+autowrap_mode = 3
 
 [node name="Separator" type="Control" parent="RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/ATPBalancePanel/VBoxContainer"]
 custom_minimum_size = Vector2(0, 5)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes the ATP balance bar title text

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
