### PR TITLE
Fixed auto-evo errors coming from previous miche scores missing

### DIFF
--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AutoEvo;
 using Godot;
+using Xoshiro.PRNG64;
 using Thread = System.Threading.Thread;
 
 /// <summary>
@@ -357,7 +358,7 @@ public class AutoEvoRun
 
             combinedExternalEffects.TryGetValue(key, out var existingEffectAmount);
 
-            // We can ignore coefficients because we trust that CalculateFinalExternalEffectSizes has been called first
+            // We can ignore coefficients because we trust that CalculateFinalExternalEffectSizes has been called first,
             // and so we also don't need to
 
             combinedExternalEffects[key] = existingEffectAmount + entry.Constant;
@@ -381,6 +382,8 @@ public class AutoEvoRun
     /// </summary>
     protected virtual void GatherInfo(Queue<IRunStep> steps)
     {
+        var random = new XoShiRo256starstar();
+
         var map = Parameters.World.Map;
         var worldSettings = Parameters.World.WorldSettings;
 
@@ -404,10 +407,7 @@ public class AutoEvoRun
         {
             steps.Enqueue(new ModifyExistingSpecies(entry.Value, new SimulationCache(worldSettings), worldSettings));
 
-            for (int i = 0; i < Constants.AUTO_EVO_MOVE_ATTEMPTS; ++i)
-            {
-                steps.Enqueue(new MigrateSpecies(entry.Value, new SimulationCache(worldSettings)));
-            }
+            steps.Enqueue(new MigrateSpecies(entry.Value, new SimulationCache(worldSettings), random));
         }
 
         // The new populations don't depend on the mutations, this is so that when

--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -155,8 +155,8 @@ public class RunResults : IEnumerable<KeyValuePair<Species, RunResults.SpeciesRe
                         continue;
 
                     // Debugging code which can be enabled to track how much pruning happens
-                    GD.Print($"Removed Patch migration to {spreads[i].To} from {spreads[j].From} for " +
-                        $"species {species} as this is a duplicate migration target");
+                    /*GD.Print($"Removed Patch migration to {spreads[i].To} from {spreads[j].From} for " +
+                        $"species {species} as this is a duplicate migration target");*/
 
                     spreads.RemoveAt(i);
 

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -185,13 +185,11 @@ public static class MichePopulation
         // Note that this modifies the miche tree while simulating
         var miche = populations.GetMicheForPatch(patch);
 
-        var scores = new Dictionary<Species, float>();
         var workMemory = new HashSet<Species>();
-        miche.SetupScores(scores, workMemory);
 
         foreach (var extraSpecies in simulationConfiguration.ExtraSpecies)
         {
-            miche.InsertSpecies(extraSpecies, patch, scores, cache, false, workMemory);
+            miche.InsertSpecies(extraSpecies, patch, null, cache, false, workMemory);
         }
 
         // This prevents duplicates caused by ExtraSpecies

--- a/src/auto-evo/steps/GenerateMiche.cs
+++ b/src/auto-evo/steps/GenerateMiche.cs
@@ -140,13 +140,15 @@ public class GenerateMiche : IRunStep
 
     public Miche PopulateMiche(Miche miche)
     {
-        var scores = new Dictionary<Species, float>();
+        // If no species, don't need to do anything
+        if (patch.SpeciesInPatch.Count < 1)
+            return miche;
+
         var workMemory = new HashSet<Species>();
-        miche.SetupScores(scores, workMemory);
 
         foreach (var species in patch.SpeciesInPatch.Keys)
         {
-            miche.InsertSpecies(species, patch, scores, cache, false, workMemory);
+            miche.InsertSpecies(species, patch, null, cache, false, workMemory);
         }
 
         return miche;

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -3,68 +3,112 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Xoshiro.PRNG32;
 
 /// <summary>
 ///   Step that generates species migrations for each patch
 /// </summary>
+/// <remarks>
+///   <para>
+///     TODO: this can currently cause migrations for a single species from many patches to move to a single patch
+///     this is unsupported by <see cref="RunResults.GetMigrationsTo"/> so these migrations are removed by
+///     <see cref="RemoveInvalidMigrations"/> but it would be better if this class was fixed instead, probably. The old
+///     approach processed migrations *per species* instead of per patch to not hit in to the same data model
+///     limitation. To track how much this happens a debug print can be uncommented in
+///     RemoveDuplicateTargetPatchMigrations.
+///   </para>
+/// </remarks>
 public class MigrateSpecies : IRunStep
 {
-    private Patch patch;
-    private SimulationCache cache;
-    private Random random;
+    private readonly Patch patch;
+    private readonly SimulationCache cache;
+    private readonly Random random;
 
-    public MigrateSpecies(Patch patch, SimulationCache cache)
+    private readonly HashSet<Species> speciesWorkMemory = new();
+
+    /// <summary>
+    ///   To avoid generating duplicate migrations, this remembers
+    /// </summary>
+    private readonly List<(Species Species, Patch Patch)> alreadyDoneMigrations = new();
+
+    private int stepsDone;
+
+    private List<Species>? occupants;
+
+    public MigrateSpecies(Patch patch, SimulationCache cache, Random randomSource)
     {
         this.patch = patch;
         this.cache = cache;
 
         // TODO: take in a random seed (would help to make sure the random cannot result in the same sequence as
         // this class instances are allocated in a pretty tight loop
-        random = new Random();
+        random = new XoShiRo128starstar(randomSource.Next());
     }
 
-    public int TotalSteps => 1;
+    public bool Done => stepsDone >= Constants.AUTO_EVO_MOVE_ATTEMPTS;
+
+    public int TotalSteps => Constants.AUTO_EVO_MOVE_ATTEMPTS;
 
     public bool CanRunConcurrently => true;
 
     public bool RunStep(RunResults results)
     {
-        var miche = results.GetMicheForPatch(patch);
+        ++stepsDone;
 
-        var occupantsSet = new HashSet<Species>();
-        miche.GetOccupants(occupantsSet);
+        if (occupants == null)
+        {
+            var miche = results.GetMicheForPatch(patch);
 
-        if (occupantsSet.Count < 1)
-            return true;
+            var occupantsSet = new HashSet<Species>();
+            miche.GetOccupants(occupantsSet);
 
-        var occupants = occupantsSet.ToList();
+            occupants = occupantsSet.ToList();
+        }
+
+        if (occupants.Count < 1)
+            return Done;
 
         var species = occupants.Random(random);
 
         // Player has a separate GUI to control their migrations purposefully so auto-evo doesn't do it automatically
         if (species.PlayerSpecies)
-            return true;
+            return Done;
+
+        // TODO: should a single species be allowed to migrate to multiple patches at once or just one migration in
+        // general?
+        /*foreach (var (doneSpecies, _) in alreadyDoneMigrations)
+        {
+            if (doneSpecies == species)
+                return Done;
+        }*/
 
         var population = patch.GetSpeciesSimulationPopulation(species);
         if (population < Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION)
-            return true;
+            return Done;
 
         // Select a random adjacent target patch
         // TODO: could prefer patches this species is not already in or about to go extinct, or really anything other
         // than random selection
         var target = patch.Adjacent.Random(random);
+
+        foreach (var (doneSpecies, donePatch) in alreadyDoneMigrations)
+        {
+            if (doneSpecies == species && donePatch == target)
+                return Done;
+        }
+
         var targetMiche = results.GetMicheForPatch(target);
 
         // Calculate random amount of population to send
         var moveAmount = (long)random.Next(population * Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION_FRACTION,
             population * Constants.AUTO_EVO_MAXIMUM_MOVE_POPULATION_FRACTION);
 
-        if (moveAmount > 0 && targetMiche.InsertSpecies(species, patch, null, cache, true, occupantsSet))
+        if (moveAmount > 0 && targetMiche.InsertSpecies(species, patch, null, cache, true, speciesWorkMemory))
         {
             results.AddMigrationResultForSpecies(species, new SpeciesMigration(patch, target, moveAmount));
-            return true;
+            alreadyDoneMigrations.Add((species, target));
         }
 
-        return true;
+        return Done;
     }
 }

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -59,10 +59,7 @@ public class MigrateSpecies : IRunStep
         var moveAmount = (long)random.Next(population * Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION_FRACTION,
             population * Constants.AUTO_EVO_MAXIMUM_MOVE_POPULATION_FRACTION);
 
-        var scores = new Dictionary<Species, float>();
-        miche.SetupScores(scores, occupantsSet);
-
-        if (moveAmount > 0 && targetMiche.InsertSpecies(species, patch, scores, cache, true, occupantsSet))
+        if (moveAmount > 0 && targetMiche.InsertSpecies(species, patch, null, cache, true, occupantsSet))
         {
             results.AddMigrationResultForSpecies(species, new SpeciesMigration(patch, target, moveAmount));
             return true;

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -149,16 +149,13 @@ public class ModifyExistingSpecies : IRunStep
         // Add these mutant species into a new miche
         // TODO: add some way to avoid the deep copy here
         var newMiche = miche.DeepCopy();
-        var scores = new Dictionary<Species, float>();
         var workMemory = new HashSet<Species>();
-        newMiche.SetupScores(scores, workMemory);
 
         foreach (var mutation in mutationsToTry)
         {
             mutation.Item2.OnEdited();
 
-            if (newMiche.InsertSpecies(mutation.Item2, patch, scores, cache, false, workMemory))
-                scores[mutation.Item2] = 0;
+            newMiche.InsertSpecies(mutation.Item2, patch, null, cache, false, workMemory);
         }
 
         newOccupantsWorkMemory.Clear();

--- a/src/auto-evo/steps/RemoveInvalidMigrations.cs
+++ b/src/auto-evo/steps/RemoveInvalidMigrations.cs
@@ -19,6 +19,7 @@ public class RemoveInvalidMigrations : IRunStep
         foreach (var species in speciesToCheck)
         {
             results.RemoveMigrationsForSplitPatches(species);
+            results.RemoveDuplicateTargetPatchMigrations(species);
         }
 
         return true;


### PR DESCRIPTION
for a species that was being attempted to be inserted into the miche tree. Hopefully this was the only mistake I made when converting to a style that does fewer memory allocations.

**Brief Description of What This PR Does**

This PR does some stuff...

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
auto-evo not working on master branch

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
