### PR TITLE
Reduce delay on patch selection in editor

### DIFF
--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
@@ -80,6 +80,9 @@ public partial class EarlyMulticellularEditor : EditorBase<EditorAction, Microbe
     public Patch CurrentPatch => patchMapTab.CurrentPatch;
 
     [JsonIgnore]
+    public Patch? TargetPatch => patchMapTab.TargetPatch;
+
+    [JsonIgnore]
     public Patch? SelectedPatch => patchMapTab.SelectedPatch;
 
     [JsonIgnore]
@@ -110,8 +113,6 @@ public partial class EarlyMulticellularEditor : EditorBase<EditorAction, Microbe
     public void OnCurrentPatchUpdated(Patch patch)
     {
         cellEditorTab.OnCurrentPatchUpdated(patch);
-
-        reportTab.UpdatePatchDetails(patch);
 
         cellEditorTab.UpdateBackgroundImage(patch.BiomeTemplate);
     }
@@ -203,7 +204,7 @@ public partial class EarlyMulticellularEditor : EditorBase<EditorAction, Microbe
 
             reportTab.UpdateTimeIndicator(CurrentGame.GameWorld.TotalPassedTime);
 
-            reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.SelectedPatch);
+            reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.TargetPatch);
         }
 
         cellEditorTab.UpdateBackgroundImage(CurrentPatch.BiomeTemplate);
@@ -223,8 +224,6 @@ public partial class EarlyMulticellularEditor : EditorBase<EditorAction, Microbe
         {
             editorComponent.Init(this, fresh);
         }
-
-        patchMapTab.OnSelectedPatchChanged = OnSelectPatchForReportTab;
     }
 
     protected override void OnEnterEditor()
@@ -268,7 +267,7 @@ public partial class EarlyMulticellularEditor : EditorBase<EditorAction, Microbe
             reportTab.UpdateAutoEvoResults(autoEvoSummary.ToString(), autoEvoExternal.ToString());
         }
 
-        reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.SelectedPatch);
+        reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.TargetPatch);
     }
 
     protected override void OnUndoPerformed()
@@ -327,6 +326,7 @@ public partial class EarlyMulticellularEditor : EditorBase<EditorAction, Microbe
             {
                 reportTab.Show();
                 SetEditorObjectVisibility(false);
+                reportTab.UpdatePatchDetailsIfNeeded(SelectedPatch ?? CurrentPatch);
                 break;
             }
 
@@ -422,11 +422,6 @@ public partial class EarlyMulticellularEditor : EditorBase<EditorAction, Microbe
         }
 
         base.Dispose(disposing);
-    }
-
-    private void OnSelectPatchForReportTab(Patch patch)
-    {
-        reportTab.UpdatePatchDetails(patch, patch);
     }
 
     private void OnStartEditingCellType(string? name, bool switchTab)

--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
@@ -204,7 +204,7 @@ public partial class EarlyMulticellularEditor : EditorBase<EditorAction, Microbe
 
             reportTab.UpdateTimeIndicator(CurrentGame.GameWorld.TotalPassedTime);
 
-            reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.TargetPatch);
+            reportTab.UpdatePatchDetails(CurrentPatch, TargetPatch);
         }
 
         cellEditorTab.UpdateBackgroundImage(CurrentPatch.BiomeTemplate);
@@ -267,7 +267,7 @@ public partial class EarlyMulticellularEditor : EditorBase<EditorAction, Microbe
             reportTab.UpdateAutoEvoResults(autoEvoSummary.ToString(), autoEvoExternal.ToString());
         }
 
-        reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.TargetPatch);
+        reportTab.UpdatePatchDetails(CurrentPatch, TargetPatch);
     }
 
     protected override void OnUndoPerformed()

--- a/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
+++ b/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
@@ -237,7 +237,7 @@ public partial class LateMulticellularEditor : EditorBase<EditorAction, Multicel
 
             reportTab.UpdateTimeIndicator(CurrentGame.GameWorld.TotalPassedTime);
 
