### PR TITLE
Fixed icons in custom dropdowns

### DIFF
--- a/src/auto-evo/AutoEvoExploringTool.tscn
+++ b/src/auto-evo/AutoEvoExploringTool.tscn
@@ -663,6 +663,7 @@ label_settings = ExtResource("5_6c001")
 
 [node name="ResultsLabel" parent="GUI/VBoxContainer/HistoryReportSplit/Report/ResultsPanel/MarginContainer/ScrollContainer/VBoxContainer" instance=ExtResource("5")]
 layout_mode = 2
+fit_content = true
 
 [node name="Viewer" type="Control" parent="GUI/VBoxContainer/HistoryReportSplit"]
 visible = false

--- a/src/engine/common_systems/AnimationControlSystem.cs
+++ b/src/engine/common_systems/AnimationControlSystem.cs
@@ -54,7 +54,9 @@ public sealed class AnimationControlSystem : AEntitySetSystem<float>
         if (animation.StopPlaying)
         {
             // Reset this to make sure the animation doesn't start again behind our backs
-            player.Autoplay = null;
+            // But only if not already in the tree, as Godot will complain uselessly about this
+            if (!player.IsInsideTree())
+                player.Autoplay = null;
 
             // TODO: parameter in the component to allow passing reset: false?
             player.Stop();

--- a/src/gui_common/CustomDropDown.cs
+++ b/src/gui_common/CustomDropDown.cs
@@ -30,7 +30,7 @@ public partial class CustomDropDown : MenuButton
     {
         Popup = GetPopup();
 
-        cachedPopupVSeparation = Popup.GetThemeConstant("vseparation");
+        cachedPopupVSeparation = Popup.GetThemeConstant("v_separation");
 
         var checkSize = Popup.GetThemeIcon("checked").GetSize();
 
@@ -227,7 +227,7 @@ public partial class CustomDropDown : MenuButton
             {
                 if (item.Separator && item.Text != "default")
                 {
-                    height += font.GetHeight() + Popup.GetThemeConstant("vseparation");
+                    height += font.GetHeight() + Popup.GetThemeConstant("v_separation");
                     continue;
                 }
 
@@ -241,14 +241,14 @@ public partial class CustomDropDown : MenuButton
                 // See the comment about QueueRedraw() problems with the new Popup implementation in this file
                 DrawTextureRect(item.Icon, new Rect2(position, iconSize), false, item.Color);
 
-                height += font.GetHeight() + Popup.GetThemeConstant("vseparation");
+                height += font.GetHeight() + Popup.GetThemeConstant("v_separation");
             }
         }
     }
 
     private void OnPopupAboutToShow()
     {
-        Popup.AddThemeConstantOverride("vseparation", -14);
+        Popup.AddThemeConstantOverride("v_separation", -14);
 
         // Animate slide down
 
@@ -257,7 +257,8 @@ public partial class CustomDropDown : MenuButton
         tween.SetTrans(Tween.TransitionType.Cubic);
         tween.SetEase(Tween.EaseType.Out);
 
-        tween.TweenProperty(Popup, "custom_constants/vseparation", cachedPopupVSeparation, 0.1).From(-14);
+        // TODO: cache string name
+        tween.TweenProperty(Popup, "theme_override_constants/v_separation", cachedPopupVSeparation, 0.1).From(-14);
     }
 
     /// <summary>

--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -129,14 +129,14 @@ public partial class PlayerMicrobeInput : NodeWithInput
     }
 
     [RunOnKey("g_secrete_slime")]
-    public void SecreteSlime(float delta)
+    public void SecreteSlime(double delta)
     {
         if (!stage.HasPlayer)
             return;
 
         ref var control = ref stage.Player.Get<MicrobeControl>();
 
-        control.QueueSecreteSlime(ref stage.Player.Get<OrganelleContainer>(), stage.Player, delta);
+        control.QueueSecreteSlime(ref stage.Player.Get<OrganelleContainer>(), stage.Player, (float)delta);
     }
 
     [RunOnKeyDown("g_toggle_engulf")]

--- a/src/microbe_stage/gui/CompoundPanels.cs
+++ b/src/microbe_stage/gui/CompoundPanels.cs
@@ -7,8 +7,8 @@ using Godot;
 /// </summary>
 public partial class CompoundPanels : BarPanelBase
 {
-    private readonly StringName vSeparationReference = new("vseparation");
-    private readonly StringName hSeparationReference = new("hseparation");
+    private readonly StringName vSeparationReference = new("v_separation");
+    private readonly StringName hSeparationReference = new("h_separation");
 
     private readonly List<CompoundProgressBar> agentsCreatedBars = new();
 

--- a/src/microbe_stage/gui/EnvironmentPanel.cs
+++ b/src/microbe_stage/gui/EnvironmentPanel.cs
@@ -5,8 +5,8 @@
 /// </summary>
 public partial class EnvironmentPanel : BarPanelBase
 {
-    private readonly StringName vSeparationReference = new("vseparation");
-    private readonly StringName hSeparationReference = new("hseparation");
+    private readonly StringName vSeparationReference = new("v_separation");
+    private readonly StringName hSeparationReference = new("h_separation");
 
     public override void AddPrimaryBar(CompoundProgressBar bar)
     {

--- a/src/thriveopedia/pages/wiki/OrganelleLinkButton.tscn
+++ b/src/thriveopedia/pages/wiki/OrganelleLinkButton.tscn
@@ -20,7 +20,10 @@ icon_alignment = 1
 expand_icon = true
 
 [node name="Label" type="Label" parent="."]
+custom_minimum_size = Vector2(64, 0)
 layout_mode = 2
 label_settings = ExtResource("3_bvs72")
+horizontal_alignment = 1
+autowrap_mode = 3
 
 [connection signal="pressed" from="Button" to="." method="OnPressed"]


### PR DESCRIPTION
**Brief Description of What This PR Does**
Switched some stuff to the standard Godot to get the icons displaying again for dropdown items

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
