### PR TITLE
Made AI activity score be much lower during the night (to hopefully encourage sessility and energy conservation)

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -967,6 +967,16 @@ public static class Constants
 
     public const float AI_BASE_TOXIN_SHOOT_ANGLE_PRECISION = 5;
 
+    /// <summary>
+    ///   How much less active cells are during the night
+    /// </summary>
+    public const float AI_ACTIVITY_NIGHT_MULTIPLIER = 0.5f;
+
+    public const float AI_ACTIVITY_NIGHT_MULTIPLIER_SESSILE = 0.02f;
+
+    public const float AI_ACTIVITY_TO_BE_FULLY_ACTIVE_DURING_NIGHT = 340;
+    public const float AI_ACTIVITY_TO_BE_SESSILE_DURING_NIGHT = 50;
+
     // Personality Mutation
     public const float MAX_SPECIES_PERSONALITY_MUTATION = 40.0f;
     public const float MIN_SPECIES_PERSONALITY_MUTATION = -40.0f;

--- a/src/general/base_stage/CreatureStageHUDBase.cs
+++ b/src/general/base_stage/CreatureStageHUDBase.cs
@@ -314,7 +314,7 @@ public partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSta
         sunlight = SimulationParameters.Instance.GetCompound("sunlight");
         temperature = SimulationParameters.Instance.GetCompound("temperature");
 
-        // Setup bars. In the future it'd be nice to setup bars as needed for the player for allowing easily adding
+        // Setup bars. In the future it'd be nice to set up bars as needed for the player for allowing easily adding
         // new compound types
         var barScene = GD.Load<PackedScene>("res://src/microbe_stage/gui/CompoundProgressBar.tscn");
 

--- a/src/microbe_stage/BiomeConditions.cs
+++ b/src/microbe_stage/BiomeConditions.cs
@@ -185,7 +185,7 @@ public class BiomeConditions : ICloneable
     }
 
     /// <summary>
-    ///   Checks if the method <see cref="GetAmbientCompoundsThatVary"/> would return true.
+    ///   Checks if the method <see cref="GetAmbientCompoundsThatVary"/> would return true
     /// </summary>
     /// <returns>True if there are compounds that vary</returns>
     public bool HasCompoundsThatVary()
@@ -202,6 +202,28 @@ public class BiomeConditions : ICloneable
         }
 
         return false;
+    }
+
+    /// <summary>
+    ///   Returns true if the specified compound varies during the day / night cycle
+    /// </summary>
+    /// <param name="compound">Compound type to check</param>
+    /// <returns>True if compound varies</returns>
+    public bool IsVaryingCompound(Compound compound)
+    {
+        const float epsilon = 0.000001f;
+
+        bool hasNormally = Compounds.TryGetValue(compound, out var normal);
+        bool hasMinimum = MinimumCompounds.TryGetValue(compound, out var minimnum);
+
+        // Not varying if the numbers are the same
+        if (!hasNormally && !hasMinimum)
+            return false;
+
+        if (hasNormally && hasMinimum && Math.Abs(normal.Ambient - minimnum.Ambient) < epsilon)
+            return false;
+
+        return true;
     }
 
     public void Check(string name)

--- a/src/microbe_stage/BiomeConditions.cs
+++ b/src/microbe_stage/BiomeConditions.cs
@@ -184,6 +184,26 @@ public class BiomeConditions : ICloneable
         }
     }
 
