### PR TITLE
Fixes Issue #5230

### DIFF
--- a/src/thriveopedia/pages/wiki/OrganelleInfoBox.tscn
+++ b/src/thriveopedia/pages/wiki/OrganelleInfoBox.tscn
@@ -51,7 +51,7 @@ label_settings = ExtResource("3_vcfpd")
 custom_minimum_size = Vector2(80, 60)
 layout_mode = 2
 expand_mode = 1
-stretch_mode = 6
+stretch_mode = 4
 
 [node name="Model" type="TextureRect" parent="MarginContainer/VBoxContainer"]
 visible = false
@@ -59,7 +59,7 @@ custom_minimum_size = Vector2(250, 250)
 layout_mode = 2
 size_flags_horizontal = 3
 expand_mode = 1
-stretch_mode = 6
+stretch_mode = 4
 
 [node name="HSeparator2" type="HSeparator" parent="MarginContainer/VBoxContainer"]
 modulate = Color(1, 1, 1, 0.25098)


### PR DESCRIPTION
Issue #5230: Images in the Thriveopedia are cut off before displaying the full image, as shown below.

https://ibb.co/yY5pz3V

This should fix issue #5230.

Changed the stretch mode in the 'Icon' image to be Keep Aspect Ratio. This keeps it within the box.

Changed the stretch mode in the 'Model' image to be Keep Aspect Ratio - it was having a similar problem.

Screenshot of fixes:

https://ibb.co/0DdybDq

**Brief Description of What This PR Does**

Changes Stretch Mode for 'Icon' and 'Model' to Keep Aspect Ratio in the Thriveopedia Organelle info box area.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

fixes #5230

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
