### PR TITLE
Tweak oxygen production to result in higher max values

### DIFF
--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -3,10 +3,10 @@
     "Name": "RESPIRATION",
     "Inputs": {
       "oxygen": 1,
-      "glucose": 0.14
+      "glucose": 0.15
     },
     "Outputs": {
-      "atp": 91,
+      "atp": 110,
       "carbondioxide": 1
     },
     "IsMetabolismProcess": true
@@ -192,10 +192,10 @@
     "Name": "RESPIRATION",
     "Inputs": {
       "oxygen": 1,
-      "glucose": 0.08
+      "glucose": 0.09
     },
     "Outputs": {
-      "atp": 38,
+      "atp": 45,
       "carbondioxide": 1
     },
     "IsMetabolismProcess": true

--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -164,7 +164,7 @@
         "nitrogen": {
           "Amount": 0,
           "Density": 0,
-          "Ambient": 0.7
+          "Ambient": 0.6
         },
         "sunlight": {
           "Amount": 0,
@@ -723,7 +723,7 @@
         "nitrogen": {
           "Amount": 0,
           "Density": 0,
-          "Ambient": 0.7
+          "Ambient": 0.6
         },
         "sunlight": {
           "Amount": 0,
@@ -988,7 +988,7 @@
         "nitrogen": {
           "Amount": 0,
           "Density": 0,
-          "Ambient": 0.7
+          "Ambient": 0.6
         },
         "sunlight": {
           "Amount": 0,
@@ -1303,7 +1303,7 @@
         "nitrogen": {
           "Amount": 0,
           "Density": 0,
-          "Ambient": 0.7
+          "Ambient": 0.6
         },
         "sunlight": {
           "Amount": 0,
@@ -1564,7 +1564,7 @@
         "nitrogen": {
           "Amount": 0,
           "Density": 0,
-          "Ambient": 0.7
+          "Ambient": 0.6
         },
         "sunlight": {
           "Amount": 0,
@@ -1806,7 +1806,7 @@
         "nitrogen": {
           "Amount": 0,
           "Density": 0,
-          "Ambient": 0.7
+          "Ambient": 0.6
         },
         "sunlight": {
           "Amount": 0,
@@ -2039,7 +2039,7 @@
         "nitrogen": {
           "Amount": 0,
           "Density": 0,
-          "Ambient": 0.7
+          "Ambient": 0.6
         },
         "sunlight": {
           "Amount": 0,
@@ -2320,7 +2320,7 @@
         "nitrogen": {
           "Amount": 0,
           "Density": 0,
-          "Ambient": 0.7
+          "Ambient": 0.6
         },
         "sunlight": {
           "Amount": 0,
@@ -2566,7 +2566,7 @@
         "nitrogen": {
           "Amount": 0,
           "Density": 0,
-          "Ambient": 0.7
+          "Ambient": 0.6
         },
         "sunlight": {
           "Amount": 0,
@@ -2893,7 +2893,7 @@
         "nitrogen": {
           "Amount": 0,
           "Density": 0,
-          "Ambient": 0.7
+          "Ambient": 0.6
         },
         "sunlight": {
           "Amount": 0,

--- a/src/general/world_effects/PhotosynthesisProductionEffect.cs
+++ b/src/general/world_effects/PhotosynthesisProductionEffect.cs
@@ -30,9 +30,12 @@ public class PhotosynthesisProductionEffect : IWorldEffect
 
     private void ApplyCompoundsAddition()
     {
-        var outputModifier = 1.0f;
+        // These affect the final balance
+        var outputModifier = 1.5f;
         var inputModifier = 1.0f;
-        var modifier = 0.0001f;
+
+        // This affects how fast the conditions change, but also the final balance somewhat
+        var modifier = 0.00015f;
 
         List<TweakedProcess> microbeProcesses = [];
 
@@ -68,6 +71,9 @@ public class PhotosynthesisProductionEffect : IWorldEffect
 
                 foreach (var process in microbeProcesses)
                 {
+                    if (process.Process.InternalName == "protein_respiration")
+                        _ = 1;
+
                     // Only handle relevant processes
                     if (!IsProcessRelevant(process.Process))
                         continue;
@@ -83,6 +89,8 @@ public class PhotosynthesisProductionEffect : IWorldEffect
                     // unnecessarily consume environmental oxygen
                     var effectiveSpeed =
                         (process.Process.IsMetabolismProcess ? balanceModifier : 1) * rate.CurrentSpeed;
+
+                    // TODO: maybe photosynthesis should also only try to reach glucose balance of +0?
 
                     // Inputs take away compounds scaled by the speed and population of the species
                     foreach (var input in process.Process.Inputs)
@@ -170,9 +178,9 @@ public class PhotosynthesisProductionEffect : IWorldEffect
                 return true;
         }
 
-        foreach (var input in process.Outputs)
+        foreach (var output in process.Outputs)
         {
-            if (input.Key.ID is Compound.Oxygen or Compound.Carbondioxide)
+            if (output.Key.ID is Compound.Oxygen or Compound.Carbondioxide)
                 return true;
         }
 

--- a/src/general/world_effects/VolcanismEffect.cs
+++ b/src/general/world_effects/VolcanismEffect.cs
@@ -7,11 +7,11 @@ using Newtonsoft.Json;
 [JSONDynamicTypeAllowed]
 public class VolcanismEffect : IWorldEffect
 {
-    private const float VentsCO2Strength = 0.1f;
+    private const float VentsCO2Strength = 0.15f;
     private const float VentsCO2Threshold = 0.3f;
 
-    private const float SurfaceCO2Strength = 0.015f;
-    private const float SurfaceCO2Threshold = 0.13f;
+    private const float SurfaceCO2Strength = 0.025f;
+    private const float SurfaceCO2Threshold = 0.15f;
 
     private const float FloorCO2Strength = 0.005f;
     private const float FloorCO2Threshold = 0.1f;

--- a/src/general/world_effects/VolcanismEffect.cs
+++ b/src/general/world_effects/VolcanismEffect.cs
@@ -10,8 +10,8 @@ public class VolcanismEffect : IWorldEffect
     private const float VentsCO2Strength = 0.1f;
     private const float VentsCO2Threshold = 0.3f;
 
-    private const float SurfaceCO2Strength = 0.01f;
-    private const float SurfaceCO2Threshold = 0.15f;
+    private const float SurfaceCO2Strength = 0.015f;
+    private const float SurfaceCO2Threshold = 0.13f;
 
     private const float FloorCO2Strength = 0.005f;
     private const float FloorCO2Threshold = 0.1f;
@@ -44,8 +44,10 @@ public class VolcanismEffect : IWorldEffect
                 ProduceCO2(patchKeyValue.Value, VentsCO2Strength, VentsCO2Threshold);
             }
             else if (patchKeyValue.Value.BiomeType is BiomeType.Epipelagic or BiomeType.Coastal or BiomeType.Estuary
-                     or BiomeType.Tidepool)
+                     or BiomeType.Tidepool or BiomeType.IceShelf)
             {
+                // Ice shelf gets co2 here as it seems to be pretty often the driver for early oxygen in the world
+
                 // Surface patches are given some CO2 from assumed volcanic activity on land
                 ProduceCO2(patchKeyValue.Value, SurfaceCO2Strength, SurfaceCO2Threshold);
             }


### PR DESCRIPTION
**Brief Description of What This PR Does**

This now makes oxygen reach around 20% with the surface patches usually being around 10-15% once photosynthesisers have existed for a few generations at 900 Myr or so.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
