### PR TITLE
Adds missing models in Art Gallery

### DIFF
--- a/simulation_parameters/common/gallery.json
+++ b/simulation_parameters/common/gallery.json
@@ -214,7 +214,7 @@
             "Type": "ModelScene"
           },
           {
-            "ResourcePath": "res://assets/models/IronRockBanan.tscn",
+            "ResourcePath": "res://assets/models/easter_eggs/IronRockBanan.tscn",
             "Type": "ModelScene"
           },
           {

--- a/simulation_parameters/common/gallery.json
+++ b/simulation_parameters/common/gallery.json
@@ -149,7 +149,7 @@
             "ResourcePath": "res://assets/models/Iceshard1.tscn",
             "Type": "ModelScene"
           },
-	        {
+          {
             "ResourcePath": "res://assets/models/IceChunkSmall1.tscn",
             "Type": "ModelScene"
           },

--- a/simulation_parameters/common/gallery.json
+++ b/simulation_parameters/common/gallery.json
@@ -149,7 +149,7 @@
             "ResourcePath": "res://assets/models/Iceshard1.tscn",
             "Type": "ModelScene"
           },
-	      {
+	        {
             "ResourcePath": "res://assets/models/IceChunkSmall1.tscn",
             "Type": "ModelScene"
           },

--- a/simulation_parameters/common/gallery.json
+++ b/simulation_parameters/common/gallery.json
@@ -214,10 +214,6 @@
             "Type": "ModelScene"
           },
           {
-            "ResourcePath": "res://assets/models/easter_eggs/IronRockBanan.tscn",
-            "Type": "ModelScene"
-          },
-          {
             "ResourcePath": "res://assets/models/organelles/Axon.tscn",
             "Type": "ModelScene"
           },

--- a/simulation_parameters/common/gallery.json
+++ b/simulation_parameters/common/gallery.json
@@ -182,11 +182,11 @@
             "Type": "ModelScene"
           },
           {
-            "ResourcePath": "res://assets/models/PhosphateChunkApatiteSmall1.tscn",
+            "ResourcePath": "res://assets/models/PhosphateChunkStruviteLarge.tscn",
             "Type": "ModelScene"
           },
           {
-            "ResourcePath": "res://assets/models/PhosphateChunkStruviteLarge.tscn",
+            "ResourcePath": "res://assets/models/PhosphateChunkApatiteSmall1.tscn",
             "Type": "ModelScene"
           },
           {

--- a/simulation_parameters/common/gallery.json
+++ b/simulation_parameters/common/gallery.json
@@ -149,6 +149,50 @@
             "ResourcePath": "res://assets/models/Iceshard1.tscn",
             "Type": "ModelScene"
           },
+	      {
+            "ResourcePath": "res://assets/models/IceChunkSmall1.tscn",
+            "Type": "ModelScene"
+          },
+          {
+            "ResourcePath": "res://assets/models/IceChunkSmall2.tscn",
+            "Type": "ModelScene"
+          },
+          {
+            "ResourcePath": "res://assets/models/IceChunkLarge1.tscn",
+            "Type": "ModelScene"
+          },
+          {
+            "ResourcePath": "res://assets/models/IceChunkLarge2.tscn",
+            "Type": "ModelScene"
+          },
+          {
+            "ResourcePath": "res://assets/models/IceChunkLarge3.tscn",
+            "Type": "ModelScene"
+          },
+          {
+            "ResourcePath": "res://assets/models/IceChunkSnowflake.tscn",
+            "Type": "ModelScene"
+          },
+          {
+            "ResourcePath": "res://assets/models/PhosphateChunkStruviteSmall1.tscn",
+            "Type": "ModelScene"
+          },
+          {
+            "ResourcePath": "res://assets/models/PhosphateChunkStruviteSmall2.tscn",
+            "Type": "ModelScene"
+          },
+          {
+            "ResourcePath": "res://assets/models/PhosphateChunkApatiteSmall1.tscn",
+            "Type": "ModelScene"
+          },
+          {
+            "ResourcePath": "res://assets/models/PhosphateChunkStruviteLarge.tscn",
+            "Type": "ModelScene"
+          },
+          {
+            "ResourcePath": "res://assets/models/PhosphateChunkApatiteLarge1.tscn",
+            "Type": "ModelScene"
+          },
           {
             "ResourcePath": "res://assets/models/Iron3.tscn",
             "Type": "ModelScene"
@@ -167,6 +211,10 @@
           },
           {
             "ResourcePath": "res://assets/models/IronRock2.tscn",
+            "Type": "ModelScene"
+          },
+          {
+            "ResourcePath": "res://assets/models/IronRockBanan.tscn",
             "Type": "ModelScene"
           },
           {
@@ -224,6 +272,10 @@
             "Type": "ModelScene"
           },
           {
+            "ResourcePath": "res://assets/models/organelles/Hydrogenase.tscn",
+            "Type": "ModelScene"
+          },
+          {
             "ResourcePath": "res://assets/models/organelles/Myofibril.tscn",
             "Type": "ModelScene"
           },
@@ -252,6 +304,10 @@
             "Type": "ModelScene"
           },
           {
+            "ResourcePath": "res://assets/models/organelles/PilusInjector.tscn",
+            "Type": "ModelScene"
+          },
+          {
             "ResourcePath": "res://assets/models/organelles/Rusticyanin.tscn",
             "Type": "ModelScene"
           },
@@ -266,6 +322,10 @@
           },
           {
             "ResourcePath": "res://assets/models/organelles/Thermoplast.tscn",
+            "Type": "ModelScene"
+          },
+          {
+            "ResourcePath": "res://assets/models/organelles/Ferroplast.tscn",
             "Type": "ModelScene"
           },
           {


### PR DESCRIPTION
**Adds missing models in Art Gallery**

Add the missing models of new ice chunks, phosphate chunks, hydrogenase, pilus injectisome upgrade, and ferroplast to the art gallery.

**Related Issues**
Closes #5432 


https://github.com/user-attachments/assets/5ab3b6d5-fcc2-42d9-911b-47e7c532f0b5
It works 👍 

https://github.com/Revolutionary-Games/Thrive/pull/5592 with correct branch name

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
