### PR TITLE
Miche Population Calculation Fixes

### DIFF
--- a/src/auto-evo/AutoEvoGlobalCache.cs
+++ b/src/auto-evo/AutoEvoGlobalCache.cs
@@ -42,7 +42,7 @@ public class AutoEvoGlobalCache
         MetabolicStabilityPressure = new MetabolicStabilityPressure(10.0f);
 
         MinorGlucoseConversionEfficiencyPressure = new CompoundConversionEfficiencyPressure(glucose, atp, 0.75f);
-        MaintainGlucose = new MaintainCompoundPressure(glucose, 1.0f);
+        MaintainGlucose = new MaintainCompoundPressure(glucose, 1.5f);
 
         GlucoseConversionEfficiencyPressure = new CompoundConversionEfficiencyPressure(glucose, atp, 1.5f);
         GlucoseCloudPressure = new CompoundCloudPressure(glucose, worldSettings.DayNightCycleEnabled, 1.0f);

--- a/src/auto-evo/Miche.cs
+++ b/src/auto-evo/Miche.cs
@@ -254,14 +254,14 @@ public class Miche
     {
         public HashSet<Species> WorkingHashSet = new();
 
-        private List<Dictionary<Species, float>> ScoreDictionaries = new();
+        private readonly List<Dictionary<Species, float>> scoreDictionaries = new();
 
         public Dictionary<Species, float> GetScoresAtDepth(int depth)
         {
-            while (ScoreDictionaries.Count <= depth)
-                ScoreDictionaries.Add(new Dictionary<Species, float>());
+            while (scoreDictionaries.Count <= depth)
+                scoreDictionaries.Add(new Dictionary<Species, float>());
 
-            return ScoreDictionaries[depth];
+            return scoreDictionaries[depth];
         }
     }
 }

--- a/src/auto-evo/Miche.cs
+++ b/src/auto-evo/Miche.cs
@@ -125,26 +125,6 @@ public class Miche
         newChild.Parent = this;
     }
 
-    public int GetDeepestDepth()
-    {
-        return GetDeepestDepth(1);
-    }
-
-    public int GetDeepestDepth(int depth)
-    {
-        if (IsLeafNode())
-            return depth;
-
-        var maxDepth = depth;
-
-        foreach (var child in Children)
-        {
-            maxDepth = Math.Max(maxDepth, child.GetDeepestDepth(depth + 1));
-        }
-
-        return maxDepth;
-    }
-
     /// <summary>
     ///   Inserts a species into any spots on the tree where the species is a better fit than any current occupants
     /// </summary>
@@ -177,7 +157,7 @@ public class Miche
             return true;
         }
 
-        var newScores = workingMemory.ScoreDictionaries[depth];
+        var newScores = workingMemory.GetScoresAtDepth(depth);
         newScores.Clear();
 
         workingMemory.WorkingHashSet.Clear();
@@ -267,20 +247,21 @@ public class Miche
             (Occupant == null ? 17 : Occupant.GetHashCode()) * 5171;
     }
 
+    /// <summary>
+    ///   Working memory used to reduce memory allocations in miche.insert()
+    /// </summary>
     public class InsertWorkingMemory
     {
         public HashSet<Species> WorkingHashSet = new();
 
-        public List<Dictionary<Species, float>> ScoreDictionaries;
+        private List<Dictionary<Species, float>> ScoreDictionaries = new();
 
-        public InsertWorkingMemory(Miche miche)
+        public Dictionary<Species, float> GetScoresAtDepth(int depth)
         {
-            ScoreDictionaries = [];
-
-            for (var i = 0; i < miche.GetDeepestDepth(); ++i)
-            {
+            while (ScoreDictionaries.Count <= depth)
                 ScoreDictionaries.Add(new Dictionary<Species, float>());
-            }
+
+            return ScoreDictionaries[depth];
         }
     }
 }

--- a/src/auto-evo/Miche.cs
+++ b/src/auto-evo/Miche.cs
@@ -158,7 +158,6 @@ public class Miche
         }
 
         var newScores = workingMemory.GetScoresAtDepth(depth);
