### PR TITLE
Only play placement sound on actions it makes sense for

### DIFF
--- a/src/general/base_stage/EditorBase.cs
+++ b/src/general/base_stage/EditorBase.cs
@@ -505,13 +505,13 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
         }
     }
 
-    public virtual void OnValidAction()
+    public virtual void OnValidAction(IEnumerable<CombinableActionData> actions)
     {
         foreach (var editorComponent in GetAllEditorComponents())
         {
             if (editorComponent.Visible)
             {
-                editorComponent.OnValidAction();
+                editorComponent.OnValidAction(actions);
                 break;
             }
         }

--- a/src/general/base_stage/EditorComponentBase.cs
+++ b/src/general/base_stage/EditorComponentBase.cs
@@ -150,7 +150,7 @@ public partial class EditorComponentBase<TEditor> : ControlWithInput, IEditorCom
         PlayInvalidActionSound();
     }
 
-    public virtual void OnValidAction()
+    public virtual void OnValidAction(IEnumerable<CombinableActionData> actions)
     {
         throw new GodotAbstractMethodNotOverriddenException();
     }

--- a/src/general/base_stage/HexEditorComponentBase.cs
+++ b/src/general/base_stage/HexEditorComponentBase.cs
@@ -647,7 +647,23 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
         return true;
     }
 
-    public override void OnValidAction()
+    public override void OnValidAction(IEnumerable<CombinableActionData> actions)
+    {
+        var anyPlacement = typeof(HexPlacementActionData<,>);
+        var anyMove = typeof(HexMoveActionData<,>);
+
+        foreach (var data in actions)
+        {
+            var type = data.GetType();
+            if (type.IsAssignableToGenericType(anyPlacement) || type.IsAssignableToGenericType(anyMove))
+            {
+                PlayHexPlacementSound();
+                break;
+            }
+        }
+    }
+
+    public void PlayHexPlacementSound()
     {
         GUICommon.Instance.PlayCustomSound(hexPlacementSound, 0.7f);
     }
@@ -742,7 +758,7 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
         OnMoveWillSucceed();
 
         Editor.EnqueueAction(action);
-        Editor.OnValidAction();
+        Editor.OnValidAction(action.Data);
         UpdateSymmetryButton();
         return true;
     }

--- a/src/general/base_stage/IEditor.cs
+++ b/src/general/base_stage/IEditor.cs
@@ -92,7 +92,7 @@ public interface IEditor : ISaveLoadedTracked
 
     public void OnInvalidAction();
 
-    public void OnValidAction();
+    public void OnValidAction(IEnumerable<CombinableActionData> actions);
 
     /// <summary>
     ///   Request from the user to exit the editor anyway

--- a/src/general/base_stage/IEditorComponent.cs
+++ b/src/general/base_stage/IEditorComponent.cs
@@ -37,7 +37,13 @@ public interface IEditorComponent
 
     public void OnInvalidAction();
 
-    public void OnValidAction();
+    /// <summary>
+    ///   Triggered when a valid action occurs. Can be used to implement sounds for example or other GUI feedback.
+    /// </summary>
+    /// <param name="actions">
+    ///   The valid actions, can be used to filter when something special should happen based on the action type
+    /// </param>
+    public void OnValidAction(IEnumerable<CombinableActionData> actions);
 
     /// <summary>
     ///   Notify this component about the freebuild status. Many components don't need to react to this, they can

--- a/src/late_multicellular_stage/editor/MetaballEditorComponentBase.cs
+++ b/src/late_multicellular_stage/editor/MetaballEditorComponentBase.cs
@@ -446,7 +446,23 @@ public partial class MetaballEditorComponentBase<TEditor, TCombinedAction, TActi
         return true;
     }
 
-    public override void OnValidAction()
+    public override void OnValidAction(IEnumerable<CombinableActionData> actions)
+    {
+        var anyPlacement = typeof(MetaballPlacementActionData<>);
+        var anyMove = typeof(MetaballMoveActionData<>);
+
+        foreach (var data in actions)
+        {
+            var type = data.GetType();
+            if (type.IsAssignableToGenericType(anyPlacement) || type.IsAssignableToGenericType(anyMove))
+            {
+                PlayMetaballPlacementSound();
+                break;
+            }
+        }
+    }
+
+    public void PlayMetaballPlacementSound()
     {
         GUICommon.Instance.PlayCustomSound(hexPlacementSound, 0.7f);
     }
@@ -551,7 +567,7 @@ public partial class MetaballEditorComponentBase<TEditor, TCombinedAction, TActi
         OnMoveWillSucceed();
 
         Editor.EnqueueAction(action);
-        Editor.OnValidAction();
+        Editor.OnValidAction(action.Data);
         UpdateSymmetryButton();
         return true;
     }

--- a/src/microbe_stage/editor/BehaviourEditorSubComponent.cs
+++ b/src/microbe_stage/editor/BehaviourEditorSubComponent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Godot;
 using Newtonsoft.Json;
 
@@ -94,7 +95,7 @@ public partial class BehaviourEditorSubComponent : EditorComponentBase<ICellEdit
     {
     }
 
-    public override void OnValidAction()
+    public override void OnValidAction(IEnumerable<CombinableActionData> actions)
     {
     }
 

--- a/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
+++ b/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
@@ -206,7 +206,7 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
     {
     }
 
-    public override void OnValidAction()
+    public override void OnValidAction(IEnumerable<CombinableActionData> actions)
     {
     }
 

--- a/src/microbe_stage/editor/PatchMapEditorComponent.cs
+++ b/src/microbe_stage/editor/PatchMapEditorComponent.cs
@@ -160,7 +160,7 @@ public partial class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEdi
     {
     }
 
-    public override void OnValidAction()
+    public override void OnValidAction(IEnumerable<CombinableActionData> actions)
     {
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

A new approach to only play the placement sound when an action succeeded that is of placement or moving type

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

closes #4578
closes #3386

closes #5069

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
