### PR TITLE
Add option to migrate without moving player themselves

### DIFF
--- a/locale/af.po
+++ b/locale/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -40,6 +40,9 @@ msgstr "op ge gee."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abissale vlakte(niks nie)"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Word wakker ({0:F1}/{1:F1})"
@@ -2856,6 +2859,34 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Beweeg na die wakker stadium. Besikbaar na jy genoeg brain krag het (tiepe selle met \"axons\")."
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/ar.po
+++ b/locale/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2023-03-13 09:01+0000\n"
 "Last-Translator: Xradiation <tamimzain@hotmail.com>\n"
 "Language-Team: Arabic <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ar/>\n"
@@ -42,6 +42,9 @@ msgstr "تم الإلغاء."
 
 msgid "ABYSSOPELAGIC"
 msgstr "أعماق البحر"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "استيقظ ({0:F1} / {1:F1})"
@@ -2918,6 +2921,34 @@ msgstr "تستخدم خليتك [thrive:compound type=\"atp\"][/thrive:compound]
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "استمر إلا مرحلة الاستيقاظ. يصبح متاحًا بمجرد أن تكون قوة العقل كافية (أنسجة مع محاور)."
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/be.po
+++ b/locale/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2023-09-21 09:24+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Belarusian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/be/>\n"
@@ -42,6 +42,9 @@ msgstr "Адменяно"
 
 msgid "ABYSSOPELAGIC"
 msgstr "Абіссапелагічны"
+
+msgid "ACCEPT"
+msgstr ""
 
 #, fuzzy
 msgid "ACTION_AWAKEN"
@@ -2855,6 +2858,34 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Перамясціцца на стадыю Абуджэння. Дасягома толькі калі ў вас ёсць дастатковая колькасць развітасці мозга (Размясціце аксон у які небудзь тып клеткі)."
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/bg.po
+++ b/locale/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/bg/>\n"
@@ -42,6 +42,9 @@ msgstr "Прекратена."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Абисал"
+
+msgid "ACCEPT"
+msgstr ""
 
 #, fuzzy
 msgid "ACTION_AWAKEN"
@@ -3295,6 +3298,44 @@ msgstr "  {0}: Среща се в {1} от създанията, средно п
 
 msgid "MIDDLE_MOUSE"
 msgstr "Среден бутон"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Количеството"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Създаването на модификацията е неуспешно"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Наблюдавайте нивото на здравето си, което се намира до нивото на [thrive:compound type=\"АТФ\"][/thrive:compound] (долу вдясно).\n"
+"Вашата клетка ще умре, ако изгуби всичките си точки здраве.\n"
+"Ако имате [thrive:compound type=\"АТФ\"][/thrive:compound], точките здраве се възстановяват.\n"
+"Събирайте [thrive:compound type=\"глюкоза\"][/thrive:compound] за да произвеждате [thrive:compound type=\"АТФ\"][/thrive:compound]."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "Вкаменете тези създания, за да ги запазите в музея. Може да го посетите от Трайвопедията или да заредите създанията в редактора."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(определя разхода на мутационни точки в редактора)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(определя разхода на мутационни точки в редактора)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Отваряне на страницата ни в „Patreon“"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} млн"
@@ -7406,9 +7447,6 @@ msgstr "Отдалечаване"
 
 #~ msgid "E_DOT"
 #~ msgstr "„Е“."
-
-#~ msgid "RATE"
-#~ msgstr "Количеството"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/bn.po
+++ b/locale/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2023-09-10 12:18+0000\n"
 "Last-Translator: Mahbeer Alam Sarker <mahbeeralamsarker@gmail.com>\n"
 "Language-Team: Bengali <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/bn/>\n"
@@ -41,6 +41,9 @@ msgid "ABORTED_DOT"
 msgstr "সমাপ্ত করা হয়েছে।"
 
 msgid "ABYSSOPELAGIC"
+msgstr ""
+
+msgid "ACCEPT"
 msgstr ""
 
 msgid "ACTION_AWAKEN"
@@ -2871,6 +2874,37 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "(এআই প্রজাতির পরিবর্তনের গতি)"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(এআই প্রজাতির পরিবর্তনের গতি)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(এআই প্রজাতির পরিবর্তনের গতি)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "একটি নতুন কী বাইন্ডিং যোগ করুন"
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ca/>\n"
@@ -43,6 +43,9 @@ msgstr "Avortat."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Zona abissal"
+
+msgid "ACCEPT"
+msgstr ""
 
 #, fuzzy
 msgid "ACTION_AWAKEN"
@@ -3286,6 +3289,48 @@ msgstr "Estadístiques de la Cèl·lula"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Clic del mig del ratolí"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "La velocitat"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Creació de Mod Fallida"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Estigues atent a la barra de salut, que hi ha al costat de la barra d'ATP (a la part inferior dreta de la pantalla).\n"
+"Si la teva cèl·lula es queda sense energia, es morirà.\n"
+"Pots recuperar la teva salut (autoregeneració) si tens prou quantitat d'ATP.\n"
+"Assegurat de recol·lectar prou Glucosa per no quedar-te sense ATP."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"Els microbis agressius perseguiran les preses a més distància\n"
+"i és més probable que s'enfrontin a depredadors quan siguin atacats.\n"
+"Els microbis pacífics desistiran de perseguir les seves preses abans\n"
+"i és menys probable que facin servir toxines contra depredadors."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(cost d'orgànuls, membranes i altres elements a l'editor)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(cost d'orgànuls, membranes i altres elements a l'editor)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Pausar el joc"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"
@@ -7416,9 +7461,6 @@ msgstr "Zoom enfora"
 
 #~ msgid "E_DOT"
 #~ msgstr "la tecla E."
-
-#~ msgid "RATE"
-#~ msgstr "La velocitat"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/cs/>\n"
@@ -42,6 +42,9 @@ msgstr "Přerušeno."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abysopelagiál (hloubka oceánu do 6000m)"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Probudit se ({0:F1}/{1:F1})"
@@ -3315,6 +3318,48 @@ msgstr "Statistika organizmu"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Tlačítko kolečka myši"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Tempo"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Vytvoření módu se nezdařilo"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Dávej pozor na svou zdravotní lištu vedle lišty ATP (vpravo dole).\n"
+"Tvá buňka zemře, pokud jí dojde zdraví.\n"
+"Regenerace zdraví probíhá za předpokladu, že máš dostatek ATP.\n"
+"Nezapomeň shromáždit dostatek glukózy k produkci ATP."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"Agresivní mikrobi budou pronásledovat kořist na větší vzdálenosti\n"
+"a při napadení predátory jsou náchylnější k boji.\n"
+"Mírumilovní mikrobi se na větší vzdálenosti nezapojují do boje s ostatními\n"
+"a je méně pravděpodobné, že budou používat toxiny proti predátorům."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(cena organel, membrán a jiných věcí v editoru)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(cena organel, membrán a jiných věcí v editoru)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Navštivte náš Patreon"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"
@@ -7430,9 +7475,6 @@ msgstr "Oddálit"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "Tempo"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/da.po
+++ b/locale/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-09 13:22+0000\n"
 "Last-Translator: Magnus Norling Svane <magn665e@icloud.com>\n"
 "Language-Team: Danish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/da/>\n"
@@ -42,6 +42,9 @@ msgstr "Afbrudt."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abyssopelagisk"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Opvågne ({0:F1}/{1:F1})"
@@ -2848,6 +2851,34 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Tag til opvågningsstadiet. Tilgængelig, når du har nok hjernekraft (vævstype med axoner)."
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/de.po
+++ b/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: German <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/de/>\n"
@@ -42,6 +42,9 @@ msgstr "Abgebrochen."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abyssal"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Erwachen ({0:F1}/{1:F1})"
@@ -3275,6 +3278,44 @@ msgstr "Organismus-Statistik"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Mittlere Maus"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Rate"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Moderstellung fehlgeschlagen"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Achte auf deinen Gesundheitsbalken neben dem ATP-Balken (unten rechts).\n"
+"Deine Zelle stirbt, wenn Ihre Gesundheit ausgeht.\n"
+"Du regenerierst Gesundheit, solange du ATP hast.\n"
+"Achten darauf, dass du genügend Glukose sammelst, um ATP zu produzieren."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "Mache diese Spezies zu einem Fossil um sie im Museum zu speichern. Du kannst von der Thriveopedia auf das Museum zugreifen, oder Fossile im Sandboxeditor laden."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(Kosten für Organellen, Membranen und andere Gegenstände im Editor)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(Kosten für Organellen, Membranen und andere Gegenstände im Editor)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Besuche unsere Patreon Seite"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} Mio"
@@ -7373,9 +7414,6 @@ msgstr "Herauszoomen"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "Rate"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/el.po
+++ b/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2022-03-31 05:02+0000\n"
 "Last-Translator: Apostolos Paschidis <tolissius@gmail.com>\n"
 "Language-Team: Greek <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/el/>\n"
@@ -43,6 +43,9 @@ msgid "ABORTED_DOT"
 msgstr ""
 
 msgid "ABYSSOPELAGIC"
+msgstr ""
+
+msgid "ACCEPT"
 msgstr ""
 
 msgid "ACTION_AWAKEN"
@@ -2874,6 +2877,33 @@ msgid "MICROBE_STAGE_ORGANELLE_DIVISION"
 msgstr "Χρησιμοποιήστε τα πλήκτρα [thrive:input]g_move_forward[/thrive:input],[thrive:input]g_move_left[/thrive:input],[thrive:input]g_move_backwards[/thrive:input],[thrive:input]g_move_right[/thrive:input] και το ποντίκι για να κινηθείτε. Το[thrive:input]g_fire_toxin[/thrive:input] για να απελευθερώσετε [thrive:compound type=\"oxytoxy\"][/thrive:compound] εάν έχετε κενοτόπιο τοξίνης και το [thrive:input]g_toggle_engulf[/thrive:input] για να εναλλάξετε την λειτουργία απορρόφησης. Μπορείτε να αλλάξετε την μεγέθυνση με την ροδέλα τού ποντικιού."
 
 msgid "MIDDLE_MOUSE"
+msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_TOOLTIP"
 msgstr ""
 
 msgid "MILLION_ABBREVIATION"

--- a/locale/en.po
+++ b/locale/en.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 12:02+0200\n"
-"PO-Revision-Date: 2024-07-23 12:05+0200\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
+"PO-Revision-Date: 2024-07-24 11:26+0300\n"
 "Last-Translator: Teashrock <kajitsu22@gmail.com>\n"
 "Language-Team: English <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/en/>\n"
 "Language: en\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Poedit 3.4.1\n"
+"X-Generator: Poedit 3.4.4\n"
 "Generated-By: Babel 2.8.0\n"
 
 msgid "2D_MOVEMENT_TYPE_SELECTION"
@@ -1304,9 +1304,6 @@ msgstr "Description is too long"
 
 msgid "DESPAWN_ENTITIES"
 msgstr "Despawn All Entities"
-
-msgid "DESTINATION_PATCH"
-msgstr "Destination Patch"
 
 msgid "DETECTED_CPU_COUNT"
 msgstr "Detected CPU count:"
@@ -3154,11 +3151,29 @@ msgstr "Middle mouse"
 msgid "MIGRATE"
 msgstr "Migrate"
 
-msgid "MIGRATION_EXPLANATION"
-msgstr "Migrate your species without moving yourself from source patch to destination patch"
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Error: failed to add migration, please check migration parameters"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr "Going to migrate population from {0} to ..."
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr "Going to migrate {2} units of population from {0} to {1}"
+
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "Select a destination patch for the migration that is connected to the source patch"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr "Only one migration can be performed per editor session. You can view the queued migration below and keep it or cancel it to create a different migration"
+
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "Select how much population to migrate from the source patch to the destination"
+
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "Select a patch that has your species in it currently to act as the source for the migration"
 
 msgid "MIGRATION_TOOLTIP"
-msgstr "Migrate your species without moving yourself"
+msgstr "Migrate your species between patches without moving the patch you are in yourself"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"
@@ -4653,9 +4668,6 @@ msgstr "Sound Team Lead"
 
 msgid "SOUND_TEAM_LEADS"
 msgstr "Sound Team Leads"
-
-msgid "SOURCE_PATCH"
-msgstr "Source Patch"
 
 msgid "SPACE"
 msgstr "Space"
@@ -6986,6 +6998,12 @@ msgstr "Zoom in"
 
 msgid "ZOOM_OUT"
 msgstr "Zoom out"
+
+#~ msgid "DESTINATION_PATCH"
+#~ msgstr "Destination Patch"
+
+#~ msgid "SOURCE_PATCH"
+#~ msgstr "Source Patch"
 
 #~ msgid "BASSBOOST"
 #~ msgstr "Bassboost"

--- a/locale/en.po
+++ b/locale/en.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
-"PO-Revision-Date: 2024-07-22 14:00+0200\n"
+"POT-Creation-Date: 2024-07-23 12:02+0200\n"
+"PO-Revision-Date: 2024-07-23 12:05+0200\n"
 "Last-Translator: Teashrock <kajitsu22@gmail.com>\n"
 "Language-Team: English <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/en/>\n"
 "Language: en\n"
@@ -42,6 +42,9 @@ msgstr "Aborted."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abyssopelagic"
+
+msgid "ACCEPT"
+msgstr "Accept"
 
 msgid "ACTION_AWAKEN"
 msgstr "Awaken ({0:F1} / {1:F1})"
@@ -1301,6 +1304,9 @@ msgstr "Description is too long"
 
 msgid "DESPAWN_ENTITIES"
 msgstr "Despawn All Entities"
+
+msgid "DESTINATION_PATCH"
+msgstr "Destination Patch"
 
 msgid "DETECTED_CPU_COUNT"
 msgstr "Detected CPU count:"
@@ -3145,6 +3151,15 @@ msgstr ""
 msgid "MIDDLE_MOUSE"
 msgstr "Middle mouse"
 
+msgid "MIGRATE"
+msgstr "Migrate"
+
+msgid "MIGRATION_EXPLANATION"
+msgstr "Migrate your species without moving yourself from source patch to destination patch"
+
+msgid "MIGRATION_TOOLTIP"
+msgstr "Migrate your species without moving yourself"
+
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"
 
@@ -4638,6 +4653,9 @@ msgstr "Sound Team Lead"
 
 msgid "SOUND_TEAM_LEADS"
 msgstr "Sound Team Leads"
+
+msgid "SOURCE_PATCH"
+msgstr "Source Patch"
 
 msgid "SPACE"
 msgstr "Space"
@@ -7551,9 +7569,6 @@ msgstr "Zoom out"
 
 #~ msgid "EDIAERESIS"
 #~ msgstr "Ë"
-
-#~ msgid "IGRAVE"
-#~ msgstr "Ì"
 
 #~ msgid "IACUTE"
 #~ msgstr "Í"

--- a/locale/eo.po
+++ b/locale/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/eo/>\n"
@@ -42,6 +42,9 @@ msgstr "Nuligita."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abisma zono"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr ""
@@ -3335,6 +3338,44 @@ msgstr "Organisma Statistiko"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Meza musbutono"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Takso"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Aŭtomata evolucio malsukcesis"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Rigardu vian sanstaton apud la ATP-breto (malsupre dekstre).\n"
+"Via ĉelo mortas, se ĝi elĉerpiĝas.\n"
+"Vi regeneras sanon dum vi havas ATP-ojn.\n"
+"Certigu kolekti sufiĉe da glukozo por produkti ATP-ojn."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "{0} loĝantaro ŝanĝiĝis per {1} pro: {2}"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "{0} loĝantaro ŝanĝiĝis per {1} pro: {2}"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(la rapideco de mutacio en AI-specioj)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Aldonunovan funkcion por klavo"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"
@@ -7537,9 +7578,6 @@ msgstr "Malzomu"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "Takso"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-07-06 16:31+0000\n"
 "Last-Translator: Jorge Maldonado Ventura <jorgesumle@freakspot.net>\n"
 "Language-Team: Spanish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/es/>\n"
@@ -42,6 +42,9 @@ msgstr "Abortado."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abisopelágico"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Despertar ({0:F1} / {1:F1})"
@@ -3314,6 +3317,44 @@ msgstr "Estadísticas del Organismo"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Clic central"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Eficiencia"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Creación de Mod Fallida"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Mantén la atención en la barra de PS al lado de la barra de ATP (parte inferior derecha).\n"
+"Tu célula muere si se queda sin PS.\n"
+"Mientras tengas ATP, regenerarás tus PS.\n"
+"Asegúrate de conseguir suficiente glucosa para producir ATP."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "Fosiliza esta especie para preservarla en el Museo. Puedes acceder al Museo desde la Thrivepedia, o abrir especies fosilizadas en el editor libre."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(Costo de orgánulos, membranas, y otros objetos en el editor)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(Costo de orgánulos, membranas, y otros objetos en el editor)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Visita nuestro Patreon"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"
@@ -7461,9 +7502,6 @@ msgstr "Alejar el zoom"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "Eficiencia"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/es_AR.po
+++ b/locale/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-22 23:22+0000\n"
 "Last-Translator: Paz <pazpiderit@gmail.com>\n"
 "Language-Team: Spanish (Argentina) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/es_AR/>\n"
@@ -42,6 +42,9 @@ msgstr "Abortado ."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abisopelágico"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Recién levantado ({0:F1} / {1:F1})"
@@ -3168,6 +3171,38 @@ msgstr "Mover organela"
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Normal"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "Normal"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "Normal"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(Velocidad en la que las especies guiadas por IA mutan)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Disparar toxina"
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/et.po
+++ b/locale/et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Estonian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/et/>\n"
@@ -45,6 +45,9 @@ msgstr "Katkestatud."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abyss"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr ""
@@ -3380,6 +3383,51 @@ msgstr "Organismi statistika"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Keskmine hiir"
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Modifikatsiooni loomine ebaõnnestus"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Hoidke oma terviseribal silm peal ATP riba kõrval (all paremal).\n"
+"Teie rakk sureb, kui selle tervis otsa saab.\n"
+"Kui teil on ATP, taastate tervist.\n"
+"Veenduge, et kogute piisavalt glükoosi ATP tootmiseks."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"Agressiivsed mikroobid ajavad saaki taga suuremate vahemaade tagant\n"
+"ja nad võitlevad rünnaku korral tõenäolisemalt kiskjatega.\n"
+"Rahumeelsed mikroobid ei haara teisi kaugemal\n"
+"ja kasutavad vähem tõenäoliselt toksiine röövloomade vastu."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+"Aktiivsed mikroobid jooksevad ja kukuvad, kui midagi huvitavat ei juhtu.\n"
+"Sessiilsed mikroobid on paigal ja ootavad enne tegutsemist, kuni keskkond muutub."
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+"Aktiivsed mikroobid jooksevad ja kukuvad, kui midagi huvitavat ei juhtu.\n"
+"Sessiilsed mikroobid on paigal ja ootavad enne tegutsemist, kuni keskkond muutub."
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Peata mäng"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"

--- a/locale/fi.po
+++ b/locale/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-02-20 12:10+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Finnish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/fi/>\n"
@@ -42,6 +42,9 @@ msgstr "Peruutettu."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abyssaalivyöhyke"
+
+msgid "ACCEPT"
+msgstr ""
 
 #, fuzzy
 msgid "ACTION_AWAKEN"
@@ -3390,6 +3393,52 @@ msgstr "Statistiikkaa organismista"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Hiiren keskimmäinen painike"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Nopeus"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Auto-evon suorittaminen epäonnistui"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Seuraa tarkoin alhaalla oikealla näkyviä palkkeja.\n"
+"Solusi kuolee, jos sen terveyspalkki loppuu.\n"
+"Terveyspalkkisi kasvaa silloin kun solullasi on ATP:tä.\n"
+"Pidä huolta, että keräät tarpeeksi glukoosia tuottaaksesi ATP:tä."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"Aggressiiviset mikrobit kulkevat pidempiä etäisyyksiä jahdatessaan muita\n"
+"ja taistelevat todennäköisemmin takaisin hyökkääjiäänsä vastaan.\n"
+"Passiiviset mikrobit pysyttelevät enemmän paikallaan ja eivät yleensä\n"
+"käytä esimerkiksi myrkkyjä toisia mikrobeja vastaan."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+"Aktiiviset mikrobit vilistävät ja mukeltavat, kun mitään mielenkiintoista ei tapahdu.\n"
+"Lakoniset mikrobit pysyttelevät mieluummin paikoillaan odottaen ympäristön muutoksia reagoidakseen niihin."
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+"Aktiiviset mikrobit vilistävät ja mukeltavat, kun mitään mielenkiintoista ei tapahdu.\n"
+"Lakoniset mikrobit pysyttelevät mieluummin paikoillaan odottaen ympäristön muutoksia reagoidakseen niihin."
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Laita peli tauolle"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"
@@ -7524,9 +7573,6 @@ msgstr "Zoomaa ulospäin"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "Nopeus"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-07-16 16:22+0000\n"
 "Last-Translator: syl <syl@gresille.org>\n"
 "Language-Team: French <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/fr/>\n"
@@ -42,6 +42,9 @@ msgstr "Abandonné."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abyssopélagique"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "S'éveiller ({0:F1} / {1:F1})"
@@ -3185,6 +3188,44 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr "Clic molette"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Taux"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Échec de la fossilisation"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Gardez un œil sur votre barre de santé près de votre barre d'[thrive:compound type=\"atp\"][/thrive:compound] (en bas à droite).\n"
+"Votre cellule meurt si elle est à court de vie.\n"
+"Vous régénérez votre santé tant que vous avez de l'[thrive:compound type=\"atp\"][/thrive:compound].\n"
+"Faites en sorte de collecter assez de [thrive:compound type=\"glucose\"][/thrive:compound] pour produire de l'[thrive:compound type=\"atp\"][/thrive:compound]."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "Les différents types de toxines ont des effets variés qui sont plus efficaces contre certains types de cellules. Si une cellule possède plusieurs types de toxines, celles-ci sont utilisées successivement plutôt que toutes à la fois."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(coût des organites, membranes et autres éléments dans l'éditeur)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(coût des organites, membranes et autres éléments dans l'éditeur)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Visitez notre page Patreon"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"
@@ -7283,9 +7324,6 @@ msgstr "Dézoomer"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "Taux"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/frm.po
+++ b/locale/frm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -39,6 +39,9 @@ msgid "ABORTED_DOT"
 msgstr ""
 
 msgid "ABYSSOPELAGIC"
+msgstr ""
+
+msgid "ACCEPT"
 msgstr ""
 
 msgid "ACTION_AWAKEN"
@@ -2844,6 +2847,33 @@ msgid "MICROBE_STAGE_ORGANELLE_DIVISION"
 msgstr ""
 
 msgid "MIDDLE_MOUSE"
+msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_TOOLTIP"
 msgstr ""
 
 msgid "MILLION_ABBREVIATION"

--- a/locale/he.po
+++ b/locale/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/he/>\n"
@@ -42,6 +42,9 @@ msgstr "הופל."
 
 msgid "ABYSSOPELAGIC"
 msgstr "אביסלפלגיים"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "התעורר ({0:F1} / {1:F1})"
@@ -3283,6 +3286,48 @@ msgstr "סטטיסטיקת האורגניזם"
 
 msgid "MIDDLE_MOUSE"
 msgstr "גלגלת העכבר"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "קצב"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "יצירת מוד נכשלה"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"עקוב אחרי מד החיים שלך שליד מד הATP (בימין התחתון).\n"
+"התא שלך ימות אם יגמר לו החיים.\n"
+"ואתה מתרפא כל עוד יש לך ATP.\n"
+"הקפד לאסוף מספיק גלוקוז ליצור ATP."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"מיקרובים אגרסיבים ירדפו אחרי הטרפם למרחקים\n"
+"והם לרוב נוטים להילחם בטורפים כשהם מותקפים.\n"
+"מיקרובים שלווים לא יתקפו אחרים למרחקים\n"
+"ופחות נוטים להשתמש ברעלנים כנגד טורפים."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(העלות של אברונים, ממברנה וחפצים אחרים בעורך)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(העלות של אברונים, ממברנה וחפצים אחרים בעורך)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "ראו את דף הפטריון שלנו"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} מיליון"
@@ -7389,9 +7434,6 @@ msgstr "זום החוצה"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "קצב"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/hr.po
+++ b/locale/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-02-21 15:28+0000\n"
 "Last-Translator: Gabriel Glavica <gabriel.glavicacretni@gmail.com>\n"
 "Language-Team: Croatian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/hr/>\n"
@@ -42,6 +42,9 @@ msgstr "Pobačen."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abisopelagičar"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Probuditi ({0:F1} / {1:F1})"
@@ -3006,6 +3009,49 @@ msgstr "[thrive:input]g_move_forward[/thrive:input],[thrive:input]g_move_left[/t
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"Agresivni mikrobi će loviti plijen na većim udaljenostima\n"
+"i veća je šansa da će se braniti kada su napadnuti.\n"
+"Mirni mikrobi neće se baviti s drugima na većim udaljenostima\n"
+"i manja je šansa da će koristiti toksine protiv predatora."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+"Agresivni mikrobi će loviti plijen na većim udaljenostima\n"
+"i veća je šansa da će se braniti kada su napadnuti.\n"
+"Mirni mikrobi neće se baviti s drugima na većim udaljenostima\n"
+"i manja je šansa da će koristiti toksine protiv predatora."
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+"Agresivni mikrobi će loviti plijen na većim udaljenostima\n"
+"i veća je šansa da će se braniti kada su napadnuti.\n"
+"Mirni mikrobi neće se baviti s drugima na većim udaljenostima\n"
+"i manja je šansa da će koristiti toksine protiv predatora."
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Kreni u fazu buđenja. Moguće kada imaš dovoljno moždane snage (vrsta tkiva s aksionima)"
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-03-14 12:20+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hungarian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/hu/>\n"
@@ -42,6 +42,9 @@ msgstr "Megszakítva."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abisszopelágikus"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Felébred ({0:F1} / {1:F1})"
@@ -3273,6 +3276,47 @@ msgstr "  {0}: Megtalálható a {1} fajokban, átlagosan {2} darabja"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Görgő"
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Mod létrehozása sikertelen"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Tartsd szemmel az életerő csíkot az ATP mérő mellett (jobb alsó sarok).\n"
+"A sejted meghal, ha elfogy az életereje.\n"
+"Addig regenerálódik a sejted, amíg rendelkezik ATP-vel.\n"
+"Figyelj arra, hogy elegendő glükózt gyűjts az ATP előállításához."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"Az agresszív sejtek a prédáikat távolabbról is le fogják vadászni,\n"
+"és nagyobb eséllyel küzdenek más ragadozók ellen, ha megtámadják őket.\n"
+"A békés sejtek nem kergetnek más prédákat,\n"
+"és kevesebb eséllyel használnak mérgeket ragadozók ellen."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(a szervek, membránok, és egyéb dolgok költsége a szerkesztőben)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(a szervek, membránok, és egyéb dolgok költsége a szerkesztőben)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Játék szüneteltetése"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"

--- a/locale/id.po
+++ b/locale/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/id/>\n"
@@ -42,6 +42,9 @@ msgstr "Dibatalkan."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abisopelagik"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr ""
@@ -3324,6 +3327,43 @@ msgstr "Statistika Organisme"
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Auto-evo gagal bekerja"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Perhatikan bilah health di sebelah bilah ATP (kanan bawah).\n"
+"Selmu mati jika kehabisan health.\n"
+"Kamu memperbarui health ketika memiliki ATP.\n"
+"Pastikan telah mengumpulkan glukosa yang cukup untuk memproduksi ATP."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "{0} populasi berubah {1} karena: {2}"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "{0} populasi berubah {1} karena: {2}"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(kecepatan mutasi spesies AI)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Tambah keybind baru"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} jt"

--- a/locale/it.po
+++ b/locale/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Italian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/it/>\n"
@@ -42,6 +42,9 @@ msgstr "Processo annullato."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abissopelagico"
+
+msgid "ACCEPT"
+msgstr ""
 
 #, fuzzy
 msgid "ACTION_AWAKEN"
@@ -3277,6 +3280,48 @@ msgstr "Statistiche dell'organismo"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Clic centrale"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Il tasso"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Creazione della mod fallita"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Tieni d'occhio la barra della tua salute vicino alla barra dell'ATP (in basso a destra).\n"
+"Se si svuota, la tua cellula muore.\n"
+"Recuperi salute se hai ATP disponibile.\n"
+"Assicurati di raccogliere abbastanza glucosio per produrre ATP."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"I microbi aggressivi inseguono le prede per grandi distanze\n"
+"e sono più propensi a combattere quando aggrediti.\n"
+"I microbi pacifici, invece, ignorano i soggetti lontani\n"
+"e sono meno inclini a sparare tossine ai propri predatori."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(costo di organuli, membrane e altri oggetti nell'editor)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(costo di organuli, membrane e altri oggetti nell'editor)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Metti in pausa il gioco"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} Mln"
@@ -7411,9 +7456,6 @@ msgstr "Zoom indietro"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "Il tasso"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/ka.po
+++ b/locale/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-07-13 12:22+0000\n"
 "Last-Translator: NorwayFun <temuri.doghonadze@gmail.com>\n"
 "Language-Team: Georgian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ka/>\n"
@@ -42,6 +42,9 @@ msgstr "გაუქმებულია."
 
 msgid "ABYSSOPELAGIC"
 msgstr "აბისოპელაგიური"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "გაიღვიძა ({0:F1} / {1:F1})"
@@ -2875,6 +2878,38 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr "თაგუნას შუა ღილაკი"
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "მოდის შექმნა ჩავარდა"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "(მოთამაშის სახეობის ოსმორეგულაციის ფასი)"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(მოთამაშის სახეობის ოსმორეგულაციის ფასი)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(სიჩქარე, რომლითაც AI-ის სახეობები განიცდიან მუტაციას)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "ეწვიეთ ჩვენს Patreon-ის გვერდს"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} მლნ"

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ko/>\n"
@@ -42,6 +42,9 @@ msgstr "중지됨."
 
 msgid "ABYSSOPELAGIC"
 msgstr "심해원양성"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr ""
