### PR TITLE
Optimize SCALIS

### DIFF
--- a/src/late_multicellular_stage/Scalis.cs
+++ b/src/late_multicellular_stage/Scalis.cs
@@ -133,7 +133,7 @@ public class Scalis : IMeshGeneratingFunction
             }
         }
 
-        return value / 2.0f;
+        return value / NormalizationFactor(i, sigma);
     }
 
     public Color GetColour(Vector3 pos)

--- a/src/late_multicellular_stage/Scalis.cs
+++ b/src/late_multicellular_stage/Scalis.cs
@@ -28,7 +28,7 @@ public class Scalis : IMeshGeneratingFunction
     /// <remarks>
     ///   <para>
     ///     i-th element here refers to the i-th point's bone in points[]. If that point has no parent, then it has no
-    ///     bone, so the distance in this array is meningless for the point.
+    ///     bone, so the distance in this array is meaningless for the point.
     ///   </para>
     /// </remarks>
     private readonly float[] boneMaxSquareDistanceCache;
@@ -49,19 +49,19 @@ public class Scalis : IMeshGeneratingFunction
 
         boneMaxSquareDistanceCache = new float[points.Length];
 
-        for (i = 0; i < points.Length; i++)
+        for (i = 0; i < points.Length; ++i)
         {
             var point = points[i];
 
-            if (point.Parent == null)
+            var pointParent = point.Parent;
+            if (pointParent == null)
                 continue;
 
-            float maxDistanceFromCenter = (point.Position - point.Parent!.Position).Length() * 0.5f
-                + point.Radius + point.Parent!.Radius;
+            float maxDistanceFromCenter = (point.Position - pointParent.Position).Length() * 0.5f
+                + point.Radius + pointParent.Radius;
             maxDistanceFromCenter *= CutoffPointMultiplier;
 
-            boneMaxSquareDistanceCache[i] =
-                Mathf.Pow(maxDistanceFromCenter, 2.0f);
+            boneMaxSquareDistanceCache[i] = Mathf.Pow(maxDistanceFromCenter, 2.0f);
         }
 
         if (points.Length == 1)

--- a/src/late_multicellular_stage/Scalis.cs
+++ b/src/late_multicellular_stage/Scalis.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Godot;
 
 /// <summary>

--- a/src/late_multicellular_stage/Scalis.cs
+++ b/src/late_multicellular_stage/Scalis.cs
@@ -49,16 +49,18 @@ public class Scalis : IMeshGeneratingFunction
 
         boneMaxSquareDistanceCache = new float[points.Length];
 
-        for (int j = 0; j < points.Length; j++)
+        for (i = 0; i < points.Length; i++)
         {
-            if (points[j].Parent == null)
+            var point = points[i];
+
+            if (point.Parent == null)
                 continue;
 
-            float maxDistanceFromCenter = (points[j].Position - points[j].Parent!.Position).Length() * 0.5f
-                + points[j].Radius + points[j].Parent!.Radius;
+            float maxDistanceFromCenter = (point.Position - point.Parent!.Position).Length() * 0.5f
+                + point.Radius + point.Parent!.Radius;
             maxDistanceFromCenter *= CutoffPointMultiplier;
 
-            boneMaxSquareDistanceCache[j] =
+            boneMaxSquareDistanceCache[i] =
                 Mathf.Pow(maxDistanceFromCenter, 2.0f);
         }
 

--- a/src/late_multicellular_stage/Scalis.cs
+++ b/src/late_multicellular_stage/Scalis.cs
@@ -22,6 +22,15 @@ public class Scalis : IMeshGeneratingFunction
     /// </summary>
     private readonly MulticellularMetaball[] points;
 
+    /// <summary>
+    ///   Max squared distance from a bone's center for a point to be calculated.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     i-th element here refers to the i-th point's bone in points[]. If that point has no parent, then it has no
+    ///     bone, so the distance in this array is meningless for the point.
+    ///   </para>
+    /// </remarks>
     private readonly float[] boneMaxSquareDistanceCache;
 
     private float surfaceValue = 1.0f;
@@ -205,11 +214,6 @@ public class Scalis : IMeshGeneratingFunction
             return b;
 
         return linePos;
-    }
-
-    private float SquareCutoffValue(Vector3 pos, Vector3 a, Vector3 b)
-    {
-        return (ClosestPoint(pos, a, b) - pos).LengthSquared();
     }
 
     private float Convolution(int k, int i, Vector3 pointA, Vector3 pointB, Vector3 pointP)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Optimizes SCALIS by switching to a better cutoff algorithm. More specifically, it is now based on square distance to line's center, which is cheaper to calculate than distance to closest point on line (which it was previosly based on).

In my testing, there was an x2 increase in performance.
I.e. around 0.13s -> 0.06s on the default multicellular creature.

**Related Issues**

SCALIS was too slow

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
