### PR TITLE
Close organelle menu when leaving cell editor

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1084,6 +1084,11 @@ public partial class CellEditorComponent :
         editedProperties.Colour = Colour;
         editedProperties.MembraneRigidity = Rigidity;
 
+        // The organelle menu may still be open if using keyboard/controler navigation.
+        // https://github.com/Revolutionary-Games/Thrive/issues/4470
+        // Since the organelle menu will be reparented to the ModalManager, it is necessary close it manually.
+        organelleMenu.Close();
+
         if (!IsMulticellularEditor)
         {
             GD.Print("MicrobeEditor: updated organelles for species: ", editedSpecies.FormattedName);


### PR DESCRIPTION
**Brief Description of What This PR Does**

Automatically close the organelle menu when leaving the cell editor. It would appear that earlier changes have fixed the crashes reported earlier.

**Related Issues**

Closes #4470

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
