### PR TITLE
Adds missing models in Art Gallery

### DIFF
--- a/simulation_parameters/common/gallery.json
+++ b/simulation_parameters/common/gallery.json
@@ -214,10 +214,6 @@
             "Type": "ModelScene"
           },
           {
-            "ResourcePath": "res://assets/models/easter_eggs/IronRockBanan.tscn",
-            "Type": "ModelScene"
-          },
-          {
             "ResourcePath": "res://assets/models/organelles/Axon.tscn",
             "Type": "ModelScene"
           },


### PR DESCRIPTION
**Adds missing models in Art Gallery**

Add the missing models of new ice chunks, phosphate chunks, hydrogenase, pilus injectisome upgrade, and ferroplast to the art gallery.

**Related Issues**
Closes #5432 


https://github.com/user-attachments/assets/5ab3b6d5-fcc2-42d9-911b-47e7c532f0b5
It works 👍 

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
