### PR TITLE
Reduced unnecessary StringName allocations (key prompts, checking presses)

### DIFF
--- a/src/engine/input/InputManager.cs
+++ b/src/engine/input/InputManager.cs
@@ -15,6 +15,8 @@ using Godot;
 [GodotAutoload]
 public partial class InputManager : Node
 {
+    private static readonly Dictionary<string, bool> CheckedInputActionNames = new();
+
     private static InputManager? staticInstance;
 
     private readonly List<WeakReference> destroyedListeners = new();
@@ -222,6 +224,23 @@ public partial class InputManager : Node
 
         // Everything that isn't a controller is currently a keyboard
         return ActiveInputMethod.Keyboard;
+    }
+
+    /// <summary>
+    ///   Checks if something is a valid Thrive input action name. This is preferable to <c>InputMap.HasAction</c> as
+    ///   this caches the results.
+    /// </summary>
+    /// <param name="potentialActionName">Action name to check, for example <c>"g_move_forward"</c></param>
+    /// <returns>True if valid</returns>
+    public static bool IsValidInputAction(string potentialActionName)
+    {
+        if (CheckedInputActionNames.TryGetValue(potentialActionName, out var result))
+            return result;
+
+        result = InputMap.HasAction(potentialActionName);
+        CheckedInputActionNames[potentialActionName] = result;
+
+        return result;
     }
 
     public override void _Ready()

--- a/src/engine/input/RunOnKeyAttribute.cs
+++ b/src/engine/input/RunOnKeyAttribute.cs
@@ -20,6 +20,12 @@ public class RunOnKeyAttribute : InputAttribute
     protected object[]? cachedMethodCallParameters;
 
     /// <summary>
+    ///   Cached name for unused axis. This seems like it doesn't affect hot reload thankfully.
+    ///   Due to concerns about preventing Godot hot reload this was not initially cached but now is.
+    /// </summary>
+    private static readonly StringName UnusedAxisName = new("unused");
+
+    /// <summary>
     ///   Priming comes to effect when an input gets pressed for less than one frame
     ///   (when the release input gets detected before OnProcess could be called)
     /// </summary>
@@ -34,7 +40,7 @@ public class RunOnKeyAttribute : InputAttribute
     {
         if (inputName.StartsWith(CAPTURED_MOUSE_AS_AXIS_PREFIX))
         {
-            InputName = new StringName("unused");
+            InputName = UnusedAxisName;
 
             // TODO: maybe split this actively
             MultiPartInputName = CAPTURED_MOUSE_AS_AXIS_PREFIX;

--- a/src/general/base_stage/CreatureStageHUDBase.cs
+++ b/src/general/base_stage/CreatureStageHUDBase.cs
@@ -876,10 +876,18 @@ public partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSta
         ejectEngulfedHotkey.Visible = showEject;
 
         engulfHotkey.ButtonPressed = engulfOn;
-        fireToxinHotkey.ButtonPressed = Input.IsActionPressed(fireToxinHotkey.ActionName);
-        secreteSlimeHotkey.ButtonPressed = Input.IsActionPressed(secreteSlimeHotkey.ActionName);
-        signalingAgentsHotkey.ButtonPressed = Input.IsActionPressed(signalingAgentsHotkey.ActionName);
-        ejectEngulfedHotkey.ButtonPressed = Input.IsActionPressed(ejectEngulfedHotkey.ActionName);
+
+        if (fireToxinHotkey.ActionNameAsStringName != null)
+            fireToxinHotkey.ButtonPressed = Input.IsActionPressed(fireToxinHotkey.ActionNameAsStringName);
+
+        if (secreteSlimeHotkey.ActionNameAsStringName != null)
+            secreteSlimeHotkey.ButtonPressed = Input.IsActionPressed(secreteSlimeHotkey.ActionNameAsStringName);
+
+        if (signalingAgentsHotkey.ActionNameAsStringName != null)
+            signalingAgentsHotkey.ButtonPressed = Input.IsActionPressed(signalingAgentsHotkey.ActionNameAsStringName);
+
+        if (ejectEngulfedHotkey.ActionNameAsStringName != null)
+            ejectEngulfedHotkey.ButtonPressed = Input.IsActionPressed(ejectEngulfedHotkey.ActionNameAsStringName);
     }
 
     /// <summary>

--- a/src/gui_common/ActionButton.cs
+++ b/src/gui_common/ActionButton.cs
@@ -1,4 +1,5 @@
 ﻿using Godot;
+using Newtonsoft.Json;
 
 /// <summary>
 ///   A hotkey representing and visualizing an input for in-game actions.
@@ -54,6 +55,13 @@ public partial class ActionButton : Button
             UpdateKeyPrompt();
         }
     }
