### PR TITLE
Added new auto-evo debuffs for species that should have trouble with the night

### DIFF
--- a/Thrive.sln.DotSettings
+++ b/Thrive.sln.DotSettings
@@ -772,6 +772,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=safecrlf/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Scifi/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Skippable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=sessility/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=slerp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=slerped/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=slerps/@EntryIndexedValue">True</s:Boolean>

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -317,17 +317,6 @@ public static class Constants
     public const float LIGHT_LEVEL_UPDATE_INTERVAL = 0.1f;
 
     /// <summary>
-    ///   Day and night are assumed to be the same length (half of the day)
-    /// </summary>
-    public const float LIGHT_NIGHT_FRACTION = 0.5f;
-
-    /// <summary>
-    ///   If filling up on some compound takes more than this fraction of the total day+night length a warning is given
-    ///   in the GUI
-    /// </summary>
-    public const float LIGHT_DAY_FILL_TIME_WARNING_THRESHOLD = 0.5f;
-
-    /// <summary>
     ///   When night is closer than this number of seconds and a cell spawns, it gets extra resources to survive.
     /// </summary>
     public const float INITIAL_RESOURCE_BUFF_WHEN_NIGHT_CLOSER_THAN = 30.0f;
@@ -1016,8 +1005,11 @@ public static class Constants
     public const float AUTO_EVO_CHUNK_ENERGY_AMOUNT = 90000000;
     public const float AUTO_EVO_CHUNK_AMOUNT_NERF = 0.01f;
 
-    public const float AUTO_EVO_MINIMUM_VIABLE_RESERVE_PER_TIME_UNIT = 1.0f;
-    public const float AUTO_EVO_NON_VIABLE_RESERVE_PENALTY = 10;
+    public const float AUTO_EVO_NIGHT_STORAGE_NOT_ENOUGH_PENALTY = 0.1f;
+    public const float AUTO_EVO_NIGHT_SESSILITY_COLLECTING_PENALTY_MULTIPLIER = 1.2f;
+    public const float AUTO_EVO_MAX_NIGHT_SESSILITY_COLLECTING_PENALTY = 0.7f;
+
+    public const float AUTO_EVO_MAX_BONUS_FROM_ENVIRONMENTAL_STORAGE = 2.5f;
 
     public const int AUTO_EVO_MINIMUM_SPECIES_SIZE_BEFORE_SPLIT = 80;
     public const bool AUTO_EVO_ALLOW_SPECIES_SPLIT_ON_NO_MUTATION = true;

--- a/src/auto-evo/simulation/PopulationSimulation.cs
+++ b/src/auto-evo/simulation/PopulationSimulation.cs
@@ -164,6 +164,7 @@ public static class PopulationSimulation
 
         var populations = simulationConfiguration.Results;
         bool trackEnergy = simulationConfiguration.CollectEnergyInformation;
+        bool dayNightCycle = worldSettings.DayNightCycleEnabled;
 
         // This algorithm version is for microbe species
         // TODO: add simulation for multicellular
