### PR TITLE
Fix tooltips for the new graphical auto-evo buttons

### DIFF
--- a/src/microbe_stage/editor/SpeciesResultButton.cs
+++ b/src/microbe_stage/editor/SpeciesResultButton.cs
@@ -145,6 +145,7 @@ public partial class SpeciesResultButton : Button
         var tooltip = ToolTipManager.Instance.GetToolTip<SpeciesPreviewTooltip>("speciesPreview");
         if (tooltip != null && ToolTipManager.Instance.MainToolTip == tooltip)
         {
+            ToolTipManager.Instance.MainToolTip = null;
             ToolTipManager.Instance.Display = false;
         }
     }

--- a/src/microbe_stage/editor/SpeciesResultButton.cs
+++ b/src/microbe_stage/editor/SpeciesResultButton.cs
@@ -143,7 +143,8 @@ public partial class SpeciesResultButton : Button
     private void OnMouseExit()
     {
         var tooltip = ToolTipManager.Instance.GetToolTip<SpeciesPreviewTooltip>("speciesPreview");
-        if (tooltip != null && ToolTipManager.Instance.MainToolTip == tooltip)
+        if (tooltip != null && ToolTipManager.Instance.MainToolTip == tooltip &&
+            tooltip.PreviewSpecies == shownForSpecies)
         {
             ToolTipManager.Instance.MainToolTip = null;
             ToolTipManager.Instance.Display = false;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes the new auto-evo buttons' species preview tooltips behaving weirdly.

**Related Issues**

Fixes #5523

Based on my testing, it wasn't an engine issue. Rather, it happened because `TooltipManager` only hides 'previous' tooltips, while the species tooltip sometimes didn't become a 'previous' tooltip, causing it to not be hidden.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
