### PR TITLE
Fixed strain code taking base movement ATP while not moving

### DIFF
--- a/src/microbe_stage/systems/MicrobeMovementSystem.cs
+++ b/src/microbe_stage/systems/MicrobeMovementSystem.cs
@@ -195,10 +195,17 @@ public sealed class MicrobeMovementSystem : AEntitySetSystem<float>
                 strain.IsUnderStrain = false;
             }
 
-            // Remove ATP due to strain even if not moving
-            // This is calculated similarly to the regular movement cost for consistency
-            var strainCost = Constants.BASE_MOVEMENT_ATP_COST * organelles.HexCount * delta * strainMultiplier;
-            compounds.TakeCompound(atp, strainCost);
+            // Remove ATP due to strain even if not moving (but only if strain is active, because otherwise this would
+            // take the movement cost even while not moving meaning the editor ATP balance bar would be totally
+            // inaccurate)
+            if (strainMultiplier > 1)
+            {
+                // This is calculated similarly to the regular movement cost for consistency
+                // TODO: is it fine for this to be so punishing? By taking the base movement cost here even though
+                // the cell is not moving (this could take just the portion of strain multiplier that is above 1)
+                var strainCost = Constants.BASE_MOVEMENT_ATP_COST * organelles.HexCount * delta * strainMultiplier;
+                compounds.TakeCompound(atp, strainCost);
+            }
 
             // Slime jets work even when not holding down any movement keys
             var jetMovement = CalculateMovementFromSlimeJets(ref organelles);


### PR DESCRIPTION
causing the ATP balance bar to not be accurate when stationary

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://steamcommunity.com/app/1779200/discussions/0/4763207146662849460/

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
