### PR TITLE
Food chain related miche data saving and loading

### DIFF
--- a/src/auto-evo/Miche.cs
+++ b/src/auto-evo/Miche.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 /// <summary>
 ///   A node for the Miche Tree
@@ -15,10 +16,24 @@ using System.Linq;
 ///     For a fuller explanation see docs/auto_evo.md
 ///   </para>
 /// </remarks>
+/// <remarks>
+///   <para>
+///     This is partially saved to be able to display info about the auto-evo run in the editor after loading a save.
+///     This has to be a reference to work with the parent miche reference. This uses Thrive serializer as the fields
+///     can already refer back to this object.
+///   </para>
+/// </remarks>
+[JsonObject(IsReference = true)]
+[UseThriveSerializer]
 public class Miche
 {
+    [JsonProperty]
     public readonly SelectionPressure Pressure;
+
+    [JsonProperty]
     public readonly List<Miche> Children = new();
+
+    [JsonProperty]
     public Miche? Parent;
 
     /// <summary>
@@ -29,6 +44,7 @@ public class Miche
     ///     Occupant should always be null if this Miche is not a leaf node (children is not empty).
     ///   </para>
     /// </remarks>
+    [JsonProperty]
     public Species? Occupant;
 
     public Miche(SelectionPressure pressure)

--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -35,6 +35,12 @@ public class RunResults
     // afterwards when loading from a save
     private readonly List<PossibleSpecies> modifiedSpecies = new();
 
+    /// <summary>
+    ///   Miche tree generated for this auto-evo run. This is partially saved (some subobjects are excluded) so that
+    ///   food chain tab information can be displayed after loading a save.
+    /// </summary>
+    [JsonProperty]
+    [JsonConverter(typeof(DictionaryWithJSONKeysConverter<Patch, Miche>))]
     private readonly Dictionary<Patch, Miche> micheByPatch = new();
 
     public enum NewSpeciesType

--- a/src/auto-evo/mutation_strategy/IMutationStrategy.cs
+++ b/src/auto-evo/mutation_strategy/IMutationStrategy.cs
@@ -2,10 +2,12 @@
 
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 public interface IMutationStrategy<T>
     where T : Species
 {
+    [JsonIgnore]
     public bool Repeatable { get; }
 
     /// <summary>

--- a/src/auto-evo/selection_pressure/AvoidPredationSelectionPressure.cs
+++ b/src/auto-evo/selection_pressure/AvoidPredationSelectionPressure.cs
@@ -1,7 +1,11 @@
 ﻿namespace AutoEvo;
 
+using Newtonsoft.Json;
+
+[JSONDynamicTypeAllowed]
 public class AvoidPredationSelectionPressure : SelectionPressure
 {
+    [JsonProperty]
     public readonly Species Predator;
 
     // Needed for translation extraction
@@ -29,6 +33,7 @@ public class AvoidPredationSelectionPressure : SelectionPressure
         Predator = predator;
     }
 
+    [JsonIgnore]
     public override LocalizedString Name => NameString;
 
     public override float Score(Species species, Patch patch, SimulationCache cache)

--- a/src/auto-evo/selection_pressure/ChunkCompoundPressure.cs
+++ b/src/auto-evo/selection_pressure/ChunkCompoundPressure.cs
@@ -1,7 +1,9 @@
 ﻿namespace AutoEvo;
 
 using System;
+using Newtonsoft.Json;
 
+[JSONDynamicTypeAllowed]
 public class ChunkCompoundPressure : SelectionPressure
 {
     // Needed for translation extraction
@@ -12,18 +14,28 @@ public class ChunkCompoundPressure : SelectionPressure
 
     private readonly CompoundDefinition atp = SimulationParameters.GetCompound(Compound.ATP);
 
+    [JsonProperty]
     private readonly string chunkType;
+
+    [JsonProperty]
     private readonly LocalizedString readableName;
+
     private readonly CompoundDefinition compound;
+
+    // Needed for saving to work
+    [JsonProperty(nameof(compound))]
+    private readonly Compound compoundRaw;
 
     public ChunkCompoundPressure(string chunkType, LocalizedString readableName, Compound compound, float weight) :
         base(weight, [])
     {
+        compoundRaw = compound;
         this.compound = SimulationParameters.GetCompound(compound);
         this.chunkType = chunkType;
         this.readableName = readableName;
     }
 
+    [JsonIgnore]
     public override LocalizedString Name => NameString;
 
     public override float Score(Species species, Patch patch, SimulationCache cache)

--- a/src/auto-evo/selection_pressure/CompoundCloudPressure.cs
+++ b/src/auto-evo/selection_pressure/CompoundCloudPressure.cs
@@ -1,7 +1,9 @@
 ﻿namespace AutoEvo;
 
 using System;
+using Newtonsoft.Json;
 
+[JSONDynamicTypeAllowed]
 public class CompoundCloudPressure : SelectionPressure
 {
     // Needed for translation extraction
@@ -10,8 +12,12 @@ public class CompoundCloudPressure : SelectionPressure
 
     // ReSharper restore ArrangeObjectCreationWhenTypeEvident
 
+    [JsonProperty]
     private readonly Compound compound;
+
     private readonly CompoundDefinition compoundDefinition;
+
+    [JsonProperty]
     private readonly bool isDayNightCycleEnabled;
 
     public CompoundCloudPressure(Compound compound, bool isDayNightCycleEnabled, float weight) :
@@ -29,6 +35,7 @@ public class CompoundCloudPressure : SelectionPressure
         this.isDayNightCycleEnabled = isDayNightCycleEnabled;
     }
 
+    [JsonIgnore]
     public override LocalizedString Name => NameString;
 
     public override float Score(Species species, Patch patch, SimulationCache cache)

--- a/src/auto-evo/selection_pressure/CompoundConversionEfficiencyPressure.cs
+++ b/src/auto-evo/selection_pressure/CompoundConversionEfficiencyPressure.cs
@@ -1,8 +1,14 @@
 ﻿namespace AutoEvo;
 
+using Newtonsoft.Json;
+
+[JSONDynamicTypeAllowed]
 public class CompoundConversionEfficiencyPressure : SelectionPressure
 {
+    [JsonIgnore]
     public readonly CompoundDefinition FromCompound;
+
+    [JsonIgnore]
     public readonly CompoundDefinition ToCompound;
 
     // Needed for translation extraction
@@ -11,16 +17,27 @@ public class CompoundConversionEfficiencyPressure : SelectionPressure
 
     // ReSharper restore ArrangeObjectCreationWhenTypeEvident
 
+    // These two are needed purely for saving to work
+    [JsonProperty]
+    private readonly Compound compound;
+
+    [JsonProperty]
+    private readonly Compound outCompound;
+
     public CompoundConversionEfficiencyPressure(Compound compound, Compound outCompound, float weight) :
         base(weight, [
             AddOrganelleAnywhere.ThatConvertBetweenCompounds(compound, outCompound),
             RemoveOrganelle.ThatCreateCompound(outCompound),
         ])
     {
+        this.compound = compound;
+        this.outCompound = outCompound;
+
         FromCompound = SimulationParameters.GetCompound(compound);
         ToCompound = SimulationParameters.GetCompound(outCompound);
     }
 
+    [JsonIgnore]
     public override LocalizedString Name => NameString;
 
     public override float Score(Species species, Patch patch, SimulationCache cache)

--- a/src/auto-evo/selection_pressure/EnvironmentalCompoundPressure.cs
+++ b/src/auto-evo/selection_pressure/EnvironmentalCompoundPressure.cs
@@ -1,7 +1,9 @@
 ﻿namespace AutoEvo;
 
 using System;
+using Newtonsoft.Json;
 
+[JSONDynamicTypeAllowed]
 public class EnvironmentalCompoundPressure : SelectionPressure
 {
     // Needed for translation extraction
@@ -14,7 +16,16 @@ public class EnvironmentalCompoundPressure : SelectionPressure
 
     private readonly CompoundDefinition createdCompound;
     private readonly CompoundDefinition compound;
+
+    [JsonProperty]
     private readonly float energyMultiplier;
+
+    // These two are needed purely for saving to work
+    [JsonProperty(nameof(compound))]
+    private readonly Compound compoundRaw;
+
+    [JsonProperty(nameof(createdCompound))]
+    private readonly Compound createdCompoundRaw;
 
     public EnvironmentalCompoundPressure(Compound compound, Compound createdCompound, float energyMultiplier,
         float weight) :
@@ -22,6 +33,9 @@ public class EnvironmentalCompoundPressure : SelectionPressure
             AddOrganelleAnywhere.ThatUseCompound(compound),
         ])
     {
+        compoundRaw = compound;
+        createdCompoundRaw = createdCompound;
+
         this.compound = SimulationParameters.GetCompound(compound);
 
         if (this.compound.IsCloud)
@@ -36,6 +50,7 @@ public class EnvironmentalCompoundPressure : SelectionPressure
         this.energyMultiplier = energyMultiplier;
     }
 
+    [JsonIgnore]
     public override LocalizedString Name => NameString;
 
     public override float Score(Species species, Patch patch, SimulationCache cache)

--- a/src/auto-evo/selection_pressure/MaintainCompoundPressure.cs
+++ b/src/auto-evo/selection_pressure/MaintainCompoundPressure.cs
@@ -1,7 +1,9 @@
 ﻿namespace AutoEvo;
 
 using System;
+using Newtonsoft.Json;
 
+[JSONDynamicTypeAllowed]
 public class MaintainCompoundPressure : SelectionPressure
 {
     // Needed for translation extraction
@@ -12,14 +14,20 @@ public class MaintainCompoundPressure : SelectionPressure
 
     private readonly CompoundDefinition compound;
 
+    // Needed for saving to work
+    [JsonProperty(nameof(compound))]
+    private readonly Compound compoundRaw;
+
     public MaintainCompoundPressure(Compound compound, float weight) : base(weight, [
         AddOrganelleAnywhere.ThatCreateCompound(compound),
         RemoveOrganelle.ThatUseCompound(compound),
     ])
     {
+        compoundRaw = compound;
         this.compound = SimulationParameters.GetCompound(compound);
     }
 
+    [JsonIgnore]
     public override LocalizedString Name => NameString;
 
     public override float Score(Species species, Patch patch, SimulationCache cache)

--- a/src/auto-evo/selection_pressure/MetabolicStabilityPressure.cs
+++ b/src/auto-evo/selection_pressure/MetabolicStabilityPressure.cs
@@ -1,5 +1,8 @@
 ﻿namespace AutoEvo;
 
+using Newtonsoft.Json;
+
+[JSONDynamicTypeAllowed]
 public class MetabolicStabilityPressure : SelectionPressure
 {
     // Needed for translation extraction
@@ -15,6 +18,7 @@ public class MetabolicStabilityPressure : SelectionPressure
     {
     }
 
+    [JsonIgnore]
     public override LocalizedString Name => NameString;
 
     public override float Score(Species species, Patch patch, SimulationCache cache)

--- a/src/auto-evo/selection_pressure/NoOpPressure.cs
+++ b/src/auto-evo/selection_pressure/NoOpPressure.cs
@@ -1,8 +1,11 @@
 ﻿namespace AutoEvo;
 
+using Newtonsoft.Json;
+
 /// <summary>
 ///   This pressure does nothing, but is used as a placeholder node in the Miche Tree
 /// </summary>
+[JSONDynamicTypeAllowed]
 public class NoOpPressure : SelectionPressure
 {
     // Needed for translation extraction
@@ -15,6 +18,7 @@ public class NoOpPressure : SelectionPressure
     {
     }
 
+    [JsonIgnore]
     public override LocalizedString Name => NameString;
 
     public override float Score(Species species, Patch patch, SimulationCache cache)

--- a/src/auto-evo/selection_pressure/PredationEffectivenessPressure.cs
+++ b/src/auto-evo/selection_pressure/PredationEffectivenessPressure.cs
@@ -1,7 +1,11 @@
 ﻿namespace AutoEvo;
 
+using Newtonsoft.Json;
+
+[JSONDynamicTypeAllowed]
 public class PredationEffectivenessPressure : SelectionPressure
 {
+    [JsonProperty]
     public readonly Species Prey;
 
     // Needed for translation extraction
@@ -28,6 +32,7 @@ public class PredationEffectivenessPressure : SelectionPressure
         Prey = prey;
     }
 
+    [JsonIgnore]
     public override LocalizedString Name => NameString;
 
     public override float Score(Species species, Patch patch, SimulationCache cache)

--- a/src/auto-evo/selection_pressure/PredatorRoot.cs
+++ b/src/auto-evo/selection_pressure/PredatorRoot.cs
@@ -1,5 +1,8 @@
 ﻿namespace AutoEvo;
 
+using Newtonsoft.Json;
+
+[JSONDynamicTypeAllowed]
 public class PredatorRoot : SelectionPressure
 {
     // Needed for translation extraction
@@ -17,6 +20,7 @@ public class PredatorRoot : SelectionPressure
     {
     }
 
+    [JsonIgnore]
     public override LocalizedString Name => NameString;
 
     public override float Score(Species species, Patch patch, SimulationCache cache)

--- a/src/auto-evo/selection_pressure/RootPressure.cs
+++ b/src/auto-evo/selection_pressure/RootPressure.cs
@@ -1,5 +1,8 @@
 ﻿namespace AutoEvo;
 
+using Newtonsoft.Json;
+
+[JSONDynamicTypeAllowed]
 public class RootPressure : SelectionPressure
 {
     // Needed for translation extraction
@@ -16,6 +19,7 @@ public class RootPressure : SelectionPressure
     {
     }
 
+    [JsonIgnore]
     public override LocalizedString Name => NameString;
 
     public override float Score(Species species, Patch patch, SimulationCache cache)

--- a/src/auto-evo/selection_pressure/SelectionPressure.cs
+++ b/src/auto-evo/selection_pressure/SelectionPressure.cs
@@ -1,22 +1,28 @@
 ﻿namespace AutoEvo;
 
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 /// <summary>
 ///   Selection pressures in miches both score species how well they do and also generate mutations for species to be
 ///   better in terms of this selection pressure
 /// </summary>
+[JSONDynamicTypeAllowed]
 public abstract class SelectionPressure
 {
-    public readonly float Strength;
+    [JsonProperty]
+    public readonly float Weight;
+
+    [JsonIgnore]
     public readonly List<IMutationStrategy<MicrobeSpecies>> Mutations;
 
-    public SelectionPressure(float strength, List<IMutationStrategy<MicrobeSpecies>> mutations)
+    public SelectionPressure(float weight, List<IMutationStrategy<MicrobeSpecies>> mutations)
     {
-        Strength = strength;
+        Weight = weight;
         Mutations = mutations;
     }
 
+    [JsonIgnore]
     public abstract LocalizedString Name { get; }
 
     public abstract float Score(Species species, Patch patch, SimulationCache cache);
@@ -39,12 +45,12 @@ public abstract class SelectionPressure
 
         if (newScore > oldScore)
         {
-            return newScore / oldScore * Strength;
+            return newScore / oldScore * Weight;
         }
 
         if (oldScore > newScore)
         {
-            return -(oldScore / newScore) * Strength;
+            return -(oldScore / newScore) * Weight;
         }
 
         return 0;

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -259,7 +259,7 @@ public static class MichePopulation
                     // Weighted score is intentionally not used here as negatives break everything
                     var score = rawScore /
                         cache.GetPressureScore(currentMiche.Pressure, patch, (MicrobeSpecies)node.Occupant!) *
-                        currentMiche.Pressure.Strength;
+                        currentMiche.Pressure.Weight;
 
                     if (simulationConfiguration.WorldSettings.AutoEvoConfiguration.StrictNicheCompetition)
                         score *= score;

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -533,10 +533,10 @@ public class ModifyExistingSpecies : IRunStep
             foreach (var pressure in pressures)
             {
                 strengthX += cache.GetPressureScore(pressure, patch, x.Item1) /
-                    cache.GetPressureScore(pressure, patch, baseSpecies) * pressure.Strength;
+                    cache.GetPressureScore(pressure, patch, baseSpecies) * pressure.Weight;
 
                 strengthY += cache.GetPressureScore(pressure, patch, y.Item1) /
-                    cache.GetPressureScore(pressure, patch, baseSpecies) * pressure.Strength;
+                    cache.GetPressureScore(pressure, patch, baseSpecies) * pressure.Weight;
             }
 
             if (strengthX > strengthY)

--- a/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
+++ b/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
@@ -228,7 +228,19 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
 
         autoEvoResults = results;
 
-        CreateGraphicalReportForPatch();
+        if (selectedReportSubtab == ReportSubtab.AutoEvo)
+        {
+            CreateGraphicalReportForPatch();
+        }
+        else
+        {
+            queuedAutoEvoReportUpdate = true;
+
+            if (selectedReportSubtab == ReportSubtab.FoodChain)
+            {
+                foodChainData.DisplayFoodChainIfRequired(autoEvoResults, PatchToShowInfoFor, PlayerSpecies);
+            }
+        }
     }
 
     public void DisplayAutoEvoFailure(string extra)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes the food chain GUI work after loading a save (thanks to saving and loading the miche tree, which creates quite a lot of unnecessary objects but I couldn't really come up with a clean way to otherwise store the information needed for the food chain tab)

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
