### PR TITLE
Adjust photosynthesis to have same glucose output ratio as before

### DIFF
--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -35,11 +35,11 @@
     "Name": "PHOTOSYNTHESIS",
     "Inputs": {
       "sunlight": 1,
-      "carbondioxide": 3
+      "carbondioxide": 0.27
     },
     "Outputs": {
-      "glucose": 0.04,
-      "oxygen": 3
+      "glucose": 0.12,
+      "oxygen": 0.27
     }
   },
   "cytotoxinSynthesis": {
@@ -214,11 +214,11 @@
     "Name": "PHOTOSYNTHESIS",
     "Inputs": {
       "sunlight": 1,
-      "carbondioxide": 1
+      "carbondioxide": 0.081
     },
     "Outputs": {
-      "glucose": 0.012,
-      "oxygen": 1
+      "glucose": 0.036,
+      "oxygen": 0.081
     }
   },
   "iron_chemolithoautotrophy": {

--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -38,7 +38,7 @@
       "carbondioxide": 0.27
     },
     "Outputs": {
-      "glucose": 0.12,
+      "glucose": 0.48,
       "oxygen": 0.27
     }
   },


### PR DESCRIPTION
**Brief Description of What This PR Does**
the dynamic compounds experimental PR that multiplied the carbon dioxide requirement by a ton but didn't modify the glucose output so this should correct photosynthesis to be a viable glucose source again

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
reports after the RC about photosynthesis output problems

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
