### PR TITLE
Set eukaryotic engulfer size modifier to 2 which should be (more) accurate

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -750,7 +750,7 @@ public static class Constants
     /// </summary>
     public const float ENGULF_SIZE_RATIO_REQ = 1.5f;
 
-    public const float EUKARYOTIC_ENGULF_SIZE_MULTIPLIER = 1.5f;
+    public const float EUKARYOTIC_ENGULF_SIZE_MULTIPLIER = 2.0f;
 
     /// <summary>
     ///   The duration for which an engulfable object can't be engulfed after being expelled.

--- a/src/microbe_stage/components/Engulfer.cs
+++ b/src/microbe_stage/components/Engulfer.cs
@@ -85,6 +85,7 @@ public static class EngulferHelpers
         {
             ref var engulfable = ref target.Get<Engulfable>();
 
+            // Cannot engulf something that is already engulfed
             if (engulfable.PhagocytosisStep != PhagocytosisPhase.None)
                 return EngulfCheckResult.NotInEngulfMode;
 
@@ -97,18 +98,12 @@ public static class EngulferHelpers
                 return EngulfCheckResult.CannotCannibalize;
 
             // Needs to be big enough to engulf
-            if (engulfer.EngulfingSize < engulfable.AdjustedEngulfSize * Constants.ENGULF_SIZE_RATIO_REQ)
+            var targetSize = engulfable.AdjustedEngulfSize;
+            if (engulfer.EngulfingSize < targetSize * Constants.ENGULF_SIZE_RATIO_REQ)
                 return EngulfCheckResult.TargetTooBig;
 
             // Limit amount of things that can be engulfed at once
-            if (engulfer.UsedEngulfingCapacity >= engulfer.EngulfStorageSize ||
-                engulfer.UsedEngulfingCapacity + engulfable.AdjustedEngulfSize >= engulfer.EngulfStorageSize)
-            {
-                return EngulfCheckResult.IngestedMatterFull;
-            }
-
-            // Too many things attempted to be pulled in at once
-            if (engulfer.UsedEngulfingCapacity + engulfable.AdjustedEngulfSize >= engulfer.EngulfStorageSize)
+            if (engulfer.UsedEngulfingCapacity + targetSize >= engulfer.EngulfStorageSize)
             {
                 return EngulfCheckResult.IngestedMatterFull;
             }


### PR DESCRIPTION
**Brief Description of What This PR Does**

To go from half size you need to multiply by 2 to get back to 1. Also, slightly clarified the logic in engulf check as it seemed to have a duplicate check in it.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Recurring feedback about the engulf sizes being visually not clear

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
