### PR TITLE
Fixed orphaned node count increasing after editor session

### DIFF
--- a/src/engine/DebugOverlays.SceneTreeDumper.cs
+++ b/src/engine/DebugOverlays.SceneTreeDumper.cs
@@ -21,6 +21,11 @@ public partial class DebugOverlays
 
         file.Close();
 
+        // TODO: maybe this should have a separate button?
+#if DEBUG
+        PrintOrphanedNodes();
+#endif
+
         GD.Print("Scene tree dumped to \"", SCENE_DUMP_FILE, "\"");
     }
 
@@ -30,5 +35,11 @@ public partial class DebugOverlays
 
         foreach (Node child in node.GetChildren())
             DumpSceneTreeToFile(child, file, indent + 1);
+    }
+
+    private static void PrintOrphanedNodes()
+    {
+        GD.Print("Orphaned nodes:");
+        PrintOrphanNodes();
     }
 }

--- a/src/engine/DebugOverlays.SceneTreeDumper.cs
+++ b/src/engine/DebugOverlays.SceneTreeDumper.cs
@@ -1,4 +1,5 @@
-﻿using Godot;
+﻿using System;
+using Godot;
 
 /// <summary>
 ///   Partial class: Scene tree dumper
@@ -21,9 +22,11 @@ public partial class DebugOverlays
 
         file.Close();
 
-        // TODO: maybe this should have a separate button?
+        // TODO: maybe this should have a separate button? (if added the if should be removed to always try to print
+        // the orphaned nodes)
 #if DEBUG
-        PrintOrphanedNodes();
+        if (Performance.GetMonitor(Performance.Monitor.ObjectOrphanNodeCount) > 0)
+            PrintOrphanedNodes();
 #endif
 
         GD.Print("Scene tree dumped to \"", SCENE_DUMP_FILE, "\"");
@@ -40,6 +43,25 @@ public partial class DebugOverlays
     private static void PrintOrphanedNodes()
     {
         GD.Print("Orphaned nodes:");
+
+        PrintOrphanedCountStatistics(false);
+
         PrintOrphanNodes();
+
+        PrintOrphanedCountStatistics(true);
+    }
+
+    private static void PrintOrphanedCountStatistics(bool always)
+    {
+        var orphanedCount = Performance.GetMonitor(Performance.Monitor.ObjectOrphanNodeCount);
+
+        if (Math.Abs(orphanedCount - GetOrphanedCacheItems()) < 0.1)
+        {
+            GD.Print("All orphaned Nodes are accounted for in cache items waiting re-use");
+        }
+        else if (always)
+        {
+            GD.Print($"Total orphaned items: {orphanedCount}");
+        }
     }
 }

--- a/src/engine/NodeHelpers.cs
+++ b/src/engine/NodeHelpers.cs
@@ -234,6 +234,33 @@ public static class NodeHelpers
     }
 
     /// <summary>
+    ///   Recursively counts the children of the given Node
+    /// </summary>
+    /// <param name="node">Where to start counting</param>
+    /// <param name="includeInternal">If true internal Nodes are also counted</param>
+    public static int RecursiveCountChildren(this Node node, bool includeInternal = false)
+    {
+        int childCount = node.GetChildCount(includeInternal);
+
+        int count = 0;
+
+        for (int i = 0; i < childCount; ++i)
+        {
+            var child = node.GetChild(i, includeInternal);
+
+            if (child == null)
+            {
+                GD.PrintErr("Error getting child when counting recursively");
+                break;
+            }
+
+            count += RecursiveCountChildren(child, includeInternal);
+        }
+
+        return childCount + count;
+    }
+
+    /// <summary>
     ///   Gets the parent of a Node as a Spatial in a way that actually works (Godot inbuilt method for this fails
     ///   randomly)
     /// </summary>

--- a/src/gui_common/charts/DataPoint.cs
+++ b/src/gui_common/charts/DataPoint.cs
@@ -158,6 +158,12 @@ public partial class DataPoint : Control, ICloneable, IEquatable<DataPoint>
         DataPointCache.Push(point);
     }
 
+    public static int GetDataPointCacheSize()
+    {
+        // This works only as long as no child nodes are added to any DataPoint node
+        return DataPointCache.Count;
+    }
+
     public override void _Ready()
     {
         graphMarkerCircle = GD.Load<Texture2D>("res://assets/textures/gui/bevel/graphMarkerCircle.png");
@@ -310,7 +316,7 @@ public partial class DataPoint : Control, ICloneable, IEquatable<DataPoint>
 
     private void UpdateRectSize()
     {
-        // Increased by 10 for a more bigger cursor detection area
+        // Increased by 10 for a bigger cursor detection area
         Size = new Vector2(size + 10, size + 10);
     }
 

--- a/src/gui_common/tooltip/ToolTipHelper.cs
+++ b/src/gui_common/tooltip/ToolTipHelper.cs
@@ -55,6 +55,19 @@ public static class ToolTipHelper
         DefaultToolTipCache.Push(toolTip);
     }
 
+    public static int GetDefaultToolTipCacheSize()
+    {
+        int count = 0;
+
+        // Need to also count children to get an accurate count
+        foreach (var toolTip in DefaultToolTipCache)
+        {
+            count += 1 + toolTip.RecursiveCountChildren();
+        }
+
+        return count;
+    }
+
     /// <summary>
     ///   Registers a Control mouse enter and exit event if hasn't already yet to the callbacks for the given
     ///   custom tooltip. Note that the code calling this must call


### PR DESCRIPTION
**Brief Description of What This PR Does**

caches used by the editor are now properly accounted for so that the orphaned count is 0 in the metrics panel after the editor

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #5091

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
