### PR TITLE
Make compound clouds and 3D objects' lighting depend on the light level

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1036,8 +1036,6 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
 
         var currentPatch = GameWorld.Map.CurrentPatch;
 
-        // TODO: it would make more sense for the GameWorld to update its patch map data based on the
-        // light cycle in it.
         patchManager.UpdatePatchBiome(currentPatch);
         patchManager.UpdateAllPatchLightLevels(currentPatch.BiomeTemplate);
 

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1046,8 +1046,7 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         {
             // This might need to be refactored for efficiency, but it works for now
             var lightLevel =
-                currentPatch.Biome.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient *
-                GameWorld.LightCycle.DayLightFraction;
+                currentPatch.Biome.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient;
 
             // Normalise by maximum light level in the patch
             Camera.LightLevel = lightLevel / maxLightLevel;

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1037,7 +1037,7 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         var currentPatch = GameWorld.Map.CurrentPatch;
 
         patchManager.UpdatePatchBiome(currentPatch);
-        patchManager.UpdateAllPatchLightLevels(currentPatch.BiomeTemplate);
+        patchManager.UpdateAllPatchLightLevels(currentPatch);
 
         HUD.UpdateEnvironmentalBars(GameWorld.Map.CurrentPatch.Biome);
 

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1046,7 +1046,7 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         // Updates the background lighting and does various post-effects
         if (templateMaxLightLevel > 0.0f && maxLightLevel > 0.0f)
         {
-            // This might need to be refactored for efficiency but, it works for now
+            // This might need to be refactored for efficiency, but it works for now
             var lightLevel =
                 currentPatch.Biome.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient *
                 GameWorld.LightCycle.DayLightFraction;

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1034,10 +1034,12 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         if (GameWorld.Map.CurrentPatch == null)
             return;
 
+        var currentPatch = GameWorld.Map.CurrentPatch;
+
         // TODO: it would make more sense for the GameWorld to update its patch map data based on the
         // light cycle in it.
-        patchManager.UpdatePatchBiome(GameWorld.Map.CurrentPatch);
-        GameWorld.UpdateGlobalLightLevels();
+        patchManager.UpdatePatchBiome(currentPatch);
+        patchManager.UpdateAllPatchLightLevels(currentPatch.BiomeTemplate);
 
         HUD.UpdateEnvironmentalBars(GameWorld.Map.CurrentPatch.Biome);
 
@@ -1046,7 +1048,7 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         {
             // This might need to be refactored for efficiency but, it works for now
             var lightLevel =
-                GameWorld.Map.CurrentPatch!.Biome.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient *
+                currentPatch.Biome.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient *
                 GameWorld.LightCycle.DayLightFraction;
 
             // Normalise by maximum light level in the patch

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -145,8 +145,7 @@ public class PatchManager : IChildPropertiesLoadCallback
 
         gameWorld.UpdateGlobalLightLevels();
 
-        var multiplier = biome.Conditions.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient *
-            gameWorld.LightCycle.DayLightFraction;
+        var multiplier = biome.Conditions.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient;
         compoundCloudSystem.SetBrightnessModifier(multiplier * (compoundCloudBrightness - 1.0f) + 1.0f);
         UpdateLight(biome);
     }

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -151,14 +151,13 @@ public class PatchManager : IChildPropertiesLoadCallback
 
         if (maxLightLevel > 0.0f)
         {
-            multiplier = biome.Conditions.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient * biome.;
+            multiplier = biome.Conditions.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient *
+                CurrentGame!.GameWorld.LightCycle.DayLightFraction;
         }
         else
         {
             multiplier = 1.0f;
         }
-
-        GD.Print(multiplier, biome.Conditions.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient);
 
         compoundCloudSystem.SetBrightnessModifier(multiplier * (compoundCloudBrightness - 1.0f) + 1.0f);
         UpdateLight(biome, multiplier);

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -143,9 +143,11 @@ public class PatchManager : IChildPropertiesLoadCallback
         if (!gameWorld.WorldSettings.DayNightCycleEnabled)
             return;
 
-        var multiplier = gameWorld.LightCycle.DayLightFraction;
-        compoundCloudSystem.SetBrightnessModifier(multiplier * (compoundCloudBrightness - 1.0f) + 1.0f);
         gameWorld.UpdateGlobalLightLevels();
+
+        var multiplier = biome.Conditions.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient *
+            gameWorld.LightCycle.DayLightFraction;
+        compoundCloudSystem.SetBrightnessModifier(multiplier * (compoundCloudBrightness - 1.0f) + 1.0f);
         UpdateLight(biome);
     }
 

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -106,7 +106,7 @@ public class PatchManager : IChildPropertiesLoadCallback
 
         // Change the lighting
         compoundCloudBrightness = currentPatch.BiomeTemplate.CompoundCloudBrightness;
-        UpdateAllPatchLightLevels(currentPatch.BiomeTemplate);
+        UpdateAllPatchLightLevels(currentPatch);
 
         return patchIsChanged;
     }