@@ -186,9 +187,9 @@ public static class PopulationSimulation
         {
             new EnvironmentalFoodSource(patch, Sunlight, Constants.AUTO_EVO_SUNLIGHT_ENERGY_AMOUNT),
             new EnvironmentalFoodSource(patch, Temperature, Constants.AUTO_EVO_THERMOSYNTHESIS_ENERGY_AMOUNT),
-            new CompoundFoodSource(patch, Glucose),
-            new CompoundFoodSource(patch, HydrogenSulfide),
-            new CompoundFoodSource(patch, Iron),
+            new CompoundFoodSource(patch, Glucose, dayNightCycle),
+            new CompoundFoodSource(patch, HydrogenSulfide, dayNightCycle),
+            new CompoundFoodSource(patch, Iron, dayNightCycle),
             new ChunkFoodSource(patch, "marineSnow"),
             new ChunkFoodSource(patch, "ironSmallChunk"),
             new ChunkFoodSource(patch, "ironBigChunk"),

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -13,6 +13,11 @@ using Systems;
 ///     caching is moved to a higher level in the auto-evo, that needs to be considered.
 ///   </para>
 /// </remarks>
+/// <remarks>
+///   <para>
+///     TODO: would be better to reuse instances of this class after clearing them for next use
+///   </para>
+/// </remarks>
 public class SimulationCache
 {
     private readonly Compound oxytoxy = SimulationParameters.Instance.GetCompound("oxytoxy");
@@ -37,6 +42,10 @@ public class SimulationCache
 
     private readonly Dictionary<(MicrobeSpecies, BiomeConditions, Compound), float>
         cachedEnergyCreationScoreForSpecies = new();
+
+    private readonly Dictionary<(MicrobeSpecies, BiomeConditions), bool> cachedUsesVaryingCompounds = new();
+
+    private readonly Dictionary<(MicrobeSpecies, BiomeConditions), float> cachedStorageScores = new();
 
     public SimulationCache(WorldGenerationSettings worldSettings)
     {
@@ -231,6 +240,37 @@ public class SimulationCache
         return cached;
     }
 
+    public bool GetUsesVaryingCompoundsForSpecies(MicrobeSpecies species, BiomeConditions biomeConditions)
+    {
+        var key = (species, biomeConditions);
+
+        if (cachedUsesVaryingCompounds.TryGetValue(key, out var cached))
+        {
+            return cached;
+        }
+
+        cached = MicrobeInternalCalculations.UsesDayVaryingCompounds(species.Organelles, biomeConditions, null);
+
+        cachedUsesVaryingCompounds.Add(key, cached);
+        return cached;
+    }
+
+    public float GetStorageAndDayGenerationScore(MicrobeSpecies species, BiomeConditions biomeConditions,
+        Compound compound)
+    {
+        var key = (species, biomeConditions);
+
+        if (cachedStorageScores.TryGetValue(key, out var cached))
+        {
+            return cached;
+        }
+
+        cached = CalculateStorageScore(species, biomeConditions, compound);
+
+        cachedStorageScores.Add(key, cached);
+        return cached;
+    }
+
     public bool MatchesSettings(WorldGenerationSettings checkAgainst)
     {
         return worldSettings.Equals(checkAgainst);
@@ -272,5 +312,80 @@ public class SimulationCache
 
         cachedPredationToolsRawScores.Add(microbeSpecies, predationToolsRawScores);
         return predationToolsRawScores;
+    }
+
+    private float CalculateStorageScore(MicrobeSpecies species, BiomeConditions biomeConditions, Compound compound)
+    {
+        // TODO: maybe a bit lower value to determine when moving kicks in (though optimally the calculation could
+        // take in a float in range 0-1 to make much more gradual behaviour changes possible)
+        var moving = species.Behaviour.Activity >= Constants.AI_ACTIVITY_TO_BE_FULLY_ACTIVE_DURING_NIGHT;
+
+        float daySeconds = worldSettings.DayLength * worldSettings.DaytimeFraction;
+
+        var cachedCapacities =
+            MicrobeInternalCalculations.GetTotalSpecificCapacity(species.Organelles, out var cachedCapacity);
+
+        Dictionary<Compound, CompoundBalance>? dayCompoundBalances = null;
+        var (canSurvive, requiredAmounts) = MicrobeInternalCalculations.CalculateNightStorageRequirements(
+            species.Organelles, species.MembraneType, moving, species.PlayerSpecies, biomeConditions, worldSettings,
+            ref dayCompoundBalances);
+
+        if (dayCompoundBalances == null)
+            throw new Exception("Day compound balance should have been calculated");
+
+        var resultCompounds =
+            MicrobeInternalCalculations.GetCompoundsProducedByProcessesTakingIn(compound, species.Organelles);
+
+        float cacheScore = 0;
+        int scoreCount = 0;
+
+        foreach (var requiredAmount in requiredAmounts)
+        {
+            // Handle only the relevant compound type
+            if (requiredAmount.Value <= 0 ||
+                (!resultCompounds.Contains(requiredAmount.Key) && requiredAmount.Key != compound))
+            {
+                continue;
+            }
+
+            cacheScore += cachedCapacities.GetValueOrDefault(requiredAmount.Key, cachedCapacity) / requiredAmount.Value;
+            ++scoreCount;
+        }
+
+        if (scoreCount == 0)
+        {
+            // No scores (maybe all production is negative or irrelevant compound type)
+            return 1;
+        }
+
+        // Additionally penalize species that cannot generate enough compounds during the day to fill required
+        // amount of storage
+        foreach (var handledCompound in resultCompounds)
+        {
+            if (!dayCompoundBalances.TryGetValue(handledCompound, out var dayBalance) || !(dayBalance.Balance >= 0))
+                continue;
+
+            var dayGenerated = dayBalance.Balance * daySeconds;
+            var required = requiredAmounts.GetValueOrDefault(handledCompound, 0);
+
+            if (!(dayGenerated < required))
+                continue;
+
+            if (required <= 0)
+                throw new Exception("Required compound amount should not be zero or negative");
+
+            float insufficientProductionScore = dayGenerated / required;
+            cacheScore *= insufficientProductionScore;
+        }
+
+        cacheScore /= scoreCount;
+
+        // Extra penalty if cell cannot store enough stuff to survive to make that situation much more harsh
+        if (!canSurvive)
+        {
+            cacheScore *= Constants.AUTO_EVO_NIGHT_STORAGE_NOT_ENOUGH_PENALTY;
+        }
+
+        return Math.Clamp(cacheScore, 0, Constants.AUTO_EVO_MAX_BONUS_FROM_ENVIRONMENTAL_STORAGE);
     }
 }

--- a/src/auto-evo/simulation/food_source/CompoundFoodSource.cs
+++ b/src/auto-evo/simulation/food_source/CompoundFoodSource.cs
@@ -35,9 +35,7 @@ public class CompoundFoodSource : RandomEncounterFoodSource
             simulationCache, worldSettings);
 
         // Species that are less active during the night get a small penalty here based on their activity
