### PR TITLE
Fixed editor timeline global and local buttons being able to be on at the same time

### DIFF
--- a/src/microbe_stage/editor/MicrobeEditorReportComponent.tscn
+++ b/src/microbe_stage/editor/MicrobeEditorReportComponent.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=3 uid="uid://qdqcbnri7vsw"]
+[gd_scene load_steps=25 format=3 uid="uid://qdqcbnri7vsw"]
 
 [ext_resource type="PackedScene" path="res://src/gui_common/CustomRichTextLabel.tscn" id="2"]
 [ext_resource type="LabelSettings" uid="uid://dcekwe8j7ep16" path="res://src/gui_common/fonts/Title-SemiBold-AlmostHuge.tres" id="3_ocn33"]
@@ -31,6 +31,8 @@ corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
 [sub_resource type="StyleBoxEmpty" id="30"]
+
+[sub_resource type="ButtonGroup" id="ButtonGroup_hdykd"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_d1pk0"]
 
@@ -341,6 +343,7 @@ theme_override_fonts/font = ExtResource("10_dmd4f")
 theme_override_font_sizes/font_size = 12
 toggle_mode = true
 action_mode = 0
+button_group = SubResource("ButtonGroup_hdykd")
 text = "GLOBAL_INITIAL_LETTER"
 
 [node name="LocalFilter" type="Button" parent="MarginContainer/HSplitContainer/PanelContainer/MarginContainer/VBoxContainer/TimelinePanel/MarginContainer/MarginContainer/HBoxContainer"]
@@ -352,6 +355,7 @@ theme_override_fonts/font = ExtResource("10_dmd4f")
 theme_override_font_sizes/font_size = 12
 toggle_mode = true
 action_mode = 0
+button_group = SubResource("ButtonGroup_hdykd")
 text = "LOCAL_INITIAL_LETTER"
 
 [node name="TopFade" type="TextureRect" parent="MarginContainer/HSplitContainer/PanelContainer/MarginContainer/VBoxContainer/TimelinePanel"]

--- a/src/microbe_stage/editor/TimelineEventHighlight.tres
+++ b/src/microbe_stage/editor/TimelineEventHighlight.tres
@@ -1,13 +1,12 @@
-[gd_resource type="StyleBoxTexture" load_steps=3 format=2]
+[gd_resource type="StyleBoxTexture" load_steps=3 format=3 uid="uid://b6ugrigxlvajw"]
 
-[sub_resource type="Gradient" id=1]
-colors = PackedColorArray( 0.0666667, 0.509804, 0.835294, 0.470588, 0.0666667, 0.698039, 0.835294, 0 )
+[sub_resource type="Gradient" id="1"]
+colors = PackedColorArray(0.0666667, 0.509804, 0.835294, 0.470588, 0.0666667, 0.698039, 0.835294, 0)
 
-[sub_resource type="GradientTexture2D" id=2]
-gradient = SubResource( 1 )
+[sub_resource type="GradientTexture2D" id="2"]
+gradient = SubResource("1")
+width = 1024
 
 [resource]
-texture = SubResource( 2 )
-region_rect = Rect2( 0, 0, 2048, 1 )
-margin_left = 3.0
-margin_right = 3.0
+texture = SubResource("2")
+region_rect = Rect2(0, 0, 2048, 1)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes two regressions from Godot 4 migration: missing item group and too narrow stylebox gradient

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
reported on the community discord but I didn't keep a link

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