-            reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.TargetPatch);
+            reportTab.UpdatePatchDetails(CurrentPatch, TargetPatch);
         }
 
         UpdateBackgrounds(CurrentPatch);
@@ -292,7 +292,7 @@ public partial class LateMulticellularEditor : EditorBase<EditorAction, Multicel
             reportTab.UpdateAutoEvoResults(autoEvoSummary.ToString(), autoEvoExternal.ToString());
         }
 
-        reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.TargetPatch);
+        reportTab.UpdatePatchDetails(CurrentPatch, TargetPatch);
     }
 
     protected override void OnUndoPerformed()

--- a/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
+++ b/src/late_multicellular_stage/editor/LateMulticellularEditor.cs
@@ -105,6 +105,9 @@ public partial class LateMulticellularEditor : EditorBase<EditorAction, Multicel
     public Patch CurrentPatch => patchMapTab.CurrentPatch;
 
     [JsonIgnore]
+    public Patch? TargetPatch => patchMapTab.TargetPatch;
+
+    [JsonIgnore]
     public Patch? SelectedPatch => patchMapTab.SelectedPatch;
 
     [JsonIgnore]
@@ -135,8 +138,6 @@ public partial class LateMulticellularEditor : EditorBase<EditorAction, Multicel
     public void OnCurrentPatchUpdated(Patch patch)
     {
         cellEditorTab.OnCurrentPatchUpdated(patch);
-
-        reportTab.UpdatePatchDetails(patch);
 
         UpdateBackgrounds(patch);
     }
@@ -236,7 +237,7 @@ public partial class LateMulticellularEditor : EditorBase<EditorAction, Multicel
 
             reportTab.UpdateTimeIndicator(CurrentGame.GameWorld.TotalPassedTime);
 
-            reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.SelectedPatch);
+            reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.TargetPatch);
         }
 
         UpdateBackgrounds(CurrentPatch);
@@ -256,8 +257,6 @@ public partial class LateMulticellularEditor : EditorBase<EditorAction, Multicel
         {
             editorComponent.Init(this, fresh);
         }
-
-        patchMapTab.OnSelectedPatchChanged = OnSelectPatchForReportTab;
     }
 
     protected override void UpdateHistoryCallbackTargets(ActionHistory<EditorAction> actionHistory)
@@ -293,7 +292,7 @@ public partial class LateMulticellularEditor : EditorBase<EditorAction, Multicel
             reportTab.UpdateAutoEvoResults(autoEvoSummary.ToString(), autoEvoExternal.ToString());
         }
 
-        reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.SelectedPatch);
+        reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.TargetPatch);
     }
 
     protected override void OnUndoPerformed()
@@ -354,6 +353,7 @@ public partial class LateMulticellularEditor : EditorBase<EditorAction, Multicel
             {
                 reportTab.Show();
                 SetEditorObjectVisibility(false);
+                reportTab.UpdatePatchDetailsIfNeeded(SelectedPatch ?? CurrentPatch);
                 break;
             }
 
@@ -457,11 +457,6 @@ public partial class LateMulticellularEditor : EditorBase<EditorAction, Multicel
         }
 
         base.Dispose(disposing);
-    }
-
-    private void OnSelectPatchForReportTab(Patch patch)
-    {
-        reportTab.UpdatePatchDetails(patch, patch);
     }
 
     private void UpdateBackgrounds(Patch patch)

