### PR TITLE
Fix double refunding of organelle upgrade MP

### DIFF
--- a/src/microbe_stage/editor/action_data/OrganelleUpgradeActionData.cs
+++ b/src/microbe_stage/editor/action_data/OrganelleUpgradeActionData.cs
@@ -41,7 +41,7 @@ public class OrganelleUpgradeActionData : EditorCombinableActionData<CellType>
 
     protected override ActionInterferenceMode GetInterferenceModeWithGuaranteed(CombinableActionData other)
     {
-        // Organelle upgrades can never combine since the user will have already been refunded for the cost of the old choice.
+        // Organelle upgrades can never combine since the old choice will have already been refunded.
         // https://github.com/Revolutionary-Games/Thrive/issues/5524
 
         return ActionInterferenceMode.NoInterference;

--- a/src/microbe_stage/editor/action_data/OrganelleUpgradeActionData.cs
+++ b/src/microbe_stage/editor/action_data/OrganelleUpgradeActionData.cs
@@ -31,6 +31,11 @@ public class OrganelleUpgradeActionData : EditorCombinableActionData<CellType>
         var newUpgrades = NewUpgrades.UnlockedFeatures.Except(OldUpgrades.UnlockedFeatures)
             .Where(u => availableUpgrades.ContainsKey(u)).Select(u => availableUpgrades[u]);
 
+        // TODO: Removals should cost MP: https://github.com/Revolutionary-Games/Thrive/issues/4095
+        // var removedUpgrades = OldUpgrades.UnlockedFeatures.Except(NewUpgrades.UnlockedFeatures)
+        //     .Where(u => availableUpgrades.ContainsKey(u)).Select(u => availableUpgrades[u]);
+        // ? removedUpgrades.Sum(u => u.MPCost);
+
         cost += newUpgrades.Sum(u => u.MPCost);
 
         return cost;

--- a/src/microbe_stage/editor/action_data/OrganelleUpgradeActionData.cs
+++ b/src/microbe_stage/editor/action_data/OrganelleUpgradeActionData.cs
@@ -41,13 +41,8 @@ public class OrganelleUpgradeActionData : EditorCombinableActionData<CellType>
 
     protected override ActionInterferenceMode GetInterferenceModeWithGuaranteed(CombinableActionData other)
     {
-        if (other is OrganelleUpgradeActionData upgradeActionData)
-        {
-            if (ReferenceEquals(UpgradedOrganelle, upgradeActionData.UpgradedOrganelle))
-                return ActionInterferenceMode.Combinable;
-        }
-
-        // The replacing action is in the remove organelle action
+        // Organelle upgrades can never combine since the user will have already been refunded for the cost of the old choice.
+        // https://github.com/Revolutionary-Games/Thrive/issues/5524
 
         return ActionInterferenceMode.NoInterference;
     }

--- a/src/microbe_stage/editor/action_data/OrganelleUpgradeActionData.cs
+++ b/src/microbe_stage/editor/action_data/OrganelleUpgradeActionData.cs
@@ -25,24 +25,26 @@ public class OrganelleUpgradeActionData : EditorCombinableActionData<CellType>
 
         // TODO: allow custom upgrades to have a cost
 
-        // Calculate the costs of the selected new general upgrades (minus the cost of removed upgrades)
+        // Calculate the costs of the selected new general upgrades
         var availableUpgrades = UpgradedOrganelle.Definition.AvailableUpgrades;
 
         var newUpgrades = NewUpgrades.UnlockedFeatures.Except(OldUpgrades.UnlockedFeatures)
             .Where(u => availableUpgrades.ContainsKey(u)).Select(u => availableUpgrades[u]);
-        var removedUpgrades = OldUpgrades.UnlockedFeatures.Except(NewUpgrades.UnlockedFeatures)
-            .Where(u => availableUpgrades.ContainsKey(u)).Select(u => availableUpgrades[u]);
 
         cost += newUpgrades.Sum(u => u.MPCost);
-        cost -= removedUpgrades.Sum(u => u.MPCost);
 
         return cost;
     }
 
     protected override ActionInterferenceMode GetInterferenceModeWithGuaranteed(CombinableActionData other)
     {
-        // Organelle upgrades can never combine since the old choice will have already been refunded.
-        // https://github.com/Revolutionary-Games/Thrive/issues/5524
+        if (other is OrganelleUpgradeActionData upgradeActionData)
+        {
+            if (ReferenceEquals(UpgradedOrganelle, upgradeActionData.UpgradedOrganelle))
+                return ActionInterferenceMode.Combinable;
+        }
+
+        // The replacing action is in the remove organelle action
 
         return ActionInterferenceMode.NoInterference;
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

When changing the organelle upgrade repeatedly in the same editor cycle, MP would be refunded twice (as detailed in #5524). This is because the cost of an upgrade also includes the negated cost of the current upgrade, meanwhile the editor refunds MP where `ActionInterferenceMode.Combinable` is returned as the interference mode.

I initially fixed this by not combining the actions. However I have now changed the implementation to avoid the negated cost.

**Related Issues**
Closes #5524

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
