### PR TITLE
Fixed auto-evo prediction always predicting 0 population

### DIFF
--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -417,7 +417,7 @@ public class AutoEvoRun
         // The new populations don't depend on the mutations, but will take into account changes in the miche tree.
         // This is so that when the player edits their species the other species they are competing
         // against are the same (so we can show some performance predictions in the editor and suggested changes)
-        steps.Enqueue(new CalculatePopulation(autoEvoConfiguration, worldSettings, map, null, null, true));
+        steps.Enqueue(new CalculatePopulation(autoEvoConfiguration, worldSettings, map, null, true));
 
         AddPlayerSpeciesPopulationChangeClampStep(steps, map, Parameters.World.PlayerSpecies);
 

--- a/src/auto-evo/EditorAutoEvoRun.cs
+++ b/src/auto-evo/EditorAutoEvoRun.cs
@@ -30,8 +30,8 @@ public class EditorAutoEvoRun : AutoEvoRun
         }
 
         steps.Enqueue(new CalculatePopulation(configuration, worldSettings, map,
-            new List<Species> { ModifiedProperties },
-            new List<Species> { OriginalEditedSpecies }, true));
+            new Dictionary<Species, Species>
+                { { OriginalEditedSpecies, ModifiedProperties } }, true));
 
         AddPlayerSpeciesPopulationChangeClampStep(steps, map,
             OriginalEditedSpecies.PlayerSpecies ? ModifiedProperties : null, OriginalEditedSpecies);

--- a/src/auto-evo/selection_pressure/PredationEffectivenessPressure.cs
+++ b/src/auto-evo/selection_pressure/PredationEffectivenessPressure.cs
@@ -33,7 +33,8 @@ public class PredationEffectivenessPressure : SelectionPressure
     public override float Score(Species species, Patch patch, SimulationCache cache)
     {
         // No Cannibalism
-        if (species == Prey)
+        // Compared by ID here to make sure temporary species variants are not allowed to predate themselves
+        if (species.ID == Prey.ID)
         {
             return 0.0f;
         }

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Godot;
 using Xoshiro.PRNG64;
 
 /// <summary>
@@ -84,6 +85,14 @@ public static class MichePopulation
             {
                 // Copy replacement species to simulate
                 species.Add(replacement);
+
+#if DEBUG
+                if (replacement.ID != candidateSpecies.ID)
+                {
+                    GD.PrintErr("Replacement species ID should match the replaced species, otherwise bad " +
+                        "things will happen");
+                }
+#endif
                 continue;
             }
 

--- a/src/auto-evo/simulation/SimulationConfiguration.cs
+++ b/src/auto-evo/simulation/SimulationConfiguration.cs
@@ -28,28 +28,17 @@ public class SimulationConfiguration
     public RunResults Results { get; set; } = new();
 
     /// <summary>
-    ///   List of species to ignore in the map for simulation.
+    ///   Dictionary of species replacements to perform before running the simulation.
     /// </summary>
     /// <remarks>
     ///   <para>
-    ///     If there is an extra species matching index of an entry here, the population of the species here is used
-    ///     for the initial population of the extra species.
-    ///   </para>
-    /// </remarks>
-    /// <value>The excluded species.</value>
-    public List<Species> ExcludedSpecies { get; set; } = new();
-
-    /// <summary>
-    ///   List of extra species to simulate in addition to the ones in the map.
-    /// </summary>
-    /// <remarks>
-    ///   <para>
-    ///     If a population for the extra species is not found through ExcludedSpecies the global population from
-    ///     the Species object is used for all patches.
+    ///     The keys in this dictionary are the old species, which when processed are instead immediately replaced by
+    ///     their respective values. So this is a mapping from an old species to a new one that should be used instead
+    ///     of the old one in the simulation.
     ///   </para>
     /// </remarks>
     /// <value>The extra species.</value>
-    public List<Species> ExtraSpecies { get; set; } = new();
+    public Dictionary<Species, Species> ReplacedSpecies { get; set; } = new();
 
     /// <summary>
     ///   Migrations to apply before running the simulation.

--- a/src/auto-evo/steps/CalculatePopulation.cs
+++ b/src/auto-evo/steps/CalculatePopulation.cs
@@ -11,19 +11,16 @@ public class CalculatePopulation : IRunStep
     private readonly IAutoEvoConfiguration configuration;
     private readonly PatchMap map;
     private readonly WorldGenerationSettings worldSettings;
-    private readonly List<Species>? extraSpecies;
-    private readonly List<Species>? excludedSpecies;
+    private readonly Dictionary<Species, Species>? replaceSpecies;
     private readonly bool collectEnergyInfo;
 
     public CalculatePopulation(IAutoEvoConfiguration configuration, WorldGenerationSettings worldSettings,
-        PatchMap map, List<Species>? extraSpecies = null, List<Species>? excludedSpecies = null,
-        bool collectEnergyInfo = false)
+        PatchMap map, Dictionary<Species, Species>? replaceSpecies = null, bool collectEnergyInfo = false)
     {
         this.configuration = configuration;
         this.worldSettings = worldSettings;
         this.map = map;
-        this.extraSpecies = extraSpecies;
-        this.excludedSpecies = excludedSpecies;
+        this.replaceSpecies = replaceSpecies;
         this.collectEnergyInfo = collectEnergyInfo;
     }
 
@@ -42,11 +39,13 @@ public class CalculatePopulation : IRunStep
 
         // ReSharper restore RedundantArgumentDefaultValue
 
-        if (extraSpecies != null)
-            config.ExtraSpecies = extraSpecies;
-
-        if (excludedSpecies != null)
-            config.ExcludedSpecies = excludedSpecies;
+        if (replaceSpecies != null)
+        {
+            foreach (var entry in replaceSpecies)
+            {
+                config.ReplacedSpecies.Add(entry.Key, entry.Value);
+            }
+        }
 
         // Directly feed the population results to the main results object
 

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1873,6 +1873,13 @@ public partial class CellEditorComponent :
             throw new InvalidOperationException("can't start auto-evo prediction without current cell properties"),
             hexTemporaryMemory, hexTemporaryMemory2);
 
+        // Need to copy player species property to have auto-evo treat the predicted population the same way as
+        // the player in a real run
+        if (Editor.EditedBaseSpecies.PlayerSpecies)
+        {
+            cachedAutoEvoPredictionSpecies.BecomePlayerSpecies();
+        }
+
         CopyEditedPropertiesToSpecies(cachedAutoEvoPredictionSpecies);
 
         var run = new EditorAutoEvoRun(Editor.CurrentGame.GameWorld, Editor.CurrentGame.GameWorld.AutoEvoGlobalCache,


### PR DESCRIPTION
**Brief Description of What This PR Does**

Also I tried to fix the prediction showing the player predating on themselves but I couldn't fix that (I'll open an issue next).

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
