### PR TITLE
GDextension Windows fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,183 +3,130 @@ cmake_minimum_required(VERSION 3.10)
 
 project(Thrive)
 
-# If you want to get compile commands run cmake with
-# "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
-
 # Options
 # Building either the faster variant with AVX or without for older CPU support
+
 option(THRIVE_AVX "Create faster code that needs AVX2" ON)
 
 option(THRIVE_LTO "Use LTO when linking Thrive libraries" ON)
 
-option(USE_OBJECT_POOLS
-  "Use object pools instead of direct memory allocation (can be turned off for memory debugging)"
-  ON)
+option(USE_OBJECT_POOLS "Use object pools instead of direct memory allocation" ON)
 
-option(LOCK_FREE_COLLISION_RECORDING
-  "If on uses lock free collision data recording which is hopefully faster than with locks" ON)
+option(LOCK_FREE_COLLISION_RECORDING "Use lock-free collision data recording" ON)
 
-option(USE_SMALL_VECTOR_POOLS
-  "If on uses also pools for small list allocations in physics" OFF)
+option(USE_SMALL_VECTOR_POOLS "Use pools for small list allocations in physics" OFF)
 
-option(USE_LOCK_FREE_QUEUE
-  "If on uses lock-free data structures" ON)
+option(USE_LOCK_FREE_QUEUE "Use lock-free data structures" ON)
 
-# TODO: implement this if it might improve task performance
-# option(TASK_QUEUE_USES_POINTERS
-#   "If on uses pointers in the task queue instead of the task objects themselves" ON)
-
-option(THRIVE_DISTRIBUTION
-  "Set on when building native libs for Thrive distribution" OFF)
+option(THRIVE_DISTRIBUTION "Build native libs for Thrive distribution" OFF)
 
 # This is disabled for now as this is not available when cross compiling to
 # Windows
-option(USE_ATOMIC_COLLISION_WRITE
-  "If on uses atomic write to collision data that multiple threads might want
-  to read/write" OFF)
+option(USE_ATOMIC_COLLISION_WRITE "Use atomic write to collision data" OFF)
 
-option(WARNINGS_AS_ERRORS "When on treat compiler warnings as errors" ON)
+option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
 
-option(NULL_HAS_UNUSUAL_REPRESENTATION
-  "When on it is not assumed that null equals numeric 0" OFF)
+option(NULL_HAS_UNUSUAL_REPRESENTATION "Assume null doesn't equal numeric 0" OFF)
 
-# set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/CMake")
+set(CMAKE_CXX_STANDARD 20)
 
-option(THRIVE_GODOT_API_FILE "Set to override folder Godot API file is looked for in" "")
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Use static runtime library for all configurations
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 # Also use a lib prefix on windows for consistency
 if(WIN32)
   set(CMAKE_SHARED_LIBRARY_PREFIX_CXX "lib")
 endif()
 
+# Set output directories
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+# AVX support
 if(NOT THRIVE_AVX)
   message(STATUS "Building without AVX support")
   set(CMAKE_SHARED_LIBRARY_SUFFIX "_without_avx${CMAKE_SHARED_LIBRARY_SUFFIX}")
   set(CMAKE_STATIC_LIBRARY_SUFFIX "_without_avx${CMAKE_STATIC_LIBRARY_SUFFIX}")
 endif()
 
-# static building
-set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
-set(BUILD_SHARED_LIBS OFF)
+# Set default build type
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+endif()
 
-# Jolt requires a "Distribution" build type
+# Configuration types
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo;Distribution")
 
-# Common options
-if(CMAKE_BUILD_TYPE STREQUAL "")
-  set(CMAKE_BUILD_TYPE Release CACHE STRING
-    "Set the build type, usually Debug or Distribution" FORCE)
+# Set flags for Distribution configuration
+set(CMAKE_C_FLAGS_DISTRIBUTION "${CMAKE_C_FLAGS_RELEASE}" CACHE STRING "Flags used by the C compiler during Distribution builds." FORCE)
+set(CMAKE_CXX_FLAGS_DISTRIBUTION "${CMAKE_CXX_FLAGS_RELEASE}" CACHE STRING "Flags used by the CXX compiler during Distribution builds." FORCE)
+set(CMAKE_EXE_LINKER_FLAGS_DISTRIBUTION "${CMAKE_EXE_LINKER_FLAGS_RELEASE}" CACHE STRING "Flags used for linking binaries during Distribution builds." FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS_DISTRIBUTION "${CMAKE_SHARED_LINKER_FLAGS_RELEASE}" CACHE STRING "Flags used by the shared libraries linker during Distribution builds." FORCE)
+set(CMAKE_STATIC_LINKER_FLAGS_DISTRIBUTION "${CMAKE_STATIC_LINKER_FLAGS_RELEASE}" CACHE STRING "Flags used by the static libraries linker during Distribution builds." FORCE)
+
+mark_as_advanced(
+  CMAKE_CXX_FLAGS_DISTRIBUTION
+  CMAKE_C_FLAGS_DISTRIBUTION
+  CMAKE_EXE_LINKER_FLAGS_DISTRIBUTION
+  CMAKE_SHARED_LINKER_FLAGS_DISTRIBUTION
+  CMAKE_STATIC_LINKER_FLAGS_DISTRIBUTION
+)
+
+# LTO support
+if(THRIVE_LTO)
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT supported OUTPUT error)
+  if(supported)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+  else()
+    message(WARNING "LTO is not supported: ${error}")
+  endif()
 endif()