-        newScores.Clear();
 
         workingMemory.WorkingHashSet.Clear();
         GetOccupants(workingMemory.WorkingHashSet);
@@ -167,6 +166,7 @@ public class Miche
         if (scoresSoFar == null)
         {
             // Initial call, not recursive
+
             foreach (var currentSpecies in workingMemory.WorkingHashSet)
             {
                 newScores[currentSpecies] =
@@ -248,11 +248,11 @@ public class Miche
     }
 
     /// <summary>
-    ///   Working memory used to reduce memory allocations in miche.insert()
+    ///   Working memory used to reduce memory allocations in <see cref="Miche.InsertSpecies"/>
     /// </summary>
     public class InsertWorkingMemory
     {
-        public HashSet<Species> WorkingHashSet = new();
+        public readonly HashSet<Species> WorkingHashSet = new();
 
         private readonly List<Dictionary<Species, float>> scoreDictionaries = new();
 
@@ -261,7 +261,12 @@ public class Miche
             while (scoreDictionaries.Count <= depth)
                 scoreDictionaries.Add(new Dictionary<Species, float>());
 
-            return scoreDictionaries[depth];
+            var result = scoreDictionaries[depth];
+
+            // Clear any previous data before returning to make calling this method simpler
+            result.Clear();
+
+            return result;
         }
     }
 }

--- a/src/auto-evo/mutations/MutationLogicFunctions.cs
+++ b/src/auto-evo/mutations/MutationLogicFunctions.cs
@@ -1,7 +1,6 @@
 ﻿namespace AutoEvo;
 
 using System.Linq;
-using Microsoft.Extensions.Logging.Abstractions;
 
 public class MutationLogicFunctions
 {

--- a/src/auto-evo/mutations/MutationLogicFunctions.cs
+++ b/src/auto-evo/mutations/MutationLogicFunctions.cs
@@ -1,6 +1,7 @@
 ﻿namespace AutoEvo;
 
 using System.Linq;
+using Microsoft.Extensions.Logging.Abstractions;
 
 public class MutationLogicFunctions
 {
@@ -21,7 +22,7 @@ public class MutationLogicFunctions
             newSpecies.Genus = parentSpecies.Genus;
         }
 
-        newSpecies.Epithet = SimulationParameters.Instance.NameGenerator.GenerateNameSection(lowercase = true);
+        newSpecies.Epithet = SimulationParameters.Instance.NameGenerator.GenerateNameSection(null, true);
     }
 
     private static bool MicrobeSpeciesIsNewGenus(MicrobeSpecies species1, MicrobeSpecies species2)

--- a/src/auto-evo/mutations/MutationLogicFunctions.cs
+++ b/src/auto-evo/mutations/MutationLogicFunctions.cs
@@ -21,7 +21,7 @@ public class MutationLogicFunctions
             newSpecies.Genus = parentSpecies.Genus;
         }
 
-        newSpecies.Epithet = SimulationParameters.Instance.NameGenerator.GenerateNameSection();
+        newSpecies.Epithet = SimulationParameters.Instance.NameGenerator.GenerateNameSection(lowercase = true);
     }
 
     private static bool MicrobeSpeciesIsNewGenus(MicrobeSpecies species1, MicrobeSpecies species2)

--- a/src/auto-evo/selection_pressure/ChunkCompoundPressure.cs
+++ b/src/auto-evo/selection_pressure/ChunkCompoundPressure.cs
@@ -36,7 +36,7 @@ public class ChunkCompoundPressure : SelectionPressure
 
         // Speed is not too important to chunk microbes
         // But all else being the same faster is better than slower
-        score += cache.GetSpeedForSpecies(microbeSpecies) * 0.1f;
+        score += MathF.Pow(cache.GetSpeedForSpecies(microbeSpecies), 0.4f);
 
         // Diminishing returns on storage
         score += (Mathf.Pow(microbeSpecies.StorageCapacities.Nominal + 1, 0.8f) - 1) / 0.8f;

--- a/src/auto-evo/selection_pressure/CompoundCloudPressure.cs
+++ b/src/auto-evo/selection_pressure/CompoundCloudPressure.cs
@@ -33,7 +33,7 @@ public class CompoundCloudPressure : SelectionPressure
         if (species is not MicrobeSpecies microbeSpecies)
             return 0;
 
