### PR TITLE
Enabled sprinting by default (fixed keybinding, running with no ATP, GUI tweaks)

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1587,6 +1587,12 @@ public static class Constants
 
     public const float CONTROLLER_AXIS_REBIND_REQUIRED_STRENGTH = 0.5f;
 
+    /// <summary>
+    ///   Used to allow bindings like CTRL+A to happen while also allowing CTRL to be bound by itself if no further
+    ///   keys are pressed for this amount of time.
+    /// </summary>
+    public const float MODIFIER_KEY_REBIND_DELAY = 0.5f;
+
     public const float CONTROLLER_DEFAULT_DEADZONE = 0.2f;
 
     /// <summary>

--- a/src/general/WorldGenerationSettings.cs
+++ b/src/general/WorldGenerationSettings.cs
@@ -55,7 +55,7 @@ public class WorldGenerationSettings
     public bool LAWK { get; set; }
 
     /// <summary>
-    ///   Whether or not experimental features are enabled this game
+    ///   Whether experimental features are enabled this game
     /// </summary>
     public bool ExperimentalFeatures { get; set; }
 

--- a/src/general/base_stage/CreatureStageHUDBase.cs
+++ b/src/general/base_stage/CreatureStageHUDBase.cs
@@ -175,6 +175,8 @@ public partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSta
     private readonly Dictionary<Compound, float> gatheredCompounds = new();
     private readonly Dictionary<Compound, float> totalNeededCompounds = new();
 
+    private readonly StringName barFillName = new("fill");
+
     // This block of controls is split from the reset as some controls are protected and these are private
 #pragma warning disable CA2213
     [Export]
@@ -772,11 +774,11 @@ public partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSta
 
             if (strainIsRed)
             {
-                strainBar.AddThemeStyleboxOverride("fill", strainBarRedFill);
+                strainBar.AddThemeStyleboxOverride(barFillName, strainBarRedFill);
             }
             else
             {
-                strainBar.RemoveThemeStyleboxOverride("fill");
+                strainBar.RemoveThemeStyleboxOverride(barFillName);
             }
         }
 
@@ -1158,6 +1160,8 @@ public partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSta
             fadeParameterName.Dispose();
 
             strainBarRedFill?.Dispose();
+
+            barFillName.Dispose();
         }
 
         base.Dispose(disposing);

--- a/src/general/base_stage/CreatureStageHUDBase.cs
+++ b/src/general/base_stage/CreatureStageHUDBase.cs
@@ -750,12 +750,6 @@ public partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSta
 
     protected void UpdateStrain()
     {
-        if (!stage!.GameWorld.WorldSettings.ExperimentalFeatures)
-        {
-            strainBar.Visible = false;
-            return;
-        }
-
         var readStrainFraction = ReadPlayerStrainFraction();
 
         // Skip the rest of the method if player does not have strain
@@ -1036,7 +1030,7 @@ public partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSta
         signalingAgentsHotkey.Visible = showingSignaling;
         ejectEngulfedHotkey.Visible = showEject;
         mucocystHotkey.Visible = showMucocyst;
-        sprintHotkey.Visible = showSprint && stage!.GameWorld.WorldSettings.ExperimentalFeatures;
+        sprintHotkey.Visible = showSprint;
 
         sprintHotkey.ButtonPressed = isSprinting;
         engulfHotkey.ButtonPressed = engulfOn;

--- a/src/gui_common/thrive_theme.tres
+++ b/src/gui_common/thrive_theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=73 format=3 uid="uid://b4cx0o110g4b6"]
+[gd_resource type="Theme" load_steps=75 format=3 uid="uid://b4cx0o110g4b6"]
 
 [ext_resource type="FontVariation" uid="uid://dgd4ajpji2jb1" path="res://assets/fonts/variants/Jura-SemiBold.tres" id="1_fiqxx"]
 [ext_resource type="Texture2D" uid="uid://bjchgyy3gt2vp" path="res://assets/textures/gui/bevel/grab.png" id="2"]
@@ -416,6 +416,22 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y7g70"]
+bg_color = Color(0, 0.290196, 0.34902, 0.470588)
+border_color = Color(0, 0.129412, 0.156863, 1)
+corner_radius_top_left = 2
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bi4pt"]
+bg_color = Color(0, 0.74902, 0.713726, 0.588235)
+border_color = Color(1, 1, 1, 0)
+corner_radius_top_left = 2
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
+
 [sub_resource type="StyleBoxFlat" id="32"]
 content_margin_left = 10.0
 content_margin_top = 0.0
