### PR TITLE
Make cell membrane more wavy

### DIFF
--- a/shaders/Membrane.gdshader
+++ b/shaders/Membrane.gdshader
@@ -31,26 +31,26 @@ void vertex(){
     VERTEX.z += sin(worldVertex.x * movementWigglyNess - TIME / 4.0f) / 10.f
         * wigglyNess * size;
     
-    float verticalWave = sin(NODE_POSITION_WORLD.z * movementWigglyNess
-        + VERTEX.z * 0.8f + TIME / 4.0f);
-    float horizontalWave = sin(NODE_POSITION_WORLD.x * movementWigglyNess
-        + VERTEX.x * 0.8f + TIME / 4.0f);
+    float verticalWave = sin(NODE_POSITION_WORLD.z * movementWigglyNess * 0.25f
+        + worldVertex.z * 0.4f + TIME / 4.0f);
+    float horizontalWave = sin(NODE_POSITION_WORLD.x * movementWigglyNess * 0.25f
+        + worldVertex.x * 0.4f + TIME / 4.0f);
     VERTEX.y += (verticalWave + horizontalWave + 2.0f)
         * 0.25f * wigglyNess * abs(worldVertex.y);
     
-	vec2 verticalTangent = normalize(vec2(-abs(cos(NODE_POSITION_WORLD.z * movementWigglyNess
-        + VERTEX.z * 0.8f + TIME / 4.0f)), 1.0f))
-	    * 0.75f * wigglyNess * abs(worldVertex.y);
-	vec2 horizontalTangent = normalize(vec2(-abs(cos(NODE_POSITION_WORLD.x * movementWigglyNess
-	    + VERTEX.x * 0.8f + TIME / 4.0f)), 1.0f))
-	    * 0.75f * wigglyNess * abs(worldVertex.y);
+	vec2 verticalTangent = normalize(vec2(abs(cos(NODE_POSITION_WORLD.z * movementWigglyNess * 0.25f
+        + worldVertex.z * 0.4f + TIME / 4.0f)), 1.0f))
+	    * 0.25f * wigglyNess * abs(worldVertex.y);
+	vec2 horizontalTangent = normalize(vec2(abs(cos(NODE_POSITION_WORLD.x * movementWigglyNess * 0.25f
+        + worldVertex.x * 0.4f + TIME / 4.0f)), 1.0f))
+	    * 0.25f * wigglyNess * abs(worldVertex.y);
 	
-    NORMAL += vec3(horizontalTangent.x, horizontalTangent.y + verticalTangent.y, verticalTangent.x);
-    BINORMAL += vec3(horizontalTangent.y, -horizontalTangent.x - verticalTangent.x, verticalTangent.y);
+    NORMAL += vec3(-horizontalTangent.x, horizontalTangent.y + verticalTangent.y, -verticalTangent.x);
+    TANGENT += vec3(horizontalTangent.y, -horizontalTangent.x - verticalTangent.x, verticalTangent.y);
     
     NORMAL = normalize(NORMAL);
-    BINORMAL = normalize(BINORMAL);
-    TANGENT = cross(NORMAL, BINORMAL);
+    TANGENT = normalize(TANGENT);
+    BINORMAL = cross(NORMAL, TANGENT);
 }
 
 float fresnel(float power, vec3 normal, vec3 view)