-        var score = cache.GetSpeedForSpecies(microbeSpecies);
+        var score = MathF.Pow(cache.GetSpeedForSpecies(microbeSpecies), 0.6f);
 
         // Species that are less active during the night get a small penalty here based on their activity
         if (isDayNightCycleEnabled && cache.GetUsesVaryingCompoundsForSpecies(microbeSpecies, patch.Biome))

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -190,7 +190,7 @@ public static class MichePopulation
         // Note that this modifies the miche tree while simulating
         var miche = populations.GetMicheForPatch(patch);
 
-        var workMemory = new HashSet<Species>();
+        var insertWorkMemory = new Miche.InsertWorkingMemory(miche);
 
         var species = new HashSet<Species>();
 
@@ -199,7 +199,7 @@ public static class MichePopulation
         {
             if (simulationConfiguration.ReplacedSpecies.TryGetValue(currentSpecies, out var replacement))
             {
-                miche.InsertSpecies(replacement, patch, null, cache, false, workMemory);
+                miche.InsertSpecies(replacement, patch, null, cache, false, insertWorkMemory);
 
                 species.Add(replacement);
                 continue;

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -215,8 +215,9 @@ public static class MichePopulation
         if (species.Count < 1)
             return;
 
-        // TODO: When supporting Multicell Species replace the is Microbe Species with a null check
         var leafNodes = new List<Miche>();
+
+        // TODO: When supporting multicellular species replace the is MicrobeSpecies with a null check
         miche.GetLeafNodes(leafNodes, x => x.Occupant is MicrobeSpecies);
 
         // TODO: check if energy should be calculated as doubles because the summed numbers can get pretty high that
@@ -243,7 +244,7 @@ public static class MichePopulation
                 if (currentSpecies is not MicrobeSpecies microbeSpecies)
                     continue;
 
-                var transversalScore = 0.0f;
+                var traversalScore = 0.0f;
 
                 foreach (var currentMiche in currentBackTraversal)
                 {
@@ -251,7 +252,7 @@ public static class MichePopulation
 
                     if (rawScore <= 0)
                     {
-                        transversalScore = 0;
+                        traversalScore = 0;
                         break;
                     }
 
@@ -263,18 +264,19 @@ public static class MichePopulation
                     if (simulationConfiguration.WorldSettings.AutoEvoConfiguration.StrictNicheCompetition)
                         score *= score;
 
-                    transversalScore += score;
+                    traversalScore += score;
                 }
 
-                totalScore += transversalScore;
-                scoresDictionary[currentSpecies] += transversalScore;
+                totalScore += traversalScore;
+                scoresDictionary[currentSpecies] += traversalScore;
             }
+
+            // No need to process species if there isn't any score to give any energy
+            if (totalScore <= 0)
+                continue;
 
             foreach (var currentSpecies in species)
             {
-                if (totalScore <= 0)
-                    break;
-
                 var micheEnergy = node.Pressure.GetEnergy(patch) * (scoresDictionary[currentSpecies] / totalScore);
 
                 if (trackEnergy && micheEnergy > 0)

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -213,7 +213,7 @@ public static class MichePopulation
             return;
 
         var leafNodes = new List<Miche>();
-        miche.GetLeafNodes(leafNodes, x => x.Occupant != null && x.Occupant is MicrobeSpecies);
+        miche.GetLeafNodes(leafNodes, x => x.Occupant is MicrobeSpecies);
 
         // TODO: check if energy should be calculated as doubles because the summed numbers can get pretty high that
         // might benefit from extra precision

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -212,6 +212,7 @@ public static class MichePopulation
         if (species.Count < 1)
             return;
 
+        // TODO: When supporting Multicell Species replace the is Microbe Species with a null check
         var leafNodes = new List<Miche>();
         miche.GetLeafNodes(leafNodes, x => x.Occupant is MicrobeSpecies);
 

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -211,19 +211,7 @@ public class SimulationCache
             return cached;
         }
 
-        cached = ProcessSystem.CalculateProcessMaximumSpeed(process, biomeConditions, CompoundAmountType.Average);
-
-        foreach (var input in process.Process.Inputs)
-        {
-            if (biomeConditions.Compounds.TryGetValue(input.Key, out var inputCompoundData))
-            {
-                if (inputCompoundData.Amount <= 0 && inputCompoundData.Ambient <= 0)
-                {
-                    cached.CurrentSpeed = 0;
-                    break;
-                }
-            }
-        }
+        cached = ProcessSystem.CalculateProcessMaximumSpeed(process, biomeConditions, CompoundAmountType.Average, true);
 
         cachedProcessSpeeds.Add(key, cached);
         return cached;

--- a/src/auto-evo/steps/GenerateMiche.cs
+++ b/src/auto-evo/steps/GenerateMiche.cs
@@ -1,7 +1,5 @@
 ﻿namespace AutoEvo;
 
-using System.Collections.Generic;
-
 /// <summary>
 ///   Dynamically generates the <see cref="Miche"/> tree for each <see cref="Patch"/>
 /// </summary>
@@ -144,11 +142,11 @@ public class GenerateMiche : IRunStep
         if (patch.SpeciesInPatch.Count < 1)
             return miche;
 
-        var workMemory = new HashSet<Species>();
+        var insertWorkMemory = new Miche.InsertWorkingMemory(miche);
 
         foreach (var species in patch.SpeciesInPatch.Keys)
         {
-            miche.InsertSpecies(species, patch, null, cache, false, workMemory);
+            miche.InsertSpecies(species, patch, null, cache, false, insertWorkMemory);
         }
 
         return miche;

--- a/src/auto-evo/steps/GenerateMiche.cs
+++ b/src/auto-evo/steps/GenerateMiche.cs
@@ -142,7 +142,7 @@ public class GenerateMiche : IRunStep
         if (patch.SpeciesInPatch.Count < 1)
             return miche;
 
-        var insertWorkMemory = new Miche.InsertWorkingMemory(miche);
+        var insertWorkMemory = new Miche.InsertWorkingMemory();
 
         foreach (var species in patch.SpeciesInPatch.Keys)
         {

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -14,6 +14,7 @@ public class MigrateSpecies : IRunStep
     private readonly WorldGenerationSettings worldSettings;
     private readonly SimulationCache cache;
     private readonly Random random;
+    private readonly Miche.InsertWorkingMemory insertWorkingMemory;
 
     public MigrateSpecies(Species species, PatchMap map, WorldGenerationSettings worldSettings, SimulationCache cache,
         Random randomSource)
@@ -22,6 +23,8 @@ public class MigrateSpecies : IRunStep
         this.cache = cache;
         this.map = map;
         this.worldSettings = worldSettings;
+
+        insertWorkingMemory = new Miche.InsertWorkingMemory();
 
         random = new XoShiRo128starstar(randomSource.NextInt64());
     }
@@ -97,9 +100,7 @@ public class MigrateSpecies : IRunStep
                 var moveAmount = (long)random.Next(population * Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION_FRACTION,
                     population * Constants.AUTO_EVO_MAXIMUM_MOVE_POPULATION_FRACTION);
 
-                var insertWorkMemory = new Miche.InsertWorkingMemory(targetMiche);
-
-                if (moveAmount > 0 && targetMiche.InsertSpecies(species, patch, null, cache, true, insertWorkMemory))
+                if (moveAmount > 0 && targetMiche.InsertSpecies(species, patch, null, cache, true, insertWorkingMemory))
                 {
                     results.AddMigrationResultForSpecies(species, new SpeciesMigration(patch, target, moveAmount));
                     usedTargets.Add(target);

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -15,8 +15,6 @@ public class MigrateSpecies : IRunStep
     private readonly SimulationCache cache;
     private readonly Random random;
 
-    private readonly HashSet<Species> speciesWorkMemory = new();
-
     public MigrateSpecies(Species species, PatchMap map, WorldGenerationSettings worldSettings, SimulationCache cache,
         Random randomSource)
     {
@@ -99,7 +97,9 @@ public class MigrateSpecies : IRunStep
                 var moveAmount = (long)random.Next(population * Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION_FRACTION,
                     population * Constants.AUTO_EVO_MAXIMUM_MOVE_POPULATION_FRACTION);
 
-                if (moveAmount > 0 && targetMiche.InsertSpecies(species, patch, null, cache, true, speciesWorkMemory))
+                var insertWorkMemory = new Miche.InsertWorkingMemory(targetMiche);
+
+                if (moveAmount > 0 && targetMiche.InsertSpecies(species, patch, null, cache, true, insertWorkMemory))
                 {
                     results.AddMigrationResultForSpecies(species, new SpeciesMigration(patch, target, moveAmount));
                     usedTargets.Add(target);

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -14,7 +14,7 @@ public class MigrateSpecies : IRunStep
     private readonly WorldGenerationSettings worldSettings;
     private readonly SimulationCache cache;
     private readonly Random random;
-    private readonly Miche.InsertWorkingMemory insertWorkingMemory;
+    private readonly Miche.InsertWorkingMemory insertWorkingMemory = new();
 
     public MigrateSpecies(Species species, PatchMap map, WorldGenerationSettings worldSettings, SimulationCache cache,
         Random randomSource)
@@ -23,8 +23,6 @@ public class MigrateSpecies : IRunStep
         this.cache = cache;
         this.map = map;
         this.worldSettings = worldSettings;
-
-        insertWorkingMemory = new Miche.InsertWorkingMemory();
 
         random = new XoShiRo128starstar(randomSource.NextInt64());
     }

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -62,6 +62,7 @@ public class ModifyExistingSpecies : IRunStep
     private Dictionary<Species, long>.Enumerator speciesEnumerator;
 
     private Miche? miche;
+    private Miche.InsertWorkingMemory? insertWorkingMemory;
 
     private Step step;
 
@@ -112,6 +113,8 @@ public class ModifyExistingSpecies : IRunStep
             miche.GetOccupants(speciesWorkMemory);
 
             miche.GetLeafNodes(nonEmptyLeafNodes, emptyLeafNodes, x => x.Occupant != null);
+
+            insertWorkingMemory = new Miche.InsertWorkingMemory(miche);
         }
 
         // This auto-evo step is split into sub steps so that each run doesn't take many seconds like it would
@@ -191,7 +194,7 @@ public class ModifyExistingSpecies : IRunStep
                     // WARNING: this modifies the miche tree meaning that no other step may be running at the same time
                     // that uses the miche tree for the same patch. And no further auto-evo steps after this can use
                     // the original miche tree state.
-                    miche.InsertSpecies(mutation.MutatedSpecies, patch, null, cache, false, workMemory);
+                    miche.InsertSpecies(mutation.MutatedSpecies, patch, null, cache, false, insertWorkingMemory!);
                 }
 
                 newOccupantsWorkMemory.Clear();

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -315,6 +315,7 @@ public class ModifyExistingSpecies : IRunStep
 
         // This section of the code tries to mutate species into unfilled miches
         // Not exactly realistic, but more diversity is more fun for the player
+        // TODO: Make this an auto-evo option
         foreach (var emptyLeafNode in emptyLeafNodes)
         {
             currentTraversal.Clear();

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -62,7 +62,7 @@ public class ModifyExistingSpecies : IRunStep
     private Dictionary<Species, long>.Enumerator speciesEnumerator;
 
     private Miche? miche;
-    private Miche.InsertWorkingMemory? insertWorkingMemory;
+    private Miche.InsertWorkingMemory insertWorkingMemory;
 
     private Step step;
 
@@ -80,6 +80,7 @@ public class ModifyExistingSpecies : IRunStep
         // Patch species count is used to know how many steps there are to perform
         expectedSpeciesCount = patch.SpeciesInPatch.Count;
         speciesEnumerator = patch.SpeciesInPatch.GetEnumerator();
+        insertWorkingMemory = new Miche.InsertWorkingMemory();
     }
 
     private enum Step
@@ -113,8 +114,6 @@ public class ModifyExistingSpecies : IRunStep
             miche.GetOccupants(speciesWorkMemory);
 
             miche.GetLeafNodes(nonEmptyLeafNodes, emptyLeafNodes, x => x.Occupant != null);
-
-            insertWorkingMemory = new Miche.InsertWorkingMemory(miche);
         }
 
         // This auto-evo step is split into sub steps so that each run doesn't take many seconds like it would
