### PR TITLE
Create a photostudio priority system

### DIFF
--- a/src/early_multicellular_stage/CellBillboard.cs
+++ b/src/early_multicellular_stage/CellBillboard.cs
@@ -12,6 +12,12 @@ using Godot;
 /// </remarks>
 public partial class CellBillboard : Node3D
 {
+    /// <summary>
+    ///   The priority that the generated image tasks will have. The lower the number, the higher the priority.
+    /// </summary>
+    [Export]
+    public int Priority = 1;
+
     private int displayedHash;
 
     private ICellDefinition? displayedCell;
@@ -151,7 +157,7 @@ public partial class CellBillboard : Node3D
         displayedHash = displayedCell.GetVisualHashCode();
 
         // TODO: caching image tasks with the hash code
-        imageTask = new ImageTask(displayedCell);
+        imageTask = new ImageTask(displayedCell, priority: Priority);
 
         PhotoStudio.Instance.SubmitTask(imageTask);
 

--- a/src/engine/ImageTask.cs
+++ b/src/engine/ImageTask.cs
@@ -6,6 +6,9 @@ using Godot;
 /// </summary>
 public class ImageTask
 {
+    /// <summary>
+    ///   This task's priority. The lower the number, the higher the priority.
+    /// </summary>
     public readonly int Priority = 1;
 
     private readonly bool storePlainImage;

--- a/src/engine/ImageTask.cs
+++ b/src/engine/ImageTask.cs
@@ -9,7 +9,7 @@ public class ImageTask
     /// <summary>
     ///   This task's priority. The lower the number, the higher the priority.
     /// </summary>
-    public readonly int Priority = 1;
+    public readonly int Priority;
 
     private readonly bool storePlainImage;
 

--- a/src/engine/ImageTask.cs
+++ b/src/engine/ImageTask.cs
@@ -6,20 +6,24 @@ using Godot;
 /// </summary>
 public class ImageTask
 {
+    public readonly int Priority = 1;
+
     private readonly bool storePlainImage;
 
     private ImageTexture? finalImage;
     private Image? plainImage;
 
-    public ImageTask(IScenePhotographable photographable, bool storePlainImage = false)
+    public ImageTask(IScenePhotographable photographable, bool storePlainImage = false, int priority = 1)
     {
         this.storePlainImage = storePlainImage;
+        Priority = priority;
         ScenePhotographable = photographable;
     }
 
-    public ImageTask(ISimulationPhotographable photographable, bool storePlainImage = false)
+    public ImageTask(ISimulationPhotographable photographable, bool storePlainImage = false, int priority = 1)
     {
         this.storePlainImage = storePlainImage;
+        Priority = priority;
         SimulationPhotographable = photographable;
     }
 

--- a/src/engine/PhotoStudio.cs
+++ b/src/engine/PhotoStudio.cs
@@ -469,7 +469,13 @@ public partial class PhotoStudio : SubViewport
     {
         public int Compare((int, int) x, (int, int) y)
         {
-            return x.CompareTo(y);
+            if (x.Item1 < y.Item1)
+                return -1;
+
+            if (x.Item1 > y.Item1)
+                return 1;
+
+            return x.Item2.CompareTo(y.Item2);
         }
     }
 }

--- a/src/engine/PhotoStudio.cs
+++ b/src/engine/PhotoStudio.cs
@@ -39,7 +39,7 @@ public partial class PhotoStudio : SubViewport
     private readonly Dictionary<ISimulationPhotographable.SimulationType, IWorldSimulation> worldSimulations = new();
     private readonly Dictionary<IWorldSimulation, Node3D> simulationWorldRoots = new();
 
-    private readonly PriorityQueue<ImageTask, (int Priority, int Index)> tasks = new();
+    private readonly PriorityQueue<ImageTask, (int Priority, int Index)> tasks = new(new TaskComparer());
     private ImageTask? currentTask;
     private Step currentTaskStep = Step.NoTask;
 
@@ -463,5 +463,13 @@ public partial class PhotoStudio : SubViewport
         simulationWorldRoots[worldSimulation] = node;
 
         return node;
+    }
+
+    private class TaskComparer : IComparer<(int, int)>
+    {
+        public int Compare((int, int) x, (int, int) y)
+        {
+            return x.CompareTo(y);
+        }
     }
 }

--- a/src/engine/PhotoStudio.cs
+++ b/src/engine/PhotoStudio.cs
@@ -45,7 +45,7 @@ public partial class PhotoStudio : SubViewport
 
     /// <summary>
     ///   <see cref="PriorityQueue{TElement, TPriority}"/> doesn't guarantee the first-in-first-out order.
