### PR TITLE
Reduced base endosymbiosis time costs by one

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1522,7 +1522,7 @@ public static class Constants
     ///   How many times a target species needs to be engulfed for it to be completed (in the base case, this is
     ///   lowered with more organelle instances)
     /// </summary>
-    public const int ENDOSYMBIOSIS_COST_BASE = 6;
+    public const int ENDOSYMBIOSIS_COST_BASE = 5;
 
     public const int ENDOSYMBIOSIS_COST_REDUCTION_PER_ORGANELLE = 1;
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

to make it easier to get endosymbionts with species lasting less time now

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
