### PR TITLE
Make auto-evo timeline not claim species extinct when saved by external effects

### DIFF
--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -1253,7 +1253,6 @@ public class RunResults
 
                 if (globalPopulation <= 0)
                 {
-                    // TODO: see https://github.com/Revolutionary-Games/Thrive/issues/2958
                     LogEventGloballyAndLocally(world, patch,
                         new LocalizedString("TIMELINE_SPECIES_EXTINCT", species.FormattedNameBbCodeUnstyled),
                         species.PlayerSpecies, false, "extinction.png");

--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -1276,7 +1276,7 @@ public class RunResults
                             species.PlayerSpecies, false, "popDown.png");
                     }
                 }
-                else
+                else if (finalPatchPopulation <= 0)
                 {
                     patch.LogEvent(new LocalizedString("TIMELINE_SPECIES_EXTINCT_LOCAL",
                         species.FormattedNameBbCodeUnstyled), species.PlayerSpecies, false, "extinctionLocal.png");


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes auto-evo timeline showing species as extinct when they aren't.

The issue was seemingly a wrong if condition, rather that external effects not being taken into account

**Related Issues**

Fixes #2958
Fixes #3086

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
