### PR TITLE
Fix light level bar sunlight icon aspect ratio

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.tscn
+++ b/src/microbe_stage/editor/CellEditorComponent.tscn
@@ -453,6 +453,7 @@ size_flags_vertical = 4
 tooltip_text = "SUNLIGHT"
 texture = ExtResource("15")
 expand_mode = 1
+stretch_mode = 5
 
 [node name="Control" type="Control" parent="TopPanel/PanelContainer/MarginContainer/HBoxContainer"]
 custom_minimum_size = Vector2(10, 0)


### PR DESCRIPTION
**Brief Description of What This PR Does**

it was set to the wrong stretch mode

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/228300288023461893/958598553389903913/1301582294104150100

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
