### PR TITLE
Fix 3D Menu Background Emitter Jitter

### DIFF
--- a/assets/models/menu_backgrounds/MainMenuScene3.tscn
+++ b/assets/models/menu_backgrounds/MainMenuScene3.tscn
@@ -151,7 +151,7 @@ normal_enabled = true
 normal_scale = 1.77
 normal_texture = ExtResource("8_xuumh")
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_pjgps"]
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_44oje"]
 resource_local_to_scene = true
 cull_mode = 2
 vertex_color_use_as_albedo = true
@@ -375,4 +375,4 @@ material_override = SubResource("StandardMaterial3D_a10jh")
 
 [node name="iron22" parent="." instance=ExtResource("6")]
 transform = Transform3D(-0.0125223, 2.60165, 0.0173912, 0.707826, 0.0426514, -1.13572, -0.775451, -0.00308044, -1.03696, -13.7744, -0.214223, 2.02327)
-material_override = SubResource("StandardMaterial3D_pjgps")
+material_override = SubResource("StandardMaterial3D_44oje")

--- a/assets/models/menu_backgrounds/UnderwaterSmoke.tscn
+++ b/assets/models/menu_backgrounds/UnderwaterSmoke.tscn
@@ -69,7 +69,6 @@ amount = 50
 lifetime = 2.0
 preprocess = 3.3
 speed_scale = 0.26
-fixed_fps = 50
 collision_base_size = 0.0
 local_coords = true
 draw_order = 2


### PR DESCRIPTION
**Brief Description of What This PR Does**

Attempts to fix jittering in the main menu 3d background emitters, reported on high-resolution monitors. Resets the emitter physics frame rates to default values. This will need testing on appropriate equipment.

**Related Issues**

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
