### PR TITLE
Rework Cilia Equations to reduce absurd boosts

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -308,9 +308,10 @@ public static class Constants
     public const float CILIA_PULL_RADIUS_PER_CILIA = 0.70f;
 
     /// <summary>
-    ///   1 means that each cilia counts as 1 in the pulling force
+    ///   1 means that each cilia counts as 1 in the pulling force.
+    ///   Smaller values mean diminishing returns.
     /// </summary>
-    public const float CILIA_FORCE_MULTIPLIER_PER_CILIA = 1;
+    public const float CILIA_FORCE_EXPONENT_PER_CILIA = 0.9f;
 
     public const float CILIA_PULLING_FORCE_FALLOFF_FACTOR = 0.1f;
     public const float CILIA_CURRENT_GENERATION_ANIMATION_SPEED = 5.0f;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -298,7 +298,7 @@ public static class Constants
     /// </summary>
     public const float CILIA_ROTATION_SAMPLE_INTERVAL = 0.1f;
 
-    public const float CILIA_PULLING_FORCE = 500000.0f;
+    public const float CILIA_PULLING_FORCE = 200000.0f;
     public const float CILIA_PULLING_FORCE_FIELD_RADIUS = 16.0f;
 
     /// <summary>
@@ -313,7 +313,7 @@ public static class Constants
     /// </summary>
     public const float CILIA_FORCE_EXPONENT_PER_CILIA = 0.9f;
 
-    public const float CILIA_PULLING_FORCE_FALLOFF_FACTOR = 0.1f;
+    public const float CILIA_PULLING_FORCE_FALLOFF_FACTOR = 0.05f;
     public const float CILIA_CURRENT_GENERATION_ANIMATION_SPEED = 5.0f;
 
     public const int MICROBE_SPAWN_RADIUS = 350;

--- a/src/microbe_stage/organelle_components/CiliaComponent.cs
+++ b/src/microbe_stage/organelle_components/CiliaComponent.cs
@@ -235,7 +235,7 @@ public class CiliaComponent : IOrganelleComponent
             return;
         }
 
-        ciliaCountForForce = 1 + (ciliaCountForForce - 1) * Constants.CILIA_FORCE_MULTIPLIER_PER_CILIA;
+        ciliaCountForForce = 1 + Mathf.Pow(ciliaCountForForce - 1, Constants.CILIA_FORCE_EXPONENT_PER_CILIA);
 
         ref var microbePosition = ref microbeEntity.Get<WorldPosition>();
         ref var microbePhysicsControl = ref microbeEntity.Get<ManualPhysicsControl>();
@@ -267,7 +267,7 @@ public class CiliaComponent : IOrganelleComponent
                 return;
 
             float force = Constants.CILIA_PULLING_FORCE * ciliaCountForForce * delta /
-                (distance * Constants.CILIA_PULLING_FORCE_FALLOFF_FACTOR);
+                Mathf.Max(1.0f, distance * Constants.CILIA_PULLING_FORCE_FALLOFF_FACTOR);
 
             ref var targetPhysics = ref pulledEntity.Get<ManualPhysicsControl>();
             targetPhysics.ImpulseToGive +=

--- a/src/microbe_stage/organelle_components/CiliaComponent.cs
+++ b/src/microbe_stage/organelle_components/CiliaComponent.cs
@@ -235,7 +235,7 @@ public class CiliaComponent : IOrganelleComponent
             return;
         }
 
-        ciliaCountForForce = 1 + Mathf.Pow(ciliaCountForForce - 1, Constants.CILIA_FORCE_EXPONENT_PER_CILIA);
+        ciliaCountForForce = 1 + MathF.Pow(ciliaCountForForce - 1, Constants.CILIA_FORCE_EXPONENT_PER_CILIA);
 
         ref var microbePosition = ref microbeEntity.Get<WorldPosition>();
         ref var microbePhysicsControl = ref microbeEntity.Get<ManualPhysicsControl>();
@@ -267,7 +267,7 @@ public class CiliaComponent : IOrganelleComponent
                 return;
 
             float force = Constants.CILIA_PULLING_FORCE * ciliaCountForForce * delta /
-                Mathf.Max(1.0f, distance * Constants.CILIA_PULLING_FORCE_FALLOFF_FACTOR);
+                MathF.Max(1.0f, distance * Constants.CILIA_PULLING_FORCE_FALLOFF_FACTOR);
 
             ref var targetPhysics = ref pulledEntity.Get<ManualPhysicsControl>();
             targetPhysics.ImpulseToGive +=


### PR DESCRIPTION
**Brief Description of What This PR Does**
**Related Issues**

Addresses #5534 in more of a "pro-fun" way, by preventing problems with pulling at closer than 1 distance, and pulling a 0.9 exponent on extra cilia. We could nerf that more if we need to.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
