### PR TITLE
Added safety eject for engulfed objects in None state

### DIFF
--- a/src/microbe_stage/systems/EngulfedDigestionSystem.cs
+++ b/src/microbe_stage/systems/EngulfedDigestionSystem.cs
@@ -75,7 +75,15 @@ public sealed class EngulfedDigestionSystem : AEntitySetSystem<float>
         ref var engulfer = ref entity.Get<Engulfer>();
 
         if (engulfer.EngulfedObjects == null || engulfer.EngulfedObjects.Count < 1)
+        {
+            // When something ejects its last engulfed object, the used engulfing size needs to be still updated
+
+            // TODO: determine if it is faster to always write this value or compare first
+            if (engulfer.UsedEngulfingCapacity > 0)
+                engulfer.UsedEngulfingCapacity = 0;
+
             return;
+        }
 
         ref var organelles = ref entity.Get<OrganelleContainer>();
         var compounds = entity.Get<CompoundStorage>().Compounds;
@@ -94,6 +102,9 @@ public sealed class EngulfedDigestionSystem : AEntitySetSystem<float>
             return;
 
         var engulferIsPlayer = entity.Has<PlayerMarker>();
+
+        // TODO: if the entity is a colony with the player being the lead cell should that situation set
+        // engulferIsPlayer?
 
         float usedCapacity = 0;
 
@@ -144,6 +155,12 @@ public sealed class EngulfedDigestionSystem : AEntitySetSystem<float>
                 // Still need to consider the size of this thing for the engulf storage, otherwise cells can start
                 // pulling in too much
                 usedCapacity += engulfable.AdjustedEngulfSize;
+
+                if (engulfable.PhagocytosisStep == PhagocytosisPhase.None)
+                {
+                    GD.PrintErr("Engulfed object is in engulfed list while being not in engulfed state");
+                }
+
                 continue;
             }
 

--- a/src/microbe_stage/systems/EngulfedHandlingSystem.cs
+++ b/src/microbe_stage/systems/EngulfedHandlingSystem.cs
@@ -102,7 +102,7 @@ public sealed class EngulfedHandlingSystem : AEntitySetSystem<float>
             }
 
             // If the engulfing entity is dead, then this should have been ejected. The simulation world also has
-            // a on entity destroy callback that should do this so things are going pretty wrong if this is
+            // an on entity destroy callback that should do this so things are going pretty wrong if this is
             // triggered
             if (!engulfable.HostileEngulfer.IsAlive)
             {


### PR DESCRIPTION
**Brief Description of What This PR Does**

and made EngulfedDigestionSystem always update used ingestion capacity to ensure it doesn't leave outdated values there once the last object that was engulfed is ejected

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #5309

but doesn't address the underlying cause (though I did add some more safety checking code): https://github.com/Revolutionary-Games/Thrive/issues/5311 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