@@ -3293,6 +3296,44 @@ msgstr "생체 상태창"
 
 msgid "MIDDLE_MOUSE"
 msgstr "마우스 가운데 버튼"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "비율"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "자동 진화 실행 실패"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"ATP 막대 옆의 생명력 막대를 주시하세요(오른쪽 아래).\n"
+"생명력이 모두 떨어지면 세포는 죽게 됩니다.\n"
+"ATP가 있다면 재생할 것입니다.\n"
+"ATP를 만들기 위하여 충분한 포도당을 수집하세요."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "다음으로 인하여 개체 수가 {0} 에서 {1} 로 변화됨: {2}"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "이 패널은 Auto-Evo가 예측에 사용하는 숫자들을 보여줍니다. 하나의 종이 얻을 수 있는 에너지의 총량과 그 종의 한 개체당 필요한 에너지 비용이 최종 개체수를 결정합니다. Auto-Evo는 현실을 간략화한 모델을 사용하여 하나의 종이 얻을 수 있는 에너지로부터 그 종이 얼마나 잘 기능하고 있는지 계산합니다. 각각의 에너지원에 대해, 종이 해당 에너지원으로부터 얻는 에너지의 양이 표시됩니다. 이에 더하여 해당 에너지원으로부터 얻을 수 있는 에너지의 총량이 표시됩니다. 주어진 에너지의 총량에 비해 해당 종이 얻는 양의 비율은 해당 종의 적합도가 적합도 총량에 비해 얼마나 높은지에 따라 결정됩니다. 적합도는 종이 에너지원을 얼마나 잘 활용할 수 있는지 측정하는 지표입니다."
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(AI 종이 변이하는 속도)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "새로운 키 배치 추가"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} 백만"
@@ -7438,9 +7479,6 @@ msgstr "축소"
 
 #~ msgid "E_DOT"
 #~ msgstr "E 키."
-
-#~ msgid "RATE"
-#~ msgstr "비율"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/la.po
+++ b/locale/la.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2023-04-25 19:02+0000\n"
 "Last-Translator: AliquisDeNusquam <culhaneb9@gmail.com>\n"
 "Language-Team: Latin <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/la/>\n"