@@ -828,6 +844,10 @@ RichTextLabel/styles/focus = null
 RichTextLabel/styles/normal = null
 ScrollContainer/styles/bg = null
 SpinBox/icons/updown = null
+SprintBar/base_type = &"ProgressBar"
+SprintBar/font_sizes/font_size = 12
+SprintBar/styles/background = SubResource("StyleBoxFlat_y7g70")
+SprintBar/styles/fill = SubResource("StyleBoxFlat_bi4pt")
 TabBar/colors/font_color_bg = Color(0, 0, 0, 1)
 TabBar/colors/font_color_disabled = Color(0, 0, 0, 1)
 TabBar/colors/font_color_fg = Color(0, 0, 0, 1)

--- a/src/late_multicellular_stage/MulticellularHUD.tscn
+++ b/src/late_multicellular_stage/MulticellularHUD.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=45 format=3 uid="uid://5m75uu7qtg8x"]
+[gd_scene load_steps=46 format=3 uid="uid://5m75uu7qtg8x"]
 
 [ext_resource type="Theme" uid="uid://b4cx0o110g4b6" path="res://src/gui_common/thrive_theme.tres" id="5"]
 [ext_resource type="PackedScene" uid="uid://u7o6febei0qr" path="res://src/gui_common/MouseHoverPanel.tscn" id="6"]
@@ -6,7 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://dvmlda3belyek" path="res://assets/textures/gui/bevel/actions/OpenInventory.png" id="9"]
 [ext_resource type="Script" path="res://src/late_multicellular_stage/MulticellularHUD.cs" id="11"]
 [ext_resource type="PackedScene" uid="uid://dwkek50fju0fu" path="res://src/microbe_stage/PatchNameOverlay.tscn" id="12"]
-[ext_resource type="PackedScene" path="res://src/microbe_stage/ProcessPanel.tscn" id="13"]
+[ext_resource type="PackedScene" uid="uid://dgqw7nudbxobi" path="res://src/microbe_stage/ProcessPanel.tscn" id="13"]
 [ext_resource type="PackedScene" uid="uid://cf65ovetig4om" path="res://src/microbe_stage/gui/EnvironmentPanel.tscn" id="13_ayo6l"]
 [ext_resource type="PackedScene" uid="uid://bk6re4dgb8r3n" path="res://src/microbe_stage/gui/CompoundPanels.tscn" id="14_47uq8"]
 [ext_resource type="PackedScene" uid="uid://g70pm5ndiqf2" path="res://src/microbe_stage/gui/PatchExtinctionBox.tscn" id="16"]
@@ -39,12 +39,12 @@
 [ext_resource type="PackedScene" uid="uid://qwg2dluu8ow0" path="res://src/microbe_stage/PausePrompt.tscn" id="77"]
 [ext_resource type="PackedScene" path="res://src/gui_common/ActionButton.tscn" id="78"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_oa3p7"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_gpwlk"]
 bg_color = Color(1, 0.301961, 0.301961, 1)
-corner_radius_top_left = 4
-corner_radius_top_right = 4
-corner_radius_bottom_right = 4
-corner_radius_bottom_left = 4
+corner_radius_top_left = 2
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
 
 [sub_resource type="StyleBoxFlat" id="28"]
 bg_color = Color(0.47451, 0.560784, 0.588235, 0.392157)
@@ -157,7 +157,7 @@ mucocystHotkey = NodePath("ScrollContainer/HotBar/Shield")
 sprintHotkey = NodePath("ScrollContainer/HotBar/Sprint")
 strainBar = NodePath("Strain")
 damageScreenEffect = NodePath("DamageEffect")
-strainBarRedFill = SubResource("StyleBoxFlat_oa3p7")
+strainBarRedFill = SubResource("StyleBoxFlat_gpwlk")
 pausePrompt = NodePath("PausePrompt")
 pauseInfo = NodePath("PausePrompt/PauseInfo")
 hudMessages = NodePath("HUDMessages")
@@ -584,15 +584,20 @@ layout_mode = 1
 
 [node name="Strain" type="ProgressBar" parent="."]
 visible = false
