### PR TITLE
Fixed modifier info labels causing errors only when game was exported

### DIFF
--- a/src/general/utils/StringUtils.cs
+++ b/src/general/utils/StringUtils.cs
@@ -256,7 +256,8 @@ public static class StringUtils
 
     public static string FormatPositiveWithLeadingPlus(float value)
     {
-        if (value < 0)
+        // This check works better than "< 0" as this handles negative zero
+        if (float.IsNegative(value))
             return value.ToString(CultureInfo.CurrentCulture);
 
         return '+' + value.ToString(CultureInfo.CurrentCulture);
@@ -272,7 +273,7 @@ public static class StringUtils
 
     public static string FormatPositiveWithLeadingPlus(string formatted, double value)
     {
-        if (value < 0)
+        if (double.IsNegative(value))
             return formatted;
 
         return '+' + formatted;
@@ -474,7 +475,7 @@ public static class StringUtils
 
         if (number < 0)
         {
-            // This also isn't a thing in roman numerals but we should support this
+            // This also isn't a thing in roman numerals, but we should support this
             builder.Append('-');
 
             number *= -1;

--- a/src/gui_common/tooltip/ToolTipManager.tscn
+++ b/src/gui_common/tooltip/ToolTipManager.tscn
@@ -266,7 +266,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="metabolosome" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -293,7 +293,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="chromatophore" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -315,7 +315,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="chemoSynthesizingProteins" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -340,7 +340,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="rusticyanin" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -362,7 +362,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="nitrogenase" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -384,7 +384,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="oxytoxyProteins" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -407,7 +407,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="thermosynthase" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -446,7 +446,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="VScrollBar2" type="VScrollBar" parent="GroupHolder/organelleSelection/thermosynthase/MarginContainer/VBoxContainer/Description" index="1"]
@@ -490,7 +490,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="slimeJet" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -512,7 +512,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="pilus" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -528,7 +528,7 @@ ThriveopediaPageName = "pilus"
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="chemoreceptor" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -544,7 +544,7 @@ ThriveopediaPageName = "chemoreceptor"
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="cilia" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -561,7 +561,7 @@ ThriveopediaPageName = "cilia"
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="bindingAgent" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -584,7 +584,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="nucleus" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -606,7 +606,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+10"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="mitochondrion" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -629,7 +629,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+2"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="chloroplast" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -652,7 +652,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+3"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="thermoplast" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -675,7 +675,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+2"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="chemoplast" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -698,7 +698,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+2"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="nitrogenfixingplastid" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -721,7 +721,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+2"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="vacuole" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -745,7 +745,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="oxytoxy" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -768,7 +768,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="signalingAgent" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -791,7 +791,7 @@ ModifierIcon = ExtResource("9")
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="bioluminescentVacuole" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -848,7 +848,7 @@ layout_mode = 2
 mouse_filter = 2
 DisplayName = "OSMOREGULATION_COST"
 ModifierValue = "+1"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="axon" parent="GroupHolder/organelleSelection" instance=ExtResource("5")]
@@ -925,7 +925,7 @@ ModifierIcon = ExtResource("7")
 [node name="osmoregulationCost" parent="GroupHolder/membraneSelection/single/MarginContainer/VBoxContainer/ModifierList" index="1" instance=ExtResource("2")]
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="resourceAbsorptionSpeed" parent="GroupHolder/membraneSelection/single/MarginContainer/VBoxContainer/ModifierList" index="2" instance=ExtResource("2")]
@@ -962,7 +962,7 @@ ModifierIcon = ExtResource("7")
 [node name="osmoregulationCost" parent="GroupHolder/membraneSelection/double/MarginContainer/VBoxContainer/ModifierList" index="1" instance=ExtResource("2")]
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="resourceAbsorptionSpeed" parent="GroupHolder/membraneSelection/double/MarginContainer/VBoxContainer/ModifierList" index="2" instance=ExtResource("2")]
@@ -999,7 +999,7 @@ ModifierIcon = ExtResource("7")
 [node name="osmoregulationCost" parent="GroupHolder/membraneSelection/cellulose/MarginContainer/VBoxContainer/ModifierList" index="1" instance=ExtResource("2")]
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="resourceAbsorptionSpeed" parent="GroupHolder/membraneSelection/cellulose/MarginContainer/VBoxContainer/ModifierList" index="2" instance=ExtResource("2")]
@@ -1051,7 +1051,7 @@ ModifierIcon = ExtResource("7")
 [node name="osmoregulationCost" parent="GroupHolder/membraneSelection/chitin/MarginContainer/VBoxContainer/ModifierList" index="1" instance=ExtResource("2")]
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="resourceAbsorptionSpeed" parent="GroupHolder/membraneSelection/chitin/MarginContainer/VBoxContainer/ModifierList" index="2" instance=ExtResource("2")]
@@ -1103,7 +1103,7 @@ ModifierIcon = ExtResource("7")
 [node name="osmoregulationCost" parent="GroupHolder/membraneSelection/calciumCarbonate/MarginContainer/VBoxContainer/ModifierList" index="1" instance=ExtResource("2")]
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="resourceAbsorptionSpeed" parent="GroupHolder/membraneSelection/calciumCarbonate/MarginContainer/VBoxContainer/ModifierList" index="2" instance=ExtResource("2")]
@@ -1156,7 +1156,7 @@ ModifierIcon = ExtResource("7")
 [node name="osmoregulationCost" parent="GroupHolder/membraneSelection/silica/MarginContainer/VBoxContainer/ModifierList" index="1" instance=ExtResource("2")]
 layout_mode = 2
 DisplayName = "OSMOREGULATION_COST"
