### PR TITLE
Faster diffuse of compounds between patches

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1188,6 +1188,9 @@ public static class Constants
     public const float GLUCOSE_MIN = 0.0f;
 
     // Tweak variable for how fast compounds diffuse between patches
+    public const float COMPOUND_DIFFUSE_BASE_MOVE_AMOUNT_SIMPLE = 0.8f;
+
+    // More complex square root distance movement calculation variables:
     public const float COMPOUND_DIFFUSE_BASE_MOVE_AMOUNT = 1;
     public const float COMPOUND_DIFFUSE_BASE_DISTANCE = 1;
 

--- a/src/general/world_effects/CompoundDiffusionEffect.cs
+++ b/src/general/world_effects/CompoundDiffusionEffect.cs
@@ -4,8 +4,9 @@ using Godot;
 using Newtonsoft.Json;
 
 /// <summary>
-///   An effect diffusing specially marked compounds between patches (and also takes ocean depth into account) in
-///   contrast to <see cref="AllCompoundDiffusionEffect"/>
+///   An effect diffusing specially marked compounds between patches (and also takes ocean depth into account). This
+///   operates on specific compounds as it causes a bit of a mess and unintended effects if all compounds are always
+///   allowed to move.
 /// </summary>
 [JSONDynamicTypeAllowed]
 public class CompoundDiffusionEffect : IWorldEffect

--- a/src/general/world_effects/PhotosynthesisProductionEffect.cs
+++ b/src/general/world_effects/PhotosynthesisProductionEffect.cs
@@ -4,7 +4,7 @@ using Systems;
 
 /// <summary>
 ///   Creates oxygen based on photosynthesizers (and removes carbon). And does the vice versa for oxygen consumption
-///   to balance things out. This is kind of a simplified version of <see cref="CompoundProductionEffect"/>
+///   to balance things out.
 /// </summary>
 [JSONDynamicTypeAllowed]
 public class PhotosynthesisProductionEffect : IWorldEffect


### PR DESCRIPTION
**Brief Description of What This PR Does**

Gets just the simpler fast diffuse between patches from https://github.com/Revolutionary-Games/Thrive/pull/5693 so that it can be put in for 0.8.0

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
