### PR TITLE
Fixed auto-evo migration using wrong patch to calculate

### DIFF
--- a/src/auto-evo/Miche.cs
+++ b/src/auto-evo/Miche.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Newtonsoft.Json;
 
 /// <summary>
@@ -46,6 +47,8 @@ public class Miche
     /// </remarks>
     [JsonProperty]
     public Species? Occupant;
+
+    private bool locked;
 
     public Miche(SelectionPressure pressure)
     {
@@ -137,6 +140,8 @@ public class Miche
 
     public void AddChild(Miche newChild)
     {
+        ThrowIfLocked();
+
         Children.Add(newChild);
         newChild.Parent = this;
     }
@@ -235,8 +240,7 @@ public class Miche
 
     public Miche DeepCopy()
     {
-        // This doesn't copy pressures, but it shouldn't need to
-        // Pressures should not have state outside init
+        // This doesn't copy pressures, but it shouldn't need to as pressures should not have any state outside init
 
         if (IsLeafNode())
         {
@@ -254,6 +258,17 @@ public class Miche
         return newMiche;
     }
 
+    /// <summary>
+    ///   Mark miche as added to the simulation, locks this from having the children modified
+    /// </summary>
+    public void Lock()
+    {
+        if (locked)
+            throw new InvalidOperationException("Miche is already locked");
+
+        locked = true;
+    }
+
     public override int GetHashCode()
     {
         var parentHash = Parent != null ? Parent.GetHashCode() : 53;
@@ -261,6 +276,16 @@ public class Miche
         // TODO: as Occupant can change it should not be used as part of the hash code
         return Pressure.GetHashCode() * 131 ^ parentHash * 587 ^
             (Occupant == null ? 17 : Occupant.GetHashCode()) * 5171;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ThrowIfLocked()
+    {
+        if (locked)
+        {
+            throw new InvalidOperationException(
+                "This operation cannot be done after miche is added to the simulation (locked)");
+        }
     }
 
     /// <summary>

--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -74,9 +74,9 @@ public class RunResults
         {
             if (!micheByPatch.TryAdd(patch, miche))
                 throw new InvalidOperationException("Patch already has a miche");
-        }
 
-        miche.Lock();
+            miche.Lock();
+        }
     }
 
     public void AddMutationResultForSpecies(Species species, Species? mutated,

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -98,7 +98,7 @@ public class MigrateSpecies : IRunStep
                 var moveAmount = (long)random.Next(population * Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION_FRACTION,
                     population * Constants.AUTO_EVO_MAXIMUM_MOVE_POPULATION_FRACTION);
 
-                if (moveAmount > 0 && targetMiche.InsertSpecies(species, patch, null, cache, true, insertWorkingMemory))
+                if (moveAmount > 0 && targetMiche.InsertSpecies(species, target, null, cache, true, insertWorkingMemory))
                 {
                     results.AddMigrationResultForSpecies(species, new SpeciesMigration(patch, target, moveAmount));
                     usedTargets.Add(target);

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -98,7 +98,8 @@ public class MigrateSpecies : IRunStep
                 var moveAmount = (long)random.Next(population * Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION_FRACTION,
                     population * Constants.AUTO_EVO_MAXIMUM_MOVE_POPULATION_FRACTION);
 
-                if (moveAmount > 0 && targetMiche.InsertSpecies(species, target, null, cache, true, insertWorkingMemory))
+                if (moveAmount > 0 &&
+                    targetMiche.InsertSpecies(species, target, null, cache, true, insertWorkingMemory))
                 {
                     results.AddMigrationResultForSpecies(species, new SpeciesMigration(patch, target, moveAmount));
                     usedTargets.Add(target);


### PR DESCRIPTION
**Brief Description of What This PR Does**

the resulting miche (it used the source patch instead of the target patch)

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
When adding a miche that uses chunks only present in some patches I noticed errors where it tried to be processed for chunks that didn't exist in a patch. Eventually after adding a lot of other error checking code I noticed that the migration miche accidentally used the source patch data and the target miche rather than pairing up the miche with the target patch. So this fixes that but also adds a bit of other safety code.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