+
+    /// <summary>
+    ///   When <see cref="ActionName"/> is set this is the resolved StringName variant of that for easy access
+    ///   without needing to construct string names constantly
+    /// </summary>
+    [JsonIgnore]
+    public StringName? ActionNameAsStringName => keyPrompt?.ResolvedAction;
 
     public override void _Ready()
     {

--- a/src/gui_common/CustomRichTextLabel.cs
+++ b/src/gui_common/CustomRichTextLabel.cs
@@ -502,8 +502,7 @@ public partial class CustomRichTextLabel : RichTextLabel
 
             case ThriveBbCode.Input:
             {
-                // TODO: cache for valid input actions: https://github.com/Revolutionary-Games/Thrive/issues/4983
-                if (!InputMap.HasAction(input))
+                if (!InputManager.IsValidInputAction(input))
                 {
                     GD.PrintErr($"Input action: \"{input}\" doesn't exist, referenced in bbcode");
                     break;

--- a/src/gui_common/HoldKeyPrompt.cs
+++ b/src/gui_common/HoldKeyPrompt.cs
@@ -76,7 +76,7 @@ public partial class HoldKeyPrompt : KeyPrompt
 
         if (!string.IsNullOrEmpty(ActionName))
         {
-            var pressed = Input.IsActionPressed(ActionName);
+            var pressed = ResolvedAction != null && Input.IsActionPressed(ResolvedAction);
             var oldProgress = holdProgress;
 
             if (pressed)

--- a/src/late_multicellular_stage/editor/EditorCamera3D.cs
+++ b/src/late_multicellular_stage/editor/EditorCamera3D.cs
@@ -73,6 +73,8 @@ public partial class EditorCamera3D : Camera3D
     [Export]
     public Vector3 RotateAroundPoint = Vector3.Zero;
 
+    private readonly StringName panModeAction = new("e_pan_mode");
+
     /// <summary>
     ///   To make the 3D math reasonable to implement here, we use the x,y and distance values to rotate the camera
     ///   around the target point and panning is just an offset on top of that.
@@ -284,9 +286,19 @@ public partial class EditorCamera3D : Camera3D
         return true;
     }
 
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            panModeAction.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
     private bool IsPanModeWanted()
     {
-        return Input.IsActionPressed("e_pan_mode");
+        return Input.IsActionPressed(panModeAction);
     }
 
     private void PanCamera(Vector3 panAmount)

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -435,7 +435,9 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
         unbindAllHotkey.Visible = organelles.CanUnbind(ref species, player);
 
         bindingModeHotkey.ButtonPressed = control.State == MicrobeState.Binding;
-        unbindAllHotkey.ButtonPressed = Input.IsActionPressed(unbindAllHotkey.ActionName);
+
+        if (unbindAllHotkey.ActionNameAsStringName != null)
+            unbindAllHotkey.ButtonPressed = Input.IsActionPressed(unbindAllHotkey.ActionNameAsStringName);
     }
 
     protected override void UpdateHoverInfo(float delta)

--- a/src/tutorial/microbe_stage/MicrobeMovement.cs
+++ b/src/tutorial/microbe_stage/MicrobeMovement.cs
@@ -7,8 +7,15 @@ using Newtonsoft.Json;
 /// <summary>
 ///   Microbe movement tutorial with key prompts around the cell
 /// </summary>
+#pragma warning disable CA1001 // just has some StringNames that aren't critical to Dispose
 public class MicrobeMovement : TutorialPhase
+#pragma warning restore CA1001
 {
+    private readonly StringName moveForward = new("g_move_forward");
+    private readonly StringName moveLeft = new("g_move_left");
+    private readonly StringName moveRight = new("g_move_right");
+    private readonly StringName moveBackwards = new("g_move_backwards");
+
     [JsonProperty]
     private float keyPromptRotation;
 
@@ -120,22 +127,22 @@ public class MicrobeMovement : TutorialPhase
     {
         // This does not use the input system because when OnProcess is called in a tutorial is complicated, so
         // when this code is triggered would be different using the input system
-        if (Input.IsActionPressed("g_move_forward"))
+        if (Input.IsActionPressed(moveForward))
         {
             moveForwardTime += delta;
         }
 
-        if (Input.IsActionPressed("g_move_left"))
+        if (Input.IsActionPressed(moveLeft))
         {
             moveLeftTime += delta;
         }
 
-        if (Input.IsActionPressed("g_move_right"))
+        if (Input.IsActionPressed(moveRight))
         {
             moveRightTime += delta;
         }
 
-        if (Input.IsActionPressed("g_move_backwards"))
+        if (Input.IsActionPressed(moveBackwards))
         {
             moveBackwardsTime += delta;
         }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Further removes unnecessary StringName allocations, I think now all StringName allocations during gameplay are likely gone (though there might be some category of StringNames I haven't realized is there and as such I missed it).

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #4983

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
