### PR TITLE
Only use forced engulf mode if ATP is below 45% of max storage

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -855,6 +855,12 @@ public static class Constants
     public const float ENGULF_NO_ATP_TRIGGER_THRESHOLD = 0.7f;
 
     /// <summary>
+    ///   On top of <see cref="ENGULF_NO_ATP_TRIGGER_THRESHOLD"/> ATP needs to be less than this fraction of storage.
+    ///   This is to protect small cells that have only like max of 1 storage.
+    /// </summary>
+    public const float ENGULF_NO_ATP_FRACTION_OF_STORAGE_BELOW = 0.45f;
+
+    /// <summary>
     ///   How often in seconds damage is checked and applied when cell digests a toxic cell
     /// </summary>
     public const float TOXIN_DIGESTION_DAMAGE_CHECK_INTERVAL = 0.9f;


### PR DESCRIPTION
**Brief Description of What This PR Does**

to ensure small cells don't accidentally take the engulf ATP damage

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