@@ -133,7 +133,7 @@ public class PatchManager : IChildPropertiesLoadCallback
         processSystem.SetBiome(currentPatch.Biome);
     }
 
-    public void UpdateAllPatchLightLevels(Biome biome)
+    public void UpdateAllPatchLightLevels(Patch currentPatch)
     {
         if (CurrentGame == null)
             throw new InvalidOperationException($"{nameof(PatchManager)} doesn't have {nameof(CurrentGame)} set");
@@ -145,14 +145,13 @@ public class PatchManager : IChildPropertiesLoadCallback
 
         gameWorld.UpdateGlobalLightLevels();
 
-        var maxLightLevel = biome.Conditions.GetCompound(Compound.Sunlight, CompoundAmountType.Biome).Ambient;
+        var maxLightLevel = currentPatch.Biome.GetCompound(Compound.Sunlight, CompoundAmountType.Biome).Ambient;
 
         float multiplier;
 
         if (maxLightLevel > 0.0f)
         {
-            multiplier = biome.Conditions.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient *
-                CurrentGame!.GameWorld.LightCycle.DayLightFraction;
+            multiplier = currentPatch.Biome.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient;
         }
         else
         {
@@ -160,7 +159,7 @@ public class PatchManager : IChildPropertiesLoadCallback
         }
 
         compoundCloudSystem.SetBrightnessModifier(multiplier * (compoundCloudBrightness - 1.0f) + 1.0f);
-        UpdateLight(biome, multiplier);
+        UpdateLight(currentPatch.BiomeTemplate, multiplier);
     }
 
     public void ApplySaveState(Patch? patch, float brightness)

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -159,7 +159,7 @@ public class PatchManager : IChildPropertiesLoadCallback
         }
 
         compoundCloudSystem.SetBrightnessModifier(multiplier * (compoundCloudBrightness - 1.0f) + 1.0f);
-        UpdateLight(currentPatch.BiomeTemplate, 0.2f + 0.8f * multiplier);
+        UpdateWorldLighting(currentPatch.BiomeTemplate, 0.2f + 0.8f * multiplier);
     }
 
     public void ApplySaveState(Patch? patch, float brightness)
@@ -317,7 +317,7 @@ public class PatchManager : IChildPropertiesLoadCallback
         }
     }
 
-    private void UpdateLight(Biome biome, float lightLevel)
+    private void UpdateWorldLighting(Biome biome, float lightLevel)
     {
         worldLight.Position = new Vector3(0, 0, 0);
         worldLight.LookAt(biome.Sunlight.Direction, new Vector3(0, 1, 0));

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -159,7 +159,7 @@ public class PatchManager : IChildPropertiesLoadCallback
         }
 
         compoundCloudSystem.SetBrightnessModifier(multiplier * (compoundCloudBrightness - 1.0f) + 1.0f);
-        UpdateLight(currentPatch.BiomeTemplate, multiplier);
+        UpdateLight(currentPatch.BiomeTemplate, 0.2f + 0.8f * multiplier);
     }
 
     public void ApplySaveState(Patch? patch, float brightness)

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -105,10 +105,8 @@ public class PatchManager : IChildPropertiesLoadCallback
         UpdateSpawners(currentPatch, spawnEnvironment);
 
         // Change the lighting
