### PR TITLE
Fix photostudio's distance calculation formula

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1558,7 +1558,7 @@ public static class Constants
 
     public const float PHOTO_STUDIO_CAMERA_FOV = 70;
     public const float PHOTO_STUDIO_CAMERA_HALF_ANGLE = PHOTO_STUDIO_CAMERA_FOV / 2.0f;
-    public const float PHOTO_STUDIO_CELL_RADIUS_MULTIPLIER = 0.80f;
+    public const float PHOTO_STUDIO_CELL_RADIUS_MULTIPLIER = 1.20f;
 
     public const int RESOURCE_LOAD_TARGET_MIN_FPS = 60;
     public const float RESOURCE_TIME_BUDGET_PER_FRAME = 1.0f / RESOURCE_LOAD_TARGET_MIN_FPS;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1558,7 +1558,7 @@ public static class Constants
 
     public const float PHOTO_STUDIO_CAMERA_FOV = 70;
     public const float PHOTO_STUDIO_CAMERA_HALF_ANGLE = PHOTO_STUDIO_CAMERA_FOV / 2.0f;
-    public const float PHOTO_STUDIO_CELL_RADIUS_MULTIPLIER = 1.20f;
+    public const float PHOTO_STUDIO_CELL_RADIUS_MULTIPLIER = 1.50f;
 
     public const int RESOURCE_LOAD_TARGET_MIN_FPS = 60;
     public const float RESOURCE_TIME_BUDGET_PER_FRAME = 1.0f / RESOURCE_LOAD_TARGET_MIN_FPS;

--- a/src/engine/PhotoStudio.cs
+++ b/src/engine/PhotoStudio.cs
@@ -103,11 +103,9 @@ public partial class PhotoStudio : SubViewport
         if (radius <= 0)
             throw new ArgumentException("radius needs to be over 0");
 
-        // TODO: figure out if the camera FOV or FOV / 2 is the right thing to use here
-        float angle = Constants.PHOTO_STUDIO_CAMERA_FOV;
+        float angle = Constants.PHOTO_STUDIO_CAMERA_HALF_ANGLE;
 
-        // Some right angle triangle math that's hopefully right
-        return MathF.Tan(MathUtils.DEGREES_TO_RADIANS * angle) * radius;
+        return MathF.Tan(MathF.PI * 0.5f - MathUtils.DEGREES_TO_RADIANS * angle) * radius;
     }
 
     public override void _Ready()


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes photostudio's formula for calculating the distance to the photographed object.

Additionally, changes a constant to compensate for the formula being changed; otherwise the distance calculated is slightly less than it should be.

The reasoning for the new formula:
![image](https://github.com/user-attachments/assets/adef4612-3db8-4325-ba47-294af723a524)

**Related Issues**

A TODO in the code

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