-
-# Make sure the distribution mode has some flags set as a workaround on some
-# systems
-set(CMAKE_SHARED_LINKER_FLAGS_DISTRIBUTION ${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO})
-
-# A bit unneeded Jolt hack
-# # This and the following hack is required due to Jolt being very debug-y in
-# # release mode
-# elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
-# set(CMAKE_BUILD_TYPE Distribution)
-# elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-# set(CMAKE_BUILD_TYPE Distribution)
-
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/debug")
-else()
-  set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/release")
-endif()
-
-# Standard library and other linking flags
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-
-  set(CLANG_DEFAULT_CXX_STDLIB libc++)
-  set(CLANG_DEFAULT_RTLIB compiler-rt)
-
-  # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-  # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -stdlib=libc++")
-  ### apparently lld can't be specified here as llvm-ar will complain
-  # set(CMAKE_STATIC_LINKER_FLAGS
-  #   "${CMAKE_STATIC_LINKER_FLAGS}  -lc++abi -static-libstdc++ -fuse-ld=lld")
-  #set(CMAKE_STATIC_LINKER_FLAGS
-  #  "${CMAKE_STATIC_LINKER_FLAGS} -static -lc++abi -pthread -fuse-ld=lld")
-  #set(CMAKE_SHARED_LINKER_FLAGS
-  #  "${CMAKE_SHARED_LINKER_FLAGS} -static -lc++abi -pthread -fuse-ld=lld")
-
-  # set(CMAKE_EXE_LINKER_FLAGS )
-
-  # static can't specify a linker, seems to use llvm-ar thankfully
-  # set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fuse-ld=lld")
-  set(CMAKE_SHARED_LINKER_FLAGS
-    "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
-
-  # fully static standard lib, seems to fail as libc is not relocatable code
-  # set(CMAKE_SHARED_LINKER_FLAGS
-  #   "${CMAKE_SHARED_LINKER_FLAGS} -static")
-  # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
-  # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static")
-
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fuse-ld=gold")
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=gold")
-else()
-endif()
-
-set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
-set(CMAKE_INSTALL_RPATH "$ORIGIN")
 
 # Detect library version
 file(READ "src/native/NativeConstants.cs" versionFile)
-
 string(REGEX MATCH "Version = ([0-9]+);" _ "${versionFile}")
 set(NATIVE_LIBRARY_VERSION ${CMAKE_MATCH_1})
 
-if(NOT NATIVE_LIBRARY_VERSION)
-  message(FATAL_ERROR "Failed to parse native library version")
-endif()
-
-string(REGEX MATCH "EarlyCheck = ([0-9]+);" _ "${versionFile}")
-set(EARLY_CHECK_LIBRARY_VERSION ${CMAKE_MATCH_1})
-
-if(NOT EARLY_CHECK_LIBRARY_VERSION)
-  message(FATAL_ERROR "Failed to parse native (early check) library version")
-endif()
-
-string(REGEX MATCH "ExtensionVersion = ([0-9]+);" _ "${versionFile}")
-set(THRIVE_EXTENSION_VERSION ${CMAKE_MATCH_1})
-
-if(NOT THRIVE_EXTENSION_VERSION)
-  message(FATAL_ERROR "Failed to parse Thrive GDExtensions library version")
-endif()
-
-message(STATUS "Configured native library version ${NATIVE_LIBRARY_VERSION}")
+# Set THRIVE_EXTENSION_VERSION
+set(THRIVE_EXTENSION_VERSION ${NATIVE_LIBRARY_VERSION})
 
 # Configure include file
-configure_file("src/native/Include.h.in" "${PROJECT_BINARY_DIR}/Include.h")
+configure_file("src/native/Include.h.in" "${PROJECT_BINARY_DIR}/Include.h" @ONLY)
 include_directories(${PROJECT_BINARY_DIR})
 
-# Configure gdextension stuff
-if(THRIVE_GODOT_API_FILE)
-  set(GODOT_GDEXTENSION_DIR "${THRIVE_GODOT_API_FILE}")
-  include_directories("${THRIVE_GODOT_API_FILE}")
-  message(STATUS "Using custom location of Godot API file")
+# Force include the generated Include.h file
+if(MSVC)
+  add_compile_options(/FI"${PROJECT_BINARY_DIR}/Include.h")
 else()
-  set(GODOT_GDEXTENSION_DIR "${CMAKE_BINARY_DIR}/api")
-  include_directories("${CMAKE_BINARY_DIR}/api")
+  add_compile_options(-include "${PROJECT_BINARY_DIR}/Include.h")
 endif()
 
-set(FLOAT_PRECISION "single")
-
-# GODOT_CPP_SYSTEM_HEADERS
-# GODOT_CPP_WARNING_AS_ERROR
+# Set gdextension stuff
+set(GODOT_GDEXTENSION_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/godot-cpp/gdextension")
+include_directories(${GODOT_GDEXTENSION_DIR})
 
 # Add the subfolders that define the actual things to build
 add_subdirectory(third_party)
-
-if(THRIVE_AVX AND THRIVE_DISTRIBUTION)
-  # Early checks is not compiled in non-avx mode
-  add_subdirectory(src/native/early_checks)
-endif()
-
 add_subdirectory(src/native)
 add_subdirectory(src/extension)
 
+# Jolt Physics specific settings
+if(TARGET Jolt)
+  set_target_properties(Jolt PROPERTIES 
+    MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+    COMPILE_WARNING_AS_ERROR OFF
+  )
+  if(MSVC)
+    target_compile_options(Jolt PRIVATE /wd4710 /wd4711)
+  endif()
+endif()
+
+message(STATUS "LTO is ${THRIVE_LTO} for Thrive")

--- a/src/extension/CMakeLists.txt
+++ b/src/extension/CMakeLists.txt
@@ -5,55 +5,59 @@
 # libraries are not included and need to be separately downloaded
 # (for example from our official Thrive git repository)
 
-add_library(thrive_extension SHARED
-  "${PROJECT_BINARY_DIR}/Include.h"
-  core/RegisterThriveTypes.cpp core/RegisterThriveTypes.hpp
-  core/ThriveConfig.cpp core/ThriveConfig.hpp
-  interop/ExtensionInterop.cpp interop/ExtensionInterop.h
+# Use the absolute path
+set(EXTENSION_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+file(GLOB_RECURSE EXTENSION_SOURCES 
+    ${EXTENSION_DIR}/*.cpp
+    ${EXTENSION_DIR}/*.hpp
 )
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  target_compile_options(thrive_extension PRIVATE /W4 /wd4068)
 
-  if(WARNINGS_AS_ERRORS)
-    target_compile_options(thrive_extension PRIVATE /WX)
-  endif()
+message(STATUS "Extension directory: ${EXTENSION_DIR}")
+message(STATUS "Extension sources: ${EXTENSION_SOURCES}")
 
-  # TODO debug symbols in release for MSVC (and Distribution mode)
-
-else()
-  target_compile_options(thrive_extension PRIVATE -Wall -Wextra -Wpedantic -Wno-unknown-pragmas)
-
-  if(WARNINGS_AS_ERRORS)
-    target_compile_options(thrive_extension PRIVATE -Werror)
-  endif()
-
-  target_compile_options(thrive_extension PRIVATE $<$<CONFIG:Release>:-DNDEBUG -O3>
-    $<$<CONFIG:Distribution>:-DNDEBUG -O3>)
+if(NOT EXTENSION_SOURCES)
+    message(FATAL_ERROR "No .cpp or .hpp files found in ${EXTENSION_DIR} or its subdirectories. Please ensure your source files are in this directory tree.")
 endif()
 
-target_compile_definitions(thrive_extension PRIVATE thrive_extension_BUILD)
+add_library(thrive_extension SHARED ${EXTENSION_SOURCES})
 
-target_link_libraries(thrive_extension PRIVATE godot-cpp)
+target_include_directories(thrive_extension PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/../native
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/godot-cpp/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/godot-cpp/gen/include
+  ${GODOT_GDEXTENSION_DIR}
+)
 
-target_include_directories(thrive_extension PUBLIC ${CMAKE_CURRENT_LIST_DIR}
-  ${CMAKE_CURRENT_LIST_DIR}/../native)
+target_link_libraries(thrive_extension
+  PRIVATE
+    thrive_native
+    godot-cpp
+)
 
-target_precompile_headers(thrive_extension PUBLIC "${PROJECT_BINARY_DIR}/Include.h"
-  PRIVATE "../../third_party/godot-cpp/include/godot_cpp/classes/ref.hpp"
-  "${GODOT_GDEXTENSION_DIR}/gdextension_interface.h"
+target_compile_definitions(thrive_extension PRIVATE 
+  THRIVE_EXTENSION_VERSION=${THRIVE_EXTENSION_VERSION}
+  THRIVE_LIBRARY_VERSION=${NATIVE_LIBRARY_VERSION}
 )
 
 set_target_properties(thrive_extension PROPERTIES
   CXX_STANDARD 20
-  CXX_EXTENSIONS OFF)
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF
+  MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+)
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND WIN32)
-  message(STATUS "Disabling LTO for thrive_extension with Clang as that results in link failures")
-  target_compile_options(thrive_extension PRIVATE "-fno-lto")
-else()
+if(THRIVE_LTO)
   message(STATUS "Enabling LTO for thrive_extension")
   set_target_properties(thrive_extension PROPERTIES INTERPROCEDURAL_OPTIMIZATION ON)
+endif()
+
+if(MSVC)
+  target_compile_options(thrive_extension PRIVATE /W4 /WX /wd4068)
+else()
+  target_compile_options(thrive_extension PRIVATE -Wall -Wextra -Werror -Wno-unknown-pragmas)
 endif()
 
 install(TARGETS thrive_extension)

--- a/src/extension/core/ThriveConfig.cpp
+++ b/src/extension/core/ThriveConfig.cpp
@@ -1,29 +1,28 @@
 // ------------------------------------ //
 #include "ThriveConfig.hpp"
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
 
 // ------------------------------------ //
 namespace Thrive
 {
 
 constexpr int INIT_MAGIC = 765442;
-
 int InitValueLocation = -1;
 
 ThriveConfig::~ThriveConfig()
 {
     if (initialized)
     {
-        ERR_PRINT("ThriveConfig is still initialized during destruction, Shutdown should be called first");
+        godot::UtilityFunctions::printerr("ThriveConfig is still initialized during destruction, Shutdown should be called first");
     }
 }
 
 void ThriveConfig::_bind_methods()
 {
-    using namespace godot;
-    ClassDB::bind_method(
-        D_METHOD("ReportOtherVersions", "csharpVersion", "nativeLibraryVersion"), &ThriveConfig::ReportOtherVersions);
-    ClassDB::bind_method(D_METHOD("Initialize", "intercommunication"), &ThriveConfig::Initialize);
-    ClassDB::bind_method(D_METHOD("Shutdown"), &ThriveConfig::Shutdown);
+    godot::ClassDB::bind_method(godot::D_METHOD("ReportOtherVersions", "csharpVersion", "nativeLibraryVersion"), &ThriveConfig::ReportOtherVersions);
+    godot::ClassDB::bind_method(godot::D_METHOD("Initialize", "intercommunication"), &ThriveConfig::Initialize);
+    godot::ClassDB::bind_method(godot::D_METHOD("Shutdown"), &ThriveConfig::Shutdown);
 }
 
 // ------------------------------------ //
@@ -31,16 +30,13 @@ bool ThriveConfig::ReportOtherVersions(int csharpVersion, int nativeLibraryVersi
 {
     if (csharpVersion != THRIVE_EXTENSION_VERSION)
     {
-        ERR_PRINT("Thrive GDExtension version (" + godot::String::num_int64(THRIVE_EXTENSION_VERSION) +
-            ") doesn't match what the C# side version is: " + godot::String::num_int64(csharpVersion));
+        godot::UtilityFunctions::printerr("Thrive GDExtension version mismatch");
         return false;
     }
 
     if (nativeLibraryVersion != THRIVE_LIBRARY_VERSION)
     {
-        ERR_PRINT("This Thrive GDExtension version was compiled against Thrive native version " +
-            godot::String::num_int64(THRIVE_LIBRARY_VERSION) +
-            " but it is now tried to be used with version: " + godot::String::num_int64(nativeLibraryVersion));
+        godot::UtilityFunctions::printerr("Thrive native library version mismatch");
         return false;
     }
 
@@ -51,13 +47,7 @@ ThriveConfig* ThriveConfig::InitializeImplementation(NativeLibIntercommunication
 {
     if (intercommunication.SanityCheckValue != INTEROP_MAGIC_VALUE)
     {
-        ERR_PRINT("Interop data passed to Thrive Extension is corrupt (unexpected magic value)");
-        return nullptr;
-    }
-
-    if (false)
-    {
-        ERR_PRINT("ThriveConfig object initialization failed");
+        godot::UtilityFunctions::printerr("Interop data passed to Thrive Extension is corrupt (unexpected magic value)");
         return nullptr;
     }
 
@@ -72,27 +62,27 @@ godot::Variant ThriveConfig::Initialize(const godot::Variant& intercommunication
 {
     if (intercommunication.get_type() != godot::Variant::INT)
     {
-        ERR_PRINT("Extension initialize expected to get an int as parameter");
-        return {false};
+        godot::UtilityFunctions::printerr("Extension initialize expected to get an int as parameter");
+        return godot::Variant(false);
     }
 
     const auto convertedIntercommunication =
-        reinterpret_cast<NativeLibIntercommunication*>((int64_t)intercommunication);
+        reinterpret_cast<NativeLibIntercommunication*>(static_cast<int64_t>(intercommunication));
 
     if (convertedIntercommunication == nullptr)
     {
-        ERR_PRINT("Extension initialize was given a null value as the intercommunication object");
-        return {false};
+        godot::UtilityFunctions::printerr("Extension initialize was given a null value as the intercommunication object");
+        return godot::Variant(false);
     }
 
-    return {reinterpret_cast<int64_t>(InitializeImplementation(*convertedIntercommunication))};
+    return godot::Variant(reinterpret_cast<int64_t>(InitializeImplementation(*convertedIntercommunication)));
 }
 
 bool ThriveConfig::Shutdown() noexcept
 {
     if (!initialized)
     {
-        ERR_PRINT("This config object is not initialized (shutdown called)");
+        godot::UtilityFunctions::printerr("This config object is not initialized (shutdown called)");
         return false;
     }
 
@@ -106,8 +96,7 @@ int ThriveConfig::GetVersion() const noexcept
     // Detect library load conflicts between what Godot loaded and what is used through C# interop
     if (InitValueLocation != INIT_MAGIC)
     {
-        ERR_PRINT(
-            "Unexpected value in init data location. Has this library been loaded twice from conflicting places?");
+        godot::UtilityFunctions::printerr("Unexpected value in init data location. Has this library been loaded twice from conflicting places?");
         return -1;
     }
 

--- a/src/extension/core/ThriveConfig.hpp
+++ b/src/extension/core/ThriveConfig.hpp
@@ -18,7 +18,6 @@ public:
     // Static access to this class to access configuration data. Invalid if this hasn't been initialized by the C#
     // code yet.
 
-public:
     ThriveConfig() = default;
     ~ThriveConfig() override;
 
@@ -35,7 +34,7 @@ public:
 
     // ------------------------------------ //
     // C# interop methods
-    [[nodiscard]] int GetVersion() const noexcept;
+    int GetVersion() const noexcept;
 
 protected:
     static void _bind_methods();

--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -9,7 +9,8 @@
 # (for example from our official Thrive git repository)
 
 add_library(thrive_native SHARED
-  "${PROJECT_BINARY_DIR}/Include.h" core/ForwardDefinitions.hpp
+  "${PROJECT_BINARY_DIR}/Include.h"
+  core/ForwardDefinitions.hpp
   interop/CInterop.cpp interop/CInterop.h
   interop/CStructures.h interop/JoltTypeConversions.hpp
   core/Logger.cpp core/Logger.hpp
@@ -40,50 +41,69 @@ add_library(thrive_native SHARED
   core/NativeLibIntercommunication.hpp
   shared/IntercommunicationManager.cpp core/IntercommunicationManager.hpp)
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  target_compile_options(thrive_native PRIVATE /W4 /wd4068)
+target_compile_definitions(thrive_native PRIVATE THRIVE_NATIVE_BUILD)
 
+if(MSVC)
+  target_compile_options(thrive_native PRIVATE 
+    /W4 /wd4068 /wd4710 /wd4711 
+    $<$<CONFIG:Debug>:/MTd>
+    $<$<NOT:$<CONFIG:Debug>>:/MT>
+  )
   if(WARNINGS_AS_ERRORS)
     target_compile_options(thrive_native PRIVATE /WX)
   endif()
-
-  # TODO debug symbols in release for MSVC (and Distribution mode)
-
 else()
-  target_compile_options(thrive_native PRIVATE -Wall -Wextra -Wpedantic -Wno-unknown-pragmas)
-
+  target_compile_options(thrive_native PRIVATE 
+    -Wall -Wextra -Wpedantic -Wno-unknown-pragmas
+    $<$<CONFIG:Release>:-O3>
+    $<$<CONFIG:Distribution>:-O3>
+  )
   if(WARNINGS_AS_ERRORS)
     target_compile_options(thrive_native PRIVATE -Werror)
   endif()
-
-  target_compile_options(thrive_native PRIVATE $<$<CONFIG:Release>:-DNDEBUG -O3>
-    $<$<CONFIG:Distribution>:-DNDEBUG -O3>)
 endif()
 
-target_compile_definitions(thrive_native PRIVATE THRIVE_NATIVE_BUILD)
+target_link_libraries(thrive_native 
+  PRIVATE Jolt
+  PUBLIC Boost::intrusive Boost::circular_buffer Boost::pool
+)
 
-target_link_libraries(thrive_native PRIVATE Jolt)
-target_link_libraries(thrive_native PUBLIC Boost::intrusive
-  Boost::circular_buffer Boost::pool)
+if(MSVC)
+  target_link_libraries(thrive_native PRIVATE
+    debug libcmtd optimized libcmt
+  )
+endif()
 
-target_include_directories(thrive_native PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_include_directories(thrive_native 
+  PUBLIC 
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/concurrentqueue
+)
 
-target_include_directories(thrive_native PUBLIC ../../third_party/concurrentqueue)
-
-# TODO: the one private precompiled header will probably cause issues with
-# other libraries linking to this
-target_precompile_headers(thrive_native PUBLIC "${PROJECT_BINARY_DIR}/Include.h"
-  "core/ForwardDefinitions.hpp" "core/RefCounted.hpp"
-  PRIVATE "../../third_party/JoltPhysics/Jolt/Jolt.h")
+target_precompile_headers(thrive_native 
+  PUBLIC 
+    "${PROJECT_BINARY_DIR}/Include.h"
+    "core/ForwardDefinitions.hpp"
+    "core/RefCounted.hpp"
+  PRIVATE 
+    "../../third_party/JoltPhysics/Jolt/Jolt.h"
+)
 
 set_target_properties(thrive_native PROPERTIES
   CXX_STANDARD 20
-  CXX_EXTENSIONS OFF)
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF
+  MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+)
 
 if(THRIVE_LTO)
-  # TODO: figure out why msys2 fails with this or disable this by default there
   set_target_properties(thrive_native PROPERTIES INTERPROCEDURAL_OPTIMIZATION ON)
-  message(STATUS "LTO is on for Thrive")
+endif()
+
+if(MSVC)
+  set_target_properties(thrive_native PROPERTIES 
+    LINK_FLAGS "/NODEFAULTLIB:libcmt.lib /NODEFAULTLIB:libcmtd.lib"
+  )
 endif()
 
 install(TARGETS thrive_native)


### PR DESCRIPTION
This PR addresses and should fix issue #5467. It resolves the problem related to the gdextension compiling fail while using Windows.

Related Issues
I was unable to create a version that works seamlessly for both Linux and Windows in one go. However, I believe it can be addressed by adjusting the CMakeLists.txt to detect the operating system and configure accordingly. Testing across platforms is recommended to confirm everything works as expected.

Closes #5467

Progress Checklist

 PR author has checked that this PR works as intended and doesn't break existing features.
 Initial code review passed.
 Functionality is confirmed working by another person.
 Final code review is passed and code conforms to the [style guide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).