### PR TITLE
Fix AutoEvo Error

### DIFF
--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -302,9 +302,9 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                     {
                         var patch = world.Map.GetPatch(populationEntry.Key.ID);
 
-                        if (patch.AddSpecies(entry.Key, populationEntry.Value) != true)
+                        if (!patch.AddSpecies(entry.Key, populationEntry.Value))
                         {
-                            GD.PrintErr("RunResults has new species with invalid patch or it was failed to be added");
+                            GD.PrintErr("RunResults has new species that already exists in patch");
                         }
                     }
                 }

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -157,7 +157,8 @@ public class ModifyExistingSpecies : IRunStep
         {
             mutation.Item2.OnEdited();
 
-            newMiche.InsertSpecies(mutation.Item2, patch, scores, cache, false, workMemory);
+            if (newMiche.InsertSpecies(mutation.Item2, patch, scores, cache, false, workMemory))
+                scores[mutation.Item2] = 0;
         }
 
         newOccupantsWorkMemory.Clear();
@@ -205,7 +206,7 @@ public class ModifyExistingSpecies : IRunStep
                         var oldScore = cache.GetPressureScore(pressure, patch, species);
 
                         // Break if mutation fails a pressure
-                        if (newScore <= 0)
+                        if (newScore < 0)
                         {
                             combinedScores = -1;
                             break;

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -206,7 +206,7 @@ public class ModifyExistingSpecies : IRunStep
                         var oldScore = cache.GetPressureScore(pressure, patch, species);
 
                         // Break if mutation fails a pressure
-                        if (newScore < 0)
+                        if (newScore <= 0)
                         {
                             combinedScores = -1;
                             break;


### PR DESCRIPTION
**Brief Description of What This PR Does**

This currently fixes the dictionary part of the auto evo error. I have not yet been able to track down the duplicate species error yet which is the other one remaining

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
