### PR TITLE
Fix physics body detached method native interop returning wrong results

### DIFF
--- a/src/engine/common_systems/PhysicsBodyCreationSystem.cs
+++ b/src/engine/common_systems/PhysicsBodyCreationSystem.cs
@@ -155,6 +155,11 @@ public sealed class PhysicsBodyCreationSystem : AEntitySetSystem<float>
 
         physics.Body = body;
         shapeHolder.UpdateBodyShapeIfCreated = false;
+
+#if DEBUG
+        if (physics.Body.IsDetached)
+            throw new Exception("Physics body created in detached state");
+#endif
     }
 
     protected override void PostUpdate(float delta)

--- a/src/engine/physics/NativePhysicsBody.cs
+++ b/src/engine/physics/NativePhysicsBody.cs
@@ -69,7 +69,7 @@ public class NativePhysicsBody : IDisposable, IEquatable<NativePhysicsBody>
     public bool MicrobeControlEnabled { get; set; }
 
     public bool IsDisposed => disposed;
-    public bool IsDetached => NativeMethods.PhysicsBodyIsDetached(AccessBodyInternal());
+    public bool IsDetached => NativeMethods.PhysicsBodyIsDetached(AccessBodyInternal()) != 0;
 
     public static bool operator ==(NativePhysicsBody? left, NativePhysicsBody? right)
     {
@@ -204,8 +204,10 @@ internal static partial class NativeMethods
     [DllImport("thrive_native")]
     internal static extern void ReleasePhysicsBodyReference(IntPtr body);
 
+    // TODO: find out why this had to be converted to have return type "byte" instead of bool
+    // BUG: https://github.com/Revolutionary-Games/Thrive/issues/5676
     [DllImport("thrive_native")]
-    internal static extern bool PhysicsBodyIsDetached(IntPtr body);
+    internal static extern byte PhysicsBodyIsDetached(IntPtr body);
 
     [DllImport("thrive_native")]
     internal static extern void PhysicsBodySetUserData(IntPtr body, in Entity userData, int userDataSize);

--- a/src/native/interop/CInterop.cpp
+++ b/src/native/interop/CInterop.cpp
@@ -533,7 +533,13 @@ void ReleasePhysicsBodyReference(PhysicsBody* body)
 
 bool PhysicsBodyIsDetached(PhysicsBody* body)
 {
-    return reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->IsDetached();
+    // Due to the C# interop declaration not working correctly for this function, the return value is interpreted as
+    // a byte
+    static_assert(sizeof(bool) == 1);
+
+    const bool detached = reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->IsDetached();
+
+    return detached;
 }
 
 void PhysicsBodySetUserData(PhysicsBody* body, const char* data, int32_t dataLength)

--- a/src/native/physics/PhysicalWorld.cpp
+++ b/src/native/physics/PhysicalWorld.cpp
@@ -1364,6 +1364,15 @@ Ref<PhysicsBody> PhysicalWorld::OnBodyCreated(Ref<PhysicsBody>&& body, bool addT
     {
         physicsSystem->GetBodyInterface().AddBody(body->GetId(), JPH::EActivation::Activate);
         OnPostBodyAdded(*body);
+
+        // Sanity checking debug code (likely will never trigger)
+#ifndef NDEBUG
+        if (body->IsDetached()) [[unlikely]]
+        {
+            LOG_ERROR("Created physics body ended up in detached state.");
+            std::abort();
+        }
+#endif
     }
 
     return std::move(body);


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes the game run again with a latest recompiled native library

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

adds a workaround for https://github.com/Revolutionary-Games/Thrive/issues/5676 but I have no clue what the root problem is actually

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