-        if (isDayNightCycleEnabled &&
-            MicrobeInternalCalculations.UsesDayVaryingCompounds(((MicrobeSpecies)species).Organelles, patch.Biome,
-                null))
+        if (isDayNightCycleEnabled && simulationCache.GetUsesVaryingCompoundsForSpecies(microbeSpecies, patch.Biome))
         {
             var multiplier = species.Behaviour.Activity / Constants.AI_ACTIVITY_TO_BE_FULLY_ACTIVE_DURING_NIGHT;
 

--- a/src/general/CompoundAmountType.cs
+++ b/src/general/CompoundAmountType.cs
@@ -14,7 +14,9 @@ public enum CompoundAmountType
     Current,
 
     /// <summary>
-    ///   Maximum possible ambient compound amount (during a day/night cycle).
+    ///   Maximum possible ambient compound amount when patch conditions change over larger time spans. This is not
+    ///   the max during an in-game day, for that see <see cref="Biome"/>! Basically none of the gameplay code should
+    ///   use it, only things like patch condition update when elapsing millions of years should use this.
     /// </summary>
     Maximum,
 

--- a/src/general/DayNightCycle.cs
+++ b/src/general/DayNightCycle.cs
@@ -30,6 +30,12 @@ public class DayNightCycle : IDaylightInfo
     private float daytimeMultiplier;
 
     /// <summary>
+    ///   How big part of the day is considered to be the day. Defaults to 0.5f.
+    /// </summary>
+    [JsonIgnore]
+    private float daytimeFraction;
+
+    /// <summary>
     ///   Controller for variation in sunlight during an in-game day for the current game.
     /// </summary>
     public DayNightCycle()
@@ -68,15 +74,10 @@ public class DayNightCycle : IDaylightInfo
     /// <summary>
     ///   How long until the night starts. When negative it is currently night.
     /// </summary>
-    /// <remarks>
-    ///   <para>
-    ///     TODO: verify that this makes sense, this assumes mid-day is 0.5 and night is exactly half of the total day
-    ///     <see cref="Constants.LIGHT_NIGHT_FRACTION"/>
-    ///   </para>
-    /// </remarks>
     [JsonIgnore]
-    public float DayFractionUntilNightStart =>
-        FractionOfDayElapsed > 0.25f ? 0.75f - FractionOfDayElapsed : -FractionOfDayElapsed - 0.25f;
+    public float DayFractionUntilNightStart => FractionOfDayElapsed > daytimeFraction * 0.5f ?
+        1 - daytimeFraction * 0.5f - FractionOfDayElapsed :
+        -FractionOfDayElapsed - daytimeFraction * 0.5f;
 
     [JsonIgnore]
     public float SecondsUntilNightStart => DayFractionUntilNightStart * DayLengthRealtimeSeconds;
@@ -116,7 +117,8 @@ public class DayNightCycle : IDaylightInfo
     /// </summary>
     public void CalculateDependentLightData(WorldGenerationSettings worldSettings)
     {
-        daytimeMultiplier = CalculateDayTimeMultiplier(worldSettings.DaytimeFraction);
+        daytimeFraction = worldSettings.DaytimeFraction;
+        daytimeMultiplier = CalculateDayTimeMultiplier(daytimeFraction);
 
         AverageSunlight = isEnabled ? CalculateAverageSunlight(daytimeMultiplier) : 1.0f;
     }

--- a/src/general/GameWorld.cs
+++ b/src/general/GameWorld.cs
@@ -100,12 +100,6 @@ public class GameWorld : ISaveLoadable
         GenerationHistory.Add(0, new GenerationRecord(0,
             new Dictionary<uint, SpeciesRecordLite> { { PlayerSpecies.ID, initialSpeciesRecord } }));
 
-        if (WorldSettings.DayNightCycleEnabled)
-        {
-            // Make sure average light levels are computed already
-            UpdateGlobalAverageSunlight();
-        }
-
         UnlockProgress.UnlockAll = !settings.Difficulty.OrganelleUnlocksEnabled;
     }
 
@@ -668,17 +662,6 @@ public class GameWorld : ISaveLoadable
         foreach (var patch in Map.Patches.Values)
         {
             patch.UpdateCurrentSunlight(LightCycle.DayLightFraction);
-        }
-    }
-
-    /// <summary>
-    ///   Updates/sets the average light level of all patches according to <see cref="LightCycle"/> data.
-    /// </summary>
-    public void UpdateGlobalAverageSunlight()
-    {
-        foreach (var patch in Map.Patches.Values)
-        {
-            patch.UpdateAverageSunlight(LightCycle.AverageSunlight);
         }
     }
 

--- a/src/general/NewGameSettings.tscn
+++ b/src/general/NewGameSettings.tscn
@@ -787,7 +787,6 @@ max_value = 300.0
 step = 30.0
 value = 180.0
 rounded = true
-editable = false
 scrollable = false
 
 [node name="HSeparator" type="HSeparator" parent="CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer/VBoxContainer4/HBoxContainer/HBoxContainer"]

--- a/src/general/base_stage/EditorBase.cs
+++ b/src/general/base_stage/EditorBase.cs
@@ -710,9 +710,6 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
 
         ApplyAutoEvoResults();
 
-        // Recompute average sunlight in case auto-evo modifies things
-        CurrentGame.GameWorld.UpdateGlobalAverageSunlight();
-
         FadeIn();
     }
 

--- a/src/microbe_stage/BiomeConditions.cs
+++ b/src/microbe_stage/BiomeConditions.cs
@@ -78,7 +78,8 @@ public class BiomeConditions : ICloneable
     public IDictionary<Compound, BiomeCompoundProperties> AverageCompounds { get; }
 
     /// <summary>
-    ///   Maximum compounds during an in-game day
+    ///   Maximum compounds this patch can reach. Not related to maximum during an in-game day, for that use
+    ///   <see cref="Compounds"/>!
     /// </summary>
     [JsonIgnore]
     public IDictionary<Compound, BiomeCompoundProperties> MaximumCompounds { get; }
@@ -90,7 +91,8 @@ public class BiomeConditions : ICloneable
     public IDictionary<Compound, BiomeCompoundProperties> MinimumCompounds { get; }
 
     /// <summary>
-    ///   The normal, large timescale compound amounts
+    ///   The normal, large timescale compound amounts. The maximum amounts compounds are at during a day in this
+    ///   patch (if they wary during a day).
     /// </summary>
     /// <remarks>
     ///   <para>
@@ -102,7 +104,7 @@ public class BiomeConditions : ICloneable
 
     /// <summary>
     ///   Allows access to modification of the compound values in the biome permanently. Should only be used by
-    ///   auto-evo or map generator.
+    ///   auto-evo or map generator. After changing <see cref="AverageCompounds"/> must to be updated.
     /// </summary>
     [JsonIgnore]
     public IDictionary<Compound, BiomeCompoundProperties> ChangeableCompounds => compounds;