@@ -194,7 +193,7 @@ public class ModifyExistingSpecies : IRunStep
                     // WARNING: this modifies the miche tree meaning that no other step may be running at the same time
                     // that uses the miche tree for the same patch. And no further auto-evo steps after this can use
                     // the original miche tree state.
-                    miche.InsertSpecies(mutation.MutatedSpecies, patch, null, cache, false, insertWorkingMemory!);
+                    miche.InsertSpecies(mutation.MutatedSpecies, patch, null, cache, false, insertWorkingMemory);
                 }
 
                 newOccupantsWorkMemory.Clear();

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -29,6 +29,8 @@ public class ModifyExistingSpecies : IRunStep
 
     private readonly HashSet<Species> workMemory = new();
 
+    private readonly Miche.InsertWorkingMemory insertWorkingMemory = new();
+
     private readonly List<Miche> predatorCalculationMemory2 = new();
     private readonly List<Species> predatorPressuresTemporary = new();
 
@@ -52,8 +54,6 @@ public class ModifyExistingSpecies : IRunStep
     private readonly List<Mutation> mutationsToTry = new();
     private readonly HashSet<MicrobeSpecies> handledMutations = new();
 
-    private readonly List<Miche> speciesSpecificLeaves = new();
-
     private readonly int expectedSpeciesCount;
 
     private readonly List<Miche> nonEmptyLeafNodes = new();