-ModifierValueColor = ExtResource("10_xjuqe")
+ModifierValueFont = ExtResource("10_xjuqe")
 ModifierIcon = ExtResource("6")
 
 [node name="resourceAbsorptionSpeed" parent="GroupHolder/membraneSelection/silica/MarginContainer/VBoxContainer/ModifierList" index="2" instance=ExtResource("2")]

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -152,6 +152,10 @@ public partial class CellEditorComponent
         float healthChange = convertedRigidity * Constants.MEMBRANE_RIGIDITY_HITPOINTS_MODIFIER;
         float baseMobilityChange = -1 * convertedRigidity * Constants.MEMBRANE_RIGIDITY_BASE_MOBILITY_MODIFIER;
 
+        // Don't show negative zero
+        if (baseMobilityChange == 0 && float.IsNegative(baseMobilityChange))
+            baseMobilityChange = 0;
+
         if (healthModifier != null)
         {
             healthModifier.ModifierValue =

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -946,7 +946,7 @@ public partial class CellEditorComponent :
             return true;
 
         // Show warning popup if trying to exit with negative atp production
-        // Not shown in multicellular as the popup happens in kind of a weird place
+        // Not shown in multicellular as the popup happens in kind of weird place
         if (!IsMulticellularEditor && IsNegativeAtpProduction())
         {
             negativeAtpPopup.PopupCenteredShrink();

--- a/src/microbe_stage/editor/tooltips/ModifierInfoLabel.cs
+++ b/src/microbe_stage/editor/tooltips/ModifierInfoLabel.cs
@@ -12,8 +12,8 @@ public partial class ModifierInfoLabel : HBoxContainer
     private Label? valueLabel;
     private TextureRect? icon;
 
-    private LabelSettings modifierNameColor = null!;
-    private LabelSettings modifierValueColor = null!;
+    private LabelSettings modifierNameFont = null!;
+    private LabelSettings modifierValueFont = null!;
 
     private LabelSettings? originalModifier;
     private LabelSettings? positiveModifierColour;
@@ -50,30 +50,30 @@ public partial class ModifierInfoLabel : HBoxContainer
     }
 
     [Export]
-    public LabelSettings ModifierNameColor
+    public LabelSettings ModifierNameFont
     {
-        get => modifierNameColor;
+        get => modifierNameFont;
         set
         {
             // These null checks were added here to guard against bug only in exported game
             if (value == null!)
                 throw new ArgumentNullException();
 
-            modifierNameColor = value;
+            modifierNameFont = value;
             UpdateName();
         }
     }
 
     [Export]
-    public LabelSettings ModifierValueColor
+    public LabelSettings ModifierValueFont
     {
-        get => modifierValueColor;
+        get => modifierValueFont;
         set
         {
             if (value == null!)
                 throw new ArgumentNullException();
 
-            modifierValueColor = value;
+            modifierValueFont = value;
 
             // This is called before the cleanup below as this will stop using the data to be deleted
             UpdateValue();
@@ -115,13 +115,13 @@ public partial class ModifierInfoLabel : HBoxContainer
     public override void _Ready()
     {
         // These null checks were added here to guard against bug only in exported game
-        if (modifierNameColor == null)
+        if (modifierNameFont == null)
         {
             throw new InvalidOperationException("Modifier info label doesn't have name font set, at: " +
                 GetPath());
         }
 
-        if (modifierValueColor == null)
+        if (modifierValueFont == null)
         {
             throw new InvalidOperationException("Modifier info label doesn't have value font set, at: " +
                 GetPath());
@@ -151,7 +151,7 @@ public partial class ModifierInfoLabel : HBoxContainer
     /// </param>
     public void AdjustValueColor(float value, bool inverted = false)
     {
-        originalModifier ??= ModifierValueColor;
+        originalModifier ??= ModifierValueFont;
 
         // Note that this method doesn't set things through ModifierValueColor as that would be detected as a new
         // default colour. This is a bit of a mess as this code wasn't re-architected for Godot 4 but instead hacked
@@ -162,30 +162,30 @@ public partial class ModifierInfoLabel : HBoxContainer
             if (inverted)
             {
                 negativeModifierColour ??= originalModifier.CloneWithDifferentColour(new Color(1, 0.3f, 0.3f));
-                modifierValueColor = negativeModifierColour;
+                modifierValueFont = negativeModifierColour;
             }
             else
             {
                 positiveModifierColour ??= originalModifier.CloneWithDifferentColour(new Color(0, 1, 0));
-                modifierValueColor = positiveModifierColour;
+                modifierValueFont = positiveModifierColour;
             }
         }
         else if (value == 0)
         {
             if (originalModifier != null)
-                modifierValueColor = originalModifier;
+                modifierValueFont = originalModifier;
         }
         else
         {
             if (inverted)
             {
                 positiveModifierColour ??= originalModifier.CloneWithDifferentColour(new Color(0, 1, 0));
-                modifierValueColor = positiveModifierColour;
+                modifierValueFont = positiveModifierColour;
             }
             else
             {
                 negativeModifierColour ??= originalModifier.CloneWithDifferentColour(new Color(1, 0.3f, 0.3f));
-                modifierValueColor = negativeModifierColour;
+                modifierValueFont = negativeModifierColour;
             }
         }
 
@@ -204,7 +204,7 @@ public partial class ModifierInfoLabel : HBoxContainer
             return;
 
         nameLabel.Text = displayName;
-        nameLabel.LabelSettings = modifierNameColor;
+        nameLabel.LabelSettings = modifierNameFont;
     }
 
     private void UpdateValue()
@@ -216,7 +216,7 @@ public partial class ModifierInfoLabel : HBoxContainer
 
         valueLabel.Text = modifierValue;
 
-        valueLabel.LabelSettings = modifierValueColor;
+        valueLabel.LabelSettings = modifierValueFont;
     }
 
     private void UpdateIcon()

--- a/src/microbe_stage/editor/tooltips/ModifierInfoLabel.tscn
+++ b/src/microbe_stage/editor/tooltips/ModifierInfoLabel.tscn
@@ -10,8 +10,8 @@ offset_right = 28.0
 offset_bottom = 20.0
 size_flags_horizontal = 3
 script = ExtResource("3")
-ModifierNameColor = ExtResource("2_1r5af")
-ModifierValueColor = ExtResource("3_jhdqu")
+ModifierNameFont = ExtResource("2_1r5af")
+ModifierValueFont = ExtResource("3_jhdqu")
 
 [node name="Icon" type="TextureRect" parent="."]
 custom_minimum_size = Vector2(20, 20)


### PR DESCRIPTION
**Brief Description of What This PR Does**
Turns out it was some stale data that only got added to the scn (binary) variant of the tooltip manager when it was exported.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

Fixes this exception:
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at LabelSettingsUtils.CloneWithDifferentColour(LabelSettings settings, Color newColour) in /home/hhyyrylainen/Projects/Thrive/src/general/utils/LabelSettingsUtils.cs:line 13
   at ModifierInfoLabel.<.ctor>b__12_1() in /home/hhyyrylainen/Projects/Thrive/src/microbe_stage/editor/tooltips/ModifierInfoLabel.cs:line 37
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at ModifierInfoLabel.AdjustValueColor(Single value, Boolean inverted) in /home/hhyyrylainen/Projects/Thrive/src/microbe_stage/editor/tooltips/ModifierInfoLabel.cs:line 148
   at SelectionMenuToolTip.WriteMembraneModifierList(MembraneType referenceMembrane, MembraneType membraneType) in /home/hhyyrylainen/Projects/Thrive/src/microbe_stage/editor/tooltips/SelectionMenuToolTip.cs:line 319
   at CellEditorComponent.SetMembraneTooltips(MembraneType referenceMembrane) in /home/hhyyrylainen/Projects/Thrive/src/microbe_stage/editor/CellEditorComponent.GUI.cs:line 104
   at CellEditorComponent.SetSpeciesInfo(String name, MembraneType membrane, Color colour, Single rigidity, BehaviourDictionary behaviour) in /home/hhyyrylainen/Projects/Thrive/src/microbe_stage/editor/CellEditorComponent.cs:line 2050
   at CellEditorComponent.UpdateGUIAfterLoadingSpecies(Species species, ICellDefinition definition) in /home/hhyyrylainen/Projects/Thrive/src/microbe_stage/editor/CellEditorComponent.GUI.cs:line 667
   at CellEditorComponent.OnEditorSpeciesSetup(Species species) in /home/hhyyrylainen/Projects/Thrive/src/microbe_stage/editor/CellEditorComponent.cs:line 866
   at EditorBase`2.SetupEditedSpecies() in /home/hhyyrylainen/Projects/Thrive/src/general/base_stage/EditorBase.cs:line 825
   at MicrobeEditor.SetupEditedSpecies() in /home/hhyyrylainen/Projects/Thrive/src/microbe_stage/editor/MicrobeEditor.cs:line 339
   at EditorBase`2.InitEditor(Boolean fresh) in /home/hhyyrylainen/Projects/Thrive/src/general/base_stage/EditorBase.cs:line 569
   at MicrobeEditor.InitEditor(Boolean fresh) in /home/hhyyrylainen/Projects/Thrive/src/microbe_stage/editor/MicrobeEditor.cs:line 140
   at EditorBase`2.OnEnterEditor() in /home/hhyyrylainen/Projects/Thrive/src/general/base_stage/EditorBase.cs:line 668
   at MicrobeEditor.OnEnterEditor() in /home/hhyyrylainen/Projects/Thrive/src/microbe_stage/editor/MicrobeEditor.cs:line 188
   at EditorBase`2._Ready() in /home/hhyyrylainen/Projects/Thrive/src/general/base_stage/EditorBase.cs:line 208
   at MicrobeEditor._Ready() in /home/hhyyrylainen/Projects/Thrive/src/microbe_stage/editor/MicrobeEditor.cs:line 70
   at Godot.Node.InvokeGodotClassMethod(godot_string_name& method, NativeVariantPtrArgs args, godot_variant& ret)
   at NodeWithInput.InvokeGodotClassMethod(godot_string_name& method, NativeVariantPtrArgs args, godot_variant& ret) in /home/hhyyrylainen/Projects/Thrive/Godot.SourceGenerators/Godot.SourceGenerators.ScriptMethodsGenerator/NodeWithInput_ScriptMethods.generated.cs:line 48
   at EditorBase`2.InvokeGodotClassMethod(godot_string_name& method, NativeVariantPtrArgs args, godot_variant& ret) in /home/hhyyrylainen/Projects/Thrive/Godot.SourceGenerators/Godot.SourceGenerators.ScriptMethodsGenerator/EditorBase(Of TAction, TStage)_ScriptMethods.generated.cs:line 458
   at MicrobeEditor.InvokeGodotClassMethod(godot_string_name& method, NativeVariantPtrArgs args, godot_variant& ret) in /home/hhyyrylainen/Projects/Thrive/Godot.SourceGenerators/Godot.SourceGenerators.ScriptMethodsGenerator/MicrobeEditor_ScriptMethods.generated.cs:line 228
   at Godot.Bridge.CSharpInstanceBridge.Call(IntPtr godotObjectGCHandle, godot_string_name* method, godot_variant** args, Int32 argCount, godot_variant_call_error* refCallError, godot_variant* ret)
   at: void Godot.NativeInterop.ExceptionUtils.LogException(System.Exception) (:0)
```

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
