### PR TITLE
Fix species preview tooltips not working in Timeline tab of Editor's report

### DIFF
--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -357,7 +357,7 @@ public class AutoEvoRun
         foreach (var entry in combinedExternalEffects)
         {
             builder.Append(new LocalizedString("AUTO-EVO_POPULATION_CHANGED_2",
-                entry.Key.Species.FormattedName, entry.Value, entry.Key.Patch.Name, entry.Key.Event));
+                entry.Key.Species.FormattedNameBbCode, entry.Value, entry.Key.Patch.Name, entry.Key.Event));
 
             builder.Append('\n');
         }

--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -951,7 +951,7 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                 // TODO: these events need to dynamically reveal their names in the event log once the player
                 // discovers them
                 patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_MIGRATED_FROM",
-                    migration.Key.FormattedNameBbCodeUnstyled, migration.Value.From.VisibleName),
+                        migration.Key.FormattedNameBbCodeUnstyled, migration.Value.From.VisibleName),
                     migration.Key.PlayerSpecies, "newSpecies.png");
 
                 // Log to game world
@@ -981,8 +981,8 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                     {
                         case NewSpeciesType.FillNiche:
                             LogEventGloballyAndLocally(world, patch, new LocalizedString("TIMELINE_NICHE_FILL",
-                                    newSpeciesEntry.FormattedNameBbCodeUnstyled,
-                                    speciesResult.SplitFrom.FormattedNameBbCodeUnstyled), false, "newSpecies.png");
+                                newSpeciesEntry.FormattedNameBbCodeUnstyled,
+                                speciesResult.SplitFrom.FormattedNameBbCodeUnstyled), false, "newSpecies.png");
                             break;
                         case NewSpeciesType.SplitDueToMutation:
                             LogEventGloballyAndLocally(world, patch, new LocalizedString(

--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -924,8 +924,8 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                 }
                 else
                 {
-                    patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_EXTINCT_LOCAL", species.FormattedNameBbCodeUnstyled),
-                        species.PlayerSpecies, "extinctionLocal.png");
+                    patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_EXTINCT_LOCAL",
+                        species.FormattedNameBbCodeUnstyled), species.PlayerSpecies, "extinctionLocal.png");
                 }
 
                 if (globalPopulation != previousGlobalPopulation)
@@ -950,8 +950,8 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                 // Log to destination patch
                 // TODO: these events need to dynamically reveal their names in the event log once the player
                 // discovers them
-                patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_MIGRATED_FROM", migration.Key.FormattedNameBbCodeUnstyled,
-                        migration.Value.From.VisibleName),
+                patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_MIGRATED_FROM",
+                    migration.Key.FormattedNameBbCodeUnstyled, migration.Value.From.VisibleName),
                     migration.Key.PlayerSpecies, "newSpecies.png");
 
                 // Log to game world
@@ -981,8 +981,8 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                     {
                         case NewSpeciesType.FillNiche:
                             LogEventGloballyAndLocally(world, patch, new LocalizedString("TIMELINE_NICHE_FILL",
-                                    newSpeciesEntry.FormattedNameBbCodeUnstyled, speciesResult.SplitFrom.FormattedNameBbCodeUnstyled),
-                                false, "newSpecies.png");
+                                    newSpeciesEntry.FormattedNameBbCodeUnstyled,
+                                    speciesResult.SplitFrom.FormattedNameBbCodeUnstyled), false, "newSpecies.png");
                             break;
                         case NewSpeciesType.SplitDueToMutation:
                             LogEventGloballyAndLocally(world, patch, new LocalizedString(

--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -901,7 +901,7 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                 {
                     // TODO: see https://github.com/Revolutionary-Games/Thrive/issues/2958
                     LogEventGloballyAndLocally(world, patch,
-                        new LocalizedString("TIMELINE_SPECIES_EXTINCT", species.FormattedName),
+                        new LocalizedString("TIMELINE_SPECIES_EXTINCT", species.FormattedNameBbCode),
                         species.PlayerSpecies, "extinction.png");
 
                     continue;
@@ -912,19 +912,19 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                     if (finalPatchPopulation > previousPatchPopulation)
                     {
                         patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_POPULATION_INCREASE",
-                                species.FormattedName, finalPatchPopulation),
+                                species.FormattedNameBbCode, finalPatchPopulation),
                             species.PlayerSpecies, "popUp.png");
                     }
                     else
                     {
                         patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_POPULATION_DECREASE",
-                                species.FormattedName, finalPatchPopulation),
+                                species.FormattedNameBbCode, finalPatchPopulation),
                             species.PlayerSpecies, "popDown.png");
                     }
                 }
                 else
                 {
-                    patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_EXTINCT_LOCAL", species.FormattedName),
+                    patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_EXTINCT_LOCAL", species.FormattedNameBbCode),
                         species.PlayerSpecies, "extinctionLocal.png");
                 }
 