@@ -42,6 +42,9 @@ msgstr "Abortum est."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Profundi regio"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Excitare ({0:F1} / {1:F1})"
@@ -2967,6 +2970,38 @@ msgstr "[thrive:input]g_move_forward[/thrive:input],[thrive:input]g_move_left[/t
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Verificationes aliae problema deprehenderunt: {0}"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "(velocitas ad quam AI species mutantes)"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(velocitas ad quam AI species mutantes)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(velocitas ad quam AI species mutantes)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Addere novum botonem relegationis"
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/lb_LU.po
+++ b/locale/lb_LU.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-02-18 17:10+0000\n"
 "Last-Translator: Alex Larbière <alex@larbiere.eu>\n"
 "Language-Team: Luxembourgish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/lb/>\n"
@@ -43,6 +43,9 @@ msgid "ABORTED_DOT"
 msgstr "Ofgebrach."
 
 msgid "ABYSSOPELAGIC"
+msgstr ""
+
+msgid "ACCEPT"
 msgstr ""
 
 msgid "ACTION_AWAKEN"
@@ -2854,6 +2857,36 @@ msgid "MICROBE_STAGE_ORGANELLE_DIVISION"
 msgstr ""
 
 msgid "MIDDLE_MOUSE"
+msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "(Geschwindegkeet mat der dei kënschtlech Intelligenz hier Arten mutéieren)"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(Geschwindegkeet mat der dei kënschtlech Intelligenz hier Arten mutéieren)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(Geschwindegkeet mat der dei kënschtlech Intelligenz hier Arten mutéieren)"
+
+msgid "MIGRATION_TOOLTIP"
 msgstr ""
 
 msgid "MILLION_ABBREVIATION"

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2023-10-12 00:43+0000\n"
 "Last-Translator: Irmantas <irmantas_i@yahoo.com>\n"
 "Language-Team: Lithuanian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/lt/>\n"
@@ -42,6 +42,9 @@ msgstr "Nutrauktas."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Bedugnė"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Nubusti ({0:F1} / {1:F1})"
@@ -3047,6 +3050,43 @@ msgstr "Tam, kad atrakinti redaktorių ir dauginimąsi tau reikės surinkti [thr
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "(pradžios vieta)"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"Nusileidimas panaikins jūsų pakilusio statusą ir grąžins jus į Mikrobų Etapą. Iš ten galėsite vėl pereiti žaidimą, išsaugoję dabartinį išsaugojimą.\n"
+"\n"
+"Už naująjį peržaidimą gausite nusileidimo privilegiją. Būsimoje versijoje galėsite patys pasirinkti šį privalumą, tačiau kol kas jis visada bus 20 % sumažėjęs osmoreguliacijos koeficientas.\n"
+"\n"
+"Kai patvirtinsite nusileidimą, galėsite redaguoti žaidimo nustatymus ir pasirinkti naują pasaulio sėklą, kad galėtumėte žaisti kitame žemėlapyje arba, pavyzdžiui, išjungti LAWK."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(organelių sąnaudos, membranos ir kiti elementai redaktoriuje)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(organelių sąnaudos, membranos ir kiti elementai redaktoriuje)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Baigti žaidimą"
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/lv.po
+++ b/locale/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2023-06-24 20:02+0000\n"
 "Last-Translator: Gr0vey <monkoftime1188@gmail.com>\n"
 "Language-Team: Latvian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/lv/>\n"
@@ -42,6 +42,9 @@ msgstr "Atcelts."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abisālpelaģiāle"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr ""
@@ -3279,6 +3282,46 @@ msgstr "Organisma statistika"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Peles vidējā poga"
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "populācija:"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"Agresīvi mikrobi savu upuri dzīs ļoti tālas distances\n"
+"un ir tie, kuri visbiežāk cīnīsies ar plēsējiem, kad tie uzbrūk.\n"
+"Miermīlīgi mikrobrobi necīnīsies ar citiem pāri tālām distancēm\n"
+"un retāk lietos toksīnus pret plēsējiem."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+"Aktīvi mikrobi skraidīs apkārt un gāzīsies, kad nekas interesants nenotiek.\n"
+"Sēdošie mikrobi būs nekustīgi un gaidīs, kad vide mainīsies, pirms tie kaut ko dara."
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+"Aktīvi mikrobi skraidīs apkārt un gāzīsies, kad nekas interesants nenotiek.\n"
+"Sēdošie mikrobi būs nekustīgi un gaidīs, kad vide mainīsies, pirms tie kaut ko dara."
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,6 +47,10 @@ msgstr ""
 
 #: ../simulation_parameters/microbe_stage/biomes.json:888
 msgid "ABYSSOPELAGIC"
+msgstr ""
+
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:551
+msgid "ACCEPT"
 msgstr ""
 
 #: ../src/late_multicellular_stage/MulticellularHUD.cs:277
@@ -180,7 +184,7 @@ msgid "AMBIANCE_VOLUME"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/compounds.json:17
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:329
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:340
 msgid "AMMONIA"
 msgstr ""
 
@@ -269,7 +273,7 @@ msgstr ""
 #: ../src/microbe_stage/editor/MicrobeEditorReportComponent.cs:419
 #: ../src/microbe_stage/editor/MicrobeEditorReportComponent.tscn:471
 #: ../src/microbe_stage/editor/MicrobeEditorReportComponent.tscn:475
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:231
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:242
 msgid "ATMOSPHERIC_GASSES"
 msgstr ""
 
@@ -351,7 +355,7 @@ msgstr ""
 msgid "AUTO_EVO_FAILED"
 msgstr ""
 
-#: ../src/auto-evo/AutoEvoExploringTool.tscn:661
+#: ../src/auto-evo/AutoEvoExploringTool.tscn:662
 #: ../src/microbe_stage/editor/MicrobeEditorReportComponent.tscn:242
 msgid "AUTO_EVO_RESULTS"
 msgstr ""
@@ -391,7 +395,7 @@ msgstr ""
 msgid "AWARE_STAGE"
 msgstr ""
 
-#: ../src/auto-evo/AutoEvoExploringTool.tscn:726
+#: ../src/auto-evo/AutoEvoExploringTool.tscn:727
 #: ../src/general/MainMenu.tscn:417 ../src/general/MainMenu.tscn:476
 #: ../src/general/MainMenu.tscn:515 ../src/general/MainMenu.tscn:816
 #: ../src/general/NewGameSettings.tscn:922 ../src/general/OptionsMenu.tscn:1644
@@ -492,7 +496,7 @@ msgstr ""
 msgid "BEHAVIOUR_OPPORTUNISM"
 msgstr ""
 
-#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:260
+#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:341
 msgid "BELOW_SEA_LEVEL"
 msgstr ""
 
@@ -572,7 +576,7 @@ msgstr ""
 msgid "BIOLUMINESCENT_VACUOLE"
 msgstr ""
 
-#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:257
+#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:338
 msgid "BIOME_LABEL"
 msgstr ""
 
@@ -633,6 +637,7 @@ msgstr ""
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:19
 #: ../src/gui_common/dialogs/CustomConfirmationDialog.tscn:71
 #: ../src/microbe_stage/editor/EndosymbiosisProgressDisplay.tscn:67
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:565
 #: ../src/modding/NewModGUI.tscn:334
 #: ../src/space_stage/gui/SpaceConstructionPopup.tscn:48
 #: ../src/thriveopedia/fossilisation/FossilisationDialog.tscn:127
@@ -692,7 +697,7 @@ msgid "CAPSLOCK"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/compounds.json:174
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:281
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:292
 msgid "CARBON_DIOXIDE"
 msgstr ""
 
@@ -1028,7 +1033,7 @@ msgstr ""
 #: ../src/microbe_stage/editor/MicrobeEditorReportComponent.tscn:484
 #: ../src/microbe_stage/editor/upgrades/ChemoreceptorUpgradeGUI.tscn:33
 #: ../src/microbe_stage/gui/CompoundPanels.tscn:662
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:293
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:304
 msgid "COMPOUNDS"
 msgstr ""
 
@@ -1128,7 +1133,7 @@ msgstr ""
 msgid "CONFIRM_DELETE"
 msgstr ""
 
-#: ../src/auto-evo/AutoEvoExploringTool.tscn:735
+#: ../src/auto-evo/AutoEvoExploringTool.tscn:736
 #: ../src/general/PauseMenu.tscn:325
 #: ../src/thriveopedia/pages/ThriveopediaMuseumPage.tscn:118
 msgid "CONFIRM_EXIT"
@@ -1549,7 +1554,7 @@ msgstr ""
 msgid "CURRENT_DEVELOPERS"
 msgstr ""
 
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:121
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:132
 msgid "CURRENT_LOCATION_CAPITAL"
 msgstr ""
 
@@ -2264,7 +2269,7 @@ msgstr ""
 msgid "ESTUARY"
 msgstr ""
 
-#: ../src/auto-evo/AutoEvoExploringTool.tscn:699
+#: ../src/auto-evo/AutoEvoExploringTool.tscn:700
 msgid "EVOLUTIONARY_TREE"
 msgstr ""
 
@@ -2313,7 +2318,7 @@ msgstr ""
 msgid "EXPORT_ALL_WORLDS_TOOLTIP"
 msgstr ""
 
-#: ../src/auto-evo/AutoEvoExploringTool.tscn:740
+#: ../src/auto-evo/AutoEvoExploringTool.tscn:741
 msgid "EXPORT_SUCCESS"
 msgstr ""
 
@@ -2685,7 +2690,7 @@ msgid "GLOBAL_TIMELINE_SPECIES_MIGRATED_TO"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/compounds.json:77
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:354
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:365
 msgid "GLUCOSE"
 msgstr ""
 
@@ -2832,7 +2837,7 @@ msgid "HUD_MESSAGE_MULTIPLE"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/compounds.json:57
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:304
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:315
 msgid "HYDROGEN_SULFIDE"
 msgstr ""
 
@@ -3071,7 +3076,7 @@ msgid "IN_PROTOTYPE"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/compounds.json:139
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:404
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:415
 msgid "IRON"
 msgstr ""
 
@@ -3539,7 +3544,7 @@ msgstr ""
 msgid "LIGHT_LEVEL_DAY"
 msgstr ""
 
-#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:276
+#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:357
 msgid "LIGHT_LEVEL_LABEL_AT_NOON"
 msgstr ""
 
@@ -3547,7 +3552,7 @@ msgstr ""
 msgid "LIGHT_LEVEL_NIGHT"
 msgstr ""
 
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:226
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:237
 msgid "LIGHT_MAX"
 msgstr ""
 
@@ -4004,6 +4009,43 @@ msgstr ""
 msgid "MIDDLE_MOUSE"
 msgstr ""
 
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:474
+msgid "MIGRATE"
+msgstr ""
+
+#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:627
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:775
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:780
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:735
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+
+#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:753
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:744
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+
+#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:726
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:491
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:472
+msgid "MIGRATION_TOOLTIP"
+msgstr ""
+
 #: ../src/general/utils/StringUtils.cs:36
 msgid "MILLION_ABBREVIATION"
 msgstr ""
@@ -4308,7 +4350,7 @@ msgstr ""
 msgid "MOVE_TO_MULTICELLULAR_STAGE_TOOLTIP"
 msgstr ""
 
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:448
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:459
 msgid "MOVE_TO_THIS_PATCH"
 msgstr ""
 
@@ -4508,7 +4550,7 @@ msgid "NEXT_EDITOR_TAB"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/compounds.json:189
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:262
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:273
 msgid "NITROGEN"
 msgstr ""
 
@@ -4943,7 +4985,7 @@ msgid "OVERWRITE_SPECIES_NAME_CONFIRMATION"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/compounds.json:159
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:243
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:254
 msgid "OXYGEN"
 msgstr ""
 
@@ -5125,7 +5167,7 @@ msgstr ""
 #: ../src/microbe_stage/editor/upgrades/ToxinUpgradeGUI.cs:47
 #: ../src/microbe_stage/gui/CompoundProgressBar.cs:422
 #: ../src/microbe_stage/gui/CompoundProgressBar.cs:498
-#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:263
+#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:344
 #: ../src/microbe_stage/MicrobeHUD.cs:288
 #: ../src/microbe_stage/organelle_unlocks/WorldBasedUnlockCondition.cs:157
 #: ../src/microbe_stage/organelle_unlocks/WorldBasedUnlockCondition.cs:160
@@ -5149,7 +5191,7 @@ msgid "PER_SECOND_SLASH"
 msgstr ""
 
 #: ../simulation_parameters/microbe_stage/compounds.json:37
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:379
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:390
 msgid "PHOSPHATE"
 msgstr ""
 
@@ -5159,7 +5201,7 @@ msgid "PHOTOSYNTHESIS"
 msgstr ""
 
 #: ../src/microbe_stage/editor/MicrobeEditorReportComponent.tscn:422
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:141
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:152
 msgid "PHYSICAL_CONDITIONS"
 msgstr ""
 
@@ -5278,7 +5320,7 @@ msgstr ""
 msgid "PREDICTION_DETAILS_OPEN_TOOLTIP"
 msgstr ""
 
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:179
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:190
 msgid "PRESSURE"
 msgstr ""
 
@@ -5551,7 +5593,7 @@ msgstr ""
 msgid "RETURN_TO_MENU_TOOLTIP"
 msgstr ""
 
-#: ../src/auto-evo/AutoEvoExploringTool.tscn:734 ../src/general/PauseMenu.cs:409
+#: ../src/auto-evo/AutoEvoExploringTool.tscn:735 ../src/general/PauseMenu.cs:409
 msgid "RETURN_TO_MENU_WARNING"
 msgstr ""
 
@@ -5825,7 +5867,7 @@ msgid "SECRETE_SLIME_TOOLTIP"
 msgstr ""
 
 #: ../src/microbe_stage/editor/MicrobeEditorPatchMap.tscn:136
-#: ../src/microbe_stage/editor/PatchMapEditorComponent.cs:306
+#: ../src/microbe_stage/editor/PatchMapEditorComponent.cs:340
 #: ../src/thriveopedia/pages/ThriveopediaPatchMapPage.cs:146
 #: ../src/thriveopedia/pages/ThriveopediaPatchMapPage.tscn:82
 msgid "SEED_LABEL"
@@ -5855,7 +5897,7 @@ msgstr ""
 msgid "SELECT_A_GENERATION"
 msgstr ""
 
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:82
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:93
 msgid "SELECT_A_PATCH"
 msgstr ""
 
@@ -6150,7 +6192,7 @@ msgstr ""
 msgid "SPECIES_POPULATION"
 msgstr ""
 
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:423
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:434
 msgid "SPECIES_PRESENT"
 msgstr ""
 
@@ -6166,7 +6208,7 @@ msgstr ""
 msgid "SPECIES_TO_FIND"
 msgstr ""
 
-#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:315
+#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:396
 msgid "SPECIES_WITH_POPULATION"
 msgstr ""
 
@@ -6426,7 +6468,7 @@ msgstr ""
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:1447
 #: ../src/microbe_stage/editor/CellEditorComponent.tscn:449
 #: ../src/microbe_stage/editor/MicrobeEditorReportComponent.tscn:465
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:198
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:209
 msgid "SUNLIGHT"
 msgstr ""
 
@@ -6539,7 +6581,7 @@ msgstr ""
 #: ../src/gui_common/tooltip/ToolTipManager.tscn:1441
 #: ../src/microbe_stage/editor/MicrobeEditorReportComponent.cs:286
 #: ../src/microbe_stage/editor/MicrobeEditorReportComponent.tscn:458
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:153
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:164
 msgid "TEMPERATURE"
 msgstr ""
 
@@ -7109,7 +7151,7 @@ msgstr ""
 msgid "UNKNOWN_ORGANELLE_SYMBOL"
 msgstr ""
 
-#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:96
+#: ../src/microbe_stage/gui/PatchDetailsPanel.tscn:107
 #: ../src/microbe_stage/Patch.cs:21
 msgid "UNKNOWN_PATCH"
 msgstr ""