-custom_minimum_size = Vector2(400, 0)
+custom_minimum_size = Vector2(250, 0)
 layout_mode = 1
-anchors_preset = 5
+anchors_preset = 8
 anchor_left = 0.5
+anchor_top = 0.5
 anchor_right = 0.5
-offset_left = -200.0
-offset_right = 200.0
-offset_bottom = 27.0
+anchor_bottom = 0.5
+offset_left = -125.0
+offset_top = 183.0
+offset_right = 125.0
+offset_bottom = 198.0
 grow_horizontal = 2
+grow_vertical = 2
+theme_type_variation = &"SprintBar"
 max_value = 0.9
 step = 0.001
 show_percentage = false

--- a/src/microbe_stage/MicrobeHUD.tscn
+++ b/src/microbe_stage/MicrobeHUD.tscn
@@ -40,10 +40,10 @@
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_b2vtv"]
 bg_color = Color(1, 0.301961, 0.301961, 1)
-corner_radius_top_left = 4
-corner_radius_top_right = 4
-corner_radius_bottom_right = 4
-corner_radius_bottom_left = 4
+corner_radius_top_left = 2
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
 
 [sub_resource type="Animation" id="39"]
 resource_name = "HideCompoundsPanels"
@@ -742,15 +742,20 @@ layout_mode = 1
 
 [node name="Strain" type="ProgressBar" parent="."]
 visible = false
-custom_minimum_size = Vector2(400, 0)
+custom_minimum_size = Vector2(250, 0)
 layout_mode = 1
-anchors_preset = 5
+anchors_preset = 8
 anchor_left = 0.5
+anchor_top = 0.5
 anchor_right = 0.5
-offset_left = -200.0
-offset_right = 200.0
-offset_bottom = 27.0
+anchor_bottom = 0.5
+offset_left = -125.0
+offset_top = 183.0
+offset_right = 125.0
+offset_bottom = 198.0
 grow_horizontal = 2
+grow_vertical = 2
+theme_type_variation = &"SprintBar"
 max_value = 0.9
 step = 0.001
 show_percentage = false

--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -349,9 +349,6 @@ public partial class PlayerMicrobeInput : NodeWithInput
     [RunOnKeyDown("g_sprint")]
     public bool StartSprint()
     {
-        if (!stage.WorldSettings.ExperimentalFeatures)
-            return false;
-
         if (!stage.HasPlayer)
             return false;
 
@@ -376,9 +373,6 @@ public partial class PlayerMicrobeInput : NodeWithInput
 
     public void ToggleSprint()
     {
-        if (!stage.WorldSettings.ExperimentalFeatures)
-            return;
-
         if (!stage.HasPlayer)
             return;
 

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -737,7 +737,7 @@ public sealed class MicrobeAISystem : AEntitySetSystem<float>, ISpeciesMemberLoc
         ai.TargetPosition = chunk + new Vector3(0.5f, 0.0f, 0.5f);
         control.LookAtPoint = ai.TargetPosition;
 
-        // Check if use siderophore
+        // Check if using siderophore
         if (isIronEater && chunkIsIron && gameWorld!.WorldSettings.ExperimentalFeatures)
         {
             control.EmitSiderophore(ref organelles, entity);
@@ -789,8 +789,7 @@ public sealed class MicrobeAISystem : AEntitySetSystem<float>, ISpeciesMemberLoc
             }
 
             // Sprint until full strain
-            if (gameWorld!.WorldSettings.ExperimentalFeatures)
-                control.Sprinting = true;
+            control.Sprinting = true;
         }
 
         // If prey is confident enough, it will try and launch toxin at the predator
@@ -829,8 +828,7 @@ public sealed class MicrobeAISystem : AEntitySetSystem<float>, ISpeciesMemberLoc
         {
             control.SetMoveSpeed(Constants.AI_BASE_MOVEMENT);
 
-            if (gameWorld!.WorldSettings.ExperimentalFeatures)
-                control.Sprinting = true;
+            control.Sprinting = true;
         }
 
         // Predators can use slime jets as an ambush mechanism


### PR DESCRIPTION
**Brief Description of What This PR Does**

Enables sprinting by default. Even though not everything in https://github.com/Revolutionary-Games/Thrive/issues/5284 is done I think we'll have enough time to fix the most important things.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #5283
closes #3887

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
