### PR TITLE
Reduced new auto-evo allocations quite a lot

### DIFF
--- a/src/auto-evo/mutation_strategy/AddOrganelleAnywhere.cs
+++ b/src/auto-evo/mutation_strategy/AddOrganelleAnywhere.cs
@@ -66,11 +66,11 @@ public class AddOrganelleAnywhere : IMutationStrategy<MicrobeSpecies>
         return ThatConvertBetweenCompounds(fromCompound, toCompound, direction);
     }
 
-    public List<Tuple<MicrobeSpecies, float>> MutationsOf(MicrobeSpecies baseSpecies, float mp)
+    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp)
     {
         // If a cheaper organelle gets added this will need to be updated
         if (mp < 20)
-            return [];
+            return null;
 
         // TODO: Make this something passed in
         var random = new Random();

--- a/src/auto-evo/mutation_strategy/ChangeBehaviorScore.cs
+++ b/src/auto-evo/mutation_strategy/ChangeBehaviorScore.cs
@@ -26,7 +26,7 @@ public class ChangeBehaviorScore : IMutationStrategy<MicrobeSpecies>
     // As it cost no MP the mutation code could just repeat this forever
     public bool Repeatable => false;
 
-    public List<Tuple<MicrobeSpecies, float>> MutationsOf(MicrobeSpecies baseSpecies, float mp)
+    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp)
     {
         var newSpecies = (MicrobeSpecies)baseSpecies.Clone();
 
@@ -34,9 +34,7 @@ public class ChangeBehaviorScore : IMutationStrategy<MicrobeSpecies>
         var change = (float)new Random().NextDouble() * maxChange;
 
         if (Math.Abs(change) < 1)
-        {
-            return [];
-        }
+            return null;
 
         switch (attribute)
         {

--- a/src/auto-evo/mutation_strategy/ChangeMembraneRigidity.cs
+++ b/src/auto-evo/mutation_strategy/ChangeMembraneRigidity.cs
@@ -15,19 +15,19 @@ public class ChangeMembraneRigidity : IMutationStrategy<MicrobeSpecies>
 
     public bool Repeatable => true;
 
-    public List<Tuple<MicrobeSpecies, float>> MutationsOf(MicrobeSpecies baseSpecies, float mp)
+    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp)
     {
         const float change = Constants.AUTO_EVO_MUTATION_RIGIDITY_STEP;
         const float mpCost = change * 10 * 2;
 
         if (mp < mpCost)
-            return [];
+            return null;
 
         if (Lower && baseSpecies.MembraneRigidity == -1.0f)
-            return [];
+            return null;
 
         if (!Lower && baseSpecies.MembraneRigidity == 1.0f)
-            return [];
+            return null;
 
         var newSpecies = (MicrobeSpecies)baseSpecies.Clone();
 

--- a/src/auto-evo/mutation_strategy/ChangeMembraneType.cs
+++ b/src/auto-evo/mutation_strategy/ChangeMembraneType.cs
@@ -14,13 +14,13 @@ public class ChangeMembraneType : IMutationStrategy<MicrobeSpecies>
 
     public bool Repeatable => false;
 
-    public List<Tuple<MicrobeSpecies, float>> MutationsOf(MicrobeSpecies baseSpecies, float mp)
+    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp)
     {
         if (baseSpecies.MembraneType == membraneType)
-            return [];
+            return null;
 
         if (mp < membraneType.EditorCost)
-            return [];
+            return null;
 
         var newSpecies = (MicrobeSpecies)baseSpecies.Clone();
 

--- a/src/auto-evo/mutation_strategy/IMutationStrategy.cs
+++ b/src/auto-evo/mutation_strategy/IMutationStrategy.cs
@@ -8,5 +8,14 @@ public interface IMutationStrategy<T>
 {
     public bool Repeatable { get; }
 
-    public List<Tuple<T, float>> MutationsOf(T baseSpecies, float mp);
+    /// <summary>
+    ///   Generates mutations based on this strategy
+    /// </summary>
+    /// <param name="baseSpecies">The species to start from</param>
+    /// <param name="mp">How much MP there is to do the mutations</param>
+    /// <returns>
+    ///   List of mutated species, null if no possible mutations are found (some strategies may return an empty list
+    ///   instead in this case)
+    /// </returns>
+    public List<Tuple<T, float>>? MutationsOf(T baseSpecies, float mp);
 }

--- a/src/auto-evo/mutation_strategy/MoveOrganelleBack.cs
+++ b/src/auto-evo/mutation_strategy/MoveOrganelleBack.cs
@@ -15,12 +15,10 @@ internal class MoveOrganelleBack : IMutationStrategy<MicrobeSpecies>
 
     public bool Repeatable => true;
 
-    public List<Tuple<MicrobeSpecies, float>> MutationsOf(MicrobeSpecies baseSpecies, float mp)
+    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp)
     {
         if (mp < Constants.ORGANELLE_MOVE_COST)
-        {
-            return [];
-        }
+            return null;
 
         var mutated = new List<Tuple<MicrobeSpecies, float>>();
 

--- a/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
+++ b/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
@@ -42,10 +42,10 @@ public class RemoveOrganelle : IMutationStrategy<MicrobeSpecies>
         return ThatCreateCompound(compound);
     }
 
-    public List<Tuple<MicrobeSpecies, float>> MutationsOf(MicrobeSpecies baseSpecies, float mp)
+    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp)
     {
         if (mp < 10)
-            return [];
+            return null;
 
         // TODO: Make this something passed in
         var random = new Random();

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -127,9 +127,13 @@ public class SimulationCache
         var compoundIn = 0.0f;
         var compoundOut = 0.0f;
 
-        foreach (var organelle in species.Organelles)
+        // For maximum efficiency as this is called an absolute ton the following approach is used
+        var organelles = species.Organelles.Organelles;
+        var count = organelles.Count;
+
+        for (var i = 0; i < count; ++i)
         {
-            foreach (var process in organelle.Definition.RunnableProcesses)
+            foreach (var process in organelles[i].Definition.RunnableProcesses)
             {
                 if (process.Process.Inputs.TryGetValue(fromCompound, out var inputAmount))
                 {
@@ -168,9 +172,12 @@ public class SimulationCache
 
         cached = 0.0f;
 
-        foreach (var organelle in species.Organelles)
+        var organelles = species.Organelles.Organelles;
+        var organelleCount = organelles.Count;
+
+        for (int i = 0; i < organelleCount; ++i)
         {
-            foreach (var process in organelle.Definition.RunnableProcesses)
+            foreach (var process in organelles[i].Definition.RunnableProcesses)
             {
                 if (process.Process.Inputs.ContainsKey(fromCompound))
                 {
@@ -371,8 +378,13 @@ public class SimulationCache
         var oxytoxyScore = 0.0f;
         var mucilageScore = 0.0f;
 
-        foreach (var organelle in microbeSpecies.Organelles)
+        var organelles = microbeSpecies.Organelles.Organelles;
+        var organelleCount = organelles.Count;
+
+        for (int i = 0; i < organelleCount; ++i)
         {
+            var organelle = organelles[i];
+
             if (organelle.Definition.HasPilusComponent)
             {
                 pilusScore += Constants.AUTO_EVO_PILUS_PREDATION_SCORE;

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -380,8 +380,11 @@ public class ModifyExistingSpecies : IRunStep
                 {
                     var mutated = mutationStrategy.MutationsOf(speciesTuple.Item1, speciesTuple.Item2);
 
-                    PruneMutations(temporaryMutations2, speciesTuple.Item1, mutated, patch, cache,
-                        selectionPressures);
+                    if (mutated != null)
+                    {
+                        PruneMutations(temporaryMutations2, speciesTuple.Item1, mutated, patch, cache,
+                            selectionPressures);
+                    }
                 }
 
                 // TODO: Make these a performance setting?

--- a/src/engine/common_components/Health.cs
+++ b/src/engine/common_components/Health.cs
@@ -92,6 +92,7 @@ public static class HealthHelpers
         // This should result in at least reasonable health even if thread race conditions hit here
         health.CurrentHealth = Math.Max(0, health.CurrentHealth - damage);
 
+        // TODO: should there be a minimum damage, like 0.01 after which the cooldown is only triggered?
         health.HealthRegenCooldown = Constants.HEALTH_REGENERATION_COOLDOWN;
 
         var damageEvent = new DamageEventNotice(damageSource, damage);

--- a/src/general/HexLayout.cs
+++ b/src/general/HexLayout.cs
@@ -199,7 +199,7 @@ public abstract class HexLayout<T> : ICollection<T>, IReadOnlyList<T>
     }
 
     /// <summary>
-    ///   Searches hex list for an hex at the specified hex
+    ///   Searches hex list for a hex at the specified hex
     /// </summary>
     public T? GetElementAt(Hex location, List<Hex> temporaryHexesStorage)
     {
@@ -245,7 +245,7 @@ public abstract class HexLayout<T> : ICollection<T>, IReadOnlyList<T>
 
     public void CopyTo(T[] array, int arrayIndex)
     {
-        foreach (var hex in this)
+        foreach (var hex in existingHexes)
         {
             array[arrayIndex++] = hex;
         }

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -6,24 +6,32 @@ using Systems;
 
 public static class MicrobeInternalCalculations
 {
-    public static Vector3 MaximumSpeedDirection(IEnumerable<OrganelleTemplate> organelles)
+    public static Vector3 MaximumSpeedDirection(IReadOnlyList<OrganelleTemplate> organelles)
     {
         Vector3 maximumMovementDirection = Vector3.Zero;
 
-        var movementOrganelles = organelles.Where(o => o.Definition.HasMovementComponent)
-            .ToList();
+        var organelleCount = organelles.Count;
 
-        foreach (var organelle in movementOrganelles)
+        for (int i = 0; i < organelleCount; ++i)
         {
+            var organelle = organelles[i];
+
+            if (!organelle.Definition.HasMovementComponent)
+                continue;
+
             maximumMovementDirection += GetOrganelleDirection(organelle);
         }
 
         // After calculating the sum of all organelle directions we subtract the movement components which
-        // are symmetric and we choose the one who would benefit the max-speed the most.
-        foreach (var organelle in movementOrganelles)
+        // are symmetric, and we choose the one who would benefit the max-speed the most.
+        for (int i = 0; i < organelleCount; ++i)
         {
-            maximumMovementDirection = ChooseFromSymmetricFlagella(movementOrganelles,
-                organelle, maximumMovementDirection);
+            var organelle = organelles[i];
+
+            if (!organelle.Definition.HasMovementComponent)
+                continue;
+
+            maximumMovementDirection = ChooseFromSymmetricFlagella(organelles, organelle, maximumMovementDirection);
         }
 
         // If the flagella are positioned symmetrically we assume the forward position as default
@@ -765,6 +773,8 @@ public static class MicrobeInternalCalculations
         for (int i = 0; i < organelleCount; ++i)
         {
             var organelle = organelles[i];
+            if (!organelle.Definition.HasMovementComponent)
+                continue;
 
             if (organelle != testedOrganelle &&
                 organelle.Position + testedOrganelle.Position == new Hex(0, 0))

--- a/src/microbe_stage/OrganelleLayout.cs
+++ b/src/microbe_stage/OrganelleLayout.cs
@@ -177,7 +177,13 @@ public class OrganelleLayout<T> : HexLayout<T>
     {
         result.Clear();
 
-        result.AddRange(hex.Definition.GetRotatedHexes(hex.Orientation));
+        var rotated = hex.Definition.GetRotatedHexes(hex.Orientation);
+        var count = rotated.Count;
+
+        for (int i = 0; i < count; ++i)
+        {
+            result.Add(rotated[i]);
+        }
     }
 
     /// <summary>

--- a/src/microbe_stage/OrganelleLayout.cs
+++ b/src/microbe_stage/OrganelleLayout.cs
@@ -42,11 +42,13 @@ public class OrganelleLayout<T> : HexLayout<T>
             Vector3 weightedSum = Vector3.Zero;
 
             // TODO: shouldn't this take multihex organelles into account?
-            foreach (var organelle in Organelles)
+            var organelleList = Organelles;
+            var listLength = organelleList.Count;
+            for (int i = 0; i < listLength; ++i)
             {
                 // totalMass += organelle.Definition.Mass;
                 ++count;
-                weightedSum += Hex.AxialToCartesian(organelle.Position) /* * organelle.Definition.Mass*/;
+                weightedSum += Hex.AxialToCartesian(organelleList[i].Position) /* * organelle.Definition.Mass*/;
             }
 
             if (count == 0)

--- a/src/microbe_stage/systems/ProcessSystem.cs
+++ b/src/microbe_stage/systems/ProcessSystem.cs
@@ -169,6 +169,8 @@ public sealed class ProcessSystem : AEntitySetSystem<float>
         bool includeMovementCost, bool isPlayerSpecies, WorldGenerationSettings worldSettings,
         CompoundAmountType amountType, SimulationCache? cache)
     {
+        // TODO: cache this somehow to not need to create a bunch of these which contain dictionaries to contain
+        // further items
         var result = new EnergyBalanceInfo();
 
         float processATPProduction = 0.0f;

--- a/src/microbe_stage/systems/ProcessSystem.cs
+++ b/src/microbe_stage/systems/ProcessSystem.cs
@@ -133,7 +133,7 @@ public sealed class ProcessSystem : AEntitySetSystem<float>
     ///   Computes the energy balance for the given organelles in biome and at a given time during the day (or type
     ///   can be specified to be a different type of value)
     /// </summary>
-    public static EnergyBalanceInfo ComputeEnergyBalance(IEnumerable<OrganelleTemplate> organelles,
+    public static EnergyBalanceInfo ComputeEnergyBalance(IReadOnlyList<OrganelleTemplate> organelles,
         BiomeConditions biome, MembraneType membrane, bool includeMovementCost, bool isPlayerSpecies,
         WorldGenerationSettings worldSettings, CompoundAmountType amountType)
     {
@@ -156,7 +156,7 @@ public sealed class ProcessSystem : AEntitySetSystem<float>
     /// </param>
     /// <param name="includeMovementCost">
     ///   Only when true are movement related energy costs included in the calculation. When false base movement data
-    ///   is provided but it is not taken into account in the sums, but total movement cost is not calculated. If that
+    ///   is provided, but it is not taken into account in the sums, but total movement cost is not calculated. If that
     ///   is required then include movement cost parameter should be set to true and from the result the variables
     ///   giving balance without movement should be used as an alternative to setting this false.
     /// </param>
@@ -164,7 +164,7 @@ public sealed class ProcessSystem : AEntitySetSystem<float>
     /// <param name="worldSettings">The world generation settings for this game</param>
     /// <param name="amountType">Specifies how changes during an in-game day are taken into account</param>
     /// <param name="cache">Auto-Evo Cache for speeding up the function</param>
-    public static EnergyBalanceInfo ComputeEnergyBalance(IEnumerable<OrganelleTemplate> organelles,
+    public static EnergyBalanceInfo ComputeEnergyBalance(IReadOnlyList<OrganelleTemplate> organelles,
         BiomeConditions biome, MembraneType membrane, Vector3 onlyMovementInDirection,
         bool includeMovementCost, bool isPlayerSpecies, WorldGenerationSettings worldSettings,
         CompoundAmountType amountType, SimulationCache? cache)
@@ -177,8 +177,11 @@ public sealed class ProcessSystem : AEntitySetSystem<float>
 
         int hexCount = 0;
 
-        foreach (var organelle in organelles)
+        int organelleCount = organelles.Count;
+        for (int i = 0; i < organelleCount; ++i)
         {
+            var organelle = organelles[i];
+
             var (production, consumption) = CalculateOrganelleATPBalance(organelle, biome, amountType, cache, result);
 
             processATPProduction += production;


### PR DESCRIPTION
**Brief Description of What This PR Does**

This is probably all of the easy stuff, next would be to somehow cache species instances to avoid allocating so many of them.

This isn't as efficient as old auto-evo in terms of memory allocation count, but total allocated memory is now lower so I think this makes auto-evo good enough for now.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
