### PR TITLE
Flagella scaling autoevo

### DIFF
--- a/src/auto-evo/mutation_strategy/UpgradeOrganelle.cs
+++ b/src/auto-evo/mutation_strategy/UpgradeOrganelle.cs
@@ -1,0 +1,42 @@
+﻿using AutoEvo;
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+
+internal class UpgradeOrganelle : IMutationStrategy<MicrobeSpecies>
+{
+
+    private readonly FrozenSet<OrganelleDefinition> allOrganelles;
+    private IComponentSpecificUpgrades upgrade;
+
+    public UpgradeOrganelle(Func<OrganelleDefinition, bool> criteria, IComponentSpecificUpgrades upgrade)
+    {
+        allOrganelles = SimulationParameters.Instance.GetAllOrganelles().Where(criteria).ToFrozenSet();
+        this.upgrade = upgrade;
+    }
+
+    public bool Repeatable => true;
+
+    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp, bool lawk,
+    Random random)
+    {
+        var mutated = new List<Tuple<MicrobeSpecies, float>>();
+
+        MicrobeSpecies newSpecies = (MicrobeSpecies)baseSpecies.Clone();
+
+        foreach (OrganelleTemplate organelle in newSpecies.Organelles.Where(x => allOrganelles.Contains(x.Definition)))
+        {
+
+            if (organelle.Upgrades == null)
+            {
+                organelle.Upgrades = new OrganelleUpgrades();
+            }
+            organelle.Upgrades.CustomUpgradeData = upgrade;
+        }
+
+        mutated.Add(new Tuple<MicrobeSpecies, float>(newSpecies, mp));
+
+        return mutated;
+    }
+}

--- a/src/auto-evo/selection_pressure/MetabolicStabilityPressure.cs
+++ b/src/auto-evo/selection_pressure/MetabolicStabilityPressure.cs
@@ -11,6 +11,7 @@ public class MetabolicStabilityPressure : SelectionPressure
     public MetabolicStabilityPressure(float weight) : base(weight, [
         AddOrganelleAnywhere.ThatCreateCompound(Compound.ATP),
         RemoveOrganelle.ThatUseCompound(Compound.ATP),
+        new UpgradeOrganelle(organelle => organelle.HasMovementComponent, new FlagellumUpgrades(-1.0f))
     ])
     {
     }

--- a/src/auto-evo/selection_pressure/PredationEffectivenessPressure.cs
+++ b/src/auto-evo/selection_pressure/PredationEffectivenessPressure.cs
@@ -18,6 +18,7 @@ public class PredationEffectivenessPressure : SelectionPressure
             new AddOrganelleAnywhere(organelle => organelle.HasMovementComponent,
                 CommonMutationFunctions.Direction.Rear),
             new MoveOrganelleBack(organelle => organelle.HasMovementComponent),
+            new UpgradeOrganelle(organelle => organelle.HasMovementComponent, new FlagellumUpgrades(0.5f)),
             new ChangeBehaviorScore(ChangeBehaviorScore.BehaviorAttribute.Aggression, 150.0f),
             new ChangeBehaviorScore(ChangeBehaviorScore.BehaviorAttribute.Opportunism, 150.0f),
             new ChangeBehaviorScore(ChangeBehaviorScore.BehaviorAttribute.Fear, -150.0f),

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using AngleSharp;
 using Godot;
 using Systems;
 
@@ -212,6 +213,13 @@ public static class MicrobeInternalCalculations
 
                 float movementConstant =
                     Constants.FLAGELLA_BASE_FORCE * organelle.Definition.Components.Movement!.Momentum;
+
+                var configuration = organelle.Upgrades?.CustomUpgradeData;
+                if (configuration != null)
+                {
+                    if (configuration is FlagellumUpgrades flagellumUpgrades)
+                        movementConstant += Constants.FLAGELLA_MAX_UPGRADE_FORCE * flagellumUpgrades.LengthFraction;
+                }
 
                 if (!isBacteria)
                     movementConstant *= Constants.EUKARYOTIC_MOVEMENT_FORCE_MULTIPLIER;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds functionality for auto-evo to scale flagella. Right now only sets to one of three sizes, but we can iterate on this moving forward.

**Related Issues**


**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