@@ -933,13 +933,13 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                     if (globalPopulation > previousGlobalPopulation)
                     {
                         world.LogEvent(new LocalizedString("TIMELINE_SPECIES_POPULATION_INCREASE",
-                                species.FormattedName, globalPopulation),
+                                species.FormattedNameBbCode, globalPopulation),
                             species.PlayerSpecies, "popUp.png");
                     }
                     else
                     {
                         world.LogEvent(new LocalizedString("TIMELINE_SPECIES_POPULATION_DECREASE",
-                                species.FormattedName, globalPopulation),
+                                species.FormattedNameBbCode, globalPopulation),
                             species.PlayerSpecies, "popDown.png");
                     }
                 }
@@ -950,19 +950,19 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                 // Log to destination patch
                 // TODO: these events need to dynamically reveal their names in the event log once the player
                 // discovers them
-                patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_MIGRATED_FROM", migration.Key.FormattedName,
+                patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_MIGRATED_FROM", migration.Key.FormattedNameBbCode,
                         migration.Value.From.VisibleName),
                     migration.Key.PlayerSpecies, "newSpecies.png");
 
                 // Log to game world
                 world.LogEvent(new LocalizedString("GLOBAL_TIMELINE_SPECIES_MIGRATED_TO",
-                        migration.Key.FormattedName, migration.Value.To.VisibleName,
+                        migration.Key.FormattedNameBbCode, migration.Value.To.VisibleName,
                         migration.Value.From.VisibleName),
                     migration.Key.PlayerSpecies, "newSpecies.png");
 
                 // Log to origin patch
                 migration.Value.From.LogEvent(new LocalizedString("TIMELINE_SPECIES_MIGRATED_TO",
-                        migration.Key.FormattedName, migration.Value.To.VisibleName),
+                        migration.Key.FormattedNameBbCode, migration.Value.To.VisibleName),
                     migration.Key.PlayerSpecies, "newSpecies.png");
             }
 
@@ -981,13 +981,13 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                     {
                         case NewSpeciesType.FillNiche:
                             LogEventGloballyAndLocally(world, patch, new LocalizedString("TIMELINE_NICHE_FILL",
-                                    newSpeciesEntry.FormattedName, speciesResult.SplitFrom.FormattedName),
+                                    newSpeciesEntry.FormattedNameBbCode, speciesResult.SplitFrom.FormattedNameBbCode),
                                 false, "newSpecies.png");
                             break;
                         case NewSpeciesType.SplitDueToMutation:
                             LogEventGloballyAndLocally(world, patch, new LocalizedString(
-                                    "TIMELINE_SELECTION_PRESSURE_SPLIT", newSpeciesEntry.FormattedName,
-                                    speciesResult.SplitFrom.FormattedName),
+                                    "TIMELINE_SELECTION_PRESSURE_SPLIT", newSpeciesEntry.FormattedNameBbCode,
+                                    speciesResult.SplitFrom.FormattedNameBbCode),
                                 false, "newSpecies.png");
                             break;
                         default:

--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -901,7 +901,7 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                 {
                     // TODO: see https://github.com/Revolutionary-Games/Thrive/issues/2958
                     LogEventGloballyAndLocally(world, patch,
-                        new LocalizedString("TIMELINE_SPECIES_EXTINCT", species.FormattedNameBbCode),
+                        new LocalizedString("TIMELINE_SPECIES_EXTINCT", species.FormattedNameBbCodeNonStyled),
                         species.PlayerSpecies, "extinction.png");
 
                     continue;
@@ -912,19 +912,19 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                     if (finalPatchPopulation > previousPatchPopulation)
                     {
                         patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_POPULATION_INCREASE",
-                                species.FormattedNameBbCode, finalPatchPopulation),
+                                species.FormattedNameBbCodeNonStyled, finalPatchPopulation),
                             species.PlayerSpecies, "popUp.png");
                     }
                     else
                     {
                         patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_POPULATION_DECREASE",
-                                species.FormattedNameBbCode, finalPatchPopulation),
+                                species.FormattedNameBbCodeNonStyled, finalPatchPopulation),
                             species.PlayerSpecies, "popDown.png");
                     }
                 }
                 else
                 {
-                    patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_EXTINCT_LOCAL", species.FormattedNameBbCode),
+                    patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_EXTINCT_LOCAL", species.FormattedNameBbCodeNonStyled),
                         species.PlayerSpecies, "extinctionLocal.png");
                 }
 
@@ -933,13 +933,13 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                     if (globalPopulation > previousGlobalPopulation)
                     {
                         world.LogEvent(new LocalizedString("TIMELINE_SPECIES_POPULATION_INCREASE",
-                                species.FormattedNameBbCode, globalPopulation),
+                                species.FormattedNameBbCodeNonStyled, globalPopulation),
                             species.PlayerSpecies, "popUp.png");
                     }
                     else
                     {
                         world.LogEvent(new LocalizedString("TIMELINE_SPECIES_POPULATION_DECREASE",
-                                species.FormattedNameBbCode, globalPopulation),
+                                species.FormattedNameBbCodeNonStyled, globalPopulation),
                             species.PlayerSpecies, "popDown.png");
                     }
                 }
@@ -950,19 +950,19 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                 // Log to destination patch
                 // TODO: these events need to dynamically reveal their names in the event log once the player
                 // discovers them
-                patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_MIGRATED_FROM", migration.Key.FormattedNameBbCode,
+                patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_MIGRATED_FROM", migration.Key.FormattedNameBbCodeNonStyled,
                         migration.Value.From.VisibleName),
                     migration.Key.PlayerSpecies, "newSpecies.png");
 
                 // Log to game world
                 world.LogEvent(new LocalizedString("GLOBAL_TIMELINE_SPECIES_MIGRATED_TO",
-                        migration.Key.FormattedNameBbCode, migration.Value.To.VisibleName,
+                        migration.Key.FormattedNameBbCodeNonStyled, migration.Value.To.VisibleName,
                         migration.Value.From.VisibleName),
                     migration.Key.PlayerSpecies, "newSpecies.png");
 
                 // Log to origin patch
                 migration.Value.From.LogEvent(new LocalizedString("TIMELINE_SPECIES_MIGRATED_TO",
-                        migration.Key.FormattedNameBbCode, migration.Value.To.VisibleName),
+                        migration.Key.FormattedNameBbCodeNonStyled, migration.Value.To.VisibleName),
                     migration.Key.PlayerSpecies, "newSpecies.png");
             }
 
@@ -981,13 +981,13 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                     {
                         case NewSpeciesType.FillNiche:
                             LogEventGloballyAndLocally(world, patch, new LocalizedString("TIMELINE_NICHE_FILL",
-                                    newSpeciesEntry.FormattedNameBbCode, speciesResult.SplitFrom.FormattedNameBbCode),
+                                    newSpeciesEntry.FormattedNameBbCodeNonStyled, speciesResult.SplitFrom.FormattedNameBbCodeNonStyled),
                                 false, "newSpecies.png");
                             break;
                         case NewSpeciesType.SplitDueToMutation:
                             LogEventGloballyAndLocally(world, patch, new LocalizedString(
-                                    "TIMELINE_SELECTION_PRESSURE_SPLIT", newSpeciesEntry.FormattedNameBbCode,
-                                    speciesResult.SplitFrom.FormattedNameBbCode),
+                                    "TIMELINE_SELECTION_PRESSURE_SPLIT", newSpeciesEntry.FormattedNameBbCodeNonStyled,
+                                    speciesResult.SplitFrom.FormattedNameBbCodeNonStyled),
                                 false, "newSpecies.png");
                             break;
                         default:

