### PR TITLE
Fix extinct species not having preview in auto-evo exporer

### DIFF
--- a/src/auto-evo/AutoEvoExploringTool.cs
+++ b/src/auto-evo/AutoEvoExploringTool.cs
@@ -386,9 +386,14 @@ public partial class AutoEvoExploringTool : NodeWithInput, ISpeciesDataProvider
 
     public Species? GetActiveSpeciesData(uint speciesId)
     {
+        return GetActiveSpeciesDataFromGeneration(generationDisplayed, speciesId);
+    }
+
+    public Species? GetActiveSpeciesDataFromGeneration(int generation, uint speciesId)
+    {
         var gameWorld = world.GameProperties.GameWorld;
 
-        for (int i = generationDisplayed; i >= 0; --i)
+        for (int i = generation; i >= 0; --i)
         {
             gameWorld.GenerationHistory[i].AllSpeciesData
                 .TryGetValue(speciesId, out var speciesRecord);
@@ -891,7 +896,16 @@ public partial class AutoEvoExploringTool : NodeWithInput, ISpeciesDataProvider
     private void EvolutionaryTreeNodeSelected(int generation, uint id)
     {
         HistoryListMenuIndexChanged(generation);
-        UpdateSpeciesPreview(world.SpeciesHistoryList[generation][id]);
+
+        var species = GetActiveSpeciesDataFromGeneration(generation, id);
+
+        if (species == null)
+        {
+            GD.PrintErr("Couldn't find active species data to show");
+            return;
+        }
+
+        UpdateSpeciesPreview(species);
     }
 
     private void PatchListMenuIndexChanged(int index)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes extinct species not having previews in auto-evo exporer

**Related Issues**

Fixes #5435

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
