### PR TITLE
Made the editor load patch dependent data after auto-evo

### DIFF
--- a/src/general/TimedWorldOperations.cs
+++ b/src/general/TimedWorldOperations.cs
@@ -11,20 +11,18 @@ public class TimedWorldOperations
     private List<IWorldEffect> effects = new();
 
     /// <summary>
-    ///   Called when time passes
+    ///   Called when time passes (long timespans, like entering the editor)
     /// </summary>
     /// <remarks>
     ///   <para>
-    ///     This is different than realtime gameplay time, these are
-    ///     mostly the time jumps that happen in the editor.
+    ///     This is different from realtime gameplay time, these are mostly the time jumps that happen in the editor.
     ///   </para>
     /// </remarks>
     /// <param name="timePassed">Time passed since last call</param>
     /// <param name="totalPassed">Total time passed</param>
     public void OnTimePassed(double timePassed, double totalPassed)
     {
-        GD.Print("TimedWorldOperations: running effects. elapsed: ",
-            timePassed, " total passed: ", totalPassed);
+        GD.Print("TimedWorldOperations: running effects. elapsed: ", timePassed, " total passed: ", totalPassed);
 
         foreach (var effect in effects)
         {

--- a/src/general/base_stage/EditorBase.cs
+++ b/src/general/base_stage/EditorBase.cs
@@ -166,6 +166,9 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
         get => dayLightFraction;
         set
         {
+            if (dayLightFraction == value)
+                return;
+
             dayLightFraction = value;
 
             ApplyComponentLightLevels();
@@ -574,7 +577,7 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
         {
             SetupEditedSpecies();
 
-            // For now we only show a loading screen if auto-evo is not ready yet
+            // For now, we only show a loading screen if auto-evo is not ready yet
             if (!CurrentGame.GameWorld.IsAutoEvoFinished())
             {
                 EditorReady = false;
@@ -722,6 +725,11 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
         ApplyAutoEvoResults();
 
         FadeIn();
+
+        foreach (var editorComponent in GetAllEditorComponents())
+        {
+            editorComponent.OnEditorReady();
+        }
     }
 
     protected void SetEditorTab(EditorTab tab)

--- a/src/general/base_stage/EditorComponentBase.cs
+++ b/src/general/base_stage/EditorComponentBase.cs
@@ -106,6 +106,13 @@ public partial class EditorComponentBase<TEditor> : ControlWithInput, IEditorCom
         Init((TEditor)owningEditor, fresh);
     }
 
+    public virtual void OnEditorReady()
+    {
+        // Late initialization stuff can go here (usually overridden by component types that need that)
+        // Note that this only happens when not loading a save as when loading a save auto-evo etc. data should be
+        // ready immediately
+    }
+
     /// <summary>
     ///   Called
     /// </summary>

--- a/src/general/base_stage/IEditorComponent.cs
+++ b/src/general/base_stage/IEditorComponent.cs
@@ -13,13 +13,24 @@ public interface IEditorComponent
 
     public bool Visible { get; }
 
+    /// <summary>
+    ///   Called when initialization phase of the editor is running
+    /// </summary>
+    /// <param name="owningEditor">The editor that has the current component</param>
+    /// <param name="fresh">True when the game state was *not* loaded from a save</param>
     public void Init(IEditor owningEditor, bool fresh);
+
+    /// <summary>
+    ///   Called once editor entry has finished and the editor is fading in. Note that this only happens when not
+    ///   loading a save!
+    /// </summary>
+    public void OnEditorReady();
 
     /// <summary>
     ///   Called when the species data is ready in the editor
     /// </summary>
     /// <param name="species">
-    ///   The species that was setup, accessing more specific data through
+    ///   The species that was set up, accessing more specific data through
     ///   <see cref="EditorComponentBase{TEditor}.Editor"/> rather than casting to a derived class is recommended.
     /// </param>
     public void OnEditorSpeciesSetup(Species species);

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -788,10 +788,11 @@ public partial class CellEditorComponent :
             {
                 GD.Print("Loaded cell editor with no cell to edit set");
             }
-        }
 
-        // Send info to the GUI about the organelle effectiveness in the current patch
-        CalculateOrganelleEffectivenessInCurrentPatch();
+            // Send info to the GUI about the organelle effectiveness in the current patch
+            // When not loading a save, this is handled by OnEditorReady
+            OnPatchDataReady();
+        }
 
         if (IsMulticellularEditor)
         {
@@ -909,6 +910,13 @@ public partial class CellEditorComponent :
                 MouseHoverPositions = hoveredHexes.ToList();
             }
         }
+    }
+
+    public override void OnEditorReady()
+    {
+        // As auto-evo results can modify the patch data, we only want to calculate the effectiveness of organelles in
+        // the current patch once that data is ready (and whenever the selected patch changes of course)
+        OnPatchDataReady();
     }
 
     [RunOnKeyDown("e_primary")]
@@ -1577,6 +1585,15 @@ public partial class CellEditorComponent :
         }
 
         base.Dispose(disposing);
+    }
+
+    /// <summary>
+    ///   Called once patch data is ready for initial read
+    /// </summary>
+    private void OnPatchDataReady()
+    {
+        CalculateOrganelleEffectivenessInCurrentPatch();
+        UpdatePatchDependentBalanceData();
     }
 
     private bool PerformEndosymbiosisPlace(int q, int r)


### PR DESCRIPTION
so that latest patch compound values etc. will be used in tooltips

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
I noticed the process tooltips having outdated numbers until clicking on the day/night buttons

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