--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -901,7 +901,7 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                 {
                     // TODO: see https://github.com/Revolutionary-Games/Thrive/issues/2958
                     LogEventGloballyAndLocally(world, patch,
-                        new LocalizedString("TIMELINE_SPECIES_EXTINCT", species.FormattedNameBbCodeNonStyled),
+                        new LocalizedString("TIMELINE_SPECIES_EXTINCT", species.FormattedNameBbCodeUnstyled),
                         species.PlayerSpecies, "extinction.png");
 
                     continue;
@@ -912,19 +912,19 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                     if (finalPatchPopulation > previousPatchPopulation)
                     {
                         patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_POPULATION_INCREASE",
-                                species.FormattedNameBbCodeNonStyled, finalPatchPopulation),
+                                species.FormattedNameBbCodeUnstyled, finalPatchPopulation),
                             species.PlayerSpecies, "popUp.png");
                     }
                     else
                     {
                         patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_POPULATION_DECREASE",
-                                species.FormattedNameBbCodeNonStyled, finalPatchPopulation),
+                                species.FormattedNameBbCodeUnstyled, finalPatchPopulation),
                             species.PlayerSpecies, "popDown.png");
                     }
                 }
                 else
                 {
-                    patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_EXTINCT_LOCAL", species.FormattedNameBbCodeNonStyled),
+                    patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_EXTINCT_LOCAL", species.FormattedNameBbCodeUnstyled),
                         species.PlayerSpecies, "extinctionLocal.png");
                 }
 
@@ -933,13 +933,13 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                     if (globalPopulation > previousGlobalPopulation)
                     {
                         world.LogEvent(new LocalizedString("TIMELINE_SPECIES_POPULATION_INCREASE",
-                                species.FormattedNameBbCodeNonStyled, globalPopulation),
+                                species.FormattedNameBbCodeUnstyled, globalPopulation),
                             species.PlayerSpecies, "popUp.png");
                     }
                     else
                     {
                         world.LogEvent(new LocalizedString("TIMELINE_SPECIES_POPULATION_DECREASE",
-                                species.FormattedNameBbCodeNonStyled, globalPopulation),
+                                species.FormattedNameBbCodeUnstyled, globalPopulation),
                             species.PlayerSpecies, "popDown.png");
                     }
                 }
@@ -950,19 +950,19 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                 // Log to destination patch
                 // TODO: these events need to dynamically reveal their names in the event log once the player
                 // discovers them
-                patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_MIGRATED_FROM", migration.Key.FormattedNameBbCodeNonStyled,
+                patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_MIGRATED_FROM", migration.Key.FormattedNameBbCodeUnstyled,
                         migration.Value.From.VisibleName),
                     migration.Key.PlayerSpecies, "newSpecies.png");
 
                 // Log to game world
                 world.LogEvent(new LocalizedString("GLOBAL_TIMELINE_SPECIES_MIGRATED_TO",
-                        migration.Key.FormattedNameBbCodeNonStyled, migration.Value.To.VisibleName,
+                        migration.Key.FormattedNameBbCodeUnstyled, migration.Value.To.VisibleName,
                         migration.Value.From.VisibleName),
                     migration.Key.PlayerSpecies, "newSpecies.png");
 
                 // Log to origin patch
                 migration.Value.From.LogEvent(new LocalizedString("TIMELINE_SPECIES_MIGRATED_TO",
-                        migration.Key.FormattedNameBbCodeNonStyled, migration.Value.To.VisibleName),
+                        migration.Key.FormattedNameBbCodeUnstyled, migration.Value.To.VisibleName),
                     migration.Key.PlayerSpecies, "newSpecies.png");
             }
 