@@ -7308,7 +7350,7 @@ msgstr ""
 #: ../src/gui_common/CompoundAmount.cs:240
 #: ../src/microbe_stage/gui/CompoundProgressBar.cs:426
 #: ../src/microbe_stage/gui/CompoundProgressBar.cs:502
-#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:264
+#: ../src/microbe_stage/gui/PatchDetailsPanel.cs:345
 #: ../src/microbe_stage/organelle_unlocks/WorldBasedUnlockCondition.cs:157
 #: ../src/microbe_stage/organelle_unlocks/WorldBasedUnlockCondition.cs:160
 #: ../src/microbe_stage/organelle_unlocks/WorldBasedUnlockCondition.cs:166

--- a/locale/mk.po
+++ b/locale/mk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2023-09-15 06:55+0000\n"
 "Last-Translator: Kristijan Miracevski <mircevskihristijan30@gmail.com>\n"
 "Language-Team: Macedonian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/mk/>\n"
@@ -42,6 +42,9 @@ msgstr "Абортирано."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Абисопелагичен"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Будење ({0:F1} / {1:F1})"
@@ -2855,6 +2858,34 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Додадете ново врзување на клучот"
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/nb_NO.po
+++ b/locale/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2023-03-10 06:53+0000\n"
 "Last-Translator: Jonas Lindberg <eksno@pm.me>\n"
 "Language-Team: Norwegian Bokmål <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/nb_NO/>\n"
@@ -42,6 +42,9 @@ msgstr "Avbrutt."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abyssopelagisk"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Våkne ({0:F1} / {1:F1}"
@@ -2942,6 +2945,38 @@ msgstr "[thrive:input]g_move_forward[/thrive:input],[thrive:input]g_move_left[/t
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Ytterligere valideringer oppdaget et problem: {0}"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "(hastighet som AI muterer med)"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "Dette panelet viser tallene som auto-evo-prediksjonen tar utgangspunkt i. Den totale energien en art er i stand til å fange, og kostnaden per individ av arten, bestemmer den endelige populasjonen. Auto-evo bruker en forenklet modell av virkeligheten for å beregne hvor godt artene klarer seg basert på energien de er i stand til å samle. For hver matkilde vises det hvor mye energi arten får fra den. I tillegg vises den totale energien som er tilgjengelig fra denne kilden. Andelen arten får ut av den totale energien er basert på hvor stor kondisjonen er sammenlignet med den totale kondisjonen. Kondisjon er et mål på hvor godt arten kan utnytte den aktuelle næringskilden."
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(hastighet som AI muterer med)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Legg til en ny nøkkelbinding"
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Dutch <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/nl/>\n"
@@ -42,6 +42,9 @@ msgstr "Afgebroken."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abyssopelagisch"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Ontwaak ({0:F1} / {1:F1})"
@@ -3231,6 +3234,48 @@ msgstr "  {0}: Gevonden in {1} soorten, gemiddeld {2} per soort"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Middelste muisknop"
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Aanmaken Mod Mislukt"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Houdt de gezondheidsbalk naast de ATP-balk in de gaten (rechtsonder).\n"
+"Je cel sterft als het geen gezondheid meer heeft.\n"
+"Je cel repareert zichzelf als er ATP beschikbaar is.\n"
+"Zorg er voor dat je genoeg glucose verzamelt om ATP te produceren."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"Neerdalen zal je verheven status verwijderen en je terug naar de Microbenfase brengen. Je kunt dan in je huidige opslagbestand het spel opnieuw spelen.\n"
+"\n"
+"Je zult neerdalingsextraatjes krijgen voor de verdere spelduur. In een toekomstige versie zul je het extraatje zelf kunnen kiezen maar voor nu zul je altijd een 20% verlaging in osmoregulatiekosten krijgen. \n"
+"\n"
+"Zodra je besluit neer te dalen kun je een nieuw wereldkiemgetal kiezen om op een andere kaart te spelen. Ook kun je bijvoorbeeld LZWHK uitzetten."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(kost van organellen, membranen en andere items in de editor)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(kost van organellen, membranen en andere items in de editor)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Bezoek onze Patreonpagina"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} Mln"

--- a/locale/nl_BE.po
+++ b/locale/nl_BE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Dutch (Belgium) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/nl_BE/>\n"
@@ -42,6 +42,9 @@ msgstr "Gestopt."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abyssopelagisch"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Ontwaak ({0:F1} / {1:F1})"
@@ -3309,6 +3312,48 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr "Midden muis"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Beoordeel"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Mod creatie gefaald"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Houd je gezondheidsbalk naast de ATP-balk (rechtsonder) in de gaten.\n"
+"Je cel sterft als hij geen gezondheid meer heeft.\n"
+"Je regenereert gezondheid terwijl je ATP hebt.\n"
+"Zorg ervoor dat u voldoende glucose verzamelt om ATP te produceren."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"Agressieve microben zullen prooien over grotere afstanden achtervolgen\n"
+"en hebben meer kans om roofdieren te bestrijden wanneer ze worden aangevallen.\n"
+"Vreedzame microben zullen anderen over grotere afstanden niet betrekken\n"
+"en zullen minder snel gifstoffen tegen roofdieren te gebruiken."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(kost van organellen, membranen en andere items in de bewerker)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(kost van organellen, membranen en andere items in de bewerker)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Pauzeer het spel"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"
@@ -7444,9 +7489,6 @@ msgstr "Uitzoomen"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "Beoordeel"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-11 06:06+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Polish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/pl/>\n"
@@ -42,6 +42,9 @@ msgstr "Przerwano."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Strefa głębinowa"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Przebudzony ({0:F1} / {1:F1})"
@@ -3176,6 +3179,44 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr "Środkowy przycisk myszy"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Tempo"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Tworzenie Moda Nie Powiodło Się"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Pilnuj swojego paska zdrowia obok paska ATP (prawy dolny róg)?\n"
+"Twoja komórka umiera jeśli utraci całe swoje zdrowie.\n"
+"Możesz się zregenerować, jeśli masz wystarczająco dużo ATP.\n"
+"Upewnij się, że masz wystarczająco dużo glukozy (lub żelaza) aby syntezować ATP."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "(lokalizacja początkowa)"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(koszt organelli, błon i innych przedmiotów w edytorze)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(koszt organelli, błon i innych przedmiotów w edytorze)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Odwiedź naszego Patreona"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} MN"
@@ -7088,9 +7129,6 @@ msgstr "Oddal"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "Tempo"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-11 06:06+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/pt_BR/>\n"
@@ -42,6 +42,9 @@ msgstr "Abortado."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abissopelágico"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Despertar ({0:F1} / {1:F1})"
@@ -3223,6 +3226,49 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr "Botão do meio do mouse"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Proporção"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "A Criação do Mod Falhou"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Fique de olho na sua barra de saúde próximo a barra de ATP (canto inferior direito).\n"
+"Sua célula morre quando não tem mais saúde.\n"
+"Você regenera saúde enquanto você tem ATP.\n"
+"Certifique-se de conseguir glicose suficiente para produzir ATP."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"Descender removerá seu status de ascensão e o retornará ao Estágio Microbial. A partir daí, você poderá jogar novamente no salvamento atual.\n"
+"\n"
+"Você receberá um benefício de descensão para o novo jogo. Em uma versão futura você poderá escolher o benefício, mas por enquanto será sempre uma redução de 20% na osmorregulação.\n"
+"\n"
+"Após confirmar a descensão, você poderá editar as configurações do jogo para escolher uma nova semente de mundo e jogar em um mapa diferente ou desabilitar a vida baseada na realidade, por exemplo."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(custo das organelas, membranas e outros itens do editor)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(custo das organelas, membranas e outros itens do editor)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Visite a nossa página no Patreon"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} Mi"
@@ -7279,9 +7325,6 @@ msgstr "Diminuir o zoom"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "Proporção"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/pt_PT.po
+++ b/locale/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-11 06:06+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Portuguese (Portugal) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/pt_PT/>\n"
@@ -42,6 +42,9 @@ msgstr "Abortado."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Zona Abissopelágica"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Despertar ({0:F1} / {1:F1})"
@@ -3149,6 +3152,47 @@ msgstr "Estatísticas de Organismo"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Clique Roda Rato"
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Falha na Criação do Mod"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Fica atento à barra de saúde próximo da barra de ATP (canto inferior direito).\n"
+"A tua célula morre quando não tens mais saúde.\n"
+"Tu regeneras saúde enquanto tiveres ATP.\n"
+"Certifica-te de que consegues glicose suficiente para produzires ATP."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"Micróbios agressivos perseguirão presas em distâncias maiores\n"
+"e são mais propensos a lutar contra predadores quando atacados.\n"
+"Micróbios pacíficos não se envolvem com os outros em distâncias maiores\n"
+"e são menos propensos a usar toxinas contra predadores."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(custo de organelas, membranas e outros itens no editor)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(custo de organelas, membranas e outros itens no editor)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Visite a nossa pagina de Patreon"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"

--- a/locale/ro.po
+++ b/locale/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-03-30 03:50+0000\n"
 "Last-Translator: edy <lazareduard702@gmail.com>\n"
 "Language-Team: Romanian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ro/>\n"
@@ -42,6 +42,9 @@ msgstr "Abandonat."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abisopelagică"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Trezește ({0:F1} / {1:F1})"
@@ -2959,6 +2962,38 @@ msgstr "[thrive:input]g_move_forward[/thrive:input],[thrive:input]g_move_left[/t
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Validările adiționale au detectat o problemă: {0}"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "(viteza cu care speciile IA suferă mutații)"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(viteza cu care speciile IA suferă mutații)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(viteza cu care speciile IA suferă mutații)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Treceți la etapa de trezire. Disponibil odată ce aveți creierul suficient de dezvoltat (tip de țesut cu axoni)."
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-22 23:22+0000\n"
 "Last-Translator: Sentry Primis <sentryprime92@gmail.com>\n"
 "Language-Team: Russian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ru/>\n"
@@ -42,6 +42,9 @@ msgstr "Отменено."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Абиссопелагический"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Пробужден на {0:F1}/{1:F1}"
@@ -3142,6 +3145,43 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr "Средняя кнопка мыши"
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Не удалось создать мод"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Следите за своей шкалой здоровья рядом со шкалой [thrive:compound type=\"atp\"][/thrive:compound] (снизу справа).\n"
+"Ваша клетка умрёт, если у нее закончится здоровье.\n"
+"Вы восстанавливаете здоровье, пока у вас есть [thrive:compound type=\"atp\"][/thrive:compound].\n"
+"Убедитесь, что собрано достаточно глюкозы для производства [thrive:compound type=\"atp\"][/thrive:compound]."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "Разные типы токсинов оказывают различные эффекты, которые более эффективны против определенных типов клеток. Для клеток с несколькими различными типами токсинов они используются последовательно, а не стреляют все сразу."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(стоимость органелл, мембран и т. д. в редакторе)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(стоимость органелл, мембран и т. д. в редакторе)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Зайти на нашу страницу на Patreon"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} Млн"

--- a/locale/si_LK.po
+++ b/locale/si_LK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2022-03-22 18:22+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Sinhala <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/si/>\n"
@@ -42,6 +42,9 @@ msgid "ABORTED_DOT"
 msgstr ""
 
 msgid "ABYSSOPELAGIC"
+msgstr ""
+
+msgid "ACCEPT"
 msgstr ""
 
 msgid "ACTION_AWAKEN"
@@ -2876,6 +2879,33 @@ msgid "MICROBE_STAGE_ORGANELLE_DIVISION"
 msgstr ""
 
 msgid "MIDDLE_MOUSE"
+msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_TOOLTIP"
 msgstr ""
 
 msgid "MILLION_ABBREVIATION"

--- a/locale/sk.po
+++ b/locale/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2022-07-27 06:44+0000\n"
 "Last-Translator: Matej Maceášik <m.maceasik@gmail.com>\n"
 "Language-Team: Slovak <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sk/>\n"
@@ -43,6 +43,9 @@ msgstr "Prerušené."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abysopelagiál"
+
+msgid "ACCEPT"
+msgstr ""
 
 #, fuzzy
 msgid "ACTION_AWAKEN"
@@ -3151,6 +3154,38 @@ msgstr "Štatistika organizmu"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Tlačidlo kolieska myši"
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Vytvorenie modu zlyhalo"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "(začiatočná poloha)"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(náklady na organely, membrány a ďalšie predmety v editore)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(náklady na organely, membrány a ďalšie predmety v editore)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Pozastaviť hru"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} mil"

--- a/locale/sr_Cyrl.po
+++ b/locale/sr_Cyrl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian (cyrillic) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sr_Cyrl/>\n"
@@ -46,6 +46,9 @@ msgstr "Прекинуто."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Абисопелагик"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr ""
@@ -3344,6 +3347,44 @@ msgstr "Статистика Организма"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Средњи миш"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Стопа"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Аутоматска-еволуција није успела"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Припазите на своју здравствену траку поред ATP траке (доле десно).\n"
+"Ваша ћелија ће умрети ако остане без здравља.\n"
+"Обнављате здравље док имате ATP.\n"
+"Обавезно сакупите довољно глукозе за производњу ATP."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "Број популације од {0} променио се за {1} због: {2}"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "Број популације од {0} променио се за {1} због: {2}"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "Број популације од {0} променио се за {1} због: {2}"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Додајте ново везивање тастера"
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""
@@ -7538,9 +7579,6 @@ msgstr "Одзумирати"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "Стопа"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/sr_Latn.po
+++ b/locale/sr_Latn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian (latin) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sr_Latn/>\n"
@@ -46,6 +46,9 @@ msgstr "Prekinuto."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abisopelagik"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr ""
@@ -3208,6 +3211,39 @@ msgstr "Statistika Organizma"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Srednji miš"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Stopa"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Automatska-evolucija nije uspela"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "Broj populacije od {0} promenio se za {1} zbog: {2}"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "Broj populacije od {0} promenio se za {1} zbog: {2}"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "Broj populacije od {0} promenio se za {1} zbog: {2}"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Dodajte novo vezivanje tastera"
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""
@@ -7180,9 +7216,6 @@ msgstr "Odzumirati"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "Stopa"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-07-08 09:22+0000\n"
 "Last-Translator: Mikael L <mikael_throt@hotmail.com>\n"
 "Language-Team: Swedish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sv/>\n"
@@ -42,6 +42,9 @@ msgstr "Avbruten."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abyssopelagisk"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Uppvakna ({0:F1} / {1:F1})"
@@ -3307,6 +3310,42 @@ msgstr "Organismstatistik"
 
 msgid "MIDDLE_MOUSE"
 msgstr "Skroll klick"
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "befolkning:"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+"Aggressiva mikrober jagar byte över större avstånd\n"
+"och har större sannolikhet att kämpa emot när rovdjur attackerar.\n"
+"Fredliga mikrober attackerar inte andra över större avstånd\n"
+"och har lägre sannolikhet att använda gifter mot rovdjur."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "Den här panelen visar talen som auto-evolutionen funkar från. Den totala energin en art är kapabel av att fånga, och kosten per individ av arten, bestämmer den slutliga befolkningen. Auto-evolutionen använder en simplifierad modell av verkligheten för att beräkna hur bra en art utför baserat på energin de kan samla. För varje matkälla, det visas hur mycket energi arten"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(farten som AI arter muterar)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Självmord"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"

--- a/locale/th_TH.po
+++ b/locale/th_TH.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-07 07:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Thai <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/th/>\n"
@@ -46,6 +46,9 @@ msgstr "ยกเลิก"
 
 msgid "ABYSSOPELAGIC"
 msgstr "เขตเหวนรก"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr ""
@@ -3223,6 +3226,39 @@ msgstr "เอาออร์แกเนลล์ออก"
 
 msgid "MIDDLE_MOUSE"
 msgstr "เมาส์กลาง"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "ประเมินค่า"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "ประชากร:"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "{0} ประชากรเปลี่ยนแปลงโดย {1} เนื่องจาก: {2}"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "ดำเนินการต่อ"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} M"
@@ -7173,6 +7209,3 @@ msgstr "ซูมออก"
 
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#~ msgid "RATE"
-#~ msgstr "ประเมินค่า"

