### PR TITLE
Fixed missing JSON attribute on EndosymbiontPlaceActionData causing load failure

### DIFF
--- a/src/microbe_stage/editor/action_data/EndosymbiontPlaceActionData.cs
+++ b/src/microbe_stage/editor/action_data/EndosymbiontPlaceActionData.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 [JSONAlwaysDynamicType]
 public class EndosymbiontPlaceActionData : EditorCombinableActionData<CellType>
@@ -20,6 +21,7 @@ public class EndosymbiontPlaceActionData : EditorCombinableActionData<CellType>
     /// </summary>
     public EndosymbiosisData.InProgressEndosymbiosis? OverriddenEndosymbiosisOnUndo;
 
+    [JsonConstructor]
     public EndosymbiontPlaceActionData(OrganelleTemplate placedOrganelle, Hex placementLocation, int placementRotation,
         EndosymbiosisData.InProgressEndosymbiosis relatedEndosymbiosisAction)
     {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes me forgetting to put a json constructor attribute

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://community.revolutionarygamesstudio.com/t/error-while-loading-save-release-0-7-0/7704

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