@@ -62,7 +62,6 @@ public class ModifyExistingSpecies : IRunStep
     private Dictionary<Species, long>.Enumerator speciesEnumerator;
 
     private Miche? miche;
-    private Miche.InsertWorkingMemory insertWorkingMemory;
 
     private Step step;
 
@@ -80,7 +79,6 @@ public class ModifyExistingSpecies : IRunStep
         // Patch species count is used to know how many steps there are to perform
         expectedSpeciesCount = patch.SpeciesInPatch.Count;
         speciesEnumerator = patch.SpeciesInPatch.GetEnumerator();
-        insertWorkingMemory = new Miche.InsertWorkingMemory();
     }
 
     private enum Step

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1966,7 +1966,8 @@ public partial class CellEditorComponent :
 
         foreach (var process in processes)
         {
-            var singleProcess = ProcessSystem.CalculateProcessMaximumSpeed(process, biome, CompoundAmountType.Current);
+            var singleProcess = ProcessSystem.CalculateProcessMaximumSpeed(process, biome, CompoundAmountType.Current,
+                false);
 
             // If produces more ATP than consumes, lower down production for inputs and for outputs,
             // otherwise use maximum production values (this matches the equilibrium display mode and what happens

--- a/src/microbe_stage/systems/ProcessSystem.cs
+++ b/src/microbe_stage/systems/ProcessSystem.cs
@@ -453,14 +453,14 @@ public sealed class ProcessSystem : AEntitySetSystem<float>
     ///   Can be switched between the average, maximum etc. conditions that occur in the span of an in-game day.
     /// </summary>
     public static ProcessSpeedInformation CalculateProcessMaximumSpeed(TweakedProcess process,
-        BiomeConditions biome, CompoundAmountType pointInTimeType, bool checkIfInPatch)
+        BiomeConditions biome, CompoundAmountType pointInTimeType, bool requireInputCompoundsInBiome)
     {
         var result = new ProcessSpeedInformation(process.Process);
 
         float speedFactor = 1.0f;
         float efficiency = 1.0f;
 
-        if (checkIfInPatch)
+        if (requireInputCompoundsInBiome)
         {
             foreach (var input in process.Process.Inputs)
             {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes:
- [ ] Auto-Evo prediction incorrect
- [x] Species gain energy from failed Miches Closes:  #5391
- [x] Fix Bug that makes auto-evo think there is iron in every patch

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
