### PR TITLE
Fixed hex popup menu acting on deleted hexes

### DIFF
--- a/src/early_multicellular_stage/editor/CellPopupMenu.cs
+++ b/src/early_multicellular_stage/editor/CellPopupMenu.cs
@@ -44,6 +44,12 @@ public partial class CellPopupMenu : HexPopupMenu
         }
     }
 
+    public IEnumerable<HexWithData<CellTemplate>> GetSelectedThatAreStillValid(
+        IReadOnlyCollection<HexWithData<CellTemplate>> allValidCells)
+    {
+        return SelectedCells.Where(allValidCells.Contains);
+    }
+
     protected override void UpdateTitleLabel()
     {
         if (titleLabel == null)

--- a/src/general/base_stage/HexEditorComponentBase.cs
+++ b/src/general/base_stage/HexEditorComponentBase.cs
@@ -537,13 +537,19 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
         return true;
     }
 
-    public void StartHexMove(THexMove selectedHex)
+    public void StartHexMove(THexMove? selectedHex)
     {
         if (MovingPlacedHex != null || CanCancelAction)
         {
             // Already moving something! some code went wrong
             throw new InvalidOperationException(
                 "Can't begin hex move while another in progress (or another in-progress action)");
+        }
+
+        if (selectedHex == null)
+        {
+            GD.PrintErr("Skipping hex move start as the target has disappeared");
+            return;
         }
 
         MovingPlacedHex = selectedHex;
@@ -556,6 +562,9 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
     {
         // TODO: implement: https://github.com/Revolutionary-Games/Thrive/issues/3318
         throw new NotImplementedException();
+
+        // TODO: this needs to handle the case where the enumerable is empty (as that is a possible edge case when the
+        // player is slightly exploiting the hex popup menu)
 
         /*
         if (MovingOrganelles != null)

--- a/src/late_multicellular_stage/editor/MetaballBodyEditorComponent.cs
+++ b/src/late_multicellular_stage/editor/MetaballBodyEditorComponent.cs
@@ -845,26 +845,36 @@ public partial class MetaballBodyEditorComponent :
         if (Settings.Instance.MoveOrganellesWithSymmetry.Value)
         {
             // Start moving the cells symmetrical to the clicked cell.
-            StartMetaballMoveWithSymmetry(metaballPopupMenu.SelectedMetaballs);
+            StartMetaballMoveWithSymmetry(metaballPopupMenu.GetSelectedThatAreStillValid(editedMetaballs));
         }
         else
         {
-            StartMetaballMove(metaballPopupMenu.SelectedMetaballs.First());
+            StartMetaballMove(metaballPopupMenu.GetSelectedThatAreStillValid(editedMetaballs).FirstOrDefault());
         }
     }
 
     private void OnDeletePressed()
     {
         int alreadyDeleted = 0;
-        var action =
-            new CombinedEditorAction(metaballPopupMenu.SelectedMetaballs
-                .Select(m => TryCreateMetaballRemoveAction(m, ref alreadyDeleted)).WhereNotNull());
+        var targets = metaballPopupMenu.GetSelectedThatAreStillValid(editedMetaballs)
+            .Select(m => TryCreateMetaballRemoveAction(m, ref alreadyDeleted)).WhereNotNull().ToList();
+
+        if (targets.Count < 1)
+        {
+            GD.PrintErr("No targets found to delete");
+            return;
+        }
+
+        var action = new CombinedEditorAction(targets);
+
         EnqueueAction(action);
     }
 
     private void OnModifyPressed()
     {
-        EmitSignal(SignalName.OnCellTypeToEditSelected, metaballPopupMenu.SelectedMetaballs.First().CellType.TypeName);
+        // Should be safe for us to try to signal to edit any kind of cell so this doesn't check if the cell is removed
+        EmitSignal(SignalName.OnCellTypeToEditSelected,
+            metaballPopupMenu.SelectedMetaballs.First().CellType.TypeName);
     }
 
     /// <summary>

--- a/src/late_multicellular_stage/editor/MetaballEditorComponentBase.cs
+++ b/src/late_multicellular_stage/editor/MetaballEditorComponentBase.cs
@@ -417,12 +417,18 @@ public partial class MetaballEditorComponentBase<TEditor, TCombinedAction, TActi
         return true;
     }
 
-    public void StartMetaballMove(TMetaball selectedMetaball)
+    public void StartMetaballMove(TMetaball? selectedMetaball)
     {
         if (MovingPlacedMetaball != null)
         {
             // Already moving something! some code went wrong
             throw new InvalidOperationException("Can't begin metaball move while another in progress");
+        }
+
+        if (selectedMetaball == null)
+        {
+            GD.PrintErr("Skipping metaball move start as the target has disappeared");
+            return;
         }
 
         MovingPlacedMetaball = selectedMetaball;

--- a/src/late_multicellular_stage/editor/MetaballPopupMenu.cs
+++ b/src/late_multicellular_stage/editor/MetaballPopupMenu.cs
@@ -44,6 +44,12 @@ public partial class MetaballPopupMenu : HexPopupMenu
         }
     }
 
+    public IEnumerable<MulticellularMetaball> GetSelectedThatAreStillValid(
+        IReadOnlyCollection<MulticellularMetaball> allValidMetaballs)
+    {
+        return SelectedMetaballs.Where(allValidMetaballs.Contains);
+    }
+
     protected override void UpdateTitleLabel()
     {
         if (titleLabel == null)

--- a/src/microbe_stage/editor/CombinedEditorAction.cs
+++ b/src/microbe_stage/editor/CombinedEditorAction.cs
@@ -29,6 +29,17 @@ public class CombinedEditorAction : EditorAction
             throw new ArgumentException("Actions can't be empty");
     }
 
+    /// <summary>
+    ///   Constructor variant that takes ownership of the action list
+    /// </summary>
+    public CombinedEditorAction(List<EditorAction> actions)
+    {
+        this.actions = actions;
+
+        if (Actions.Count < 1)
+            throw new ArgumentException("Actions can't be empty");
+    }
+
     [JsonIgnore]
     public IReadOnlyList<EditorAction> Actions => actions;
 

--- a/src/microbe_stage/editor/OrganellePopupMenu.cs
+++ b/src/microbe_stage/editor/OrganellePopupMenu.cs
@@ -4,20 +4,15 @@ using System.Linq;
 using Godot;
 
 /// <summary>
-///   Manages a custom context menu solely for showing list of options for a placed organelle
-///   in the microbe editor.
+///   Manages a custom context menu solely for showing list of options for a placed organelle in the microbe editor.
 /// </summary>
 public partial class OrganellePopupMenu : HexPopupMenu
 {
     private List<OrganelleTemplate>? selectedOrganelles;
 
     /// <summary>
-    ///   The organelle the user explicitly selected. Other organelles are selected with symmetry.
-    /// </summary>
-    public OrganelleTemplate? MainOrganelle => selectedOrganelles?[0];
-
-    /// <summary>
-    ///   The placed organelles to be shown options of.
+    ///   The placed organelles to be shown options of. The main organelle is at index 0, if there are multiple
+    ///   selected with symmetry. Note that most uses should use <see cref="GetSelectedThatAreStillValid"/> instead.
     /// </summary>
     public List<OrganelleTemplate> SelectedOrganelles
     {
@@ -43,6 +38,18 @@ public partial class OrganellePopupMenu : HexPopupMenu
             UpdateDeleteButton();
             UpdateMoveButton();
         }
+    }
+
+    /// <summary>
+    ///   Filters the list of organelles this is used on to ones that are still within the list of valid ones to
+    ///   prevent removed organelles from being used.
+    /// </summary>
+    /// <param name="allValidOrganelles">Collection of all valid organelles</param>
+    /// <returns>Organelles filtered to just valid ones from <see cref="SelectedOrganelles"/></returns>
+    public IEnumerable<OrganelleTemplate> GetSelectedThatAreStillValid(
+        IReadOnlyCollection<OrganelleTemplate> allValidOrganelles)
+    {
+        return SelectedOrganelles.Where(allValidOrganelles.Contains);
     }
 
     protected override void UpdateTitleLabel()


### PR DESCRIPTION
that could be used for an infinite MP exploit

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/228300288023461893/958598553389903913/1307847140047065178
**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