@@ -981,13 +981,13 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                     {
                         case NewSpeciesType.FillNiche:
                             LogEventGloballyAndLocally(world, patch, new LocalizedString("TIMELINE_NICHE_FILL",
-                                    newSpeciesEntry.FormattedNameBbCodeNonStyled, speciesResult.SplitFrom.FormattedNameBbCodeNonStyled),
+                                    newSpeciesEntry.FormattedNameBbCodeUnstyled, speciesResult.SplitFrom.FormattedNameBbCodeUnstyled),
                                 false, "newSpecies.png");
                             break;
                         case NewSpeciesType.SplitDueToMutation:
                             LogEventGloballyAndLocally(world, patch, new LocalizedString(
-                                    "TIMELINE_SELECTION_PRESSURE_SPLIT", newSpeciesEntry.FormattedNameBbCodeNonStyled,
-                                    speciesResult.SplitFrom.FormattedNameBbCodeNonStyled),
+                                    "TIMELINE_SELECTION_PRESSURE_SPLIT", newSpeciesEntry.FormattedNameBbCodeUnstyled,
+                                    speciesResult.SplitFrom.FormattedNameBbCodeUnstyled),
                                 false, "newSpecies.png");
                             break;
                         default:

--- a/src/general/Species.cs
+++ b/src/general/Species.cs
@@ -128,7 +128,7 @@ public abstract class Species : ICloneable
         $"[i]{FormattedNameBbCodeNonStyled}[/i]";
 
     /// <summary>
-    ///   Returns <see cref="FormattedName"/> but includes bbcode tags to allow hover-over tooltips.
+    ///   Returns <see cref="FormattedName"/> but includes bbcode tags for hover-over tooltips.
     /// </summary>
     [JsonIgnore]
     public string FormattedNameBbCodeNonStyled => PlayerSpecies ?

--- a/src/general/Species.cs
+++ b/src/general/Species.cs
@@ -119,8 +119,8 @@ public abstract class Species : ICloneable
     public string FormattedName => Genus + " " + Epithet;
 
     /// <summary>
-    ///   Returns <see cref="FormattedName"/> but includes bbcode tags for styling and hover-over tooltips. Player's species will be emphasized
-    ///   with bolding.
+    ///   Returns <see cref="FormattedName"/> but includes bbcode tags for styling and hover-over tooltips. Player's
+    ///   species will be emphasized with bolding.
     /// </summary>
     [JsonIgnore]
     public string FormattedNameBbCode => PlayerSpecies ?

--- a/src/general/Species.cs
+++ b/src/general/Species.cs
@@ -119,13 +119,21 @@ public abstract class Species : ICloneable
     public string FormattedName => Genus + " " + Epithet;
 
     /// <summary>
-    ///   Returns <see cref="FormattedName"/> but includes bbcode tags for styling. Player's species will be emphasized
+    ///   Returns <see cref="FormattedName"/> but includes bbcode tags for styling and hover-over tooltips. Player's species will be emphasized
     ///   with bolding.
     /// </summary>
     [JsonIgnore]
     public string FormattedNameBbCode => PlayerSpecies ?
-        $"[url=species:{ID}][b][i]{FormattedName}[/i][/b][/url]" :
-        $"[url=species:{ID}][i]{FormattedName}[/i][/url]";
+        $"[b][i]{FormattedNameBbCodeNonStyled}[/i][/b]" :
+        $"[i]{FormattedNameBbCodeNonStyled}[/i]";
+
+    /// <summary>
+    ///   Returns <see cref="FormattedName"/> but includes bbcode tags to allow hover-over tooltips.
+    /// </summary>
+    [JsonIgnore]
+    public string FormattedNameBbCodeNonStyled => PlayerSpecies ?
+        $"[url=species:{ID}]{FormattedName}[/url]" :
+        $"[url=species:{ID}]{FormattedName}[/url]";
 
     [JsonIgnore]
     public string FormattedIdentifier => FormattedName + $" ({ID:n0})";

--- a/src/general/Species.cs
+++ b/src/general/Species.cs
@@ -124,14 +124,14 @@ public abstract class Species : ICloneable
     /// </summary>
     [JsonIgnore]
     public string FormattedNameBbCode => PlayerSpecies ?