-    ///   This offset makes up for that, being increased for each consecutive image task.
+    ///   This index offset makes up for that, being increased for each consecutive image task.
     /// </summary>
     private int lastTaskIndex;
 

--- a/src/engine/PhotoStudio.cs
+++ b/src/engine/PhotoStudio.cs
@@ -47,7 +47,7 @@ public partial class PhotoStudio : SubViewport
     ///   <see cref="PriorityQueue{TElement, TPriority}"/> doesn't guarantee the first-in-first-out order.
     ///   This offset makes up for that, being increased for each consecutive image task.
     /// </summary>
-    private int taskPriorityOffset = 0;
+    private int taskPriorityOffset;
 
     private bool waitingForBackgroundOperation;
 

--- a/src/engine/PhotoStudio.cs
+++ b/src/engine/PhotoStudio.cs
@@ -39,7 +39,7 @@ public partial class PhotoStudio : SubViewport
     private readonly Dictionary<ISimulationPhotographable.SimulationType, IWorldSimulation> worldSimulations = new();
     private readonly Dictionary<IWorldSimulation, Node3D> simulationWorldRoots = new();
 
-    private readonly PriorityQueue<ImageTask, int> tasks = new();
+    private readonly PriorityQueue<ImageTask, (int Priority, int Index)> tasks = new();
     private ImageTask? currentTask;
     private Step currentTaskStep = Step.NoTask;
 
@@ -47,7 +47,7 @@ public partial class PhotoStudio : SubViewport
     ///   <see cref="PriorityQueue{TElement, TPriority}"/> doesn't guarantee the first-in-first-out order.
     ///   This offset makes up for that, being increased for each consecutive image task.
     /// </summary>
-    private int taskPriorityOffset;
+    private int lastTaskIndex;
 
     private bool waitingForBackgroundOperation;
 
@@ -148,7 +148,7 @@ public partial class PhotoStudio : SubViewport
                 if (tasks.Count == 0)
                 {
                     // Ensuring that the offset doesn't reach int.MaxValue
-                    taskPriorityOffset = 0;
+                    lastTaskIndex = 0;
                 }
             }
         }
@@ -355,8 +355,8 @@ public partial class PhotoStudio : SubViewport
     /// <param name="task">The task to queue and run as soon as possible</param>
     public void SubmitTask(ImageTask task)
     {
-        tasks.Enqueue(task, task.Priority + taskPriorityOffset);
-        ++taskPriorityOffset;
+        tasks.Enqueue(task, (task.Priority, lastTaskIndex));
+        ++lastTaskIndex;
     }
 
     protected override void Dispose(bool disposing)

--- a/src/engine/PhotoStudio.cs
+++ b/src/engine/PhotoStudio.cs
@@ -44,8 +44,8 @@ public partial class PhotoStudio : SubViewport
     private Step currentTaskStep = Step.NoTask;
 
     /// <summary>
-    ///   <see cref="PriorityQueue{TElement, TPriority}"/> doesn't guarantee the first-in-first-out order,
-    ///   so a task priority offset has to be made to make up for that.
+    ///   <see cref="PriorityQueue{TElement, TPriority}"/> doesn't guarantee the first-in-first-out order.
+    ///   This offset makes up for that, being increased for each consecutive image task.
     /// </summary>
     private int taskPriorityOffset = 0;
 

--- a/src/engine/PhotoStudio.cs
+++ b/src/engine/PhotoStudio.cs
@@ -147,7 +147,7 @@ public partial class PhotoStudio : SubViewport
 
                 if (tasks.Count == 0)
                 {
-                    // Ensuring that the offset doesn't reach int.MinValue
+                    // Ensuring that the offset doesn't reach int.MaxValue
                     taskPriorityOffset = 0;
                 }
             }

--- a/src/engine/PhotoStudio.cs
+++ b/src/engine/PhotoStudio.cs
@@ -39,7 +39,7 @@ public partial class PhotoStudio : SubViewport
     private readonly Dictionary<ISimulationPhotographable.SimulationType, IWorldSimulation> worldSimulations = new();
     private readonly Dictionary<IWorldSimulation, Node3D> simulationWorldRoots = new();
 
-    private readonly Queue<ImageTask> tasks = new();
+    private readonly PriorityQueue<ImageTask, int> tasks = new();
     private ImageTask? currentTask;
     private Step currentTaskStep = Step.NoTask;
 
