### PR TITLE
Fix membrane dissolve effect

### DIFF
--- a/shaders/Membrane.gdshader
+++ b/shaders/Membrane.gdshader
@@ -65,6 +65,6 @@ void fragment(){
     adjusted_normals = normalize(mix(NORMAL, adjusted_normals, 1.0));
 
     ALBEDO = final.rgb;
-    ALPHA = fresnel(3.0, adjusted_normals, adjusted_view);
+    ALPHA = fresnel(3.0, adjusted_normals, adjusted_view) * round(cutoff);
     ROUGHNESS = 0.7;
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

When making changes to the membrane shader, I accidentally removed the alpha cutoff multiplier, breaking membranes' dissolve effect. This PR re-adds the alpha cutoff, restoring that effect.

**Related Issues**

—

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