--- a/locale/tok.po
+++ b/locale/tok.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2023-02-06 07:13+0000\n"
 "Last-Translator: jan-sopi <jansopi303@genocide.fun>\n"
 "Language-Team: Toki Pona <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/tok/>\n"
@@ -42,6 +42,9 @@ msgstr "ni li tawa ante."
 
 msgid "ABYSSOPELAGIC"
 msgstr "lon telo noka mute"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "kama sona ({0:F1} / {1:F1})"
@@ -2929,6 +2932,37 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "(nanpa ni: sike ante li kama ante kepeken tenpo seme)"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(nanpa ni: sike ante li kama ante kepeken tenpo seme)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(nanpa ni: sike ante li kama ante kepeken tenpo seme)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "open e lipu pi ante lili"
 
 msgid "MILLION_ABBREVIATION"
 msgstr ""

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-22 23:22+0000\n"
 "Last-Translator: punctdan <yunusemredilek@hotmail.com>\n"
 "Language-Team: Turkish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/tr/>\n"
@@ -42,6 +42,9 @@ msgstr "Durduruldu."
 
 msgid "ABYSSOPELAGIC"
 msgstr "Abissopelajik"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Uyandır ({0:F1} / {1:F1})"
@@ -3144,6 +3147,44 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr "Orta fare tuşu"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "Oran"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Mod Oluşturma Başarısız"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Gözünüz [thrive:compound type=\"atp\"]ATP[/thrive:compound] çubuğunun (sağ altta) yanındaki sağlık çubuğunda olsun.\n"
+"Hücreniz, canı tükenirse ölür.\n"
+"[thrive:compound type=\"atp\"]ATP[/thrive:compound] varken ise hücreniz iyileşir.\n"
+"[thrive:compound type=\"atp\"]ATP[/thrive:compound] üretmek için yeterli [thrive:compound type=\"glucose\"]glukoz[/thrive:compound] topladığınızdan emin olun."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "Farklı toksin türleri, belirli hücre türlerine karşı daha etkili olan, çeşitli etkilere sahiptir. Birden fazla farklı toksin türüne sahip olan hücrelerde, bu toksinler aynı anda ateşlenmek yerine sırayla kullanılır."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(organellerin, hücre zarlarının ve diğer öğelerin düzenleyicideki maliyeti)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(organellerin, hücre zarlarının ve diğer öğelerin düzenleyicideki maliyeti)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Patreon sayfamızı ziyaret edin"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} Mn"
@@ -7334,10 +7375,6 @@ msgstr "Uzaklaştır"
 #, fuzzy
 #~ msgid "E_DOT"
 #~ msgstr "E."
-
-#, fuzzy
-#~ msgid "RATE"
-#~ msgstr "Oran"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-17 20:18+0000\n"
 "Last-Translator: Teashrock <kajitsu22@gmail.com>\n"
 "Language-Team: Ukrainian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/uk/>\n"
@@ -42,6 +42,9 @@ msgstr "Перервано."
 
 msgid "ABYSSOPELAGIC"
 msgstr "морська безодня"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "Пробудити ({0:F1} / {1:F1})"
@@ -3154,6 +3157,43 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr "Колесик миші (середина миші)"
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Невдалось створити мод"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"Тримайте око на панелі зі здоров'ям поруч з панеллю АТФ (знизу справа).\n"
+"Ваша клітина помре, якщо її здоров'я скінчиться.\n"
+"Ви відновлюєте здоров'я, поки є АТФ.\n"
+"Переконайтесь, що збираєте достатню кількість глюкози для продукування АТФ."
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "Різні типи токсинів мають різноманітні ефекти, кожен з яких є ефективним проти тих чи інших типів клітин. Якщо клітина має декілька типів токсинів, вони випорскуватимуться послідовно, а не водночас."
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "(ціна органел, мембран та інших речей в редакторі)"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "(ціна органел, мембран та інших речей в редакторі)"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "Відвідайте"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0} Млн"

--- a/locale/vi.po
+++ b/locale/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -39,6 +39,9 @@ msgid "ABORTED_DOT"
 msgstr ""
 
 msgid "ABYSSOPELAGIC"
+msgstr ""
+
+msgid "ACCEPT"
 msgstr ""
 
 msgid "ACTION_AWAKEN"
@@ -2844,6 +2847,33 @@ msgid "MICROBE_STAGE_ORGANELLE_DIVISION"
 msgstr ""
 
 msgid "MIDDLE_MOUSE"
+msgstr ""
+
+msgid "MIGRATE"
+msgstr ""
+
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr ""
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr ""
+
+msgid "MIGRATION_TOOLTIP"
 msgstr ""
 
 msgid "MILLION_ABBREVIATION"

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-19 00:11+0000\n"
 "Last-Translator: Guno haozheum <guhaozhe@hsefz.cn>\n"
 "Language-Team: Chinese (Simplified) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/zh_Hans/>\n"
@@ -42,6 +42,9 @@ msgstr "已中止。"
 
 msgid "ABYSSOPELAGIC"
 msgstr "深海带"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "觉醒 ({0:F1} / {1:F1})"
@@ -3144,6 +3147,44 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr "鼠标中键"
+
+#, fuzzy
+msgid "MIGRATE"
+msgstr "速率"
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "Mod创建失败"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"随时注意你的ATP条旁边的生命值条（在屏幕右下角）。\n"
+"生命值归零你的细胞就会死。\n"
+"只要你还有ATP，你的生命值就会不断恢复。\n"
+"所以要确保总是有足够的葡萄糖来产出ATP。"
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "不同种类的毒素的效果不同，有些对特定种类的细胞会有奇效。当一个细胞有多种毒素时，它们会被依序发射而不是被同时发射。"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "（细胞器，膜和编辑器中其它选项的耗费）"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "（细胞器，膜和编辑器中其它选项的耗费）"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "访问我们在Patreon上的页面"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0}*10⁶"
@@ -7266,9 +7307,6 @@ msgstr "缩小"
 
 #~ msgid "E_DOT"
 #~ msgstr "释放毒素。"
-
-#~ msgid "RATE"
-#~ msgstr "速率"
 
 #~ msgid "BIOLUMESCENT_VACUOLE"
 #~ msgstr ""

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-07-23 09:54+0300\n"
+"POT-Creation-Date: 2024-07-24 11:43+0300\n"
 "PO-Revision-Date: 2024-06-18 05:50+0000\n"
 "Last-Translator: Xzihnago <xzihnago@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/zh_Hant/>\n"
@@ -42,6 +42,9 @@ msgstr "已中止。"
 
 msgid "ABYSSOPELAGIC"
 msgstr "深海帶"
+
+msgid "ACCEPT"
+msgstr ""
 
 msgid "ACTION_AWAKEN"
 msgstr "覺醒（{0:F1}／{1:F1}）"
@@ -3144,6 +3147,43 @@ msgstr ""
 
 msgid "MIDDLE_MOUSE"
 msgstr "滑鼠中鍵"
+
+msgid "MIGRATE"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_FAILED_TO_ADD"
+msgstr "模組創建失敗"
+
+msgid "MIGRATION_STATUS_DESTINATION_NOT_SELECTED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STATUS_TEXT"
+msgstr ""
+"密切關注[thrive:compound type=\"atp\"][/thrive:compound] 欄旁的生命值（右下方）。\n"
+"如果您的細胞耗盡了生命值，它就會死亡。\n"
+"當您擁有[thrive:compound type=\"atp\"][/thrive:compound] 時，您的生命值就會恢復。\n"
+"請確保收集足夠的[thrive:compound type=\"glucose\"][/thrive:compound] 來生產[thrive:compound type=\"atp\"][/thrive:compound]。"
+
+#, fuzzy
+msgid "MIGRATION_STEP_DESTINATION_EXPLANATION"
+msgstr "不同類型的毒素具有不同的作用，對某些類型的細胞更有效。對於具有多種不同毒素類型的細胞，它們按順序使用，而不是一次全部發射。"
+
+msgid "MIGRATION_STEP_ONLY_ONE_ALLOWED"
+msgstr ""
+
+#, fuzzy
+msgid "MIGRATION_STEP_POPULATION_EXPLANATION"
+msgstr "（編輯器中細胞器、膜和其他項目的成本）"
+
+#, fuzzy
+msgid "MIGRATION_STEP_SOURCE_EXPLANATION"
+msgstr "（編輯器中細胞器、膜和其他項目的成本）"
+
+#, fuzzy
+msgid "MIGRATION_TOOLTIP"
+msgstr "造訪我們的 Patreon 頁面"
 
 msgid "MILLION_ABBREVIATION"
 msgstr "{0}E+6"

--- a/src/auto-evo/AutoEvoExploringTool.tscn
+++ b/src/auto-evo/AutoEvoExploringTool.tscn
@@ -10,8 +10,8 @@
 [ext_resource type="LabelSettings" uid="uid://bx7mw3uvqpo42" path="res://src/gui_common/fonts/Body-Regular-Smaller.tres" id="11_crtm0"]
 [ext_resource type="Script" path="res://src/gui_common/CustomDropDown.cs" id="12"]
 [ext_resource type="PackedScene" path="res://src/microbe_stage/editor/PatchMapDrawer.tscn" id="13"]
-[ext_resource type="PackedScene" path="res://src/auto-evo/EvolutionaryTree.tscn" id="14"]
-[ext_resource type="PackedScene" path="res://src/gui_common/DraggableScrollContainer.tscn" id="16"]
+[ext_resource type="PackedScene" uid="uid://cjbhth6wlc08l" path="res://src/auto-evo/EvolutionaryTree.tscn" id="14"]
+[ext_resource type="PackedScene" uid="uid://din62wkc2pcnk" path="res://src/gui_common/DraggableScrollContainer.tscn" id="16"]
 [ext_resource type="PackedScene" uid="uid://bjl5o7oy7yr15" path="res://src/microbe_stage/gui/PatchDetailsPanel.tscn" id="17"]
 [ext_resource type="Texture2D" uid="uid://b84h4mjojeb7q" path="res://assets/textures/gui/bevel/plusButton.png" id="18"]
 [ext_resource type="Texture2D" uid="uid://bwcvbcn15kctq" path="res://assets/textures/gui/bevel/plusButtonHover.png" id="19"]
@@ -625,6 +625,7 @@ DrawDefaultMapIfEmpty = false
 [node name="PatchDetailsPanel" parent="GUI/VBoxContainer/HistoryReportSplit/PatchMap/HBoxContainer" instance=ExtResource("17")]
 layout_mode = 2
 MoveToPatchButtonVisible = false
+MigrationManagerEnabled = false
 
 [node name="Report" type="Control" parent="GUI/VBoxContainer/HistoryReportSplit"]
 visible = false
@@ -751,8 +752,8 @@ Movable = false
 [connection signal="value_changed" from="GUI/VBoxContainer/WorldEditor/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer3/FinishXGenerationsSpin" to="." method="OnFinishXGenerationsSpinBoxValueChanged"]
 [connection signal="pressed" from="GUI/VBoxContainer/WorldEditor/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer3/FinishXGenerations" to="." method="OnFinishXGenerationsButtonPressed"]
 [connection signal="value_changed" from="GUI/VBoxContainer/WorldEditor/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer4/RunXWorldsSpin" to="." method="OnRunXWorldsSpinBoxValueChanged"]
-[connection signal="pressed" from="GUI/VBoxContainer/WorldEditor/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer4/RunXWorlds" to="." method="OnRunXWorldsButtonPressed"]
 [connection signal="pressed" from="GUI/VBoxContainer/WorldEditor/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer4/RunXWorlds" to="." method="OnFinishXGenerationsButtonPressed"]
+[connection signal="pressed" from="GUI/VBoxContainer/WorldEditor/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer4/RunXWorlds" to="." method="OnRunXWorldsButtonPressed"]
 [connection signal="pressed" from="GUI/VBoxContainer/WorldEditor/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Abort" to="." method="OnAbortButtonPressed"]
 [connection signal="pressed" from="GUI/VBoxContainer/WorldEditor/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/PlayWithThis" to="." method="PlayWithCurrentSettingPressed"]
 [connection signal="pressed" from="GUI/VBoxContainer/WorldEditor/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/WorldExportButton" to="." method="ExportWorlds"]

--- a/src/microbe_stage/editor/MicrobeEditorPatchMap.tscn
+++ b/src/microbe_stage/editor/MicrobeEditorPatchMap.tscn
@@ -7,7 +7,7 @@
 [ext_resource type="Theme" uid="uid://b4cx0o110g4b6" path="res://src/gui_common/thrive_theme.tres" id="14"]
 [ext_resource type="PackedScene" path="res://src/microbe_stage/editor/PatchMapDrawer.tscn" id="18"]
 [ext_resource type="Script" path="res://src/microbe_stage/editor/MicrobeEditorPatchMap.cs" id="28"]
-[ext_resource type="PackedScene" path="res://src/gui_common/DraggableScrollContainer.tscn" id="30"]
+[ext_resource type="PackedScene" uid="uid://din62wkc2pcnk" path="res://src/gui_common/DraggableScrollContainer.tscn" id="30"]
 
 [sub_resource type="ShaderMaterial" id="28"]
 shader = ExtResource("1")
@@ -60,7 +60,7 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 
-[node name="MicrobeEditorPatchMap" type="Control"]
+[node name="MicrobeEditorPatchMap" type="Control" node_paths=PackedStringArray("mapDrawer", "detailsPanel", "seedLabel")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -69,9 +69,9 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("14")
 script = ExtResource("28")
-MapDrawerPath = NodePath("MarginContainer/HSplitContainer/MapPanel/MarginContainer/DraggableScrollContainer/PatchMapDrawer")
-PatchDetailsPanelPath = NodePath("MarginContainer/HSplitContainer/PatchDetailsPanel")
-SeedLabelPath = NodePath("MarginContainer/HSplitContainer/MapPanel/MarginContainer/VBoxContainer2/SeedLabel")
+mapDrawer = NodePath("MarginContainer/HSplitContainer/MapPanel/MarginContainer/DraggableScrollContainer/PatchMapDrawer")
+detailsPanel = NodePath("MarginContainer/HSplitContainer/PatchDetailsPanel")
+seedLabel = NodePath("MarginContainer/HSplitContainer/MapPanel/MarginContainer/VBoxContainer2/SeedLabel")
 FinishOrNextButtonPath = NodePath("MarginContainer2/NextTabButton")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]

--- a/src/microbe_stage/editor/PatchMapDrawer.cs
+++ b/src/microbe_stage/editor/PatchMapDrawer.cs
@@ -68,7 +68,7 @@ public partial class PatchMapDrawer : Control
                 return;
 
             map = value;
-            dirty = true;
+            MarkDirty();
 
             playerPatch ??= map.CurrentPatch;
         }
@@ -204,6 +204,32 @@ public partial class PatchMapDrawer : Control
     public void SetPatchEnabledStatuses(IEnumerable<Patch> patches, Func<Patch, bool> predicate)
     {
         SetPatchEnabledStatuses(patches.ToDictionary(x => x, predicate));
+    }
+
+    /// <summary>
+    ///   Runs a function to determine what to set as the enabled status for all patch nodes
+    /// </summary>
+    /// <param name="predicate">
+    ///   Predicate to run on all nodes and set the result to <see cref="PatchMapNode.Enabled"/>
+    /// </param>
+    public void ApplyPatchNodeEnabledStatus(Func<Patch, bool> predicate)
+    {
+        foreach (var (patch, node) in nodes)
+        {
+            node.Enabled = predicate(patch);
+        }
+    }
+
+    /// <summary>
+    ///   Sets patch node enabled status for all nodes
+    /// </summary>
+    /// <param name="enabled">Value to set to <see cref="PatchMapNode.Enabled"/></param>
+    public void ApplyPatchNodeEnabledStatus(bool enabled)
+    {
+        foreach (var (_, node) in nodes)
+        {
+            node.Enabled = enabled;
+        }
     }
 
     protected override void Dispose(bool disposing)

