### PR TITLE
Fixed compound bar displays when max storage is less than 1

### DIFF
--- a/src/microbe_stage/gui/CompoundProgressBar.cs
+++ b/src/microbe_stage/gui/CompoundProgressBar.cs
@@ -460,6 +460,7 @@ public partial class CompoundProgressBar : Control
 
     private void SetBarValue()
     {
+        // Scale the progress to range 0-1 which is what is used in the bar
         var target = Math.Clamp(currentValue / maxValue, 0, 1);
 
         if (SmoothBarValue)

--- a/src/microbe_stage/gui/CompoundProgressBar.cs
+++ b/src/microbe_stage/gui/CompoundProgressBar.cs
@@ -460,7 +460,7 @@ public partial class CompoundProgressBar : Control
 
     private void SetBarValue()
     {
-        var target = Math.Clamp(currentValue / maxValue, 0, maxValue);
+        var target = Math.Clamp(currentValue / maxValue, 0, 1);
 
         if (SmoothBarValue)
         {

--- a/src/microbe_stage/gui/CompoundProgressBar.cs
+++ b/src/microbe_stage/gui/CompoundProgressBar.cs
@@ -466,7 +466,7 @@ public partial class CompoundProgressBar : Control
         if (SmoothBarValue)
         {
             var tween = CreateTween();
-            tween.SetTrans(Tween.TransitionType.Expo);
+            tween.SetTrans(Tween.TransitionType.Cubic);
             tween.TweenProperty(progressBar, valueReference, target,
                 Constants.COMPOUND_BAR_VALUE_ANIMATION_TIME);
         }


### PR DESCRIPTION
**Brief Description of What This PR Does**

I think this has been a bug for a while but I now was given a save to test with so I fixed this (https://community.revolutionarygamesstudio.com/t/0-6-7-release-candidate-testing/7497/21).

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