--- a/src/microbe_stage/editor/IEditorReportData.cs
+++ b/src/microbe_stage/editor/IEditorReportData.cs
@@ -3,10 +3,20 @@
 /// </summary>
 public interface IEditorReportData : IEditor
 {
+    /// <summary>
+    ///   Returns the patch the player is currently in
+    /// </summary>
     public Patch CurrentPatch { get; }
 
+    /// <summary>
+    ///   Returns the patch the player wants to move after editing. If the player doesn't want to move, returns
+    ///   the same as <see cref="CurrentPatch"/>
+    /// </summary>
     public Patch? TargetPatch { get; }
 
+    /// <summary>
+    ///   Returns the patch the player selected in the patch map
+    /// </summary>
     public Patch? SelectedPatch { get; }
 
     public void SendAutoEvoResultsToReportComponent();

--- a/src/microbe_stage/editor/IEditorReportData.cs
+++ b/src/microbe_stage/editor/IEditorReportData.cs
@@ -5,6 +5,8 @@ public interface IEditorReportData : IEditor
 {
     public Patch CurrentPatch { get; }
 
+    public Patch? TargetPatch { get; }
+
     public Patch? SelectedPatch { get; }
 
     public void SendAutoEvoResultsToReportComponent();

--- a/src/microbe_stage/editor/IEditorReportData.cs
+++ b/src/microbe_stage/editor/IEditorReportData.cs
@@ -4,13 +4,13 @@
 public interface IEditorReportData : IEditor
 {
     /// <summary>
-    ///   Returns the patch the player is currently in
+    ///   Returns the patch the player is currently in. If the player wants to move, returns the same
+    ///   as <see cref="TargetPatch"/>
     /// </summary>
     public Patch CurrentPatch { get; }
 
     /// <summary>
-    ///   Returns the patch the player wants to move after editing. If the player doesn't want to move, returns
-    ///   the same as <see cref="CurrentPatch"/>
+    ///   Returns the patch the player wants to move after editing
     /// </summary>
     public Patch? TargetPatch { get; }
 

--- a/src/microbe_stage/editor/IEditorReportData.cs
+++ b/src/microbe_stage/editor/IEditorReportData.cs
@@ -15,7 +15,7 @@ public interface IEditorReportData : IEditor
     public Patch? TargetPatch { get; }
 
     /// <summary>
-    ///   Returns the patch the player selected in the patch map
+    ///   Returns the patch the player selected in the patch map (for displaying in the GUI)
     /// </summary>
     public Patch? SelectedPatch { get; }
 

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -20,6 +20,8 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
     [Export]
     public NodePath CellEditorTabPath = null!;
 
+    private Patch? patchToUseForReport;
+
 #pragma warning disable CA2213
     [JsonProperty]
     [AssignOnlyChildItemsOnDeserialize]
@@ -103,7 +105,7 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
     {
         cellEditorTab.OnCurrentPatchUpdated(patch);
 
-        reportTab.UpdatePatchDetails(patch);
+        patchToUseForReport = patch;
 
         cellEditorTab.UpdateBackgroundImage(patch.BiomeTemplate);
     }
@@ -293,6 +295,8 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
             {
                 reportTab.Show();
                 SetEditorObjectVisibility(false);
+
+                reportTab.UpdatePatchDetailsIfNeeded(patchToUseForReport ?? patchMapTab.CurrentPatch);
                 break;
             }
 
@@ -357,6 +361,6 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
 
     private void OnSelectPatchForReportTab(Patch patch)
     {
-        reportTab.UpdatePatchDetails(patch, patch);
+        patchToUseForReport = patch;
     }
 }

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -20,8 +20,6 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
     [Export]
     public NodePath CellEditorTabPath = null!;
 
-    private Patch? patchToUseForReport;
-
 #pragma warning disable CA2213
     [JsonProperty]
     [AssignOnlyChildItemsOnDeserialize]
@@ -56,6 +54,9 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
 
     [JsonIgnore]
     public Patch CurrentPatch => patchMapTab.CurrentPatch;
+
+    [JsonIgnore]
+    public Patch? TargetPatch => patchMapTab.TargetPatch;
 
     [JsonIgnore]
     public Patch? SelectedPatch => patchMapTab.SelectedPatch;
@@ -105,8 +106,6 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
     {
         cellEditorTab.OnCurrentPatchUpdated(patch);
 
-        patchToUseForReport = patch;
-
         cellEditorTab.UpdateBackgroundImage(patch.BiomeTemplate);
     }
 
@@ -154,7 +153,7 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
 
             reportTab.UpdateTimeIndicator(CurrentGame.GameWorld.TotalPassedTime);
 
-            reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.SelectedPatch);
+            reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.TargetPatch);
         }
 
         ProceduralDataCache.Instance.OnEnterState(MainGameState.MicrobeEditor);