-        UpdateLight(currentPatch.BiomeTemplate);
         compoundCloudBrightness = currentPatch.BiomeTemplate.CompoundCloudBrightness;
-
-        UpdateAllPatchLightLevels();
+        UpdateAllPatchLightLevels(currentPatch.BiomeTemplate);
 
         return patchIsChanged;
     }
@@ -135,7 +133,7 @@ public class PatchManager : IChildPropertiesLoadCallback
         processSystem.SetBiome(currentPatch.Biome);
     }
 
-    public void UpdateAllPatchLightLevels()
+    public void UpdateAllPatchLightLevels(Biome biome)
     {
         if (CurrentGame == null)
             throw new InvalidOperationException($"{nameof(PatchManager)} doesn't have {nameof(CurrentGame)} set");
@@ -148,6 +146,7 @@ public class PatchManager : IChildPropertiesLoadCallback
         var multiplier = gameWorld.LightCycle.DayLightFraction;
         compoundCloudSystem.SetBrightnessModifier(multiplier * (compoundCloudBrightness - 1.0f) + 1.0f);
         gameWorld.UpdateGlobalLightLevels();
+        UpdateLight(biome);
     }
 
     public void ApplySaveState(Patch? patch, float brightness)
@@ -313,7 +312,7 @@ public class PatchManager : IChildPropertiesLoadCallback
         worldLight.ShadowEnabled = biome.Sunlight.Shadows;
 
         worldLight.LightColor = biome.Sunlight.Colour;
-        worldLight.LightEnergy = biome.Sunlight.Energy;
+        worldLight.LightEnergy = biome.Sunlight.Energy * CurrentGame!.GameWorld.LightCycle.DayLightFraction;
         worldLight.LightSpecular = biome.Sunlight.Specular;
     }
 

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -145,9 +145,23 @@ public class PatchManager : IChildPropertiesLoadCallback
 
         gameWorld.UpdateGlobalLightLevels();
 
-        var multiplier = biome.Conditions.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient;
+        var maxLightLevel = biome.Conditions.GetCompound(Compound.Sunlight, CompoundAmountType.Biome).Ambient;
+
+        float multiplier;
+
+        if (maxLightLevel > 0.0f)
+        {
+            multiplier = biome.Conditions.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient * biome.;
+        }
+        else
+        {
+            multiplier = 1.0f;
+        }
+
+        GD.Print(multiplier, biome.Conditions.GetCompound(Compound.Sunlight, CompoundAmountType.Current).Ambient);
+
         compoundCloudSystem.SetBrightnessModifier(multiplier * (compoundCloudBrightness - 1.0f) + 1.0f);
-        UpdateLight(biome);
+        UpdateLight(biome, multiplier);
     }
 
     public void ApplySaveState(Patch? patch, float brightness)
@@ -305,7 +319,7 @@ public class PatchManager : IChildPropertiesLoadCallback
         }
     }
 
-    private void UpdateLight(Biome biome)
+    private void UpdateLight(Biome biome, float lightLevel)
     {
         worldLight.Position = new Vector3(0, 0, 0);
         worldLight.LookAt(biome.Sunlight.Direction, new Vector3(0, 1, 0));
@@ -313,7 +327,7 @@ public class PatchManager : IChildPropertiesLoadCallback
         worldLight.ShadowEnabled = biome.Sunlight.Shadows;
 
         worldLight.LightColor = biome.Sunlight.Colour;
-        worldLight.LightEnergy = biome.Sunlight.Energy * CurrentGame!.GameWorld.LightCycle.DayLightFraction;
+        worldLight.LightEnergy = biome.Sunlight.Energy * lightLevel;
         worldLight.LightSpecular = biome.Sunlight.Specular;
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes the lighting of 3D objects (cells, clouds, etc.) and compound clouds depend on the current light level (if the patch has day-night cycle).

**Related Issues**

Closes #3920

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
