### PR TITLE
Add various fixes against ejected dead cells not despawning

### DIFF
--- a/src/engine/common_components/Health.cs
+++ b/src/engine/common_components/Health.cs
@@ -187,6 +187,7 @@ public static class HealthHelpers
         if (health.Invulnerable && !goesThroughInvulnerability)
             return;
 
+        health.Dead = true;
         health.CurrentHealth = 0;
         health.Invulnerable = false;
     }

--- a/src/microbe_stage/components/Engulfable.cs
+++ b/src/microbe_stage/components/Engulfable.cs
@@ -312,6 +312,8 @@ public static class EngulfableHelpers
                     // shortly destroyed
                     return;
                 }
+
+                GD.PrintErr("Killed a partially digested cell that didn't have organelles set yet");
             }
         }
 
@@ -333,6 +335,13 @@ public static class EngulfableHelpers
                     entityRecord.Set(new TimedLife(10));
 
                     worldSimulation.FinishRecordingEntityCommands(recorder);
+                }
+                else
+                {
+                    // Really ensure the entity cannot live too long if already despawning
+                    ref var timedLife = ref entity.Get<TimedLife>();
+                    if (timedLife.TimeToLiveRemaining > 10)
+                        timedLife.TimeToLiveRemaining = 10;
                 }
             }
 

--- a/src/microbe_stage/systems/EngulfingSystem.cs
+++ b/src/microbe_stage/systems/EngulfingSystem.cs
@@ -44,6 +44,7 @@ using World = DefaultEcs.World;
 [WritesToComponent(typeof(MicrobeAI))]
 [WritesToComponent(typeof(TemporaryEndosymbiontInfo))]
 [WritesToComponent(typeof(DamageCooldown))]
+[WritesToComponent(typeof(TimedLife))]
 [ReadsComponent(typeof(CollisionManagement))]
 [ReadsComponent(typeof(MicrobePhysicsExtraData))]
 [ReadsComponent(typeof(OrganelleContainer))]

--- a/src/microbe_stage/systems/MicrobeDeathSystem.cs
+++ b/src/microbe_stage/systems/MicrobeDeathSystem.cs
@@ -257,6 +257,7 @@ public sealed class MicrobeDeathSystem : AEntitySetSystem<float>
         if (health.DeathProcessed)
             return;
 
+        // Update membrane damaged status
         ref var cellProperties = ref entity.Get<CellProperties>();
         if (cellProperties.CreatedMembrane != null)
         {
@@ -271,9 +272,11 @@ public sealed class MicrobeDeathSystem : AEntitySetSystem<float>
             }
         }
 
+        // Then handle death for cells that should die
         if (health.CurrentHealth <= 0 || health.Dead)
         {
-            // Ensure dead flag is always set, as otherwise this will cause "zombies"
+            // Ensure dead flag is always set, as otherwise this will cause "zombies", so that this is always retried
+            // if the death procesing cannot be done yet
             health.Dead = true;
 
             if (HandleMicrobeDeath(ref cellProperties, entity))
@@ -284,6 +287,8 @@ public sealed class MicrobeDeathSystem : AEntitySetSystem<float>
     private bool HandleMicrobeDeath(ref CellProperties cellProperties, in Entity entity)
     {
         EntityCommandRecorder? commandRecorder = null;
+
+        bool suppressChunks = false;
 
         if (entity.Has<AttachedToEntity>())
         {
@@ -299,9 +304,9 @@ public sealed class MicrobeDeathSystem : AEntitySetSystem<float>
             }
             else
             {
-                // Being engulfed handling is in OnKilled and OnExpelledFromEngulfment
-                // Dropping corpse chunks won't make sense while inside a cell (being engulfed)
-                return true;
+                // Dropping corpse chunks won't make sense while inside a cell (being engulfed), so partially the death
+                // handling is skipped
+                suppressChunks = true;
             }
         }
 
@@ -316,9 +321,8 @@ public sealed class MicrobeDeathSystem : AEntitySetSystem<float>
             }
         }
 