--- a/src/microbe_stage/editor/PatchMapEditorComponent.cs
+++ b/src/microbe_stage/editor/PatchMapEditorComponent.cs
@@ -95,6 +95,8 @@ public partial class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEdi
     {
         base.Init(owningEditor, fresh);
 
+        detailsPanel.SpeciesToUseForMigrations = Editor.CurrentGame.GameWorld.PlayerSpecies;
+
         fogOfWar = Editor.CurrentGame.FreeBuild ?
             FogOfWarMode.Ignored :
             Editor.CurrentGame.GameWorld.WorldSettings.FogOfWarMode;
@@ -378,14 +380,14 @@ public partial class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEdi
         {
             case PatchDetailsPanel.MigrationWizardStep.SelectSourcePatch:
             {
+                // Deselect current patch to allow picking it again (if the player wants it to be the start position)
+                mapDrawer.SelectedPatch = null;
+
                 // Enable filter to show only valid patches for move
 
                 mapDrawer.ApplyPatchNodeEnabledStatus(p =>
                     p.GetSpeciesSimulationPopulation(Editor.EditedBaseSpecies) > 0);
                 enabledSourcePatchFilter = true;
-
-                // Deselect current patch to allow picking it again (if the player wants it to be the start position)
-                mapDrawer.SelectedPatch = null;
 
                 break;
             }
@@ -400,9 +402,23 @@ public partial class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEdi
                 }
                 else
                 {
+                    mapDrawer.SelectedPatch = null;
+
                     mapDrawer.ApplyPatchNodeEnabledStatus(p => p != nextTo && p.Adjacent.Contains(nextTo));
                     enabledSourcePatchFilter = true;
                 }
+
+                break;
+            }
+
+            case PatchDetailsPanel.MigrationWizardStep.SelectPopulationAmount:
+            {
+                // At this step selecting any patches is not necessary or useful, so all patches are disabled for
+                // selection here for clarity
+
+                mapDrawer.SelectedPatch = null;
+                mapDrawer.ApplyPatchNodeEnabledStatus(false);
+                enabledSourcePatchFilter = true;
 
                 break;
             }

--- a/src/microbe_stage/gui/PatchDetailsPanel.cs
+++ b/src/microbe_stage/gui/PatchDetailsPanel.cs
@@ -4,11 +4,13 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using Godot;
+using Newtonsoft.Json;
 using Range = Godot.Range;
 
 /// <summary>
 ///   Shows details about a <see cref="Patch"/> in the GUI
 /// </summary>
+[JsonObject(MemberSerialization.OptIn)]
 public partial class PatchDetailsPanel : PanelContainer
 {
 #pragma warning disable CA2213
@@ -131,11 +133,16 @@ public partial class PatchDetailsPanel : PanelContainer
         Completed,
     }
 
+    [JsonIgnore]
     public Action<Patch>? OnMoveToPatchClicked { get; set; }
+
+    [JsonIgnore]
     public Action<Migration>? OnMigrationAdded { get; set; }
 
+    [JsonIgnore]
     public Action<MigrationWizardStep>? OnMigrationWizardStepChanged { get; set; }
 
+    [JsonIgnore]
     public Patch? SelectedPatch
     {
         get => targetPatch;
@@ -148,6 +155,7 @@ public partial class PatchDetailsPanel : PanelContainer
         }
     }
 
+    [JsonIgnore]
     public Patch? CurrentPatch
     {
         get => currentPatch;
@@ -161,15 +169,19 @@ public partial class PatchDetailsPanel : PanelContainer
         }
     }
 
+    [JsonIgnore]
     public bool IsPatchMoveValid { get; set; }
 
     /// <summary>
     ///   Created pending migrations
     /// </summary>
-    public List<Migration> Migrations { get; } = new();
+    [JsonProperty]
+    public List<Migration> Migrations { get; private set; } = new();
 
+    [JsonIgnore]
     public Species? SpeciesToUseForMigrations { get; set; }
 
+    [JsonIgnore]
     public MigrationWizardStep MigrationStep
     {
         get => currentMigrationStep;
@@ -184,6 +196,7 @@ public partial class PatchDetailsPanel : PanelContainer
         }
     }
 
+    [JsonIgnore]
     public Patch? CurrentMigrationSourcePatch => currentlyEditedMigration?.SourcePatch;
 
     [Export]

--- a/src/microbe_stage/gui/PatchDetailsPanel.cs
+++ b/src/microbe_stage/gui/PatchDetailsPanel.cs
@@ -4,14 +4,13 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using Godot;
+using Range = Godot.Range;
 
 /// <summary>
 ///   Shows details about a <see cref="Patch"/> in the GUI
 /// </summary>
 public partial class PatchDetailsPanel : PanelContainer
 {
-    public List<Migration> Migrations = new();
-
 #pragma warning disable CA2213
     [Export]
     private Control nothingSelected = null!;
@@ -41,25 +40,28 @@ public partial class PatchDetailsPanel : PanelContainer
     private Button? moveToPatchButton;
 
     [Export]
-    private VBoxContainer? migrationMenu;
+    private Container normalContentContainer = null!;
 
     [Export]
-    private VBoxContainer? menu;
+    private Container? migrationContentContainer;
 
     [Export]
-    private Button? migrateButton;
+    private Button? migrateStartButton;
 
     [Export]
-    private Button? migrationSource;
+    private Label migrationStepExplanation = null!;
 
     [Export]
-    private Button? migrationDestination;
+    private Label migrationStatusLabel = null!;
 
     [Export]
-    private Button? migrationAccept;
+    private Label migrationErrorLabel = null!;
 
     [Export]
-    private Button? migrationCancel;
+    private Range migrationAmountSelector = null!;
+
+    [Export]
+    private Button migrationAccept = null!;
 
     [Export]
     private CollapsibleList physicalConditionsContainer = null!;
@@ -116,9 +118,23 @@ public partial class PatchDetailsPanel : PanelContainer
     private Patch? currentPatch;
 
     private bool moveToPatchButtonVisible = true;
+    private bool migrationManagerEnabled = true;
+
+    private MigrationWizardStep currentMigrationStep;
+
+    public enum MigrationWizardStep
+    {
+        NotInProgress,
+        SelectSourcePatch,
+        SelectDestinationPatch,
+        SelectPopulationAmount,
+        Completed,
+    }
 
     public Action<Patch>? OnMoveToPatchClicked { get; set; }
-    public Action<Migration>? MigrationAdded { get; set; }
+    public Action<Migration>? OnMigrationAdded { get; set; }
+
+    public Action<MigrationWizardStep>? OnMigrationWizardStepChanged { get; set; }
 
     public Patch? SelectedPatch
     {
@@ -127,6 +143,8 @@ public partial class PatchDetailsPanel : PanelContainer
         {
             targetPatch = value;
             UpdateShownPatchDetails();
+
+            UpdateMigrationStateWithPatch(value);
         }
     }
 
@@ -145,6 +163,27 @@ public partial class PatchDetailsPanel : PanelContainer
 
     public bool IsPatchMoveValid { get; set; }
 
+    /// <summary>
+    ///   Created pending migrations
+    /// </summary>
+    public List<Migration> Migrations { get; } = new();
+
+    public MigrationWizardStep MigrationStep
+    {
+        get => currentMigrationStep;
+        set
+        {
+            if (currentMigrationStep == value)
+                return;
+
+            currentMigrationStep = value;
+            OnMigrationWizardStepChanged?.Invoke(currentMigrationStep);
+            ApplyMigrationStepGUI();
+        }
+    }
+
+    public Patch? CurrentMigrationSourcePatch => currentlyEditedMigration?.SourcePatch;
+
     [Export]
     public bool MoveToPatchButtonVisible
     {
@@ -152,6 +191,17 @@ public partial class PatchDetailsPanel : PanelContainer
         set
         {
             moveToPatchButtonVisible = value;
+            UpdateMoveToPatchButton();
+        }
+    }
+
+    [Export]
+    public bool MigrationManagerEnabled
+    {
+        get => migrationManagerEnabled;
+        set
+        {
+            migrationManagerEnabled = value;
             UpdateMoveToPatchButton();
         }
     }
@@ -237,9 +287,9 @@ public partial class PatchDetailsPanel : PanelContainer
         increaseIcon = GD.Load<Texture2D>("res://assets/textures/gui/bevel/increase.png");
         decreaseIcon = GD.Load<Texture2D>("res://assets/textures/gui/bevel/decrease.png");
 
-        Migrations = new List<Migration>();
-
         UpdateMoveToPatchButton();
+        UpdateMigrationManagerVisibility();
+        ApplyMigrationStepGUI();
     }
 
     public void UpdateShownPatchDetails()
@@ -357,9 +407,24 @@ public partial class PatchDetailsPanel : PanelContainer
             moveToPatchButton.Visible = MoveToPatchButtonVisible;
         }
 
+        UpdateBottomHSeparatorVisibility();
+    }
+
+    private void UpdateMigrationManagerVisibility()
+    {
+        if (migrateStartButton != null)
+        {
+            migrateStartButton.Visible = MigrationManagerEnabled;
+        }
+
+        UpdateBottomHSeparatorVisibility();
+    }
+
+    private void UpdateBottomHSeparatorVisibility()
+    {
         if (moveToPatchHSeparator != null)
         {
-            moveToPatchHSeparator.Visible = MoveToPatchButtonVisible;
+            moveToPatchHSeparator.Visible = MoveToPatchButtonVisible || MigrationManagerEnabled;
         }
     }
 
@@ -504,63 +569,173 @@ public partial class PatchDetailsPanel : PanelContainer
 
     private void MigrateButtonPressed()
     {
-        menu!.Visible = false;
-        migrationMenu!.Visible = true;
+        if (migrationContentContainer == null || migrateStartButton == null)
+        {
+            GD.PrintErr("Patch details panel not fully setup for migrations");
+            return;
+        }
+
+        // For now only one migration per editor cycle is allowed
+        if (Migrations.Count > 0)
+        {
+            currentlyEditedMigration = Migrations.Last();
+            MigrationStep = MigrationWizardStep.Completed;
+            return;
+        }
 
         currentlyEditedMigration = new Migration();
-
-        migrationSource!.Text = new LocalizedString("SOURCE_PATCH").ToString();
-        migrationDestination!.Text = new LocalizedString("DESTINATION_PATCH").ToString();
-    }
-
-    private void MigrateSourcePressed()
-    {
-        if (SelectedPatch == null)
-            return;
-
-        currentlyEditedMigration!.SourcePatch = SelectedPatch;
-        migrationSource!.Text = SelectedPatch.VisibleName.ToString();
-    }
-
-    private void MigrateDestinationPressed()
-    {
-        if (SelectedPatch == null)
-            return;
-
-        currentlyEditedMigration!.DestinationPatch = SelectedPatch;
-        migrationDestination!.Text = SelectedPatch.VisibleName.ToString();
+        MigrationStep = MigrationWizardStep.SelectSourcePatch;
     }
 
     private void MigrateAcceptPressed()
     {
-        if (currentlyEditedMigration!.DestinationPatch == null || currentlyEditedMigration.SourcePatch == null)
+        // When viewing a completed migration pressing accept just closes
+        if (MigrationStep == MigrationWizardStep.Completed)
         {
-            menu!.Visible = true;
-            migrationMenu!.Visible = false;
-
+            MigrationStep = MigrationWizardStep.NotInProgress;
             return;
         }
 
-        if (!currentlyEditedMigration.DestinationPatch.Adjacent.Contains(currentlyEditedMigration.SourcePatch))
+        if (MigrationStep != MigrationWizardStep.SelectPopulationAmount || currentlyEditedMigration == null)
         {
-            menu!.Visible = true;
-            migrationMenu!.Visible = false;
-
+            GD.PrintErr("Bad migration step state");
             return;
         }
 
         Migrations.Add(currentlyEditedMigration);
 
-        MigrationAdded?.Invoke(currentlyEditedMigration);
+        OnMigrationAdded?.Invoke(currentlyEditedMigration);
 
-        menu!.Visible = true;
-        migrationMenu!.Visible = false;
+        // Only perform these actions if the callback didn't want to cancel adding the migration
+        if (Migrations.Contains(currentlyEditedMigration))
+        {
+            // Close the menu after successful migration setup to flow nicely
+            MigrationStep = MigrationWizardStep.NotInProgress;
+        }
+        else
+        {
+            // Show error message
+            migrationErrorLabel.Text = Localization.Translate("MIGRATION_FAILED_TO_ADD");
+            migrationErrorLabel.Visible = true;
+        }
     }
 
     private void MigrateCancelPressed()
     {
-        menu!.Visible = true;
-        migrationMenu!.Visible = false;
+        MigrationStep = MigrationWizardStep.NotInProgress;
+
+        // Abandon migration
+        if (currentlyEditedMigration != null)
+        {
+            Migrations.Remove(currentlyEditedMigration);
+            currentlyEditedMigration = null;
+        }
+    }
+
+    /// <summary>
+    ///   Progresses migration if a suitable patch is selected
+    /// </summary>
+    private void UpdateMigrationStateWithPatch(Patch? patch)
+    {
+        if (patch == null || currentlyEditedMigration == null)
+            return;
+
+        switch (MigrationStep)
+        {
+            case MigrationWizardStep.SelectSourcePatch:
+                currentlyEditedMigration.SourcePatch = patch;
+                MigrationStep = MigrationWizardStep.SelectDestinationPatch;
+                break;
+
+            case MigrationWizardStep.SelectDestinationPatch:
+                currentlyEditedMigration.DestinationPatch = patch;
+                MigrationStep = MigrationWizardStep.SelectPopulationAmount;
+                break;
+        }
+    }
+
+    private void ApplyMigrationStepGUI()
+    {
+        normalContentContainer.Visible = MigrationStep == MigrationWizardStep.NotInProgress;
+
+        if (migrationContentContainer != null)
+        {
+            migrationContentContainer.Visible = MigrationStep != MigrationWizardStep.NotInProgress;
+
+            migrationErrorLabel.Visible = false;
+            migrationAmountSelector.Visible = MigrationStep == MigrationWizardStep.SelectPopulationAmount;
+        }
+        else
+        {
+            // Don't apply dependent values when the primary container is missing
+            return;
+        }
+
+        if (MigrationStep != MigrationWizardStep.NotInProgress)
+            UpdateMigrationStatusText();
+
+        switch (MigrationStep)
+        {
+            case MigrationWizardStep.NotInProgress:
+            {
+                migrationAccept.Disabled = true;
+
+                break;
+            }
+
+            case MigrationWizardStep.SelectSourcePatch:
+            {
+                migrationAccept.Disabled = true;
+
+                migrationStepExplanation.Text = Localization.Translate("MIGRATION_STEP_SOURCE_EXPLANATION");
+
+                break;
+            }
+
+            case MigrationWizardStep.SelectDestinationPatch:
+            {
+                migrationAccept.Disabled = true;
+
+                migrationStepExplanation.Text = Localization.Translate("MIGRATION_STEP_DESTINATION_EXPLANATION");
+
+                break;
+            }
+
+            case MigrationWizardStep.SelectPopulationAmount:
+            {
+                migrationAccept.Disabled = false;
+
+                migrationStepExplanation.Text = Localization.Translate("MIGRATION_STEP_POPULATION_EXPLANATION");
+
+                break;
+            }
+
+            case MigrationWizardStep.Completed:
+            {
+                migrationAccept.Disabled = false;
+
+                migrationStepExplanation.Text = Localization.Translate("MIGRATION_STEP_ONLY_ONE_ALLOWED");
+
+                break;
+            }
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    private void UpdateMigrationStatusText()
+    {
+        if (currentlyEditedMigration?.SourcePatch == null)
+        {
+            migrationStatusLabel.Visible = false;
+            return;
+        }
+
+        migrationStatusLabel.Visible = true;
+
+        // TODO: actual text
+        migrationStatusLabel.Text = "State of migration here";
     }
 
     public class Migration
@@ -568,6 +743,6 @@ public partial class PatchDetailsPanel : PanelContainer
         public Patch? SourcePatch;
         public Patch? DestinationPatch;
 
-        public long? Amount = 100;
+        public long Amount = 100;
     }
 }

