### PR TITLE
Made KeyPrompt queue a refresh instead of doing one immediately

### DIFF
--- a/src/gui_common/ActionButton.cs
+++ b/src/gui_common/ActionButton.cs
@@ -103,10 +103,9 @@ public partial class ActionButton : Button
 
     private void UpdateKeyPrompt()
     {
-        if (keyPrompt == null || keyPrompt.ActionName == actionName)
+        if (keyPrompt == null)
             return;
 
         keyPrompt.ActionName = actionName;
-        keyPrompt.Refresh();
     }
 }

--- a/src/gui_common/TabButtons.cs
+++ b/src/gui_common/TabButtons.cs
@@ -477,16 +477,7 @@ public partial class TabButtons : HBoxContainer
                 throw new ArgumentOutOfRangeException();
         }
 
-        if (leftButtonIndicator.ActionName != wantedLeft)
-        {
-            leftButtonIndicator.ActionName = wantedLeft;
-            leftButtonIndicator.Refresh();
-        }
-
-        if (rightButtonIndicator.ActionName != wantedRight)
-        {
-            rightButtonIndicator.ActionName = wantedRight;
-            rightButtonIndicator.Refresh();
-        }
+        leftButtonIndicator.ActionName = wantedLeft;
+        rightButtonIndicator.ActionName = wantedRight;
     }
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**
Now KeyPrompt queues a refresh for when it is next visible before it loads / updates the icon it is showing

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #1635

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