-        if (OnKilled(ref cellProperties, entity, ref commandRecorder))
+        if (OnKilled(ref cellProperties, entity, ref commandRecorder, suppressChunks))
         {
-            // TODO: engulfed death doesn't trigger this mod interface...
             ModLoader.ModInterface.TriggerOnMicrobeDied(entity, entity.Has<PlayerMarker>());
 
             if (commandRecorder != null)
@@ -340,13 +344,18 @@ public sealed class MicrobeDeathSystem : AEntitySetSystem<float>
     ///   True when the death could be processed, false if the entity isn't ready to process the death
     /// </returns>
     private bool OnKilled(ref CellProperties cellProperties, in Entity entity,
-        ref EntityCommandRecorder? commandRecorder)
+        ref EntityCommandRecorder? commandRecorder, bool suppressChunks)
     {
         ref var organelleContainer = ref entity.Get<OrganelleContainer>();
 
         if (organelleContainer.Organelles == null)
         {
             GD.Print("Can't kill a microbe yet with uninitialized organelles");
+
+            // This might cause some bugs so there's a warning print here
+            if (suppressChunks)
+                GD.PrintErr("Will handle a microbe killed in engulfed as a retry that will forge this state");
+
             return false;
         }
 
@@ -412,30 +421,35 @@ public sealed class MicrobeDeathSystem : AEntitySetSystem<float>
 
         if (engulfable.PhagocytosisStep != PhagocytosisPhase.None)
         {
-            // When dying when engulfed all of the normal actions don't apply
+            // When dying when engulfed all the normal actions don't apply (this doesn't apply when ejected)
             // Special handling for this is in EngulfableHelpers.OnExpelledFromEngulfment
             return true;
         }
 
-        var compounds = entity.Get<CompoundStorage>().Compounds;
         ref var position = ref entity.Get<WorldPosition>();
 
         ApplyDeathVisuals(ref cellProperties, ref organelleContainer, ref position, entity, commandRecorder);
 
-        // Ejecting all engulfed objects on death are now handled by EngulfingSystem
-
-        // Releasing all the agents.
-
-        if (organelleContainer.AgentVacuoleCount > 0)
+        // Chunk handling when the cell was engulfed, is handled elsewhere
+        if (!suppressChunks)
         {
-            ReleaseAllAgents(ref position, entity, compounds, species, commandRecorder);
+            // Ejecting all engulfed objects on death are now handled by EngulfingSystem
+
+            var compounds = entity.Get<CompoundStorage>().Compounds;
+
+            // Releasing all the agents.
+
+            if (organelleContainer.AgentVacuoleCount > 0)
+            {
+                ReleaseAllAgents(ref position, entity, compounds, species, commandRecorder);
+            }
+
+            var isBacteria = cellProperties.IsBacteria;
+
+            // Eject compounds and build costs as corpse chunks of the cell
+            SpawnCorpseChunks(ref organelleContainer, compounds, spawnSystem, worldSimulation, commandRecorder,
+                position.Position, random, null, isBacteria);
         }
-
-        var isBacteria = cellProperties.IsBacteria;
-
-        // Eject compounds and build costs as corpse chunks of the cell
-        SpawnCorpseChunks(ref organelleContainer, compounds, spawnSystem, worldSimulation, commandRecorder,
-            position.Position, random, null, isBacteria);
 
         ref var soundPlayer = ref entity.Get<SoundEffectPlayer>();
         soundPlayer.StopAllSounds();

--- a/src/microbe_stage/systems/MicrobeDeathSystem.cs
+++ b/src/microbe_stage/systems/MicrobeDeathSystem.cs
@@ -275,8 +275,8 @@ public sealed class MicrobeDeathSystem : AEntitySetSystem<float>
         // Then handle death for cells that should die
         if (health.CurrentHealth <= 0 || health.Dead)
         {
-            // Ensure dead flag is always set, as otherwise this will cause "zombies", so that this is always retried
-            // if the death procesing cannot be done yet
+            // Ensure dead flag is always set, as otherwise this will cause "zombies," so that this is always retried
+            // if the death processing cannot be done yet
             health.Dead = true;
 
             if (HandleMicrobeDeath(ref cellProperties, entity))
@@ -354,7 +354,7 @@ public sealed class MicrobeDeathSystem : AEntitySetSystem<float>
 
             // This might cause some bugs so there's a warning print here
             if (suppressChunks)
-                GD.PrintErr("Will handle a microbe killed in engulfed as a retry that will forge this state");
+                GD.PrintErr("Will handle a microbe killed in engulfment as a retry that will forge this state");
 
             return false;
         }
@@ -421,7 +421,8 @@ public sealed class MicrobeDeathSystem : AEntitySetSystem<float>
 
         if (engulfable.PhagocytosisStep != PhagocytosisPhase.None)
         {
-            // When dying when engulfed all the normal actions don't apply (this doesn't apply when ejected)
+            // When dying when engulfed all the normal actions don't apply (this doesn't apply when ejected as the
+            // state is cleared to none before this system sees the dead microbe)
             // Special handling for this is in EngulfableHelpers.OnExpelledFromEngulfment
             return true;
         }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds various error prints and fix attempts to make sure cells that die in engulfment / on eject are not left behind as zombie entities that don't despawn but count as dead

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://community.revolutionarygamesstudio.com/t/0-7-1-release-candidate-testing/7810/4?u=hhyyrylainen
https://discord.com/channels/464846402732687391/875766479558176778/1297120676318281729
closes #5612 (a workaround that was written earlier)
**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
