### PR TITLE
Fixed steam library loading with Godot 4

### DIFF
--- a/src/engine/FeatureInformation.cs
+++ b/src/engine/FeatureInformation.cs
@@ -46,6 +46,11 @@ public static class FeatureInformation
         return GetOS() == PlatformLinux;
     }
 
+    public static bool IsWindows()
+    {
+        return GetOS() == PlatformWindows;
+    }
+
     public static bool IsMac()
     {
         return GetOS() == PlatformMac;

--- a/src/native/interop/NativeInterop.cs
+++ b/src/native/interop/NativeInterop.cs
@@ -32,6 +32,10 @@ public static class NativeInterop
 
     private static bool printedDistributableNotice;
 
+#if DEBUG
+    private static bool printedSteamLibName;
+#endif
+
     public delegate void OnLineDraw(Vector3 from, Vector3 to, Color colour);
 
     public delegate void OnTriangleDraw(Vector3 vertex1, Vector3 vertex2, Vector3 vertex3, Color colour);
@@ -395,7 +399,11 @@ public static class NativeInterop
             }
 
 #if DEBUG
-            GD.Print("Searching for Steam library: ", steamName);
+            if (!printedSteamLibName)
+            {
+                GD.Print("Searching for Steam library: ", steamName);
+                printedSteamLibName = true;
+            }
 #endif
 
             if (LookForLibraryUpInFolders(steamName, out loaded))

--- a/src/steam/SteamClient.cs
+++ b/src/steam/SteamClient.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Godot;
 using Steamworks;
 using Directory = System.IO.Directory;
 using File = System.IO.File;
-using Object = Godot.Object;
 using Path = System.IO.Path;
 
 /// <summary>
@@ -62,6 +62,10 @@ public sealed class SteamClient : ISteamClient
 
         GD.Print("Starting Steam load");
 
+        // Need to ensure this is set for steam library loading to work
+        NativeInterop.SetDllImportResolver(Assembly.GetAssembly(typeof(SteamAPI)) ??
+            throw new Exception("Couldn't determine Steamworks.NET assembly"));
+
         if (!SteamAPI.Init())
         {
             GD.PrintErr("Failed to init Steam");
@@ -96,7 +100,7 @@ public sealed class SteamClient : ISteamClient
     }
 
     public void ConnectSignals<T>(T receiver)
-        where T : Object, ISteamSignalReceiver
+        where T : GodotObject, ISteamSignalReceiver
     {
         if (!IsLoaded)
             return;
@@ -258,8 +262,7 @@ public sealed class SteamClient : ISteamClient
         // description max length
         if (changeNotes?.Length > Steamworks.Constants.k_cchPublishedDocumentChangeDescriptionMax)
         {
-            callback.Invoke(
-                WorkshopResult.CreateFailure(Localization.Translate("CHANGE_DESCRIPTION_IS_TOO_LONG")));
+            callback.Invoke(WorkshopResult.CreateFailure(Localization.Translate("CHANGE_DESCRIPTION_IS_TOO_LONG")));
             return;
         }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes the steam compile mode to work again. Note that the C# library for steam doesn't work with latest steamworks SDK so an older SDK version needs to be used for now: https://github.com/rlabrecque/Steamworks.NET/issues/603 

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