+    /// <summary>
+    ///   Checks if the method <see cref="GetAmbientCompoundsThatVary"/> would return true.
+    /// </summary>
+    /// <returns>True if there are compounds that vary</returns>
+    public bool HasCompoundsThatVary()
+    {
+        const float epsilon = 0.000001f;
+
+        foreach (var minimumCompound in MinimumCompounds)
+        {
+            if (!MaximumCompounds.TryGetValue(minimumCompound.Key, out var maxValue) ||
+                Math.Abs(maxValue.Ambient - minimumCompound.Value.Ambient) > epsilon)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public void Check(string name)
     {
         if (compounds == null)

--- a/src/microbe_stage/IDaylightInfo.cs
+++ b/src/microbe_stage/IDaylightInfo.cs
@@ -7,6 +7,12 @@ public interface IDaylightInfo
 
     [JsonIgnore]
     public float SecondsUntilNightStart { get; }
+
+    /// <summary>
+    ///   True if currently in the night half of the day
+    /// </summary>
+    [JsonIgnore]
+    public bool IsNightCurrently => DayFractionUntilNightStart < 0;
 }
 
 public class DummyLightCycle : IDaylightInfo

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -603,6 +603,22 @@ public static class MicrobeInternalCalculations
         return required <= generated + 0.1f;
     }
 
+    /// <summary>
+    ///   Gets a modifier telling how active a species is during the night
+    /// </summary>
+    /// <param name="activity">The base activity of the species</param>
+    /// <returns>A multiplier to multiply the activity with to get effective activity during the night</returns>
+    public static float GetActivityNightModifier(float activity)
+    {
+        if (activity >= Constants.AI_ACTIVITY_TO_BE_FULLY_ACTIVE_DURING_NIGHT)
+            return 1;
+
+        if (activity <= Constants.AI_ACTIVITY_TO_BE_SESSILE_DURING_NIGHT)
+            return Constants.AI_ACTIVITY_NIGHT_MULTIPLIER_SESSILE;
+
+        return Constants.AI_ACTIVITY_NIGHT_MULTIPLIER;
+    }
+
     private static float MovementForce(float movementForce, float directionFactor)
     {
         if (directionFactor < 0)

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -464,6 +464,45 @@ public static class MicrobeInternalCalculations
     }
 
     /// <summary>
+    ///   Checks if the organelles use any processes that depend on compounds that vary during the day
+    /// </summary>
+    /// <param name="organelles">Organelles to check</param>
+    /// <param name="biomeConditions">Patch to check this in</param>
+    /// <param name="usedProcessesCache">Can be non-null to give existing memory access</param>
+    /// <returns>True if the organelles depend on any compounds that vary during the day</returns>
+    public static bool UsesDayVaryingCompounds(IReadOnlyCollection<OrganelleTemplate> organelles,
+        BiomeConditions biomeConditions, HashSet<BioProcess>? usedProcessesCache)
+    {
+        if (usedProcessesCache == null)
+        {
+            usedProcessesCache = new HashSet<BioProcess>();
+        }
+        else
+        {
+            usedProcessesCache.Clear();
+        }
+
+        foreach (var organelle in organelles)
+        {
+            foreach (var tweakedProcess in organelle.Definition.RunnableProcesses)
+            {
+                usedProcessesCache.Add(tweakedProcess.Process);
+            }
+        }
+
+        foreach (var usedProcess in usedProcessesCache)
+        {
+            foreach (var input in usedProcess.Inputs)
+            {
+                if (biomeConditions.IsVaryingCompound(input.Key))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     ///   Calculates how much storage is needed to survive the night for a cell.
     /// </summary>
     /// <returns>

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1006,8 +1006,11 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         if (GameWorld.Map.CurrentPatch == null)
             throw new InvalidOperationException("Unknown current patch");
 
-        maxLightLevel = GameWorld.Map.CurrentPatch.GetCompoundAmount("sunlight", CompoundAmountType.Maximum);
-        templateMaxLightLevel = GameWorld.Map.CurrentPatch.GetCompoundAmount("sunlight", CompoundAmountType.Template);
+        // This wasn't updated to check if the patch has day / night cycle as it might be plausible in the future
+        // that other compounds than sunlight are varying so in those cases stage visuals should probably not update
+        var sunlight = SimulationParameters.Instance.GetCompound("sunlight");
+        maxLightLevel = GameWorld.Map.CurrentPatch.GetCompoundAmount(sunlight, CompoundAmountType.Maximum);
+        templateMaxLightLevel = GameWorld.Map.CurrentPatch.GetCompoundAmount(sunlight, CompoundAmountType.Template);
     }
 
     private void SaveGame(string name)

--- a/src/microbe_stage/MicrobeWorldSimulation.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.cs
@@ -199,7 +199,7 @@ public partial class MicrobeWorldSimulation : WorldSimulationWithPhysics
 
         microbeMovementSystem = new MicrobeMovementSystem(PhysicalWorld, EntitySystem, parallelRunner);
 
-        microbeAI = new MicrobeAISystem(cloudSystem, EntitySystem, parallelRunner);
+        microbeAI = new MicrobeAISystem(cloudSystem, spawnEnvironment.DaylightInfo, EntitySystem, parallelRunner);
         microbeCollisionSoundSystem = new MicrobeCollisionSoundSystem(EntitySystem, couldParallelize);
         microbeEmissionSystem = new MicrobeEmissionSystem(this, cloudSystem, EntitySystem, couldParallelize);
 
@@ -263,6 +263,7 @@ public partial class MicrobeWorldSimulation : WorldSimulationWithPhysics
         multicellularGrowthSystem.SetWorld(currentGame.GameWorld);
         engulfingSystem.SetWorld(currentGame.GameWorld);
         engulfedDigestionSystem.SetWorld(currentGame.GameWorld);
+        microbeAI.SetWorld(currentGame.GameWorld);
 
         CloudSystem.Init(fluidCurrentsSystem);
     }

--- a/src/microbe_stage/Patch.cs
+++ b/src/microbe_stage/Patch.cs
@@ -165,6 +165,12 @@ public class Patch
     }
 
     /// <summary>
+    ///   True when this patch has compounds that vary during the day / night cycle
+    /// </summary>
+    [JsonProperty]
+    public bool HasDayAndNight => Biome.HasCompoundsThatVary();
+
+    /// <summary>
     ///   Adds all neighbors recursively to the provided <see cref="HashSet{T}"/>
     /// </summary>
     /// <param name="patch">The <see cref="Patch"/> to start from</param>

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -512,7 +512,7 @@ public partial class CellEditorComponent
     private void UpdateLightSelectionPanelVisibility()
     {
         topPanel.Visible = Editor.CurrentGame.GameWorld.WorldSettings.DayNightCycleEnabled &&
-            Editor.CurrentPatch.GetCompoundAmount(sunlight, CompoundAmountType.Maximum) > 0.0f;
+            Editor.CurrentPatch.HasDayAndNight;
 
         // When not in a patch with light, hide the useless always day selector
         if (!topPanel.Visible)

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -286,17 +286,26 @@ public sealed class MicrobeAISystem : AEntitySetSystem<float>, ISpeciesMemberLoc
         var compounds = entity.Get<CompoundStorage>().Compounds;
 
         // Adjusted behaviour values (calculated here as these are needed by various methods)
-        float speciesAggression = ourSpecies.Species.Behaviour.Aggression *
+        var speciesBehaviour = ourSpecies.Species.Behaviour;
+        float speciesAggression = speciesBehaviour.Aggression *
             (signaling.ReceivedCommand == MicrobeSignalCommand.BecomeAggressive ? 1.5f : 1.0f);
 
-        float speciesFear = ourSpecies.Species.Behaviour.Fear *
+        float speciesFear = speciesBehaviour.Fear *
             (signaling.ReceivedCommand == MicrobeSignalCommand.BecomeAggressive ? 0.75f : 1.0f);
 
-        float speciesActivity = ourSpecies.Species.Behaviour.Activity *
+        float speciesActivity = speciesBehaviour.Activity *
             (signaling.ReceivedCommand == MicrobeSignalCommand.BecomeAggressive ? 1.25f : 1.0f);
 
-        float speciesFocus = ourSpecies.Species.Behaviour.Focus;
-        float speciesOpportunism = ourSpecies.Species.Behaviour.Opportunism;
+        // Adjust activity for night if it is currently night
+        // TODO: also check if the current species relies on varying compounds (otherwise it shouldn't react to it
+        // being night)
+        if (currentlyNight)
+        {
+            speciesActivity *= MicrobeInternalCalculations.GetActivityNightModifier(speciesBehaviour.Activity);
+        }
+
+        float speciesFocus = speciesBehaviour.Focus;
+        float speciesOpportunism = speciesBehaviour.Opportunism;
 
         // If nothing is engulfing me right now, see if there's something that might want to hunt me
         Vector3? predator =


### PR DESCRIPTION
**Brief Description of What This PR Does**

Part of day/night fixes.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #3894

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
