### PR TITLE
Made some disk cache tweaks and actually implemented size pruning

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -445,6 +445,7 @@ public static class Constants
 
     public const float DISK_CACHE_DEFAULT_KEEP = 30 * 24 * 60 * 60;
     public const long DISK_CACHE_DEFAULT_MAX_SIZE = MEBIBYTE * 1024;
+    public const int DISK_CACHE_MAX_DELETES_TO_QUEUE_AT_ONCE = 500;
 
     // Base randomness for visual hashes to make different types not conflict
     public const ulong VISUAL_HASH_CELL = 2106240777368515371UL;

--- a/src/engine/caching/DiskCache.cs
+++ b/src/engine/caching/DiskCache.cs
@@ -469,7 +469,9 @@ public partial class DiskCache : Node, IComputeCache<IImageTask>
             // Convert back to Godot path
             itemPathTemp.Append(Constants.CACHE_IMAGES_FOLDER);
             itemPathTemp.Append('/');
-            itemPathTemp.Append(entry, path.Length, entry.Length - path.Length);
+
+            // +1 needs to be added here to avoid a duplicate '/'
+            itemPathTemp.Append(entry, path.Length + 1, entry.Length - 1 - path.Length);
 
             var cacheEntry = GetCacheItemEntryToUse(itemPathTemp.ToString(), CacheItemType.Png);
             itemPathTemp.Clear();


### PR DESCRIPTION
**Brief Description of What This PR Does**

as I had apparently forgotten that part

Also includes a few various tweaks I did while fully testing the cache cleaning and functionality to confirm it is good before the release

Cache disk size should now only briefly be able to go above the configured limit before the periodic cleaning check kicks in

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
