### PR TITLE
Tie jump force to mass

### DIFF
--- a/src/late_multicellular_stage/MulticellularCreature.cs
+++ b/src/late_multicellular_stage/MulticellularCreature.cs
@@ -71,6 +71,9 @@ public partial class MulticellularCreature : RigidBody3D, ISaveLoadedTracked, IC
     [JsonProperty]
     private float upDownSwimSpeed = 3;
 
+    [JsonProperty]
+    private float jumpStrength = 60;
+
     private bool actionHasSucceeded;
 
     // TODO: implement
@@ -377,7 +380,7 @@ public partial class MulticellularCreature : RigidBody3D, ISaveLoadedTracked, IC
             // TODO: only allow jumping when touching the ground
             // TODO: suppress jump when the user just interacted with a dialog to confirm something, maybe jump should
             // use the on press key thing to only trigger jumping once?
-            ApplyCentralImpulse(new Vector3(0, 1, 0) * (float)delta * 12000);
+            ApplyCentralImpulse(new Vector3(0, 1, 0) * (float)delta * jumpStrength * Mass);
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR ties the jump force of a multicellular creature to the creature's mass.

**Related Issues**

This fixes the issue of small creatures being launched into the air and big creatures being unable to get off the ground at all.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