--- a/src/microbe_stage/gui/PatchDetailsPanel.tscn
+++ b/src/microbe_stage/gui/PatchDetailsPanel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=3 uid="uid://bjl5o7oy7yr15"]
+[gd_scene load_steps=27 format=3 uid="uid://bjl5o7oy7yr15"]
 
 [ext_resource type="PackedScene" path="res://src/gui_common/CustomRichTextLabel.tscn" id="1"]
 [ext_resource type="LabelSettings" uid="uid://dcekwe8j7ep16" path="res://src/gui_common/fonts/Title-SemiBold-AlmostHuge.tres" id="3_lpicf"]
@@ -20,44 +20,49 @@
 [ext_resource type="LabelSettings" uid="uid://c07qrffjvqfw" path="res://src/gui_common/fonts/Body-Regular-Tiny.tres" id="19_6m1o4"]
 [ext_resource type="Texture2D" uid="uid://dify8alf16jac" path="res://assets/textures/gui/bevel/phosphates.png" id="21"]
 [ext_resource type="Texture2D" uid="uid://bjgfupcxx2nop" path="res://assets/textures/gui/bevel/Pressure.png" id="23"]
+[ext_resource type="LabelSettings" uid="uid://fua052cwp5ap" path="res://src/gui_common/fonts/Body-Regular-AlmostSmaller.tres" id="23_8qra5"]
+[ext_resource type="LabelSettings" uid="uid://dvqx73nhtr0y2" path="res://src/gui_common/fonts/Body-Regular-Small.tres" id="24_21yun"]
 [ext_resource type="Texture2D" uid="uid://c7cgjvfo1in67" path="res://assets/textures/gui/bevel/Temperature.png" id="25"]
+[ext_resource type="LabelSettings" uid="uid://bl7dig4lq5ko" path="res://src/gui_common/fonts/Body-Regular-Small-Red.tres" id="25_dd3af"]
 [ext_resource type="Theme" uid="uid://b4cx0o110g4b6" path="res://src/gui_common/thrive_theme.tres" id="28"]
 
 [sub_resource type="StyleBoxTexture" id="34"]
 texture = ExtResource("9")
 region_rect = Rect2(0, 0, 429, 1)
 
-[node name="PatchDetailsPanel" type="PanelContainer" node_paths=PackedStringArray("nothingSelected", "unknownPatch", "detailsContainer", "playerHere", "patchName", "biome", "depth", "moveToPatchHSeparator", "moveToPatchButton", "migrationMenu", "menu", "migrateButton", "migrationSource", "migrationDestination", "migrationAccept", "migrationCancel", "physicalConditionsContainer", "atmosphereContainer", "compoundsContainer", "speciesParentContainer")]
+[node name="PatchDetailsPanel" type="PanelContainer" node_paths=PackedStringArray("nothingSelected", "unknownPatch", "detailsContainer", "playerHere", "patchName", "biome", "depth", "moveToPatchHSeparator", "moveToPatchButton", "normalContentContainer", "migrationContentContainer", "migrateStartButton", "migrationStepExplanation", "migrationStatusLabel", "migrationErrorLabel", "migrationAmountSelector", "migrationAccept", "physicalConditionsContainer", "atmosphereContainer", "compoundsContainer", "speciesParentContainer")]
 custom_minimum_size = Vector2(340, 0)
 offset_right = 352.0
 offset_bottom = 620.0
 theme = ExtResource("28")
 script = ExtResource("4")
-nothingSelected = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/NothingSelected")
-unknownPatch = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/UnknownPatch")
-detailsContainer = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer")
-playerHere = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/VBoxContainer/PlayerHereLabel")
-patchName = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/VBoxContainer/PatchName")
-biome = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Biome")
-depth = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Depth")
-moveToPatchHSeparator = NodePath("VBoxContainer/HSeparator")
-moveToPatchButton = NodePath("VBoxContainer/MarginContainer2/MoveToPatchButton")
-migrationMenu = NodePath("MigrationMenu")
-menu = NodePath("VBoxContainer")
-migrateButton = NodePath("VBoxContainer/MarginContainer3/MigrateButton")
-migrationSource = NodePath("MigrationMenu/MarginContainer3/SourcePatch")
-migrationDestination = NodePath("MigrationMenu/MarginContainer4/DestinationPatch")
+nothingSelected = NodePath("NormalContent/MarginContainer/ScrollContainer/VBoxContainer/NothingSelected")
+unknownPatch = NodePath("NormalContent/MarginContainer/ScrollContainer/VBoxContainer/UnknownPatch")
+detailsContainer = NodePath("NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer")
+playerHere = NodePath("NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/VBoxContainer/PlayerHereLabel")
+patchName = NodePath("NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/VBoxContainer/PatchName")
+biome = NodePath("NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Biome")
+depth = NodePath("NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Depth")
+moveToPatchHSeparator = NodePath("NormalContent/HSeparator")
+moveToPatchButton = NodePath("NormalContent/MarginContainer2/MoveToPatchButton")
+normalContentContainer = NodePath("NormalContent")
+migrationContentContainer = NodePath("MigrationMenu")
+migrateStartButton = NodePath("NormalContent/MarginContainer3/MigrateButton")
+migrationStepExplanation = NodePath("MigrationMenu/MarginContainer6/MigrationStatusLabel")
+migrationStatusLabel = NodePath("MigrationMenu/MarginContainer7/MigrationSetupDescription")
+migrationErrorLabel = NodePath("MigrationMenu/MarginContainer8/MigrationError")
+migrationAmountSelector = NodePath("MigrationMenu/MarginContainer3/PopulationAmount")
 migrationAccept = NodePath("MigrationMenu/MarginContainer5/Accept")
-migrationCancel = NodePath("MigrationMenu/MarginContainer2/Cancel")
-physicalConditionsContainer = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions")
-atmosphereContainer = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses")
-compoundsContainer = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds")
-speciesParentContainer = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/SpeciesBox")
+physicalConditionsContainer = NodePath("NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions")
+atmosphereContainer = NodePath("NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses")
+compoundsContainer = NodePath("NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds")
+speciesParentContainer = NodePath("NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/SpeciesBox")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="NormalContent" type="VBoxContainer" parent="."]
+visible = false
 layout_mode = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="NormalContent"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -66,23 +71,23 @@ theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/MarginContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="NormalContent/MarginContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 follow_focus = true
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="NothingSelected" type="VBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer"]
+[node name="NothingSelected" type="VBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer"]
 visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/NothingSelected"]
