### PR TITLE
New native library version that should work on older CPUs

### DIFF
--- a/Scripts/NativeLibs.cs
+++ b/Scripts/NativeLibs.cs
@@ -738,6 +738,10 @@ public class NativeLibs
                 // No AVX build
                 shCommandBuilder.Append($"&& cmake {thriveContainerFolder} ");
                 shCommandBuilder.Append("-DTHRIVE_AVX=OFF ");
+
+                // Also older target CPU to not use as advanced instructions elsewhere which would cause an issue
+                // Nehalem is absolutely the oldest CPU architecture to have SSE 4.2
+                shCommandBuilder.Append("-DCMAKE_CXX_FLAGS=-march=nehalem ");
             }
 
             shCommandBuilder.Append("&& cmake ");

--- a/src/native/NativeConstants.cs
+++ b/src/native/NativeConstants.cs
@@ -9,7 +9,7 @@ using SharedBase.Models;
 /// </summary>
 public class NativeConstants
 {
-    public const int Version = 15;
+    public const int Version = 16;
     public const int EarlyCheck = 2;
 
     public const string LibraryFolder = "native_libs";

--- a/src/native/early_checks/CMakeLists.txt
+++ b/src/native/early_checks/CMakeLists.txt
@@ -18,8 +18,10 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # Probably really don't need to support debug symbols in release for MSVC
 else()
   # Sadly this needs to specify sandy bridge to get xgetbv working, but that
-  # is only called if AVX support is already detected, so this should be fined
-  # for older CPUs
+  # is only called if AVX support is already detected, so this should be fine
+  # for older CPUs. Nehalem is the minimum Thrive can work with but when SSE
+  # 4.2 support is not detected the slower library is used anyway and the CPU
+  # check won't have detected AVX.
   target_compile_options(early_checks PRIVATE -march=sandybridge)
 
   target_compile_options(early_checks PRIVATE -Wall -Wextra -Wpedantic -Wno-unknown-pragmas)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Turns out the problem was our C++ code being compiled for Sandybridge architecture. The solution is to compile it against Nehalem which is the oldest architecture that supports SSE 4.2

Also has updated Jolt and the other native lib changes recently.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #5239 (hopefully, pending testing from someone who has this issue).

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
