### PR TITLE
Fix timeline cleaning bug

### DIFF
--- a/src/microbe_stage/editor/TimelineTab.cs
+++ b/src/microbe_stage/editor/TimelineTab.cs
@@ -110,7 +110,7 @@ public partial class TimelineTab : PanelContainer
             globalEventsContainer.FreeChildren();
             cachedGlobalTimelineElements = new List<TimelineSection>();
 
-            foreach (var entry in editor.CurrentGame.GameWorld.EventsLog)
+            foreach (var entry in editor.CurrentGame.GameWorld.EventsLog.OrderBy(s => s.Key))
             {
                 var section = new TimelineSection(customRichTextLabelScene, eventHighlightStyleBox,
                     (entry.Key, entry.Value))


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes the timeline cleaning bug, i.e. the latest timeline entries being removed instead of the oldest. Apparently, the cleaning itself had no bugs (the oldest entries were correctly removed), but the newest entries were displayed in place of the removed old entries. Which was caused by foreach not ordering key-value pairs.

2200 MYR save for easier testing:
[2200.zip](https://github.com/user-attachments/files/16761785/2200.zip)

**Related Issues**

Closes #3135

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
