### PR TITLE
Fix the lag when zooming out in the patch map

### DIFF
--- a/src/gui_common/DraggableScrollContainer.cs
+++ b/src/gui_common/DraggableScrollContainer.cs
@@ -189,9 +189,16 @@ public partial class DraggableScrollContainer : ScrollContainer
             tween.TweenCallback(Callable.From(onPanned));
     }
 
-    public void ResetZoom()
+    public void ResetZoom(bool smoothed = true)
     {
-        Zoom(1, 1.0f);
+        if (smoothed)
+        {
+            Zoom(1, 1.0f);
+        }
+        else
+        {
+            ImmediateZoom(1);
+        }
     }
 
     public void CenterTo(Vector2 coordinates, bool smoothed)
@@ -208,7 +215,7 @@ public partial class DraggableScrollContainer : ScrollContainer
             ImmediatePan(viewCoords);
         }
 
-        ResetZoom();
+        ResetZoom(smoothed);
     }
 
     protected override void Dispose(bool disposing)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes the lag (actually just zoom returning to the default value) when initially zooming out in the patch map.

**Related Issues**

Fixes #4722

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
