### PR TITLE
Fixed saving and loading compound panel compressed state

### DIFF
--- a/src/general/base_stage/CreatureStageHUDBase.cs
+++ b/src/general/base_stage/CreatureStageHUDBase.cs
@@ -392,13 +392,9 @@ public partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSta
         // Make sure fossilization layer update won't run if it isn't open
         fossilisationButtonLayer.Visible = false;
 
-        // TODO: move these to be gotten as a method in SimulationParameters
+        // TODO: move these to be gotten as a method in SimulationParameters (similarly to `GetCloudCompounds()`)
         allAgents.Add(oxytoxy);
         allAgents.Add(mucilage);
-
-        // Apply potentially different GUI state from save
-        EnvironmentPanelCompressed = temporaryEnvironmentCompressed;
-        CompoundsPanelCompressed = temporaryCompoundCompressed;
     }
 
     public void Init(TStage containedInStage)

--- a/src/microbe_stage/gui/BarPanelBase.cs
+++ b/src/microbe_stage/gui/BarPanelBase.cs
@@ -61,7 +61,7 @@ public partial class BarPanelBase : VBoxContainer
 
     public override void _Ready()
     {
-        // To allow setting panel state before
+        // To allow setting panel state before adding to the scene tree
         UpdatePanelState();
 
         if (!showPanels)
@@ -70,10 +70,18 @@ public partial class BarPanelBase : VBoxContainer
         }
     }
 
+    /// <summary>
+    ///   Adds a new bar to this panel's primary bar area
+    /// </summary>
+    /// <param name="bar">Bar to add, may not be in this panel already</param>
+    /// <exception cref="InvalidOperationException">If called before this is added to the tree</exception>
     public virtual void AddPrimaryBar(CompoundProgressBar bar)
     {
         if (expandButton == null)
             throw new InvalidOperationException("Needs to be in tree first");
+
+        // Make sure later added bars follow the compressed state
+        bar.Compact = PanelCompressed;
 
         primaryBarContainer.AddChild(bar);
         primaryBars.Add(bar);

--- a/src/microbe_stage/gui/CompoundPanels.cs
+++ b/src/microbe_stage/gui/CompoundPanels.cs
@@ -43,12 +43,30 @@ public partial class CompoundPanels : BarPanelBase
         }
     }
 
+    /// <summary>
+    ///   If true, extra vertical space is added between items when compressed
+    /// </summary>
+    [Export]
+    public bool ApplyCompressedVerticalExtraSpace { get; set; }
+
     public override void _Ready()
     {
         base._Ready();
 
         if (!ShowAgents)
             HideImmediately();
+    }
+
+    /// <inheritdoc cref="BarPanelBase.AddPrimaryBar"/>
+    public override void AddPrimaryBar(CompoundProgressBar bar)
+    {
+        base.AddPrimaryBar(bar);
+
+        // When compressed the column state depends on bar count so that must be kept up to date
+        if (PanelCompressed)
+        {
+            UpdateCompressedColumnCount();
+        }
     }
 
     /// <summary>
@@ -58,6 +76,12 @@ public partial class CompoundPanels : BarPanelBase
     {
         if (expandButton == null)
             throw new InvalidOperationException("Needs to be in tree first");
+
+        if (PanelCompressed)
+        {
+            agentBar.Compact = true;
+            UpdateCompressedColumnCount();
+        }
 
         agentsContainer.AddChild(agentBar);
         agentsCreatedBars.Add(agentBar);
@@ -87,17 +111,12 @@ public partial class CompoundPanels : BarPanelBase
 
         if (PanelCompressed)
         {
-            primaryBarContainer.AddThemeConstantOverride(vSeparationReference, 20);
+            if (ApplyCompressedVerticalExtraSpace)
+                primaryBarContainer.AddThemeConstantOverride(vSeparationReference, 20);
+
             primaryBarContainer.AddThemeConstantOverride(hSeparationReference, 14);
 
-            if (primaryBars.Count < 4)
-            {
-                primaryBarContainer.Columns = 2;
-            }
-            else
-            {
-                primaryBarContainer.Columns = 3;
-            }
+            UpdateCompressedColumnCount();
 
             foreach (var bar in primaryBars)
             {
@@ -114,7 +133,10 @@ public partial class CompoundPanels : BarPanelBase
         else
         {
             primaryBarContainer.Columns = 1;
-            primaryBarContainer.AddThemeConstantOverride(vSeparationReference, 5);
+
+            if (ApplyCompressedVerticalExtraSpace)
+                primaryBarContainer.AddThemeConstantOverride(vSeparationReference, 5);
+
             primaryBarContainer.AddThemeConstantOverride(hSeparationReference, 0);
 
             foreach (var bar in primaryBars)
@@ -214,5 +236,17 @@ public partial class CompoundPanels : BarPanelBase
         }
 
         base.Dispose(disposing);
+    }
+
+    private void UpdateCompressedColumnCount()
+    {
+        if (primaryBars.Count < 4)
+        {
+            primaryBarContainer.Columns = 2;
+        }
+        else
+        {
+            primaryBarContainer.Columns = 3;
+        }
     }
 }

--- a/src/microbe_stage/gui/CompoundProgressBar.cs
+++ b/src/microbe_stage/gui/CompoundProgressBar.cs
@@ -510,6 +510,10 @@ public partial class CompoundProgressBar : Control
 
     private void ApplyCompactMode(bool playAnimation)
     {
+        // Do not play an animation if not inside the tree as this is still being setup
+        if (playAnimation && !IsInsideTree())
+            playAnimation = false;
+
         if (playAnimation)
         {
             var tween = CreateTween();

--- a/src/microbe_stage/gui/EnvironmentPanel.cs
+++ b/src/microbe_stage/gui/EnvironmentPanel.cs
@@ -8,6 +8,12 @@ public partial class EnvironmentPanel : BarPanelBase
     private readonly StringName vSeparationReference = new("v_separation");
     private readonly StringName hSeparationReference = new("h_separation");
 
+    /// <summary>
+    ///   If true, extra vertical space is added between items when compressed
+    /// </summary>
+    [Export]
+    public bool ApplyCompressedVerticalExtraSpace { get; set; }
+
     public override void AddPrimaryBar(CompoundProgressBar bar)
     {
         base.AddPrimaryBar(bar);
@@ -24,7 +30,10 @@ public partial class EnvironmentPanel : BarPanelBase
         if (PanelCompressed)
         {
             primaryBarContainer.Columns = 2;
-            primaryBarContainer.AddThemeConstantOverride(vSeparationReference, 20);
+
+            if (ApplyCompressedVerticalExtraSpace)
+                primaryBarContainer.AddThemeConstantOverride(vSeparationReference, 20);
+
             primaryBarContainer.AddThemeConstantOverride(hSeparationReference, 17);
 
             foreach (var bar in primaryBars)
@@ -35,7 +44,10 @@ public partial class EnvironmentPanel : BarPanelBase
         else
         {
             primaryBarContainer.Columns = 1;
-            primaryBarContainer.AddThemeConstantOverride(vSeparationReference, 4);
+
+            if (ApplyCompressedVerticalExtraSpace)
+                primaryBarContainer.AddThemeConstantOverride(vSeparationReference, 4);
+
             primaryBarContainer.AddThemeConstantOverride(hSeparationReference, 0);
 
             foreach (var bar in primaryBars)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Turned out that I didn't get this fixed when I previously worked on this, and turns out there were some underlying bugs with trying to restore the panel state.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
