### PR TITLE
Make simple rocket do an orbit turn into space

### DIFF
--- a/src/industrial_stage/IndustrialStage.cs
+++ b/src/industrial_stage/IndustrialStage.cs
@@ -395,7 +395,11 @@ public partial class IndustrialStage : StrategyStageBase, ISocietyStructureDataA
         // TODO: unit specific acceleration values / movement here
         toSpaceUnitAcceleration += (float)(delta * Constants.INDUSTRIAL_TO_SPACE_ROCKET_ACCELERATION);
 
-        toSpaceAnimatedUnit.GlobalPosition += new Vector3(0, toSpaceUnitAcceleration, 0);
+        // almost, but don't quite, level out at max height
+        var orbitTurnAngle = toSpaceAnimatedUnit.GlobalPosition.Y / (Constants.INDUSTRIAL_TO_SPACE_END_ROCKET_HEIGHT * 1.1f);
+
+        toSpaceAnimatedUnit.Rotation = new Vector3(0, 0, orbitTurnAngle * (Mathf.Pi / 2));
+        toSpaceAnimatedUnit.GlobalPosition += new Vector3(-toSpaceUnitAcceleration * orbitTurnAngle, toSpaceUnitAcceleration * (1 - orbitTurnAngle), 0);
     }
 
     private void SwitchToSpaceScene()

--- a/src/industrial_stage/IndustrialStage.cs
+++ b/src/industrial_stage/IndustrialStage.cs
@@ -396,10 +396,12 @@ public partial class IndustrialStage : StrategyStageBase, ISocietyStructureDataA
         toSpaceUnitAcceleration += (float)(delta * Constants.INDUSTRIAL_TO_SPACE_ROCKET_ACCELERATION);
 
         // almost, but don't quite, level out at max height
-        var orbitTurnAngle = toSpaceAnimatedUnit.GlobalPosition.Y / (Constants.INDUSTRIAL_TO_SPACE_END_ROCKET_HEIGHT * 1.1f);
+        var orbitTurnAngle = toSpaceAnimatedUnit.GlobalPosition.Y /
+            (Constants.INDUSTRIAL_TO_SPACE_END_ROCKET_HEIGHT * 1.1f);
 
         toSpaceAnimatedUnit.Rotation = new Vector3(0, 0, orbitTurnAngle * (Mathf.Pi / 2));
-        toSpaceAnimatedUnit.GlobalPosition += new Vector3(-toSpaceUnitAcceleration * orbitTurnAngle, toSpaceUnitAcceleration * (1 - orbitTurnAngle), 0);
+        toSpaceAnimatedUnit.GlobalPosition += new Vector3(-toSpaceUnitAcceleration * orbitTurnAngle,
+            toSpaceUnitAcceleration * (1 - orbitTurnAngle), 0);
     }
 
     private void SwitchToSpaceScene()

--- a/src/industrial_stage/IndustrialStage.cs
+++ b/src/industrial_stage/IndustrialStage.cs
@@ -395,7 +395,7 @@ public partial class IndustrialStage : StrategyStageBase, ISocietyStructureDataA
         // TODO: unit specific acceleration values / movement here
         toSpaceUnitAcceleration += (float)(delta * Constants.INDUSTRIAL_TO_SPACE_ROCKET_ACCELERATION);
 
-        // almost, but don't quite, level out at max height
+        // Almost, but don't quite, level out at max height
         var orbitTurnAngle = toSpaceAnimatedUnit.GlobalPosition.Y /
             (Constants.INDUSTRIAL_TO_SPACE_END_ROCKET_HEIGHT * 1.1f);
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Replaces the "straight up" trajectory of the rocket at the end of industrial stage with an approximation of a launch to orbit. The first fleet of space stage still floats straight out, but I've always interpreted that as being a "mature" space age fleet instead of literally being the first craft in space, since I doubt that a "simple rocket" can build a dyson swarm.

**Related Issues**

None; just for fun and accuracy.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
