### PR TITLE
Added alternative unlock condition for oxytoxy (3 deaths)

### DIFF
--- a/simulation_parameters/microbe_stage/organelles.json
+++ b/simulation_parameters/microbe_stage/organelles.json
@@ -245,6 +245,11 @@
         "EngulfedMicrobesAbove": {
           "Required": 5
         }
+      },
+      {
+        "PlayerDeathsAbove": {
+          "Required": 3
+        }
       }
     ],
     "EditorButtonGroup": "Protein",


### PR DESCRIPTION
to allow player who is being attacked to add toxins for defence

**Brief Description of What This PR Does**

This PR does some stuff...

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
