### PR TITLE
Hide osmoregulation cost section in tooltips for upgrades

### DIFF
--- a/src/microbe_stage/editor/tooltips/SelectionMenuToolTip.cs
+++ b/src/microbe_stage/editor/tooltips/SelectionMenuToolTip.cs
@@ -55,6 +55,7 @@ public partial class SelectionMenuToolTip : ControlWithInput, ICustomToolTip
     private string processesDescription = string.Empty;
     private int mpCost;
     private float osmoregulationCost;
+    private bool showOsmoregulation = true;
     private bool requiresNucleus;
     private string? thriveopediaPageName;
 
@@ -131,6 +132,23 @@ public partial class SelectionMenuToolTip : ControlWithInput, ICustomToolTip
         }
     }
 
+    /// <summary>
+    ///   If set to false hides the osmoregulation cost section of this tooltip.
+    /// </summary>
+    [Export]
+    public bool ShowOsmoregulation
+    {
+        get => showOsmoregulation;
+        set
+        {
+            if (showOsmoregulation == value)
+                return;
+
+            showOsmoregulation = value;
+            UpdateOsmoregulationCost();
+        }
+    }
+
     [Export]
     public bool RequiresNucleus
     {
@@ -177,6 +195,11 @@ public partial class SelectionMenuToolTip : ControlWithInput, ICustomToolTip
         UpdateRequiresNucleus();
         UpdateLists();
         UpdateMoreInfo();
+
+        // Apply initial hidden state to osmoregulation if it was applied before this was put into the scene tree
+        // TODO: make also other properties work before this is added to the scene tree to not cause surprise problems
+        if (!ShowOsmoregulation)
+            UpdateOsmoregulationCost();
     }
 
     public override void _EnterTree()
@@ -406,7 +429,16 @@ public partial class SelectionMenuToolTip : ControlWithInput, ICustomToolTip
         if (osmoregulationModifier == null)
             return;
 
-        osmoregulationModifier.ModifierValue = $"+{osmoregulationCost.ToString("0.###", CultureInfo.CurrentCulture)}";
+        if (ShowOsmoregulation)
+        {
+            osmoregulationModifier.Visible = true;
+            osmoregulationModifier.ModifierValue =
+                $"+{osmoregulationCost.ToString("0.###", CultureInfo.CurrentCulture)}";
+        }
+        else
+        {
+            osmoregulationModifier.Visible = false;
+        }
     }
 
     private void UpdateRequiresNucleus()

--- a/src/microbe_stage/editor/upgrades/OrganelleUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/OrganelleUpgradeGUI.cs
@@ -142,6 +142,7 @@ public partial class OrganelleUpgradeGUI : Control
                 tooltip.DisplayName = upgrade.Name;
                 tooltip.Description = upgrade.Description;
                 tooltip.MutationPointCost = cost;
+                tooltip.ShowOsmoregulation = false;
 
                 // TODO: add support for flavour text
                 // tooltip.ProcessesDescription = upgrade.Description;


### PR DESCRIPTION
**Brief Description of What This PR Does**

as upgrades do not affect osmoregulation so it was incorrectly shown, adds the ability for other places as well to easily hide that part of the tooltip if required

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Bug I noticed in SonOfMowgef's latest Thrive video

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