@@ -176,7 +178,7 @@ public class BiomeConditions : ICloneable
 
         foreach (var minimumCompound in MinimumCompounds)
         {
-            if (!MaximumCompounds.TryGetValue(minimumCompound.Key, out var maxValue) ||
+            if (!Compounds.TryGetValue(minimumCompound.Key, out var maxValue) ||
                 Math.Abs(maxValue.Ambient - minimumCompound.Value.Ambient) > epsilon)
             {
                 yield return minimumCompound.Key;
@@ -194,7 +196,7 @@ public class BiomeConditions : ICloneable
 
         foreach (var minimumCompound in MinimumCompounds)
         {
-            if (!MaximumCompounds.TryGetValue(minimumCompound.Key, out var maxValue) ||
+            if (!Compounds.TryGetValue(minimumCompound.Key, out var maxValue) ||
                 Math.Abs(maxValue.Ambient - minimumCompound.Value.Ambient) > epsilon)
             {
                 return true;
@@ -214,13 +216,13 @@ public class BiomeConditions : ICloneable
         const float epsilon = 0.000001f;
 
         bool hasNormally = Compounds.TryGetValue(compound, out var normal);
-        bool hasMinimum = MinimumCompounds.TryGetValue(compound, out var minimnum);
+        bool hasMinimum = MinimumCompounds.TryGetValue(compound, out var minimum);
 
         // Not varying if the numbers are the same
         if (!hasNormally && !hasMinimum)
             return false;
 
-        if (hasNormally && hasMinimum && Math.Abs(normal.Ambient - minimnum.Ambient) < epsilon)
+        if (hasNormally && hasMinimum && Math.Abs(normal.Ambient - minimum.Ambient) < epsilon)
             return false;
 
         return true;

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -511,51 +511,61 @@ public static class MicrobeInternalCalculations
     /// </returns>
     public static (bool CanSurvive, Dictionary<Compound, float> RequiredStorage) CalculateNightStorageRequirements(
         IReadOnlyCollection<OrganelleTemplate> organelles, MembraneType membraneType, bool moving, bool playerSpecies,
-        BiomeConditions biomeConditions, WorldGenerationSettings worldSettings)
+        BiomeConditions biomeConditions, WorldGenerationSettings worldSettings,
+        ref Dictionary<Compound, CompoundBalance>? dayCompoundBalances)
     {
-        var energyBalance = ProcessSystem.ComputeEnergyBalance(organelles, biomeConditions, membraneType,
-            moving, playerSpecies, worldSettings, CompoundAmountType.Biome);
+        if (dayCompoundBalances == null)
+        {
+            var energyBalance = ProcessSystem.ComputeEnergyBalance(organelles, biomeConditions, membraneType,
+                moving, playerSpecies, worldSettings, CompoundAmountType.Biome);
 
-        var compoundBalances = ProcessSystem.ComputeCompoundBalanceAtEquilibrium(organelles,
-            biomeConditions, CompoundAmountType.Biome, energyBalance);
+            dayCompoundBalances = ProcessSystem.ComputeCompoundBalanceAtEquilibrium(organelles,
+                biomeConditions, CompoundAmountType.Biome, energyBalance);
+        }
 
-        // TODO: is it fine to use energy balance calculated with the biome numbers here?
         var minimums = ProcessSystem.ComputeCompoundBalanceAtEquilibrium(organelles,
-            biomeConditions, CompoundAmountType.Minimum, energyBalance);
+            biomeConditions, CompoundAmountType.Minimum, ProcessSystem.ComputeEnergyBalance(organelles, biomeConditions,
+                membraneType,
+                moving, playerSpecies, worldSettings, CompoundAmountType.Minimum));
 
         var cachedCapacities = GetTotalSpecificCapacity(organelles, out var cachedCapacity);
 
-        var nightSeconds = worldSettings.DayLength * Constants.LIGHT_NIGHT_FRACTION;
+        var nightSeconds = worldSettings.DayLength * (1 - worldSettings.DaytimeFraction);
 
         bool enoughStorage = true;
         var requiredCapacities = new Dictionary<Compound, float>();
 
-        foreach (var normalBalance in compoundBalances)
+        foreach (var normalBalance in dayCompoundBalances)
         {
-            if (!minimums.TryGetValue(normalBalance.Key, out var minimumValue) ||
-                Math.Abs(minimumValue.Balance - normalBalance.Value.Balance) > 0.001f)
+            // Only handle compounds that are differently generated during the night and don't have a positive night
+            // balance
+            if (minimums.TryGetValue(normalBalance.Key, out var minimumValue) && !(minimumValue.Balance < 0) &&
+                !(Math.Abs(minimumValue.Balance - normalBalance.Value.Balance) > 0.001f))
             {
-                if (normalBalance.Value.Balance > 0.001f)
-                    continue;
-
-                // Found a compound that is generated during the day more than night
-
-                var drainRate = minimumValue?.Balance ?? normalBalance.Value.Consumption.SumValues();
-
-                // As things slowly pick up again after the night, it isn't fully this bad, this is just a worst case
-                // scenario
-                // TODO: more accurate math
-                var overestimatedDrain = drainRate * nightSeconds;
-
-                var capacity = cachedCapacities.GetValueOrDefault(normalBalance.Key, cachedCapacity);
-
-                if (overestimatedDrain > capacity)
-                {
-                    enoughStorage = false;
-                }
-
-                requiredCapacities[normalBalance.Key] = overestimatedDrain;
+                continue;
             }
+
+            // Skip things that aren't generated during the day
+            if (normalBalance.Value.Balance < 0.00001f)
+                continue;
+
+            // Found a compound that is generated during the day more than night
+
+            var drainRate = -minimumValue?.Balance ?? normalBalance.Value.Consumption.SumValues();
+
+            // As things slowly pick up again after the night, it isn't fully this bad, this is just a worst case
+            // scenario
+            // TODO: more accurate math
+            var overestimatedDrain = drainRate * nightSeconds;
+
+            var capacity = cachedCapacities.GetValueOrDefault(normalBalance.Key, cachedCapacity);
+
+            if (overestimatedDrain > capacity)
+            {
+                enoughStorage = false;
+            }
+
+            requiredCapacities[normalBalance.Key] = overestimatedDrain;
         }
 
         return (enoughStorage, requiredCapacities);

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -571,6 +571,45 @@ public static class MicrobeInternalCalculations
         return (enoughStorage, requiredCapacities);
     }
 
+    /// <summary>
+    ///   Finds all compounds that are produced from the given compound.
+    /// </summary>
+    /// <param name="compound">Compound that is used as an input</param>
+    /// <param name="organelles">Organelles present in cell</param>
+    /// <returns>The produced compounds</returns>
+    public static HashSet<Compound> GetCompoundsProducedByProcessesTakingIn(Compound compound,
+        IReadOnlyCollection<OrganelleTemplate> organelles)
+    {
+        var result = new HashSet<Compound>();
+
+        foreach (var organelle in organelles)
+        {
+            foreach (var process in organelle.Definition.RunnableProcesses)
+            {
+                bool usesInput = false;
+
+                foreach (var processInput in process.Process.Inputs)
+                {
+                    if (processInput.Key == compound)
+                    {
+                        usesInput = true;
+                        break;
+                    }
+                }
+
+                if (!usesInput)
+                    continue;
+
+                foreach (var processOutput in process.Process.Outputs)
+                {
+                    result.Add(processOutput.Key);
+                }
+            }
+        }
+
+        return result;
+    }
+
     public static void CalculatePossibleEndosymbiontsFromSpecies(MicrobeSpecies species,
         List<(OrganelleDefinition Organelle, int Cost)> result)
     {

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -707,7 +707,8 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
             if (GameWorld.WorldSettings.DayNightCycleEnabled)
             {
                 var sunlight = SimulationParameters.Instance.GetCompound("sunlight");
-                var patchSunlight = GameWorld.Map.CurrentPatch!.GetCompoundAmount(sunlight, CompoundAmountType.Biome);
+                var patchSunlight = GameWorld.Map.CurrentPatch!.Biome.GetCompound(sunlight, CompoundAmountType.Biome)
+                    .Ambient;
 
                 if (patchSunlight > Constants.DAY_NIGHT_TUTORIAL_LIGHT_MIN)
                 {
@@ -972,7 +973,9 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         if (templateMaxLightLevel > 0.0f && maxLightLevel > 0.0f)
         {
             // This might need to be refactored for efficiency but, it works for now
-            var lightLevel = GameWorld.Map.CurrentPatch!.GetCompoundAmount("sunlight") *
+            var sunlight = SimulationParameters.Instance.GetCompound("sunlight");
+            var lightLevel =
+                GameWorld.Map.CurrentPatch!.Biome.GetCompound(sunlight, CompoundAmountType.Current).Ambient *
                 GameWorld.LightCycle.DayLightFraction;
 
             // Normalise by maximum light level in the patch
@@ -1009,8 +1012,9 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         // This wasn't updated to check if the patch has day / night cycle as it might be plausible in the future
         // that other compounds than sunlight are varying so in those cases stage visuals should probably not update
         var sunlight = SimulationParameters.Instance.GetCompound("sunlight");
-        maxLightLevel = GameWorld.Map.CurrentPatch.GetCompoundAmount(sunlight, CompoundAmountType.Maximum);
-        templateMaxLightLevel = GameWorld.Map.CurrentPatch.GetCompoundAmount(sunlight, CompoundAmountType.Template);
+        maxLightLevel = GameWorld.Map.CurrentPatch.Biome.GetCompound(sunlight, CompoundAmountType.Biome).Ambient;
+        templateMaxLightLevel = GameWorld.Map.CurrentPatch.BiomeTemplate.Conditions
+            .GetCompound(sunlight, CompoundAmountType.Biome).Ambient;
     }
 
     private void SaveGame(string name)

--- a/src/microbe_stage/Patch.cs
+++ b/src/microbe_stage/Patch.cs
@@ -167,7 +167,7 @@ public class Patch
     /// <summary>
     ///   True when this patch has compounds that vary during the day / night cycle
     /// </summary>
-    [JsonProperty]
+    [JsonIgnore]
     public bool HasDayAndNight => Biome.HasCompoundsThatVary();
 
     /// <summary>
@@ -364,12 +364,8 @@ public class Patch
         gameplayPopulations.Clear();
     }
 
-    public float GetCompoundAmount(string compoundName, CompoundAmountType amountType = CompoundAmountType.Current)
-    {
-        return GetCompoundAmount(SimulationParameters.Instance.GetCompound(compoundName), amountType);
-    }
-
-    public float GetCompoundAmount(Compound compound, CompoundAmountType amountType = CompoundAmountType.Current)
+    public float GetCompoundAmountForDisplay(Compound compound,
+        CompoundAmountType amountType = CompoundAmountType.Current)
     {
         switch (compound.InternalName)
         {
@@ -400,7 +396,7 @@ public class Patch
         }
     }
 
-    public float GetCompoundAmountInSnapshot(PatchSnapshot snapshot, string compoundName)
+    public float GetCompoundAmountInSnapshotForDisplay(PatchSnapshot snapshot, string compoundName)
     {
         var compound = SimulationParameters.Instance.GetCompound(compoundName);
 
@@ -478,7 +474,7 @@ public class Patch
     {
         Biome.AverageCompounds[sunlight] = new BiomeCompoundProperties
         {
-            Ambient = Biome.MaximumCompounds[sunlight].Ambient * multiplier,
+            Ambient = Biome.Compounds[sunlight].Ambient * multiplier,
         };
     }
 
@@ -486,7 +482,7 @@ public class Patch
     {
         Biome.CurrentCompoundAmounts[sunlight] = new BiomeCompoundProperties
         {
-            Ambient = Biome.MaximumCompounds[sunlight].Ambient * multiplier,
+            Ambient = Biome.Compounds[sunlight].Ambient * multiplier,
         };
     }
 

--- a/src/microbe_stage/PatchMapGenerator.cs
+++ b/src/microbe_stage/PatchMapGenerator.cs
@@ -167,6 +167,14 @@ public static class PatchMapGenerator
         ConnectPatchesBetweenRegions(map, random);
         map.CreateAdjacenciesFromPatchData();
 
+        // Fix up initial average sunlight values. Note that in the future if there are things that update the biome
+        // available sunlight in a patch, this needs to be done again
+        float daytimeMultiplier = DayNightCycle.CalculateDayTimeMultiplier(settings.DaytimeFraction);
+        foreach (var entry in map.Patches)
+        {
+            entry.Value.UpdateAverageSunlight(DayNightCycle.CalculateAverageSunlight(daytimeMultiplier, settings));
+        }
+
         return map;
     }
 
@@ -413,6 +421,8 @@ public static class PatchMapGenerator
                 sunlightProperty.Ambient = sunlightAmount;
 
                 seafloor.Biome.ChangeableCompounds[sunlightCompound] = sunlightProperty;
+
+                // Average sunlight is updated later
 
                 // Build vents and cave position
                 if (vents != null || cave != null)

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -529,7 +529,7 @@ public partial class CellEditorComponent
     private void UpdateCompoundBalances(Dictionary<Compound, CompoundBalance> balances)
     {
         var warningTime = Editor.CurrentGame.GameWorld.LightCycle.DayLengthRealtimeSeconds *
-            Constants.LIGHT_DAY_FILL_TIME_WARNING_THRESHOLD;
+            Editor.CurrentGame.GameWorld.WorldSettings.DaytimeFraction;
 
         // Don't show warning when day/night is not enabled
         if (!Editor.CurrentGame.GameWorld.WorldSettings.DayNightCycleEnabled)
@@ -542,11 +542,11 @@ public partial class CellEditorComponent
         Dictionary<Compound, CompoundBalance> nightBalance, float nominalStorage,
         Dictionary<Compound, float> specificStorages)
     {
-        var warningTime = Editor.CurrentGame.GameWorld.LightCycle.DayLengthRealtimeSeconds *
-            Constants.LIGHT_NIGHT_FRACTION;
+        float lightFraction = Editor.CurrentGame.GameWorld.WorldSettings.DaytimeFraction;
 
-        var fillingUpTime = Editor.CurrentGame.GameWorld.LightCycle.DayLengthRealtimeSeconds *
-            Constants.LIGHT_DAY_FILL_TIME_WARNING_THRESHOLD;
+        var warningTime = Editor.CurrentGame.GameWorld.LightCycle.DayLengthRealtimeSeconds * (1 - lightFraction);
+
+        var fillingUpTime = Editor.CurrentGame.GameWorld.LightCycle.DayLengthRealtimeSeconds * lightFraction;
 
         // Don't show warning when day/night is not enabled
         if (!Editor.CurrentGame.GameWorld.WorldSettings.DayNightCycleEnabled)

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1280,8 +1280,9 @@ public partial class CellEditorComponent :
 
     public override void OnLightLevelChanged(float dayLightFraction)
     {
-        var maxLightLevel = Editor.CurrentPatch.GetCompoundAmount(sunlight, CompoundAmountType.Maximum);
-        var templateMaxLightLevel = Editor.CurrentPatch.GetCompoundAmount(sunlight, CompoundAmountType.Template);
+        var maxLightLevel = Editor.CurrentPatch.Biome.GetCompound(sunlight, CompoundAmountType.Biome).Ambient;
+        var templateMaxLightLevel =
+            Editor.CurrentPatch.GetCompoundAmountForDisplay(sunlight, CompoundAmountType.Template);
 
         // Currently, patches whose templates have zero sunlight can be given non-zero sunlight as an instance. But
         // nighttime shaders haven't been created for these patches (specifically the sea floor) so for now we can't

--- a/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
+++ b/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
@@ -328,7 +328,7 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
                     continue;
 
                 var dataPoint = DataPoint.GetDataPoint(snapshot.TimePeriod,
-                    Math.Round(patch.GetCompoundAmountInSnapshot(snapshot, entry.Key.InternalName), 3));
+                    Math.Round(patch.GetCompoundAmountInSnapshotForDisplay(snapshot, entry.Key.InternalName), 3));
                 dataPoint.MarkerColour = dataset.Colour;
 
                 dataset.AddPoint(dataPoint);

--- a/src/microbe_stage/editor/PatchMapEditorComponent.cs
+++ b/src/microbe_stage/editor/PatchMapEditorComponent.cs
@@ -168,8 +168,9 @@ public partial class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEdi
     {
         base.OnLightLevelChanged(dayLightFraction);
 
-        var maxLightLevel = Editor.CurrentPatch.Biome.MaximumCompounds[sunlight].Ambient;
-        var templateMaxLightLevel = Editor.CurrentPatch.GetCompoundAmount(sunlight, CompoundAmountType.Template);
+        var maxLightLevel = Editor.CurrentPatch.Biome.GetCompound(sunlight, CompoundAmountType.Biome).Ambient;
+        var templateMaxLightLevel =
+            Editor.CurrentPatch.GetCompoundAmountForDisplay(sunlight, CompoundAmountType.Template);
 
         // We don't want the light level in other patches be changed to zero if this callback is called while
         // we're on a patch that isn't affected by day/night effects
@@ -177,11 +178,11 @@ public partial class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEdi
         {
             foreach (var patch in Editor.CurrentGame.GameWorld.Map.Patches.Values)
             {
-                var targetMaxLightLevel = patch.Biome.MaximumCompounds[sunlight].Ambient;
+                var targetMaxLightLevel = patch.Biome.GetCompound(sunlight, CompoundAmountType.Biome);
 
                 var lightLevelAmount = new BiomeCompoundProperties
                 {
-                    Ambient = targetMaxLightLevel * dayLightFraction,
+                    Ambient = targetMaxLightLevel.Ambient * dayLightFraction,
                 };
 
                 patch.Biome.CurrentCompoundAmounts[sunlight] = lightLevelAmount;

--- a/src/microbe_stage/gui/PatchDetailsPanel.cs
+++ b/src/microbe_stage/gui/PatchDetailsPanel.cs
@@ -269,43 +269,42 @@ public partial class PatchDetailsPanel : PanelContainer
             unitFormat.FormatSafe(SelectedPatch.Biome.CurrentCompoundAmounts[temperature].Ambient, temperature.Unit);
         pressureLabel.Text = unitFormat.FormatSafe(20, "bar");
 
-        var maxLightLevel = GetCompoundAmount(SelectedPatch, sunlightCompound.InternalName, CompoundAmountType.Maximum);
+        var maxLightLevel = GetCompoundAmount(SelectedPatch, sunlightCompound, CompoundAmountType.Biome);
         lightLabel.Text =
             unitFormat.FormatSafe(percentageFormat.FormatSafe(Math.Round(GetCompoundAmount(SelectedPatch,
-                sunlightCompound.InternalName))), "lx");
+                sunlightCompound))), "lx");
         lightMax.Text = Localization.Translate("LIGHT_LEVEL_LABEL_AT_NOON").FormatSafe(
             unitFormat.FormatSafe(percentageFormat.FormatSafe(maxLightLevel), "lx"));
         lightMax.Visible = maxLightLevel > 0;
 
-        oxygenLabel.Text = percentageFormat.FormatSafe(Math.Round(
-            GetCompoundAmount(SelectedPatch, oxygenCompound.InternalName),
+        oxygenLabel.Text = percentageFormat.FormatSafe(Math.Round(GetCompoundAmount(SelectedPatch, oxygenCompound),
             Constants.ATMOSPHERIC_COMPOUND_DISPLAY_DECIMALS));
         nitrogenLabel.Text =
-            percentageFormat.FormatSafe(Math.Round(GetCompoundAmount(SelectedPatch, nitrogenCompound.InternalName),
+            percentageFormat.FormatSafe(Math.Round(GetCompoundAmount(SelectedPatch, nitrogenCompound),
                 Constants.ATMOSPHERIC_COMPOUND_DISPLAY_DECIMALS));
         co2Label.Text =
-            percentageFormat.FormatSafe(Math.Round(GetCompoundAmount(SelectedPatch, carbondioxideCompound.InternalName),
+            percentageFormat.FormatSafe(Math.Round(GetCompoundAmount(SelectedPatch, carbondioxideCompound),
                 Constants.ATMOSPHERIC_COMPOUND_DISPLAY_DECIMALS));
 
         // Compounds
         hydrogenSulfideLabel.Text =
-            Math.Round(GetCompoundAmount(SelectedPatch, hydrogensulfideCompound.InternalName),
+            Math.Round(GetCompoundAmount(SelectedPatch, hydrogensulfideCompound),
                     Constants.PATCH_CONDITIONS_COMPOUND_DISPLAY_DECIMALS)
                 .ToString(CultureInfo.CurrentCulture);
         ammoniaLabel.Text =
-            Math.Round(GetCompoundAmount(SelectedPatch, ammoniaCompound.InternalName),
+            Math.Round(GetCompoundAmount(SelectedPatch, ammoniaCompound),
                     Constants.PATCH_CONDITIONS_COMPOUND_DISPLAY_DECIMALS)
                 .ToString(CultureInfo.CurrentCulture);
         glucoseLabel.Text =
-            Math.Round(GetCompoundAmount(SelectedPatch, glucoseCompound.InternalName),
+            Math.Round(GetCompoundAmount(SelectedPatch, glucoseCompound),
                     Constants.PATCH_CONDITIONS_COMPOUND_DISPLAY_DECIMALS)
                 .ToString(CultureInfo.CurrentCulture);
         phosphateLabel.Text =
-            Math.Round(GetCompoundAmount(SelectedPatch, phosphatesCompound.InternalName),
+            Math.Round(GetCompoundAmount(SelectedPatch, phosphatesCompound),
                     Constants.PATCH_CONDITIONS_COMPOUND_DISPLAY_DECIMALS)
                 .ToString(CultureInfo.CurrentCulture);
         ironLabel.Text =
-            Math.Round(GetCompoundAmount(SelectedPatch, ironCompound.InternalName),
+            Math.Round(GetCompoundAmount(SelectedPatch, ironCompound),
                     Constants.PATCH_CONDITIONS_COMPOUND_DISPLAY_DECIMALS)
                 .ToString(CultureInfo.CurrentCulture);
 
@@ -335,10 +334,10 @@ public partial class PatchDetailsPanel : PanelContainer
         }
     }
 
-    private float GetCompoundAmount(Patch patch, string compoundName,
+    private float GetCompoundAmount(Patch patch, Compound compound,
         CompoundAmountType amountType = CompoundAmountType.Current)
     {
-        return patch.GetCompoundAmount(compoundName, amountType);
+        return patch.GetCompoundAmountForDisplay(compound, amountType);
     }
 
     /// <remarks>
@@ -384,13 +383,13 @@ public partial class PatchDetailsPanel : PanelContainer
             lightSituation.Texture = null;
         }
 
-        nextCompound = GetCompoundAmount(SelectedPatch, hydrogensulfideCompound.InternalName);
+        nextCompound = GetCompoundAmount(SelectedPatch, hydrogensulfideCompound);
 
-        if (nextCompound > GetCompoundAmount(CurrentPatch, hydrogensulfideCompound.InternalName))
+        if (nextCompound > GetCompoundAmount(CurrentPatch, hydrogensulfideCompound))
         {
             hydrogenSulfideSituation.Texture = increaseIcon;
         }
-        else if (nextCompound < GetCompoundAmount(CurrentPatch, hydrogensulfideCompound.InternalName))
+        else if (nextCompound < GetCompoundAmount(CurrentPatch, hydrogensulfideCompound))
         {
             hydrogenSulfideSituation.Texture = decreaseIcon;
         }
@@ -399,13 +398,13 @@ public partial class PatchDetailsPanel : PanelContainer
             hydrogenSulfideSituation.Texture = null;
         }
 
-        nextCompound = GetCompoundAmount(SelectedPatch, glucoseCompound.InternalName);
+        nextCompound = GetCompoundAmount(SelectedPatch, glucoseCompound);
 
-        if (nextCompound > GetCompoundAmount(CurrentPatch, glucoseCompound.InternalName))
+        if (nextCompound > GetCompoundAmount(CurrentPatch, glucoseCompound))
         {
             glucoseSituation.Texture = increaseIcon;
         }
-        else if (nextCompound < GetCompoundAmount(CurrentPatch, glucoseCompound.InternalName))
+        else if (nextCompound < GetCompoundAmount(CurrentPatch, glucoseCompound))
         {
             glucoseSituation.Texture = decreaseIcon;
         }
@@ -414,13 +413,13 @@ public partial class PatchDetailsPanel : PanelContainer
             glucoseSituation.Texture = null;
         }
 
-        nextCompound = GetCompoundAmount(SelectedPatch, ironCompound.InternalName);
+        nextCompound = GetCompoundAmount(SelectedPatch, ironCompound);
 
-        if (nextCompound > GetCompoundAmount(CurrentPatch, ironCompound.InternalName))
+        if (nextCompound > GetCompoundAmount(CurrentPatch, ironCompound))
         {
             ironSituation.Texture = increaseIcon;
         }
-        else if (nextCompound < GetCompoundAmount(CurrentPatch, ironCompound.InternalName))
+        else if (nextCompound < GetCompoundAmount(CurrentPatch, ironCompound))
         {
             ironSituation.Texture = decreaseIcon;
         }
@@ -429,13 +428,13 @@ public partial class PatchDetailsPanel : PanelContainer
             ironSituation.Texture = null;
         }
 
-        nextCompound = GetCompoundAmount(SelectedPatch, ammoniaCompound.InternalName);
+        nextCompound = GetCompoundAmount(SelectedPatch, ammoniaCompound);
 
-        if (nextCompound > GetCompoundAmount(CurrentPatch, ammoniaCompound.InternalName))
+        if (nextCompound > GetCompoundAmount(CurrentPatch, ammoniaCompound))
         {
             ammoniaSituation.Texture = increaseIcon;
         }
-        else if (nextCompound < GetCompoundAmount(CurrentPatch, ammoniaCompound.InternalName))
+        else if (nextCompound < GetCompoundAmount(CurrentPatch, ammoniaCompound))
         {
             ammoniaSituation.Texture = decreaseIcon;
         }
@@ -444,13 +443,13 @@ public partial class PatchDetailsPanel : PanelContainer
             ammoniaSituation.Texture = null;
         }
 
-        nextCompound = GetCompoundAmount(SelectedPatch, phosphatesCompound.InternalName);
+        nextCompound = GetCompoundAmount(SelectedPatch, phosphatesCompound);
 
-        if (nextCompound > GetCompoundAmount(CurrentPatch, phosphatesCompound.InternalName))
+        if (nextCompound > GetCompoundAmount(CurrentPatch, phosphatesCompound))
         {
             phosphateSituation.Texture = increaseIcon;
         }
-        else if (nextCompound < GetCompoundAmount(CurrentPatch, phosphatesCompound.InternalName))
+        else if (nextCompound < GetCompoundAmount(CurrentPatch, phosphatesCompound))
         {
             phosphateSituation.Texture = decreaseIcon;
         }

--- a/src/microbe_stage/organelle_unlocks/WorldBasedUnlockCondition.cs
+++ b/src/microbe_stage/organelle_unlocks/WorldBasedUnlockCondition.cs
@@ -133,8 +133,8 @@ public class PatchCompound : WorldBasedUnlockCondition
         if (data is not WorldAndPlayerDataSource worldArgs)
             return false;
 
-        var current = worldArgs.CurrentPatch.GetCompoundAmount(Compound!,
-            CompoundAmountType.Biome);
+        // TODO: is it correct that this uses display adjusted values?
+        var current = worldArgs.CurrentPatch.GetCompoundAmountForDisplay(Compound!, CompoundAmountType.Biome);
 
         var minSatisfied = !Min.HasValue || current >= Min;
         var maxSatisfied = !Max.HasValue || current <= Max;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Hopefully to encourage auto-evo to generate more viable species for the now by default enabled day/night cycle.

I'll be merging this immediately to make a BOTD.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #5147

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
