### PR TITLE
Fixed engulfed storage size flickering when ejecting too big objects

### DIFF
--- a/src/microbe_stage/components/Engulfer.cs
+++ b/src/microbe_stage/components/Engulfer.cs
@@ -33,7 +33,7 @@ public struct Engulfer
     public float EngulfingSize;
 
     /// <summary>
-    ///   The amount of space all of the currently engulfed objects occupy in the cytoplasm. This is used to
+    ///   The amount of space all the currently engulfed objects occupy in the cytoplasm. This is used to
     ///   determine whether a cell can ingest any more objects or not due to being full. Also contains the size of
     ///   objects being currently pulled in.
     /// </summary>
@@ -199,6 +199,12 @@ public static class EngulferHelpers
         return nearestPoint;
     }
 
+    /// <summary>
+    ///   Request ejection of an engulfable
+    /// </summary>
+    /// <returns>
+    ///   True when ejection has started, false if already was in progress, or it is impossible to eject
+    /// </returns>
     public static bool EjectEngulfable(this ref Engulfer engulfer, ref Engulfable engulfable)
     {
         // Cannot start ejecting a thing that is not in a valid state for that
@@ -213,7 +219,7 @@ public static class EngulferHelpers
             case PhagocytosisPhase.Exocytosis:
             case PhagocytosisPhase.Ejection:
                 // Already requested / happening
-                return true;
+                return false;
         }
 
         engulfable.PhagocytosisStep = PhagocytosisPhase.RequestExocytosis;

--- a/src/microbe_stage/systems/EngulfedDigestionSystem.cs
+++ b/src/microbe_stage/systems/EngulfedDigestionSystem.cs
@@ -188,6 +188,10 @@ public sealed class EngulfedDigestionSystem : AEntitySetSystem<float>
                             engulfable.RequisiteEnzymeToDigest!.Name));
                     }
 
+                    // Count the size still in this case as otherwise there's a one frame flicker of the matter
+                    // storage bar if engulfing just something that cannot be digested
+                    usedCapacity += currentEngulfableSize;
+
                     continue;
                 }
 

--- a/src/microbe_stage/systems/EngulfedDigestionSystem.cs
+++ b/src/microbe_stage/systems/EngulfedDigestionSystem.cs
@@ -132,9 +132,10 @@ public sealed class EngulfedDigestionSystem : AEntitySetSystem<float>
 
             ref var engulfable = ref engulfedObject.Get<Engulfable>();
 
-            // Expel this engulfed object if the cell loses some of its size and its ingestion capacity
-            // is overloaded
-            if (engulfer.UsedEngulfingCapacity > engulfer.EngulfStorageSize)
+            var currentEngulfableSize = engulfable.AdjustedEngulfSize;
+
+            // Expel this engulfed object if the cell loses some of its size and its ingestion capacity is overloaded
+            if (usedCapacity + currentEngulfableSize - MathUtils.EPSILON > engulfer.EngulfStorageSize)
             {
                 if (engulfer.EjectEngulfable(ref engulfable))
                 {
@@ -142,9 +143,8 @@ public sealed class EngulfedDigestionSystem : AEntitySetSystem<float>
                         new SimpleHUDMessage(Localization.Translate("NOTICE_ENGULF_STORAGE_FULL")));
                 }
 
-                // As ejecting is delayed, we need to temporarily adjust the size here so that we don't
-                // accidentally eject *everything* if we go slightly over the limit
-                engulfer.UsedEngulfingCapacity -= engulfable.AdjustedEngulfSize;
+                // As ejecting is delayed, we need to temporarily not count this in the used capacity otherwise we may
+                // accidentally eject way too much stuff
                 continue;
             }
 
@@ -154,7 +154,7 @@ public sealed class EngulfedDigestionSystem : AEntitySetSystem<float>
             {
                 // Still need to consider the size of this thing for the engulf storage, otherwise cells can start
                 // pulling in too much
-                usedCapacity += engulfable.AdjustedEngulfSize;
+                usedCapacity += currentEngulfableSize;
 
                 if (engulfable.PhagocytosisStep == PhagocytosisPhase.None)
                 {


### PR DESCRIPTION
after cell loses size, also made the other eject conditions only print their relevant message once when the ejection starts

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/228300288023461893/958598553389903913/1280833370682560533

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
