### PR TITLE
Made glucose reduction summary text only for discovered patches

### DIFF
--- a/src/general/world_effects/GlucoseReductionEffect.cs
+++ b/src/general/world_effects/GlucoseReductionEffect.cs
@@ -15,12 +15,16 @@ public class GlucoseReductionEffect : IWorldEffect
         this.targetWorld = targetWorld;
     }
 
+    public bool IncludeAllPatchesInGlucoseReductionDisplay { get; set; }
+
     public void OnRegisterToWorld()
     {
     }
 
     public void OnTimePassed(double elapsed, double totalTimePassed)
     {
+        bool includeAllPatches = IncludeAllPatchesInGlucoseReductionDisplay;
+
         var glucoseDefinition = SimulationParameters.GetCompound(Compound.Glucose);
 
         var totalAmount = 0.0f;
@@ -39,9 +43,13 @@ public class GlucoseReductionEffect : IWorldEffect
                 return;
             }
 
-            totalAmount += glucoseValue.Amount;
-            initialTotalDensity += glucoseValue.Density;
-            totalChunkAmount += patch.GetTotalChunkCompoundAmount(Compound.Glucose);
+            // Change stats are calculated either for all patches or only patches the player has discovered already
+            if (includeAllPatches || patch.Visibility == MapElementVisibility.Shown)
+            {
+                totalAmount += glucoseValue.Amount;
+                initialTotalDensity += glucoseValue.Density;
+                totalChunkAmount += patch.GetTotalChunkCompoundAmount(Compound.Glucose);
+            }
 
             // If there are microbes to be eating up the primordial soup, reduce the milk
             if (patch.SpeciesInPatch.Count > 0)
@@ -67,7 +75,8 @@ public class GlucoseReductionEffect : IWorldEffect
                     "glucoseDown.png");
             }
 
-            finalTotalDensity += patch.Biome.ChangeableCompounds[Compound.Glucose].Density;
+            if (includeAllPatches || patch.Visibility == MapElementVisibility.Shown)
+                finalTotalDensity += patch.Biome.ChangeableCompounds[Compound.Glucose].Density;
         }
 
         var initialTotalGlucose = Math.Round(initialTotalDensity * totalAmount + totalChunkAmount, 3);


### PR DESCRIPTION
**Brief Description of What This PR Does**

so that the drop percentages are again threatening in order to ensure the player will take them seriously

This shouldn't affect the actual simulation numbers at all.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
With the new report I noticed that the reduction values shown were always very low so I had this for a while on my TODO list to make the GUI more threatening again to the player to make sure people don't accidentally go all in on glucose and then fail

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