+[node name="Label" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/NothingSelected"]
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -91,12 +96,12 @@ label_settings = ExtResource("3_lpicf")
 horizontal_alignment = 1
 autowrap_mode = 3
 
-[node name="UnknownPatch" type="VBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer"]
+[node name="UnknownPatch" type="VBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer"]
 visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/UnknownPatch"]
+[node name="Label" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/UnknownPatch"]
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -105,15 +110,15 @@ label_settings = ExtResource("3_lpicf")
 horizontal_alignment = 1
 autowrap_mode = 3
 
-[node name="PatchDetailsContainer" type="VBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer"]
+[node name="PatchDetailsContainer" type="VBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 theme_override_constants/separation = 10
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer"]
 layout_mode = 2
 
-[node name="PatchName" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/VBoxContainer"]
+[node name="PatchName" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/VBoxContainer"]
 editor_description = "PLACEHOLDER"
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
@@ -123,37 +128,37 @@ label_settings = ExtResource("5_xv7pc")
 horizontal_alignment = 1
 autowrap_mode = 3
 
-[node name="PlayerHereLabel" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/VBoxContainer"]
+[node name="PlayerHereLabel" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/VBoxContainer"]
 layout_mode = 2
 text = "CURRENT_LOCATION_CAPITAL"
 label_settings = ExtResource("5_133c0")
 horizontal_alignment = 1
 
-[node name="Biome" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer"]
+[node name="Biome" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer"]
 editor_description = "PLACEHOLDER"
 layout_mode = 2
 text = "Biome: BIOME HERE"
 label_settings = ExtResource("7_o264b")
 horizontal_alignment = 1
 
-[node name="Depth" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer"]
+[node name="Depth" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer"]
 editor_description = "PLACEHOLDER"
 layout_mode = 2
 text = "200-340m below sea level"
 label_settings = ExtResource("7_o264b")
 horizontal_alignment = 1
 
-[node name="PhysicalConditions" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer" instance=ExtResource("7_np6c6")]
+[node name="PhysicalConditions" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer" instance=ExtResource("7_np6c6")]
 layout_mode = 2
 DisplayName = "PHYSICAL_CONDITIONS"
 Columns = 2
 
-[node name="Temperature" type="HBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions"]
+[node name="Temperature" type="HBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions"]
 layout_mode = 2
 size_flags_horizontal = 3
 mouse_filter = 2
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Temperature"]
+[node name="TextureRect" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Temperature"]
 custom_minimum_size = Vector2(30, 25)
 layout_mode = 2
 size_flags_vertical = 4
@@ -161,25 +166,25 @@ tooltip_text = "TEMPERATURE"
 texture = ExtResource("25")
 expand_mode = 1
 
-[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Temperature"]
+[node name="Label" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Temperature"]
 editor_description = "PLACEHOLDER"
 layout_mode = 2
 text = "52 C"
 label_settings = ExtResource("15_ng6rp")
 
-[node name="Situation" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Temperature"]
+[node name="Situation" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Temperature"]
 custom_minimum_size = Vector2(12, 12)
 layout_mode = 2
 size_flags_vertical = 4
 mouse_filter = 2
 expand_mode = 1
 
-[node name="Pressure" type="HBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions"]
+[node name="Pressure" type="HBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions"]
 layout_mode = 2
 size_flags_horizontal = 3
 mouse_filter = 2
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Pressure"]
+[node name="TextureRect" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Pressure"]
 custom_minimum_size = Vector2(30, 25)
 layout_mode = 2
 size_flags_vertical = 4
@@ -187,18 +192,18 @@ tooltip_text = "PRESSURE"
 texture = ExtResource("23")
 expand_mode = 1
 
-[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Pressure"]
+[node name="Label" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Pressure"]
 editor_description = "PLACEHOLDER"
 layout_mode = 2
 text = "102 kPA"
 label_settings = ExtResource("15_ng6rp")
 
-[node name="Light" type="HBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions"]
+[node name="Light" type="HBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions"]
 layout_mode = 2
 size_flags_horizontal = 3
 mouse_filter = 2
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Light"]
+[node name="TextureRect" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Light"]
 custom_minimum_size = Vector2(30, 25)
 layout_mode = 2
 size_flags_vertical = 4
@@ -206,44 +211,44 @@ tooltip_text = "SUNLIGHT"
 texture = ExtResource("6")
 expand_mode = 1
 
-[node name="LightInfo" type="VBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Light"]
+[node name="LightInfo" type="VBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Light"]
 custom_minimum_size = Vector2(0, 40)
 layout_mode = 2
 theme_override_constants/separation = 0
 alignment = 1
 
-[node name="Current" type="HBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Light/LightInfo"]
+[node name="Current" type="HBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Light/LightInfo"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Light/LightInfo/Current"]
+[node name="Label" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Light/LightInfo/Current"]
 layout_mode = 2
 text = "100%"
 label_settings = ExtResource("15_ng6rp")
 
-[node name="Situation" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Light/LightInfo/Current"]
+[node name="Situation" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Light/LightInfo/Current"]
 custom_minimum_size = Vector2(12, 12)
 layout_mode = 2
 size_flags_vertical = 4
 mouse_filter = 2
 expand_mode = 1
 
-[node name="MaxLabel" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Light/LightInfo"]
+[node name="MaxLabel" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions/Light/LightInfo"]
 modulate = Color(1, 1, 1, 0.501961)
 layout_mode = 2
 text = "LIGHT_MAX"
 label_settings = ExtResource("19_6m1o4")
 
-[node name="AtmosphericGasses" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer" instance=ExtResource("7_np6c6")]
+[node name="AtmosphericGasses" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer" instance=ExtResource("7_np6c6")]
 layout_mode = 2
 DisplayName = "ATMOSPHERIC_GASSES"
 Columns = 2
 
-[node name="Oxygen" type="HBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses"]
+[node name="Oxygen" type="HBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses"]
 layout_mode = 2
 size_flags_horizontal = 3
 mouse_filter = 2
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses/Oxygen"]
+[node name="TextureRect" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses/Oxygen"]
 custom_minimum_size = Vector2(30, 25)
 layout_mode = 2
 size_flags_vertical = 4
@@ -251,18 +256,18 @@ tooltip_text = "OXYGEN"
 texture = ExtResource("12")
 expand_mode = 1
 
-[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses/Oxygen"]
+[node name="Label" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses/Oxygen"]
 editor_description = "PLACEHOLDER"
 layout_mode = 2
 text = "Oxygen"
 label_settings = ExtResource("15_ng6rp")
 
-[node name="Nitrogen" type="HBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses"]
+[node name="Nitrogen" type="HBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses"]
 layout_mode = 2
 size_flags_horizontal = 3
 mouse_filter = 2
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses/Nitrogen"]
+[node name="TextureRect" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses/Nitrogen"]
 custom_minimum_size = Vector2(30, 25)
 layout_mode = 2
 size_flags_vertical = 4
@@ -270,18 +275,18 @@ tooltip_text = "NITROGEN"
 texture = ExtResource("7")
 expand_mode = 1
 
-[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses/Nitrogen"]
+[node name="Label" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses/Nitrogen"]
 editor_description = "PLACEHOLDER"
 layout_mode = 2
 text = "Nitrogen"
 label_settings = ExtResource("15_ng6rp")
 
-[node name="CO2" type="HBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses"]
+[node name="CO2" type="HBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses"]
 layout_mode = 2
 size_flags_horizontal = 3
 mouse_filter = 2
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses/CO2"]
+[node name="TextureRect" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses/CO2"]
 custom_minimum_size = Vector2(30, 25)
 layout_mode = 2
 size_flags_vertical = 4
@@ -289,22 +294,22 @@ tooltip_text = "CARBON_DIOXIDE"
 texture = ExtResource("8")
 expand_mode = 1
 
-[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses/CO2"]
+[node name="Label" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses/CO2"]
 editor_description = "PLACEHOLDER"
 layout_mode = 2
 text = "CO₂"
 label_settings = ExtResource("15_ng6rp")
 
-[node name="Compounds" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer" instance=ExtResource("7_np6c6")]
+[node name="Compounds" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer" instance=ExtResource("7_np6c6")]
 layout_mode = 2
 DisplayName = "COMPOUNDS"
 Columns = 2
 
-[node name="HydrogenSulfide" type="HBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds"]
+[node name="HydrogenSulfide" type="HBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/HydrogenSulfide"]
+[node name="TextureRect" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/HydrogenSulfide"]
 custom_minimum_size = Vector2(25, 25)
 layout_mode = 2
 size_flags_vertical = 4
@@ -312,24 +317,24 @@ tooltip_text = "HYDROGEN_SULFIDE"
 texture = ExtResource("14")
 expand_mode = 1
 
-[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/HydrogenSulfide"]
+[node name="Label" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/HydrogenSulfide"]
 editor_description = "PLACEHOLDER"
 layout_mode = 2
 text = "12%"
 label_settings = ExtResource("15_ng6rp")
 
-[node name="Situation" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/HydrogenSulfide"]
+[node name="Situation" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/HydrogenSulfide"]
 custom_minimum_size = Vector2(12, 12)
 layout_mode = 2
 size_flags_vertical = 4
 mouse_filter = 2
 expand_mode = 1
 
-[node name="Ammonia" type="HBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds"]
+[node name="Ammonia" type="HBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Ammonia"]
+[node name="TextureRect" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Ammonia"]
 custom_minimum_size = Vector2(25, 25)
 layout_mode = 2
 size_flags_vertical = 4
@@ -337,24 +342,24 @@ tooltip_text = "AMMONIA"
 texture = ExtResource("13")
 expand_mode = 1
 
-[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Ammonia"]
+[node name="Label" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Ammonia"]
 editor_description = "PLACEHOLDER"
 layout_mode = 2
 text = "5%"
 label_settings = ExtResource("15_ng6rp")
 
-[node name="Situation" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Ammonia"]
+[node name="Situation" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Ammonia"]
 custom_minimum_size = Vector2(12, 12)
 layout_mode = 2
 size_flags_vertical = 4
 mouse_filter = 2
 expand_mode = 1
 
-[node name="Glucose" type="HBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds"]
+[node name="Glucose" type="HBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Glucose"]
+[node name="TextureRect" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Glucose"]
 custom_minimum_size = Vector2(25, 25)
 layout_mode = 2
 size_flags_vertical = 4
@@ -362,24 +367,24 @@ tooltip_text = "GLUCOSE"
 texture = ExtResource("10")
 expand_mode = 1
 
-[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Glucose"]
+[node name="Label" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Glucose"]
 editor_description = "PLACEHOLDER"
 layout_mode = 2
 text = "9%"
 label_settings = ExtResource("15_ng6rp")
 
-[node name="Situation" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Glucose"]
+[node name="Situation" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Glucose"]
 custom_minimum_size = Vector2(12, 12)
 layout_mode = 2
 size_flags_vertical = 4
 mouse_filter = 2
 expand_mode = 1
 
-[node name="Phosphate" type="HBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds"]
+[node name="Phosphate" type="HBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Phosphate"]
+[node name="TextureRect" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Phosphate"]
 custom_minimum_size = Vector2(25, 25)
 layout_mode = 2
 size_flags_vertical = 4
@@ -387,24 +392,24 @@ tooltip_text = "PHOSPHATE"
 texture = ExtResource("21")
 expand_mode = 1
 
-[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Phosphate"]
+[node name="Label" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Phosphate"]
 editor_description = "PLACEHOLDER"
 layout_mode = 2
 text = "5%"
 label_settings = ExtResource("15_ng6rp")
 
-[node name="Situation" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Phosphate"]
+[node name="Situation" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Phosphate"]
 custom_minimum_size = Vector2(12, 12)
 layout_mode = 2
 size_flags_vertical = 4
 mouse_filter = 2
 expand_mode = 1
 
-[node name="Iron" type="HBoxContainer" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds"]
+[node name="Iron" type="HBoxContainer" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Iron"]
+[node name="TextureRect" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Iron"]
 custom_minimum_size = Vector2(25, 25)
 layout_mode = 2
 size_flags_vertical = 4
@@ -412,34 +417,34 @@ tooltip_text = "IRON"
 texture = ExtResource("11")
 expand_mode = 1
 
-[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Iron"]
+[node name="Label" type="Label" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Iron"]
 editor_description = "PLACEHOLDER"
 layout_mode = 2
 text = "5%"
 label_settings = ExtResource("15_ng6rp")
 
-[node name="Situation" type="TextureRect" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Iron"]
+[node name="Situation" type="TextureRect" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds/Iron"]
 custom_minimum_size = Vector2(12, 12)
 layout_mode = 2
 size_flags_vertical = 4
 mouse_filter = 2
 expand_mode = 1
 
-[node name="SpeciesBox" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer" instance=ExtResource("7_np6c6")]
+[node name="SpeciesBox" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer" instance=ExtResource("7_np6c6")]
 layout_mode = 2
 DisplayName = "SPECIES_PRESENT"
 
-[node name="SpeciesList" parent="VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/SpeciesBox" instance=ExtResource("1")]
+[node name="SpeciesList" parent="NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/SpeciesBox" instance=ExtResource("1")]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 fit_content = true
 
-[node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
+[node name="HSeparator" type="HSeparator" parent="NormalContent"]
 layout_mode = 2
 theme_override_styles/separator = SubResource("34")
 
-[node name="MarginContainer2" type="MarginContainer" parent="VBoxContainer"]
+[node name="MarginContainer2" type="MarginContainer" parent="NormalContent"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/margin_left = 10
@@ -447,14 +452,14 @@ theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="MoveToPatchButton" type="Button" parent="VBoxContainer/MarginContainer2"]
+[node name="MoveToPatchButton" type="Button" parent="NormalContent/MarginContainer2"]
 custom_minimum_size = Vector2(0, 35)
 layout_mode = 2
 focus_mode = 0
 disabled = true
 text = "MOVE_TO_THIS_PATCH"
 
-[node name="MarginContainer3" type="MarginContainer" parent="VBoxContainer"]
+[node name="MarginContainer3" type="MarginContainer" parent="NormalContent"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/margin_left = 10
@@ -462,7 +467,7 @@ theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="MigrateButton" type="Button" parent="VBoxContainer/MarginContainer3"]
+[node name="MigrateButton" type="Button" parent="NormalContent/MarginContainer3"]
 custom_minimum_size = Vector2(0, 35)
 layout_mode = 2
 tooltip_text = "MIGRATION_TOOLTIP"
@@ -470,36 +475,7 @@ focus_mode = 0
 text = "MIGRATE"
 
 [node name="MigrationMenu" type="VBoxContainer" parent="."]
-visible = false
 layout_mode = 2
-
-[node name="MarginContainer3" type="MarginContainer" parent="MigrationMenu"]
-layout_mode = 2
-size_flags_horizontal = 3
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 5
-theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
-
-[node name="SourcePatch" type="Button" parent="MigrationMenu/MarginContainer3"]
-custom_minimum_size = Vector2(0, 35)
-layout_mode = 2
-focus_mode = 0
-text = "SOURCE_PATCH"
-
-[node name="MarginContainer4" type="MarginContainer" parent="MigrationMenu"]
-layout_mode = 2
-size_flags_horizontal = 3
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 5
-theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
-
-[node name="DestinationPatch" type="Button" parent="MigrationMenu/MarginContainer4"]
-custom_minimum_size = Vector2(0, 35)
-layout_mode = 2
-focus_mode = 0
-text = "DESTINATION_PATCH"
 
 [node name="MarginContainer6" type="MarginContainer" parent="MigrationMenu"]
 layout_mode = 2
@@ -509,11 +485,56 @@ theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="Label" type="Label" parent="MigrationMenu/MarginContainer6"]
+[node name="MigrationStatusLabel" type="Label" parent="MigrationMenu/MarginContainer6"]
 custom_minimum_size = Vector2(300, 30)
 layout_mode = 2
-text = "MIGRATION_EXPLANATION"
+text = "MIGRATION_STEP_SOURCE_EXPLANATION"
+label_settings = ExtResource("23_8qra5")
 autowrap_mode = 3
+
+[node name="MarginContainer3" type="MarginContainer" parent="MigrationMenu"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="PopulationAmount" type="HSlider" parent="MigrationMenu/MarginContainer3"]
+layout_mode = 2
+rounded = true
+
+[node name="MarginContainer7" type="MarginContainer" parent="MigrationMenu"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="MigrationSetupDescription" type="Label" parent="MigrationMenu/MarginContainer7"]
+custom_minimum_size = Vector2(300, 30)
+layout_mode = 2
+label_settings = ExtResource("24_21yun")
+autowrap_mode = 3
+
+[node name="MarginContainer8" type="MarginContainer" parent="MigrationMenu"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="MigrationError" type="Label" parent="MigrationMenu/MarginContainer8"]
+custom_minimum_size = Vector2(300, 30)
+layout_mode = 2
+label_settings = ExtResource("25_dd3af")
+autowrap_mode = 3
+
+[node name="Spacer" type="Control" parent="MigrationMenu"]
+layout_mode = 2
+size_flags_vertical = 3
 
 [node name="MarginContainer5" type="MarginContainer" parent="MigrationMenu"]
 layout_mode = 2
@@ -543,9 +564,7 @@ layout_mode = 2
 focus_mode = 0
 text = "CANCEL"
 
-[connection signal="pressed" from="VBoxContainer/MarginContainer2/MoveToPatchButton" to="." method="MoveToPatchClicked"]
-[connection signal="pressed" from="VBoxContainer/MarginContainer3/MigrateButton" to="." method="MigrateButtonPressed"]
-[connection signal="pressed" from="MigrationMenu/MarginContainer3/SourcePatch" to="." method="MigrateSourcePressed"]
-[connection signal="pressed" from="MigrationMenu/MarginContainer4/DestinationPatch" to="." method="MigrateDestinationPressed"]
+[connection signal="pressed" from="NormalContent/MarginContainer2/MoveToPatchButton" to="." method="MoveToPatchClicked"]
+[connection signal="pressed" from="NormalContent/MarginContainer3/MigrateButton" to="." method="MigrateButtonPressed"]
 [connection signal="pressed" from="MigrationMenu/MarginContainer5/Accept" to="." method="MigrateAcceptPressed"]
 [connection signal="pressed" from="MigrationMenu/MarginContainer2/Cancel" to="." method="MigrateCancelPressed"]

--- a/src/microbe_stage/gui/PatchDetailsPanel.tscn
+++ b/src/microbe_stage/gui/PatchDetailsPanel.tscn
@@ -59,7 +59,6 @@ compoundsContainer = NodePath("NormalContent/MarginContainer/ScrollContainer/VBo
 speciesParentContainer = NodePath("NormalContent/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/SpeciesBox")
 
 [node name="NormalContent" type="VBoxContainer" parent="."]
-visible = false
 layout_mode = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="NormalContent"]
@@ -475,6 +474,7 @@ focus_mode = 0
 text = "MIGRATE"
 
 [node name="MigrationMenu" type="VBoxContainer" parent="."]
+visible = false
 layout_mode = 2
 
 [node name="MarginContainer6" type="MarginContainer" parent="MigrationMenu"]
@@ -566,5 +566,6 @@ text = "CANCEL"
 
 [connection signal="pressed" from="NormalContent/MarginContainer2/MoveToPatchButton" to="." method="MoveToPatchClicked"]
 [connection signal="pressed" from="NormalContent/MarginContainer3/MigrateButton" to="." method="MigrateButtonPressed"]
+[connection signal="value_changed" from="MigrationMenu/MarginContainer3/PopulationAmount" to="." method="MigrationAmountSliderChanged"]
 [connection signal="pressed" from="MigrationMenu/MarginContainer5/Accept" to="." method="MigrateAcceptPressed"]
 [connection signal="pressed" from="MigrationMenu/MarginContainer2/Cancel" to="." method="MigrateCancelPressed"]

--- a/src/microbe_stage/gui/PatchDetailsPanel.tscn
+++ b/src/microbe_stage/gui/PatchDetailsPanel.tscn
@@ -27,7 +27,7 @@
 texture = ExtResource("9")
 region_rect = Rect2(0, 0, 429, 1)
 
-[node name="PatchDetailsPanel" type="PanelContainer" node_paths=PackedStringArray("nothingSelected", "unknownPatch", "detailsContainer", "playerHere", "patchName", "biome", "depth", "moveToPatchHSeparator", "moveToPatchButton", "physicalConditionsContainer", "atmosphereContainer", "compoundsContainer", "speciesParentContainer")]
+[node name="PatchDetailsPanel" type="PanelContainer" node_paths=PackedStringArray("nothingSelected", "unknownPatch", "detailsContainer", "playerHere", "patchName", "biome", "depth", "moveToPatchHSeparator", "moveToPatchButton", "migrationMenu", "menu", "migrateButton", "migrationSource", "migrationDestination", "migrationAccept", "migrationCancel", "physicalConditionsContainer", "atmosphereContainer", "compoundsContainer", "speciesParentContainer")]
 custom_minimum_size = Vector2(340, 0)
 offset_right = 352.0
 offset_bottom = 620.0
@@ -42,6 +42,13 @@ biome = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/Pa
 depth = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Depth")
 moveToPatchHSeparator = NodePath("VBoxContainer/HSeparator")
 moveToPatchButton = NodePath("VBoxContainer/MarginContainer2/MoveToPatchButton")
+migrationMenu = NodePath("MigrationMenu")
+menu = NodePath("VBoxContainer")
+migrateButton = NodePath("VBoxContainer/MarginContainer3/MigrateButton")
+migrationSource = NodePath("MigrationMenu/MarginContainer3/SourcePatch")
+migrationDestination = NodePath("MigrationMenu/MarginContainer4/DestinationPatch")
+migrationAccept = NodePath("MigrationMenu/MarginContainer5/Accept")
+migrationCancel = NodePath("MigrationMenu/MarginContainer2/Cancel")
 physicalConditionsContainer = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/PhysicalConditions")
 atmosphereContainer = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/AtmosphericGasses")
 compoundsContainer = NodePath("VBoxContainer/MarginContainer/ScrollContainer/VBoxContainer/PatchDetailsContainer/Compounds")
@@ -447,4 +454,98 @@ focus_mode = 0
 disabled = true
 text = "MOVE_TO_THIS_PATCH"
 
+[node name="MarginContainer3" type="MarginContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="MigrateButton" type="Button" parent="VBoxContainer/MarginContainer3"]
+custom_minimum_size = Vector2(0, 35)
+layout_mode = 2
+tooltip_text = "MIGRATION_TOOLTIP"
+focus_mode = 0
+text = "MIGRATE"
+
+[node name="MigrationMenu" type="VBoxContainer" parent="."]
+visible = false
+layout_mode = 2
+
+[node name="MarginContainer3" type="MarginContainer" parent="MigrationMenu"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="SourcePatch" type="Button" parent="MigrationMenu/MarginContainer3"]
+custom_minimum_size = Vector2(0, 35)
+layout_mode = 2
+focus_mode = 0
+text = "SOURCE_PATCH"
+
+[node name="MarginContainer4" type="MarginContainer" parent="MigrationMenu"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="DestinationPatch" type="Button" parent="MigrationMenu/MarginContainer4"]
+custom_minimum_size = Vector2(0, 35)
+layout_mode = 2
+focus_mode = 0
+text = "DESTINATION_PATCH"
+
+[node name="MarginContainer6" type="MarginContainer" parent="MigrationMenu"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="Label" type="Label" parent="MigrationMenu/MarginContainer6"]
+custom_minimum_size = Vector2(300, 30)
+layout_mode = 2
+text = "MIGRATION_EXPLANATION"
+autowrap_mode = 3
+
+[node name="MarginContainer5" type="MarginContainer" parent="MigrationMenu"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="Accept" type="Button" parent="MigrationMenu/MarginContainer5"]
+custom_minimum_size = Vector2(0, 35)
+layout_mode = 2
+focus_mode = 0
+text = "ACCEPT"
+
+[node name="MarginContainer2" type="MarginContainer" parent="MigrationMenu"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="Cancel" type="Button" parent="MigrationMenu/MarginContainer2"]
+custom_minimum_size = Vector2(0, 35)
+layout_mode = 2
+focus_mode = 0
+text = "CANCEL"
+
 [connection signal="pressed" from="VBoxContainer/MarginContainer2/MoveToPatchButton" to="." method="MoveToPatchClicked"]
+[connection signal="pressed" from="VBoxContainer/MarginContainer3/MigrateButton" to="." method="MigrateButtonPressed"]
+[connection signal="pressed" from="MigrationMenu/MarginContainer3/SourcePatch" to="." method="MigrateSourcePressed"]
+[connection signal="pressed" from="MigrationMenu/MarginContainer4/DestinationPatch" to="." method="MigrateDestinationPressed"]
+[connection signal="pressed" from="MigrationMenu/MarginContainer5/Accept" to="." method="MigrateAcceptPressed"]
+[connection signal="pressed" from="MigrationMenu/MarginContainer2/Cancel" to="." method="MigrateCancelPressed"]

--- a/src/microbe_stage/gui/PatchExtinctionBox.tscn
+++ b/src/microbe_stage/gui/PatchExtinctionBox.tscn
@@ -136,6 +136,7 @@ theme_override_constants/margin_bottom = 45
 
 [node name="PatchDetailsPanel" parent="PanelContainer/MarginContainer/PatchExtinctionBoxMenu/HBoxContainer/MarginContainer2" instance=ExtResource("5")]
 layout_mode = 2
+MigrationManagerEnabled = false
 
 [node name="VSeparator2" type="VSeparator" parent="PanelContainer/MarginContainer/PatchExtinctionBoxMenu/HBoxContainer"]
 custom_minimum_size = Vector2(100, 0)


### PR DESCRIPTION
**Brief Description of What This PR Does**

If player presses button to spread, they won't be able to move this session anymore (to prevent an exploit where you can just move to patch adjacent to already inhibited one and inhibit during same session) and undo button.

**Related Issues**

https://wiki.revolutionarygamesstudio.com/wiki/Release_Roadmap#0.7.x_(the_graph_updates)

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
