### PR TITLE
Don't show gas compounds in cell compound balances or storage

### DIFF
--- a/src/microbe_stage/editor/CompoundBalanceDisplay.cs
+++ b/src/microbe_stage/editor/CompoundBalanceDisplay.cs
@@ -45,8 +45,14 @@ public partial class CompoundBalanceDisplay : VBoxContainer
     {
         childCache.UnMarkAll();
 
+        var simulationParameters = SimulationParameters.Instance;
+
         foreach (var entry in balances)
         {
+            // Skip any gas compounds as they aren't stored by cells so no point in showing in the balance
+            if (simulationParameters.GetCompoundDefinition(entry.Key).IsGas)
+                continue;
+
             var compoundControl = childCache.GetChild(entry.Key);
             var amount = entry.Value.Balance;
             compoundControl.Amount = amount;

--- a/src/microbe_stage/editor/CompoundStorageStatistics.cs
+++ b/src/microbe_stage/editor/CompoundStorageStatistics.cs
@@ -47,8 +47,16 @@ public partial class CompoundStorageStatistics : VBoxContainer
 
         storageWarningBuilder.Clear();
 
+        var simulationParameters = SimulationParameters.Instance;
+
         foreach (var entry in daytimeBalances)
         {
+            var compoundDefinition = simulationParameters.GetCompoundDefinition(entry.Key);
+
+            // Skip any gas compounds as they aren't stored by cells
+            if (compoundDefinition.IsGas)
+                continue;
+
             var storage = specialCapacities.GetValueOrDefault(entry.Key, nominalStorage);
 
             if (nightBalance.TryGetValue(entry.Key, out var nightEntry) && nightEntry.Balance < 0)
@@ -72,7 +80,7 @@ public partial class CompoundStorageStatistics : VBoxContainer
                         compoundControl.ValueColour = CompoundAmount.Colour.Red;
 
                         storageWarningBuilder.Append(new LocalizedString("COMPOUND_STORAGE_NOT_ENOUGH_SPACE",
-                            SimulationParameters.GetCompound(entry.Key).InternalName,
+                            compoundDefinition.InternalName,
                             Math.Round(lastingTime, 1),
                             Math.Round(nightDuration)));
                         storageWarningBuilder.Append(' ');
@@ -90,7 +98,7 @@ public partial class CompoundStorageStatistics : VBoxContainer
                     {
                         storageWarningBuilder.Append(new LocalizedString(
                             "COMPOUND_STORAGE_NOT_ENOUGH_GENERATED_DURING_DAY",
-                            SimulationParameters.GetCompound(entry.Key).InternalName,
+                            compoundDefinition.InternalName,
                             Math.Round(generated, 1),
                             Math.Round(required, 1)));
                         storageWarningBuilder.Append(' ');


### PR DESCRIPTION
**Brief Description of What This PR Does**

as gases aren't stored by cells so it doesn't make sense to show how long it takes to fill up on them as it isn't possible to do so

**Related Issues**



<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/464846402732687391/464846931932217354/1296266255774253148

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
