### PR TITLE
Add a miche viewer to the auto-evo prediction

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -3066,6 +3066,8 @@ public partial class CellEditorComponent :
         }
 
         micheViewer.ShowMiches(Editor.CurrentPatch, predictionMiches, Editor.CurrentGame.GameWorld.WorldSettings);
+
+        autoEvoPredictionExplanationPopup.Hide();
     }
 
     private class PendingAutoEvoPrediction

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -361,6 +361,8 @@ public partial class CellEditorComponent :
     private PendingAutoEvoPrediction? waitingForPrediction;
     private LocalizedStringBuilder? predictionDetailsText;
 
+    private Miche? predictionMiches;
+
     private OrganelleSuggestionCalculation? inProgressSuggestion;
     private bool suggestionDirty;
     private double suggestionStartTimer;
@@ -2977,6 +2979,8 @@ public partial class CellEditorComponent :
         {
             UpdateAutoEvoPredictionDetailsText();
         }
+
+        predictionMiches = results.GetMicheForPatch(Editor.CurrentPatch);
     }
 
     private void CreateAutoEvoPredictionDetailsText(
@@ -3055,16 +3059,13 @@ public partial class CellEditorComponent :
     {
         GUICommon.Instance.PlayButtonPressSound();
 
-        if (Editor.PreviousAutoEvoResults == null)
+        if (predictionMiches == null)
         {
-            GD.PrintErr("Missing auto-evo results, can't show miches");
+            GD.PrintErr("Missing miches data, can't show the popup");
             return;
         }
 
-        var patch = Editor.CurrentPatch;
-
-        micheViewer.ShowMiches(patch, Editor.PreviousAutoEvoResults.GetMicheForPatch(patch),
-            Editor.CurrentGame.GameWorld.WorldSettings);
+        micheViewer.ShowMiches(Editor.CurrentPatch, predictionMiches, Editor.CurrentGame.GameWorld.WorldSettings);
     }
 
     private class PendingAutoEvoPrediction

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -306,6 +306,9 @@ public partial class CellEditorComponent :
     [Export]
     private CustomWindow processListWindow = null!;
 
+    [Export]
+    private PopupMicheViewer micheViewer = null!;
+
     private CustomWindow autoEvoPredictionExplanationPopup = null!;
     private CustomRichTextLabel autoEvoPredictionExplanationLabel = null!;
 
@@ -3046,6 +3049,22 @@ public partial class CellEditorComponent :
     private void ToggleProcessList()
     {
         processListWindow.Visible = !processListWindow.Visible;
+    }
+
+    private void OnMicheViewRequested()
+    {
+        GUICommon.Instance.PlayButtonPressSound();
+
+        if (Editor.PreviousAutoEvoResults == null)
+        {
+            GD.PrintErr("Missing auto-evo results, can't show miches");
+            return;
+        }
+
+        var patch = Editor.CurrentPatch;
+
+        micheViewer.ShowMiches(patch, Editor.PreviousAutoEvoResults.GetMicheForPatch(patch),
+            Editor.CurrentGame.GameWorld.WorldSettings);
     }
 
     private class PendingAutoEvoPrediction

--- a/src/microbe_stage/editor/CellEditorComponent.tscn
+++ b/src/microbe_stage/editor/CellEditorComponent.tscn
@@ -1313,11 +1313,6 @@ tooltip_text = "ORGANELLE_SUGGESTION_TOOLTIP"
 mouse_filter = 1
 label_settings = ExtResource("24_ekuel")
 
-[node name="MichesViewButton" type="Button" parent="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/MarginContainer/VBoxContainer"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 14
-text = "VIEW_PATCH_MICHES"
-
 [node name="EditorComponentBottomLeftButtons" parent="." instance=ExtResource("3")]
 layout_mode = 1
 offset_top = -53.0
@@ -1507,6 +1502,11 @@ text = "AUTO-EVO_EXPLANATION_EXPLANATION"
 label_settings = ExtResource("28_qclxk")
 autowrap_mode = 3
 
+[node name="MichesViewButton" type="Button" parent="PredictionExplanation/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 14
+text = "VIEW_PATCH_MICHES"
+
 [node name="Close" type="Button" parent="PredictionExplanation/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 4
@@ -1540,7 +1540,6 @@ layout_mode = 1
 [connection signal="BalanceTypeChanged" from="RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/CompoundBalanceDisplay" to="." method="OnCompoundBalanceTypeChanged"]
 [connection signal="pressed" from="RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/ProcessListButton" to="." method="ToggleProcessList"]
 [connection signal="pressed" from="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Header/HBoxContainer/Details" to="." method="OpenAutoEvoPredictionDetails"]
-[connection signal="pressed" from="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/MarginContainer/VBoxContainer/MichesViewButton" to="." method="OnMicheViewRequested"]
 [connection signal="OnNameSet" from="EditorComponentBottomLeftButtons" to="." method="OnSpeciesNameChanged"]
 [connection signal="OnNewClicked" from="EditorComponentBottomLeftButtons" to="." method="CreateNewMicrobe"]
 [connection signal="OnRedo" from="EditorComponentBottomLeftButtons" to="." method="Redo"]
@@ -1559,6 +1558,7 @@ layout_mode = 1
 [connection signal="EndosymbiosisCancelled" from="EndosymbiosisPopup" to="." method="OnAbandonEndosymbiosisOperation"]
 [connection signal="EndosymbiosisFinished" from="EndosymbiosisPopup" to="." method="OnEndosymbiosisFinished"]
 [connection signal="SpeciesSelected" from="EndosymbiosisPopup" to="." method="OnEndosymbiosisSelected"]
+[connection signal="pressed" from="PredictionExplanation/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/MichesViewButton" to="." method="OnMicheViewRequested"]
 [connection signal="pressed" from="PredictionExplanation/VBoxContainer/Close" to="." method="CloseAutoEvoPrediction"]
 
 [editable path="CompleteEndosymbiosisWarning"]

--- a/src/microbe_stage/editor/CellEditorComponent.tscn
+++ b/src/microbe_stage/editor/CellEditorComponent.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=65 format=3 uid="uid://cwot2e52r7lx0"]
+[gd_scene load_steps=66 format=3 uid="uid://cwot2e52r7lx0"]
 
 [ext_resource type="PackedScene" uid="uid://bwegwjlcioasf" path="res://src/microbe_stage/editor/EditorComponentBottomLeftButtons.tscn" id="3"]
 [ext_resource type="Script" path="res://src/microbe_stage/editor/CellEditorComponent.cs" id="4"]
@@ -41,6 +41,7 @@
 [ext_resource type="PackedScene" uid="uid://sxqf3o1pkl0n" path="res://src/microbe_stage/editor/CompoundBalanceDisplay.tscn" id="42"]
 [ext_resource type="PackedScene" uid="uid://cwe0bjv8qtrtr" path="res://src/gui_common/TweakedColourPicker.tscn" id="43"]
 [ext_resource type="PackedScene" path="res://src/gui_common/SegmentedBar.tscn" id="44"]
+[ext_resource type="PackedScene" uid="uid://ci8lopfc3lodh" path="res://src/microbe_stage/editor/PopupMicheViewer.tscn" id="44_bxafd"]
 [ext_resource type="PackedScene" uid="uid://bq6aee8pw8y3m" path="res://src/gui_common/CollapsibleList.tscn" id="45"]
 [ext_resource type="PackedScene" uid="uid://jdsjx1iyga8d" path="res://src/microbe_stage/editor/OrganellePopupMenu.tscn" id="47"]
 
@@ -346,7 +347,7 @@ _data = {
 "show": SubResource("44")
 }
 
-[node name="CellEditorComponent" type="Control" node_paths=PackedStringArray("growthOrderTabButton", "toleranceTabButton", "growthOrderTab", "growthOrderGUI", "toleranceTab", "organelleSuggestionLoadingIndicator", "organelleSuggestionLabel", "atpBalanceLabel", "pendingEndosymbiosisPopup", "endosymbiosisButton", "endosymbiosisPopup", "calculateBalancesAsIfDay", "calculateBalancesWhenMoving", "compoundBalance", "compoundStorageLastingTimes", "notEnoughStorageWarning", "processListButton", "processList", "growthOrderNumberContainer", "processListWindow")]
+[node name="CellEditorComponent" type="Control" node_paths=PackedStringArray("growthOrderTabButton", "toleranceTabButton", "growthOrderTab", "growthOrderGUI", "toleranceTab", "organelleSuggestionLoadingIndicator", "organelleSuggestionLabel", "atpBalanceLabel", "pendingEndosymbiosisPopup", "endosymbiosisButton", "endosymbiosisPopup", "calculateBalancesAsIfDay", "calculateBalancesWhenMoving", "compoundBalance", "compoundStorageLastingTimes", "notEnoughStorageWarning", "processListButton", "processList", "growthOrderNumberContainer", "processListWindow", "micheViewer")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -421,6 +422,7 @@ processListButton = NodePath("RightPanel/VBoxContainer/Statistics/VBoxContainer/
 processList = NodePath("ProcessPanel/ScrollContainer/ProcessList")
 growthOrderNumberContainer = NodePath("GrowthOrderNumberContainer")
 processListWindow = NodePath("ProcessPanel")
+micheViewer = NodePath("PopupMicheViewer")
 IslandErrorPath = NodePath("IslandError")
 MutationPointsBarPath = NodePath("LeftPanel/MainPanel/VBoxContainer/MarginContainer2/MutationPointsBar")
 ComponentBottomLeftButtonsPath = NodePath("EditorComponentBottomLeftButtons")
@@ -1311,6 +1313,11 @@ tooltip_text = "ORGANELLE_SUGGESTION_TOOLTIP"
 mouse_filter = 1
 label_settings = ExtResource("24_ekuel")
 
+[node name="MichesViewButton" type="Button" parent="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 14
+text = "VIEW_PATCH_MICHES"
+
 [node name="EditorComponentBottomLeftButtons" parent="." instance=ExtResource("3")]
 layout_mode = 1
 offset_top = -53.0
@@ -1506,6 +1513,9 @@ size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 14
 text = "CLOSE"
 
+[node name="PopupMicheViewer" parent="." instance=ExtResource("44_bxafd")]
+layout_mode = 1
+
 [connection signal="Clicked" from="." to="EditorComponentBottomLeftButtons" method="OnClickedOffName"]
 [connection signal="gui_input" from="." to="." method="OnHexEditorGuiInput"]
 [connection signal="mouse_entered" from="." to="." method="OnHexEditorMouseEntered"]
@@ -1530,6 +1540,7 @@ text = "CLOSE"
 [connection signal="BalanceTypeChanged" from="RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/CompoundBalanceDisplay" to="." method="OnCompoundBalanceTypeChanged"]
 [connection signal="pressed" from="RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/ProcessListButton" to="." method="ToggleProcessList"]
 [connection signal="pressed" from="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Header/HBoxContainer/Details" to="." method="OpenAutoEvoPredictionDetails"]
+[connection signal="pressed" from="RightPanel/VBoxContainer/AutoEvoInfoPanel/VBoxContainer/Body/MarginContainer/VBoxContainer/MichesViewButton" to="." method="OnMicheViewRequested"]
 [connection signal="OnNameSet" from="EditorComponentBottomLeftButtons" to="." method="OnSpeciesNameChanged"]
 [connection signal="OnNewClicked" from="EditorComponentBottomLeftButtons" to="." method="CreateNewMicrobe"]
 [connection signal="OnRedo" from="EditorComponentBottomLeftButtons" to="." method="Redo"]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds a miche viewer to the auto-evo prediction explanation panel.

**Related Issues**

Closes #5682

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