@@ -180,8 +179,6 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
         {
             editorComponent.Init(this, fresh);
         }
-
-        patchMapTab.OnSelectedPatchChanged = OnSelectPatchForReportTab;
     }
 
     protected override void OnEnterEditor()
@@ -234,7 +231,7 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
             reportTab.UpdateAutoEvoResults(autoEvoSummary.ToString(), autoEvoExternal.ToString());
         }
 
-        reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.SelectedPatch);
+        reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.TargetPatch);
     }
 
     protected override void ElapseEditorEntryTime()
@@ -295,8 +292,7 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
             {
                 reportTab.Show();
                 SetEditorObjectVisibility(false);
-
-                reportTab.UpdatePatchDetailsIfNeeded(patchToUseForReport ?? patchMapTab.CurrentPatch);
+                reportTab.UpdatePatchDetailsIfNeeded(SelectedPatch ?? CurrentPatch);
                 break;
             }
 
@@ -357,10 +353,5 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
 
         CurrentGame.GameWorld.UnlockProgress.UnlockAll = true;
         cellEditorTab.UnlockAllOrganelles();
-    }
-
-    private void OnSelectPatchForReportTab(Patch patch)
-    {
-        patchToUseForReport = patch;
     }
 }

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -153,7 +153,7 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
 
             reportTab.UpdateTimeIndicator(CurrentGame.GameWorld.TotalPassedTime);
 
-            reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.TargetPatch);
+            reportTab.UpdatePatchDetails(CurrentPatch, TargetPatch);
         }
 
         ProceduralDataCache.Instance.OnEnterState(MainGameState.MicrobeEditor);
@@ -231,7 +231,7 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
             reportTab.UpdateAutoEvoResults(autoEvoSummary.ToString(), autoEvoExternal.ToString());
         }
 
-        reportTab.UpdatePatchDetails(CurrentPatch, patchMapTab.TargetPatch);
+        reportTab.UpdatePatchDetails(CurrentPatch, TargetPatch);
     }
 
     protected override void ElapseEditorEntryTime()

