### PR TITLE
Fixed clouds' visibility in lighter patches

### DIFF
--- a/shaders/CompoundCloudPlane.gdshader
+++ b/shaders/CompoundCloudPlane.gdshader
@@ -15,7 +15,7 @@ uniform vec2 UVOffset = vec2(0, 0);
 // This must evenly divide into 1 or tiling will break
 uniform float NoiseScale = 14;
 
-uniform float BrightnessMultiplier = 1.2;
+uniform float BrightnessMultiplier = 1.0;
 uniform float CLOUD_SPEED = 0.013;
 
 // Setting this too low makes the clouds invisible
@@ -60,7 +60,7 @@ void fragment() {
                   colour4 * cloud4;
 
     float adjustedAlpha = min(cloud1 + cloud2 + cloud3 + cloud4, 1.0) *
-        clamp(min(cloud1 + cloud2 + cloud3 + cloud4, 1.0) * 0.4, 0.4, 0.8);
+        clamp(min(cloud1 + cloud2 + cloud3 + cloud4, 1.0) * 0.5, 0.5, 0.9);
 
     ALPHA = adjustedAlpha;
     ALBEDO = colour.rgb;

--- a/src/microbe_stage/CompoundCloudPlane.tscn
+++ b/src/microbe_stage/CompoundCloudPlane.tscn
@@ -29,7 +29,7 @@ shader_parameter/colour3 = Color(0, 0, 0, 0)
 shader_parameter/colour4 = Color(0, 0, 0, 0)
 shader_parameter/UVOffset = Vector2(0, 0)
 shader_parameter/NoiseScale = 14
-shader_parameter/BrightnessMultiplier = 1.2
+shader_parameter/BrightnessMultiplier = 1.0
 shader_parameter/CLOUD_SPEED = 0.013
 shader_parameter/noise = SubResource("NoiseTexture2D_xdmng")
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This pr increases the cloud alpha calculation in a way that increases their visibility in lighter patches and resets the brightnessmultiplier value to 1.0

**Related Issues**

closes #5337 


**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
