### PR TITLE
Unlock Condition Tweaks

### DIFF
--- a/simulation_parameters/microbe_stage/organelles.json
+++ b/simulation_parameters/microbe_stage/organelles.json
@@ -602,6 +602,7 @@
         "ReproduceWithOrganelle": {
           "Organelle": "metabolosome",
           "Generations": 7,
+          "MinimumCount": 5,
           "InARow": true
         }
       }
@@ -640,7 +641,7 @@
     "Graphics": {
       "ScenePath": "res://assets/models/organelles/Oxytoxy.tscn"
     },
-    "Name": "TOXIN_VACUOLE",
+    "Name": "_VACUOLE",
     "ProductionColour": "#624acb",
     "ConsumptionColour": "#c4307b",
     "IconPath": "res://assets/textures/gui/bevel/parts/ToxinVacuoleIcon.png",
@@ -651,7 +652,8 @@
         },
         "ReproduceWithOrganelle": {
           "Organelle": "oxytoxyProteins",
-          "Generations": 5
+          "Generations": 5,
+          "MinimumCount": 3
         }
       }
     ],
@@ -725,7 +727,7 @@
       {
         "ReproduceWithOrganelle": {
           "Organelle": "nucleus",
-          "Generations": 5
+          "Generations": 5,
         },
         "ExcessAtpAbove": {
           "Atp": 15

--- a/simulation_parameters/microbe_stage/organelles.json
+++ b/simulation_parameters/microbe_stage/organelles.json
@@ -727,7 +727,7 @@
       {
         "ReproduceWithOrganelle": {
           "Organelle": "nucleus",
-          "Generations": 5,
+          "Generations": 5
         },
         "ExcessAtpAbove": {
           "Atp": 15

--- a/simulation_parameters/microbe_stage/organelles.json
+++ b/simulation_parameters/microbe_stage/organelles.json
@@ -641,7 +641,7 @@
     "Graphics": {
       "ScenePath": "res://assets/models/organelles/Oxytoxy.tscn"
     },
-    "Name": "_VACUOLE",
+    "Name": "TOXIN_VACUOLE",
     "ProductionColour": "#624acb",
     "ConsumptionColour": "#c4307b",
     "IconPath": "res://assets/textures/gui/bevel/parts/ToxinVacuoleIcon.png",


### PR DESCRIPTION
**Brief Description of What This PR Does**

Some balancing changes for unlock conditions, namely providing a minimum count for metabolosomes needed before unlocking mitochondria and three oxy-toxy for the toxin-vacuole. This is mainly meant to emphasize endosymbiosis, making it so that the player doesn't necessarily quickly unlock those organelles before they have a chance for endosymbiosis. We'll probably need some community feedback to fully balance this.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
