### PR TITLE
Fixed window close button passing input upwards

### DIFF
--- a/src/gui_common/dialogs/CustomWindow.cs
+++ b/src/gui_common/dialogs/CustomWindow.cs
@@ -378,7 +378,7 @@ public partial class CustomWindow : TopLevelContainer
     }
 
     /// <summary>
-    ///   Overrides the minimum size to account for default elements (e.g title, close button, margin) rect size
+    ///   Overrides the minimum size to account for default elements (e.g. title, close button, margin) rect size
     ///   and for the other custom added contents on the window.
     /// </summary>
     public override Vector2 _GetMinimumSize()
@@ -678,7 +678,8 @@ public partial class CustomWindow : TopLevelContainer
         {
             StretchMode = TextureButton.StretchModeEnum.KeepAspectCentered,
             CustomMinimumSize = new Vector2(14, 14),
-            MouseFilter = MouseFilterEnum.Pass,
+            MouseFilter = MouseFilterEnum.Stop,
+            MouseForcePassScrollEvents = false,
         };
 
         closeButton.SetAnchorsPreset(LayoutPreset.TopRight);


### PR DESCRIPTION
which caused for example the editor to try to place something

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