-        $"[b][i]{FormattedNameBbCodeNonStyled}[/i][/b]" :
-        $"[i]{FormattedNameBbCodeNonStyled}[/i]";
+        $"[b][i]{FormattedNameBbCodeUnstyled}[/i][/b]" :
+        $"[i]{FormattedNameBbCodeUnstyled}[/i]";
 
     /// <summary>
     ///   Returns <see cref="FormattedName"/> but includes bbcode tags for hover-over tooltips.
     /// </summary>
     [JsonIgnore]
-    public string FormattedNameBbCodeNonStyled => PlayerSpecies ?
+    public string FormattedNameBbCodeUnstyled => PlayerSpecies ?
         $"[url=species:{ID}]{FormattedName}[/url]" :
         $"[url=species:{ID}]{FormattedName}[/url]";
 

--- a/src/general/Species.cs
+++ b/src/general/Species.cs
@@ -131,9 +131,7 @@ public abstract class Species : ICloneable
     ///   Returns <see cref="FormattedName"/> but includes bbcode tags for hover-over tooltips.
     /// </summary>
     [JsonIgnore]
-    public string FormattedNameBbCodeUnstyled => PlayerSpecies ?
-        $"[url=species:{ID}]{FormattedName}[/url]" :
-        $"[url=species:{ID}]{FormattedName}[/url]";
+    public string FormattedNameBbCodeUnstyled => $"[url=species:{ID}]{FormattedName}[/url]";
 
     [JsonIgnore]
     public string FormattedIdentifier => FormattedName + $" ({ID:n0})";

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -486,11 +486,11 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         previousSpecies.Obsolete = true;
 
         // Log becoming multicellular in the timeline
-        GameWorld.LogEvent(new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedName),
+        GameWorld.LogEvent(new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedNameBbCode),
             true, "multicellularTimelineMembraneTouch.png");
 
         GameWorld.Map.CurrentPatch!.LogEvent(
-            new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedName),
+            new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedNameBbCode),
             true, "multicellularTimelineMembraneTouch.png");
 
         if (WorldSimulation.Processing)

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -486,11 +486,11 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         previousSpecies.Obsolete = true;
 
         // Log becoming multicellular in the timeline
-        GameWorld.LogEvent(new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedNameBbCode),
+        GameWorld.LogEvent(new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedNameBbCodeNonStyled),
             true, "multicellularTimelineMembraneTouch.png");
 
         GameWorld.Map.CurrentPatch!.LogEvent(
-            new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedNameBbCode),
+            new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedNameBbCodeNonStyled),
             true, "multicellularTimelineMembraneTouch.png");
 
         if (WorldSimulation.Processing)

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -486,11 +486,11 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         previousSpecies.Obsolete = true;
 
         // Log becoming multicellular in the timeline
-        GameWorld.LogEvent(new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedNameBbCodeNonStyled),
+        GameWorld.LogEvent(new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedNameBbCodeUnstyled),
             true, "multicellularTimelineMembraneTouch.png");
 
         GameWorld.Map.CurrentPatch!.LogEvent(
-            new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedNameBbCodeNonStyled),
+            new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedNameBbCodeUnstyled),
             true, "multicellularTimelineMembraneTouch.png");
 
         if (WorldSimulation.Processing)

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -486,8 +486,8 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         previousSpecies.Obsolete = true;
 
         // Log becoming multicellular in the timeline
-        GameWorld.LogEvent(new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedNameBbCodeUnstyled),
-            true, "multicellularTimelineMembraneTouch.png");
+        GameWorld.LogEvent(new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR",
+            previousSpecies.FormattedNameBbCodeUnstyled), true, "multicellularTimelineMembraneTouch.png");
 
         GameWorld.Map.CurrentPatch!.LogEvent(
             new LocalizedString("TIMELINE_SPECIES_BECAME_MULTICELLULAR", previousSpecies.FormattedNameBbCodeUnstyled),


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes species preview tooltips work in Timeline tab by making logs use bbcode species names.

Also fixes External effects section of Auto-evo report not having species preview tooltips, since it's somewhat related.

**Related Issues**

Closes #4912

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
