### PR TITLE
Fixed non-LAWK organelles being unlocked always after the endosymbiosis changes

### DIFF
--- a/src/microbe_stage/OrganelleDefinition.cs
+++ b/src/microbe_stage/OrganelleDefinition.cs
@@ -514,12 +514,14 @@ public class OrganelleDefinition : IRegistryType
             loadedSceneData.LoadFrom(graphics);
         }
 
-        // Use default values from the primary scene
-        loadedCorpseScene = loadedSceneData;
-
         if (!string.IsNullOrEmpty(corpseChunkGraphics.ScenePath))
         {
             loadedCorpseScene.LoadFrom(corpseChunkGraphics);
+        }
+        else
+        {
+            // Use default values from the primary scene
+            loadedCorpseScene = loadedSceneData;
         }
 
         if (!string.IsNullOrEmpty(IconPath))

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -367,6 +367,8 @@ public partial class CellEditorComponent
                     Editor.CurrentGame, autoUnlock))
             {
                 control.Undiscovered = false;
+
+                // This can end up showing non-LAWK organelles in LAWK mode, so this needs a bit of post-processing
                 control.Show();
                 continue;
             }
@@ -430,6 +432,9 @@ public partial class CellEditorComponent
             ToolTipManager.Instance.AddToolTip(tooltip, "lockedOrganelles");
             button.RegisterToolTipForControl(tooltip, true);
         }
+
+        // Apply LAWK settings so that no-unexpected organelles are shown
+        UpdateOrganelleLAWKSettings();
     }
 
     private void RemoveUndiscoveredOrganelleButtons()

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -2713,7 +2713,7 @@ public partial class CellEditorComponent :
             if (value > 0.0005f)
                 return Math.Round(value, 3);
 
-            // Small values can get really small (and still be different from getting 0 energy due to fitness) so
+            // Small values can get tiny (and still be different from getting 0 energy due to fitness) so
             // this is here for that reason
             return Math.Round(value, 8);
         }


### PR DESCRIPTION
**Brief Description of What This PR Does**

This was a bug with the unlock related changes in the endosymbiosis branch causing all organelle buttons to be visible (even non-LAWK ones).

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