@@ -343,7 +343,7 @@ public partial class PhotoStudio : SubViewport
     /// <param name="task">The task to queue and run as soon as possible</param>
     public void SubmitTask(ImageTask task)
     {
-        tasks.Enqueue(task);
+        tasks.Enqueue(task, task.Priority);
     }
 
     protected override void Dispose(bool disposing)

--- a/src/gui_common/PhotographablePreview.cs
+++ b/src/gui_common/PhotographablePreview.cs
@@ -25,6 +25,12 @@ public partial class PhotographablePreview : Control
     [Export]
     public bool KeepPlainImageInMemory;
 
+    /// <summary>
+    ///   The priority that the generated image tasks will have. The lower the number, the higher the priority.
+    /// </summary>
+    [Export]
+    public int Priority = 1;
+
 #pragma warning disable CA2213
     [Export]
     private TextureRect textureRect = null!;

--- a/src/gui_common/SpeciesPreview.cs
+++ b/src/gui_common/SpeciesPreview.cs
@@ -26,7 +26,7 @@ public partial class SpeciesPreview : PhotographablePreview
     {
         if (previewSpecies is MicrobeSpecies microbeSpecies)
         {
-            return new ImageTask(microbeSpecies, KeepPlainImageInMemory);
+            return new ImageTask(microbeSpecies, KeepPlainImageInMemory, Priority);
         }
 
         GD.PrintErr("Unknown species type to preview: ", previewSpecies);

--- a/src/microbe_stage/CellHexesPreview.cs
+++ b/src/microbe_stage/CellHexesPreview.cs
@@ -20,6 +20,6 @@ public partial class CellHexesPreview : PhotographablePreview
 
     protected override ImageTask SetupImageTask()
     {
-        return new ImageTask(new CellHexesPhotoBuilder { Species = microbeSpecies }, KeepPlainImageInMemory);
+        return new ImageTask(new CellHexesPhotoBuilder { Species = microbeSpecies }, KeepPlainImageInMemory, Priority);
     }
 }

--- a/src/microbe_stage/editor/SpeciesResultButton.tscn
+++ b/src/microbe_stage/editor/SpeciesResultButton.tscn
@@ -54,6 +54,7 @@ layout_mode = 2
 layout_mode = 2
 mouse_filter = 2
 script = ExtResource("4_6vevb")
+Priority = 5
 
 [node name="PartiallyExtinctIndicator" type="TextureRect" parent="VBoxContainer/MainContent/PhotographablePreview"]
 modulate = Color(1, 0.187455, 0, 1)

--- a/src/microbe_stage/editor/SpeciesResultButton.tscn
+++ b/src/microbe_stage/editor/SpeciesResultButton.tscn
@@ -54,7 +54,7 @@ layout_mode = 2
 layout_mode = 2
 mouse_filter = 2
 script = ExtResource("4_6vevb")
-Priority = 5
+Priority = 50
 
 [node name="PartiallyExtinctIndicator" type="TextureRect" parent="VBoxContainer/MainContent/PhotographablePreview"]
 modulate = Color(1, 0.187455, 0, 1)

--- a/src/microbe_stage/editor/tooltips/SpeciesPreviewTooltip.tscn
+++ b/src/microbe_stage/editor/tooltips/SpeciesPreviewTooltip.tscn
@@ -40,8 +40,10 @@ mouse_filter = 2
 layout_mode = 2
 mouse_filter = 2
 script = ExtResource("4")
+Priority = -1
 
 [node name="CellHexPreview" parent="HBoxContainer" instance=ExtResource("2")]
 layout_mode = 2
 mouse_filter = 2
 script = ExtResource("3")
+Priority = -1

--- a/src/microbe_stage/editor/tooltips/SpeciesPreviewTooltip.tscn
+++ b/src/microbe_stage/editor/tooltips/SpeciesPreviewTooltip.tscn
@@ -40,10 +40,10 @@ mouse_filter = 2
 layout_mode = 2
 mouse_filter = 2
 script = ExtResource("4")
-Priority = -1
+Priority = -100
 
 [node name="CellHexPreview" parent="HBoxContainer" instance=ExtResource("2")]
 layout_mode = 2
 mouse_filter = 2
 script = ExtResource("3")
-Priority = -1
+Priority = -100


### PR DESCRIPTION
**Brief Description of What This PR Does**

Changes photostudio's task queue to be a priority queue and adds priorities to image photographing tasks.

Currently, the priorities are in that order:
Tooltips > Early multicellular billboards > Cell preview buttons in the auto-evo report

**Related Issues**

Closes #5526

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
