### PR TITLE
Count and print how much total time the save upgrader took

### DIFF
--- a/src/saving/SaveUpgrader.cs
+++ b/src/saving/SaveUpgrader.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Diagnostics;
 using Godot;
 using Saving;
+using SharedBase.ModelVerifiers;
 
 /// <summary>
 ///   Allows upgrading older saves to newer versions when there are save upgrade actions programmed
@@ -36,6 +38,9 @@ public static class SaveUpgrader
     public static void PerformSaveUpgrade(SaveInformation saveInfo, string inputSave, bool backup = true,
         string? targetVersion = null)
     {
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+
         targetVersion ??= Constants.Version;
 
         if (saveInfo.ThriveVersion == targetVersion)
@@ -100,6 +105,9 @@ public static class SaveUpgrader
             // After the first step the target save is upgraded in-place so we need to overwrite the old source
             fromSave = toSave;
         }
+
+        stopwatch.Stop();
+        GD.Print($"Save upgrade took in total: {stopwatch.Elapsed}");
     }
 
     public static bool IsSaveABackup(string saveName)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Count how much total time the save upgrader took with [System.Diagnostics.Stopwatch](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.stopwatch?view=net-8.0), then print it.

This is a draft PR because I can't seem to test this as there isn't a save upgrader to 0.7.1. 

**Related Issues**

Closes #2682

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
