### PR TITLE
Fix Migration button being present in Thriveopedia

### DIFF
--- a/src/microbe_stage/gui/PatchDetailsPanel.cs
+++ b/src/microbe_stage/gui/PatchDetailsPanel.cs
@@ -217,7 +217,7 @@ public partial class PatchDetailsPanel : PanelContainer
         set
         {
             migrationManagerEnabled = value;
-            UpdateMoveToPatchButton();
+            UpdateMigrationManagerVisibility();
         }
     }
 

--- a/src/thriveopedia/pages/ThriveopediaPatchMapPage.tscn
+++ b/src/thriveopedia/pages/ThriveopediaPatchMapPage.tscn
@@ -89,6 +89,7 @@ layout_mode = 2
 custom_minimum_size = Vector2(352, 0)
 layout_mode = 2
 MoveToPatchButtonVisible = false
+MigrationManagerEnabled = false
 
 [connection signal="OnCurrentPatchCentered" from="HSplitContainer/MapPanel/MarginContainer/DraggableScrollContainer/PatchMapDrawer" to="HSplitContainer/MapPanel/MarginContainer/DraggableScrollContainer" method="CenterTo"]
 [connection signal="pressed" from="HSplitContainer/MapPanel/MarginContainer/BoxContainer/FindCurrentPatchButton" to="." method="OnFindCurrentPatchPressed"]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Removes Migration button from Thriveopedia's current game patch map.

Additionally, fixes the button's visibility not being updated by its `{get; set}` property (Move-to-patch button was updated instead).

**Related Issues**

Not related to any issue, but as I understand, the Migration button was, in the first place, not intended to be in Thriveopedia, as it is an editor function.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
