### PR TITLE
Try to fix Bathypelagic Background

### DIFF
--- a/assets/textures/background/Thrive_bathy0.png.import
+++ b/assets/textures/background/Thrive_bathy0.png.import
@@ -31,4 +31,4 @@ process/normal_map_invert_y=false
 process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
-detect_3d/compress_to=0
+detect_3d/compress_to=1

--- a/assets/textures/background/Thrive_vent0.png.import
+++ b/assets/textures/background/Thrive_vent0.png.import
@@ -31,4 +31,4 @@ process/normal_map_invert_y=false
 process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
-detect_3d/compress_to=0
+detect_3d/compress_to=1

--- a/assets/textures/background/Thrive_vent1.png.import
+++ b/assets/textures/background/Thrive_vent1.png.import
@@ -31,4 +31,4 @@ process/normal_map_invert_y=false
 process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
-detect_3d/compress_to=0
+detect_3d/compress_to=1

--- a/assets/textures/background/Thrive_vent2.png.import
+++ b/assets/textures/background/Thrive_vent2.png.import
@@ -31,4 +31,4 @@ process/normal_map_invert_y=false
 process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
-detect_3d/compress_to=0
+detect_3d/compress_to=1

--- a/assets/textures/background/Thrive_vent3.png.import
+++ b/assets/textures/background/Thrive_vent3.png.import
@@ -31,4 +31,4 @@ process/normal_map_invert_y=false
 process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
-detect_3d/compress_to=0
+detect_3d/compress_to=1


### PR DESCRIPTION
**Brief Description of What This PR Does**

I was not able to replicate the issue with a horizontal line appearing on the bathypelagic patch background, but I noticed that the only patch backgrounds not set to detect_3d/compress_to=1 were for Bathypelagic and Vents. Hopefully this fixes the issue.
(I also checked the texture and found no issues with it.)

**Related Issues**

Hopefully closes #1265

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