--- a/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
+++ b/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
@@ -134,7 +134,7 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
 
     public void UpdateReportTabPatchSelector()
     {
-        var patchSelected = currentlyDisplayedPatch ?? (Editor.TargetPatch ?? Editor.CurrentPatch);
+        var patchSelected = currentlyDisplayedPatch ?? Editor.CurrentPatch;
 
         UpdateReportTabPatchName(patchSelected);
 
@@ -226,7 +226,7 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
 
     protected override void OnTranslationsChanged()
     {
-        var patchToDisplay = currentlyDisplayedPatch ?? (Editor.TargetPatch ?? Editor.CurrentPatch);
+        var patchToDisplay = currentlyDisplayedPatch ?? Editor.CurrentPatch;
 
         Editor.SendAutoEvoResultsToReportComponent();
         UpdateTimeIndicator(Editor.CurrentGame.GameWorld.TotalPassedTime);

--- a/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
+++ b/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
@@ -134,11 +134,13 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
 
     public void UpdateReportTabPatchSelector()
     {
-        UpdateReportTabPatchName(Editor.CurrentPatch);
+        var patchSelected = currentlyDisplayedPatch ?? (Editor.TargetPatch ?? Editor.CurrentPatch);
+
+        UpdateReportTabPatchName(patchSelected);
 
         reportTabPatchSelector.Clear();
 
-        foreach (var patch in Editor.CurrentPatch.GetClosestConnectedPatches())
+        foreach (var patch in patchSelected.GetClosestConnectedPatches())
         {
             if (patch.Visibility != MapElementVisibility.Shown)
                 continue;
@@ -146,7 +148,7 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
             reportTabPatchSelector.AddItem(patch.Name.ToString(), patch.ID);
         }
 
-        reportTabPatchSelector.Select(reportTabPatchSelector.GetItemIndex(Editor.CurrentPatch.ID));
+        reportTabPatchSelector.Select(reportTabPatchSelector.GetItemIndex(patchSelected.ID));
     }
 
     public void UpdatePatchDetailsIfNeeded(Patch selectedPatch)
@@ -224,12 +226,14 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
 
     protected override void OnTranslationsChanged()
     {
+        var patchToDisplay = currentlyDisplayedPatch ?? (Editor.TargetPatch ?? Editor.CurrentPatch);
+
         Editor.SendAutoEvoResultsToReportComponent();
         UpdateTimeIndicator(Editor.CurrentGame.GameWorld.TotalPassedTime);
         UpdateGlucoseReduction(Editor.CurrentGame.GameWorld.WorldSettings.GlucoseDecay);
-        UpdateTimeline(Editor.SelectedPatch);
+        UpdateTimeline(patchToDisplay);
         UpdateReportTabPatchSelector();
-        UpdateReportTabStatistics(Editor.CurrentPatch);
+        UpdateReportTabStatistics(patchToDisplay);
     }
 
     protected override void RegisterTooltips()

--- a/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
+++ b/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
@@ -86,6 +86,8 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
     [JsonProperty]
     private ReportSubtab selectedReportSubtab = ReportSubtab.AutoEvo;
 
+    private Patch? currentlyDisplayedPatch;
+
     public enum ReportSubtab
     {
         AutoEvo,
@@ -147,8 +149,18 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
         reportTabPatchSelector.Select(reportTabPatchSelector.GetItemIndex(Editor.CurrentPatch.ID));
     }
 
+    public void UpdatePatchDetailsIfNeeded(Patch selectedPatch)
+    {
+        if (currentlyDisplayedPatch == null || currentlyDisplayedPatch != selectedPatch)
+        {
+            UpdatePatchDetails(selectedPatch);
+        }
+    }
+
     public void UpdatePatchDetails(Patch currentOrSelectedPatch, Patch? selectedPatch = null)
     {
+        currentlyDisplayedPatch = currentOrSelectedPatch;
+
         selectedPatch ??= currentOrSelectedPatch;
 
         UpdateReportTabStatistics(currentOrSelectedPatch);

--- a/src/microbe_stage/editor/PatchMapEditorComponent.cs
+++ b/src/microbe_stage/editor/PatchMapEditorComponent.cs
@@ -57,8 +57,14 @@ public partial class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEdi
     [JsonIgnore]
     public Patch CurrentPatch => targetPatch ?? playerPatchOnEntry;
 
+    /// <summary>
+    ///   Returns the patch where the player wants to move after editing
+    /// </summary>
     [JsonIgnore]
-    public Patch? SelectedPatch => targetPatch;
+    public Patch? TargetPatch => targetPatch;
+
+    [JsonIgnore]
+    public Patch? SelectedPatch => mapDrawer.SelectedPatch;
 
     /// <summary>
     ///   Called when the selected patch changes


### PR DESCRIPTION
**Brief Description of What This PR Does**

Reduces lag when selecting a patch in editor's patch map. Instead of updating auto-evo report when clicking on a patch, it now does it when opening the report tab.

Additionally, does a slight refactor of patch-related editor code. `SelectedPatch` is now the patch that the player selected, while `TargetPatch` (formerly `SelectedPatch`) is the patch that the player wants to move to

Also, fixes an issue when auto-evo report would switch to the player's current patch (instead of selected patch) on language change.

**Related Issues**

No particular issue, but I think that this change leads to better UX. Clicking around the patch map will now be much more smooth.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
