### PR TITLE
Made metabolosome locked until there's oxygen

### DIFF
--- a/simulation_parameters/microbe_stage/organelles.json
+++ b/simulation_parameters/microbe_stage/organelles.json
@@ -364,6 +364,14 @@
     "ProductionColour": "#26e0ff",
     "ConsumptionColour": "#ff5649",
     "IconPath": "res://assets/textures/gui/bevel/parts/MetabolosomeIcon.png",
+    "UnlockConditions": [
+      {
+        "PatchCompound": {
+          "Compound": "oxygen",
+          "Min": 1
+        }
+      }
+    ],
     "EditorButtonGroup": "Protein",
     "EditorButtonOrder": 1,
     "EndosymbiosisUnlocks": "mitochondrion"

--- a/src/microbe_stage/systems/ProcessSystem.cs
+++ b/src/microbe_stage/systems/ProcessSystem.cs
@@ -556,6 +556,12 @@ public sealed class ProcessSystem : AEntitySetSystem<float>
             // Environmental compound that can limit the rate
             var availableInEnvironment = GetAmbientInBiome(inputCompound, biome, pointInTimeType);
 
+            // Is a serious limit if there is none of the compound
+            if (availableInEnvironment <= 0)
+            {
+                result.WritableLimitingCompounds.Add(input.Key.ID);
+            }
+
             var availableRate = inputCompound == Compound.Temperature ?
                 CalculateTemperatureEffect(availableInEnvironment) :
                 availableInEnvironment / input.Value;
@@ -603,6 +609,8 @@ public sealed class ProcessSystem : AEntitySetSystem<float>
             {
                 // Cannot take any of this input, mark as a problem. This is helpful at least in the editor process
                 // panel view.
+                // TODO: this kind of unnecessarily marks some stuff red when environmental conditions are the real
+                // problem
                 result.WritableLimitingCompounds.Add(entry.Key.ID);
             }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

To not show it initially and allow someone to place it when it doesn't do anything

Also fixed a slight regression I caused in one of my previous PRs related to the limiting compounds shown in tooltips

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