@@ -62,8 +62,8 @@ void fragment(){
     vec4 albedo = texture(albedoTexture, UV);
 
     vec4 normalmap = texture(normalTexture, UV2);
-    //NORMAL_MAP = normalmap.xyz;
-    //NORMAL_MAP_DEPTH = 0.5f;
+    NORMAL_MAP = normalmap.xyz;
+    NORMAL_MAP_DEPTH = 0.5f;
 
     vec4 damaged = texture(damagedTexture, UV);
     vec4 final = ((albedo * healthFraction) +
@@ -86,9 +86,9 @@ void fragment(){
         + normalmap.y * BINORMAL;
 
     // Mix base normals with detail normals in some proportion (0.0 - 1.0)
-    adjusted_normals = normalize(mix(NORMAL, adjusted_normals, 0.0));
+    adjusted_normals = normalize(mix(NORMAL, adjusted_normals, 0.2));
 
-    ALBEDO = vec3(1.0f);
+    ALBEDO = final.rgb;
     ALPHA = fresnel(3.0, adjusted_normals, adjusted_view) * round(cutoff);
     ROUGHNESS = 0.7;
 }

--- a/shaders/Membrane.gdshader
+++ b/shaders/Membrane.gdshader
@@ -30,10 +30,27 @@ void vertex(){
         * wigglyNess * size;
     VERTEX.z += sin(worldVertex.x * movementWigglyNess - TIME / 4.0f) / 10.f
         * wigglyNess * size;
-
-    float cellOffset = (NODE_POSITION_WORLD.x + NODE_POSITION_WORLD.z);
-    VERTEX.y += (sin(cellOffset * movementWigglyNess + VERTEX.z + TIME / 4.0f) + 1.0f)
-        * 0.35f * wigglyNess * abs(worldVertex.y);
+    
+    float verticalWave = sin(NODE_POSITION_WORLD.z * movementWigglyNess
+        + VERTEX.z * 0.8f + TIME / 4.0f);
+    float horizontalWave = sin(NODE_POSITION_WORLD.x * movementWigglyNess
+        + VERTEX.x * 0.8f + TIME / 4.0f);
+    VERTEX.y += (verticalWave + horizontalWave + 2.0f)
+        * 0.25f * wigglyNess * abs(worldVertex.y);
+    
+	vec2 verticalTangent = normalize(vec2(-abs(cos(NODE_POSITION_WORLD.z * movementWigglyNess
+        + VERTEX.z * 0.8f + TIME / 4.0f)), 1.0f))
+	    * 0.75f * wigglyNess * abs(worldVertex.y);
+	vec2 horizontalTangent = normalize(vec2(-abs(cos(NODE_POSITION_WORLD.x * movementWigglyNess
+	    + VERTEX.x * 0.8f + TIME / 4.0f)), 1.0f))
+	    * 0.75f * wigglyNess * abs(worldVertex.y);
+	
+    NORMAL += vec3(horizontalTangent.x, horizontalTangent.y + verticalTangent.y, verticalTangent.x);
+    BINORMAL += vec3(horizontalTangent.y, -horizontalTangent.x - verticalTangent.x, verticalTangent.y);
+    
+    NORMAL = normalize(NORMAL);
+    BINORMAL = normalize(BINORMAL);
+    TANGENT = cross(NORMAL, BINORMAL);
 }
 
 float fresnel(float power, vec3 normal, vec3 view)
@@ -45,8 +62,8 @@ void fragment(){
     vec4 albedo = texture(albedoTexture, UV);
 
     vec4 normalmap = texture(normalTexture, UV2);
-    NORMAL_MAP = normalmap.xyz;
-    NORMAL_MAP_DEPTH = 0.5f;
+    //NORMAL_MAP = normalmap.xyz;
+    //NORMAL_MAP_DEPTH = 0.5f;
 
     vec4 damaged = texture(damagedTexture, UV);
     vec4 final = ((albedo * healthFraction) +
@@ -69,9 +86,9 @@ void fragment(){
         + normalmap.y * BINORMAL;
 
     // Mix base normals with detail normals in some proportion (0.0 - 1.0)
-    adjusted_normals = normalize(mix(NORMAL, adjusted_normals, 0.2));
+    adjusted_normals = normalize(mix(NORMAL, adjusted_normals, 0.0));
 
-    ALBEDO = final.rgb;
+    ALBEDO = vec3(1.0f);
     ALPHA = fresnel(3.0, adjusted_normals, adjusted_view) * round(cutoff);
     ROUGHNESS = 0.7;
 }

--- a/shaders/Membrane.gdshader
+++ b/shaders/Membrane.gdshader
@@ -31,22 +31,20 @@ void vertex(){
     VERTEX.z += sin(worldVertex.x * movementWigglyNess - TIME / 4.0f) / 10.f
         * wigglyNess * size;
     
-    float verticalWave = sin(NODE_POSITION_WORLD.z * movementWigglyNess * 0.25f
-        + worldVertex.z * 0.4f + TIME / 4.0f);
-    float horizontalWave = sin(NODE_POSITION_WORLD.x * movementWigglyNess * 0.25f
-        + worldVertex.x * 0.4f + TIME / 4.0f);
-    VERTEX.y += (verticalWave + horizontalWave + 2.0f)
+    float verticalAngle = NODE_POSITION_WORLD.z * movementWigglyNess * 0.25f
+        + worldVertex.z * 0.4f + TIME / 4.0f;
+    float horizontalAngle = NODE_POSITION_WORLD.x * movementWigglyNess * 0.25f
+        + worldVertex.x * 0.4f + TIME / 4.0f;
+    VERTEX.y += (sin(verticalAngle) + sin(horizontalAngle) + 2.0f)
         * 0.25f * wigglyNess * abs(worldVertex.y);
     
-	vec2 verticalTangent = normalize(vec2(abs(cos(NODE_POSITION_WORLD.z * movementWigglyNess * 0.25f
-        + worldVertex.z * 0.4f + TIME / 4.0f)), 1.0f))
-	    * 0.25f * wigglyNess * abs(worldVertex.y);
-	vec2 horizontalTangent = normalize(vec2(abs(cos(NODE_POSITION_WORLD.x * movementWigglyNess * 0.25f
-        + worldVertex.x * 0.4f + TIME / 4.0f)), 1.0f))
-	    * 0.25f * wigglyNess * abs(worldVertex.y);
-	
-    NORMAL += vec3(-horizontalTangent.x, horizontalTangent.y + verticalTangent.y, -verticalTangent.x);
-    TANGENT += vec3(horizontalTangent.y, -horizontalTangent.x - verticalTangent.x, verticalTangent.y);
+    vec2 verticalDerivative = normalize(vec2(abs(cos(verticalAngle)), 1.0f))
+        * 0.25f * wigglyNess * abs(worldVertex.y);
+    vec2 horizontalDerivative = normalize(vec2(abs(cos(horizontalAngle)), 1.0f))
+        * 0.25f * wigglyNess * abs(worldVertex.y);
+    
+    NORMAL += vec3(-horizontalDerivative.x, horizontalDerivative.y + verticalDerivative.y, -verticalDerivative.x);
+    TANGENT += vec3(horizontalDerivative.y, -horizontalDerivative.x - verticalDerivative.x, verticalDerivative.y);
     
     NORMAL = normalize(NORMAL);
     TANGENT = normalize(TANGENT);


### PR DESCRIPTION
**Brief Description of What This PR Does**

Continuing from #5613 

1. Makes membranes' vertical waves go in two directions (not only in one, as before)
2. Adjusts normals based on those waves to make shadows and the fresnel shader work correctly.

https://github.com/user-attachments/assets/52a74957-319c-48a8-9900-a9835d6df3a8


https://github.com/user-attachments/assets/945cf9d0-2eaf-42b6-b13f-a442092a995d



I don't think this should make it into 0.7.1, as there is the visual aspect to discuss and the performance aspect to evaluate.

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
