### PR TITLE
Add simple energy balance info without dictionaries

### DIFF
--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -79,7 +79,6 @@ public class SimulationCache
         // different species but with same organelles to be able to use the same cache value) would be nice here
         var key = (species, biomeConditions);
 
-        // TODO: check if caching instances of these objects would be better than always recreating
         if (cachedSimpleEnergyBalances.TryGetValue(key, out var cached))
         {
             return cached;
@@ -87,6 +86,7 @@ public class SimulationCache
 
         var maximumMovementDirection = MicrobeInternalCalculations.MaximumSpeedDirection(species.Organelles);
 
+        // TODO: check if caching instances of these objects would be better than always recreating
         cached = new EnergyBalanceInfoSimple();
 
         // Auto-evo uses the average values of compound during the course of a simulated day

--- a/src/microbe_stage/EnergyBalanceInfoFull.cs
+++ b/src/microbe_stage/EnergyBalanceInfoFull.cs
@@ -1,82 +1,34 @@
 ﻿using System.Collections.Generic;
 
 /// <summary>
-///   Info regarding a microbe's energy balance in a patch
+///   Info regarding a microbe's energy balance in a patch, including consumption and production
 /// </summary>
 /// <remarks>
 ///   <para>
 ///     This does not take special modes the microbe can be into account, for example engulfing or binding
 ///   </para>
+///   <para>
+///     This inherits from <see cref="EnergyBalanceInfoSimple"/> whilst also tracking the consumption and production
+///   </para>
 /// </remarks>
-public class EnergyBalanceInfo
+public class EnergyBalanceInfoFull : EnergyBalanceInfoSimple
 {
     /// <summary>
     ///   The raw list of all energy consuming things related to the microbe. The key is the action name and the
     ///   value is the total consumption of that action.
     /// </summary>
-    public Dictionary<string, float> Consumption { get; } = new();
+    public Dictionary<string, float> Consumption { get; } = [];
 
     /// <summary>
     ///   The same as <see cref="Consumption"/> but for energy production
     /// </summary>
-    public Dictionary<string, float> Production { get; } = new();
+    public Dictionary<string, float> Production { get; } = [];
 
     /// <summary>
     ///   If setup to collect required compounds to run, then this collects compounds each <see cref="Production"/>
     ///   entry requires to produce the energy.
     /// </summary>
     public Dictionary<string, Dictionary<Compound, float>>? ProductionRequiresCompounds { get; private set; }
-
-    /// <summary>
-    ///   The cost of base movement (only when moving)
-    /// </summary>
-    public float BaseMovement { get; set; }
-
-    /// <summary>
-    ///   The cost of having all flagella working at the same time (only when moving)
-    /// </summary>
-    public float Flagella { get; set; }
-
-    /// <summary>
-    ///   The cost of having all cilia working at the same time at max rotation (only when rotating)
-    /// </summary>
-    public float Cilia { get; set; }
-
-    /// <summary>
-    ///   Sum of <see cref="BaseMovement"/>, <see cref="Flagella"/>, and <see cref="Cilia"/>
-    /// </summary>
-    public float TotalMovement { get; set; }
-
-    /// <summary>
-    ///   The total osmoregulation cost for the microbe
-    /// </summary>
-    public float Osmoregulation { get; set; }
-
-    /// <summary>
-    ///   Total production of energy for all the microbe's processes (assumes there's enough resources to
-    ///   run everything)
-    /// </summary>
-    public float TotalProduction { get; set; }
-
-    /// <summary>
-    ///   The total energy consumption of the microbe while it is moving and running all processes
-    /// </summary>
-    public float TotalConsumption { get; set; }
-
-    /// <summary>
-    ///   Total energy consumption while the microbe is stationary (so everything except movement)
-    /// </summary>
-    public float TotalConsumptionStationary { get; set; }
-
-    /// <summary>
-    ///   The absolutely final balance of ATP when a microbe is going all out and running everything and moving
-    /// </summary>
-    public float FinalBalance { get; set; }
-
-    /// <summary>
-    ///   Final balance of ATP when a microbe is stationary (running processes + osmoregulation)
-    /// </summary>
-    public float FinalBalanceStationary { get; set; }
 
     public void AddConsumption(string groupName, float amount)
     {

--- a/src/microbe_stage/EnergyBalanceInfoFull.cs
+++ b/src/microbe_stage/EnergyBalanceInfoFull.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 
 /// <summary>
-///   Info regarding a microbe's energy balance in a patch, including consumption and production
+///   Info regarding a microbe's energy balance in a patch, including consumption and production info
 /// </summary>
 /// <remarks>
 ///   <para>

--- a/src/microbe_stage/EnergyBalanceInfoSimple.cs
+++ b/src/microbe_stage/EnergyBalanceInfoSimple.cs
@@ -1,0 +1,64 @@
+﻿/// <summary>
+///   Info regarding a microbe's energy balance in a patch, excluding consumption and production
+/// </summary>
+/// <remarks>
+///   <para>
+///     This does not take special modes the microbe can be into account, for example engulfing or binding
+///   </para>
+///   <para>
+///     The consumption and production is not tracked, use <see cref="EnergyBalanceInfoFull"/> to store it
+///   </para>
+/// </remarks>
+public class EnergyBalanceInfoSimple
+{
+    /// <summary>
+    ///   The cost of base movement (only when moving)
+    /// </summary>
+    public float BaseMovement { get; set; }
+
+    /// <summary>
+    ///   The cost of having all flagella working at the same time (only when moving)
+    /// </summary>
+    public float Flagella { get; set; }
+
+    /// <summary>
+    ///   The cost of having all cilia working at the same time at max rotation (only when rotating)
+    /// </summary>
+    public float Cilia { get; set; }
+
+    /// <summary>
+    ///   Sum of <see cref="BaseMovement"/>, <see cref="Flagella"/>, and <see cref="Cilia"/>
+    /// </summary>
+    public float TotalMovement { get; set; }
+
+    /// <summary>
+    ///   The total osmoregulation cost for the microbe
+    /// </summary>
+    public float Osmoregulation { get; set; }
+
+    /// <summary>
+    ///   Total production of energy for all the microbe's processes (assumes there's enough resources to
+    ///   run everything)
+    /// </summary>
+    public float TotalProduction { get; set; }
+
+    /// <summary>
+    ///   The total energy consumption of the microbe while it is moving and running all processes
+    /// </summary>
+    public float TotalConsumption { get; set; }
+
+    /// <summary>
+    ///   Total energy consumption while the microbe is stationary (so everything except movement)
+    /// </summary>
+    public float TotalConsumptionStationary { get; set; }
+
+    /// <summary>
+    ///   The absolutely final balance of ATP when a microbe is going all out and running everything and moving
+    /// </summary>
+    public float FinalBalance { get; set; }
+
+    /// <summary>
+    ///   Final balance of ATP when a microbe is stationary (running processes + osmoregulation)
+    /// </summary>
+    public float FinalBalanceStationary { get; set; }
+}

--- a/src/microbe_stage/EnergyBalanceInfoSimple.cs
+++ b/src/microbe_stage/EnergyBalanceInfoSimple.cs
@@ -1,9 +1,9 @@
 ﻿/// <summary>
-///   Info regarding a microbe's energy balance in a patch, excluding consumption and production
+///   Info regarding a microbe's energy balance in a patch, excluding consumption and production tracking
 /// </summary>
 /// <remarks>
 ///   <para>
-///     This does not take special modes the microbe can be into account, for example engulfing or binding
+///     This does not take special modes the microbe can be into account, for example, engulfing or binding
 ///   </para>
 ///   <para>
 ///     The consumption and production is not tracked, use <see cref="EnergyBalanceInfoFull"/> to store it

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -464,8 +464,10 @@ public static class MicrobeInternalCalculations
     {
         var energyBalance = new EnergyBalanceInfoSimple();
 
-        ProcessSystem.ComputeEnergyBalance(organelles, biomeConditions, membraneType,
-            moving, playerSpecies, worldSettings, CompoundAmountType.Biome, energyBalance);
+        var maximumMovementDirection = MicrobeInternalCalculations.MaximumSpeedDirection(organelles);
+        ProcessSystem.ComputeEnergyBalanceSimple(organelles, biomeConditions, membraneType,
+            maximumMovementDirection, moving, playerSpecies, worldSettings, CompoundAmountType.Biome, null,
+            energyBalance);
 
         var compoundBalances = new Dictionary<Compound, CompoundBalance>();
 
@@ -561,8 +563,8 @@ public static class MicrobeInternalCalculations
         {
             var energyBalance = new EnergyBalanceInfoSimple();
 
-            ProcessSystem.ComputeEnergyBalance(organelles, biomeConditions, membraneType,
-                moving, playerSpecies, worldSettings, CompoundAmountType.Biome, energyBalance);
+            ProcessSystem.ComputeEnergyBalanceSimple(organelles, biomeConditions, membraneType,
+                Vector3.Forward, moving, playerSpecies, worldSettings, CompoundAmountType.Biome, null, energyBalance);
 
             dayCompoundBalances = new Dictionary<Compound, CompoundBalance>();
 
@@ -572,8 +574,8 @@ public static class MicrobeInternalCalculations
 
         var energyBalanceAtMinimum = new EnergyBalanceInfoSimple();
 
-        ProcessSystem.ComputeEnergyBalance(organelles, biomeConditions, membraneType, moving, playerSpecies,
-            worldSettings, CompoundAmountType.Minimum, energyBalanceAtMinimum);
+        ProcessSystem.ComputeEnergyBalanceSimple(organelles, biomeConditions, membraneType, Vector3.Forward, moving,
+            playerSpecies, worldSettings, CompoundAmountType.Minimum, null, energyBalanceAtMinimum);
 
         var minimums = new Dictionary<Compound, CompoundBalance>();
 

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -462,7 +462,7 @@ public static class MicrobeInternalCalculations
         IReadOnlyList<OrganelleTemplate> organelles, MembraneType membraneType, bool moving, bool playerSpecies,
         BiomeConditions biomeConditions, WorldGenerationSettings worldSettings)
     {
-        var energyBalance = new EnergyBalanceInfo();
+        var energyBalance = new EnergyBalanceInfoSimple();
 
         ProcessSystem.ComputeEnergyBalance(organelles, biomeConditions, membraneType,
             moving, playerSpecies, worldSettings, CompoundAmountType.Biome, energyBalance);
@@ -559,7 +559,7 @@ public static class MicrobeInternalCalculations
     {
         if (dayCompoundBalances == null)
         {
-            var energyBalance = new EnergyBalanceInfo();
+            var energyBalance = new EnergyBalanceInfoSimple();
 
             ProcessSystem.ComputeEnergyBalance(organelles, biomeConditions, membraneType,
                 moving, playerSpecies, worldSettings, CompoundAmountType.Biome, energyBalance);
@@ -570,7 +570,7 @@ public static class MicrobeInternalCalculations
                 biomeConditions, CompoundAmountType.Biome, energyBalance, dayCompoundBalances);
         }
 
-        var energyBalanceAtMinimum = new EnergyBalanceInfo();
+        var energyBalanceAtMinimum = new EnergyBalanceInfoSimple();
 
         ProcessSystem.ComputeEnergyBalance(organelles, biomeConditions, membraneType, moving, playerSpecies,
             worldSettings, CompoundAmountType.Minimum, energyBalanceAtMinimum);

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -464,7 +464,7 @@ public static class MicrobeInternalCalculations
     {
         var energyBalance = new EnergyBalanceInfoSimple();
 
-        var maximumMovementDirection = MicrobeInternalCalculations.MaximumSpeedDirection(organelles);
+        var maximumMovementDirection = MaximumSpeedDirection(organelles);
         ProcessSystem.ComputeEnergyBalanceSimple(organelles, biomeConditions, membraneType,
             maximumMovementDirection, moving, playerSpecies, worldSettings, CompoundAmountType.Biome, null,
             energyBalance);

--- a/src/microbe_stage/OrganismStatisticsPanel.cs
+++ b/src/microbe_stage/OrganismStatisticsPanel.cs
@@ -129,7 +129,7 @@ public partial class OrganismStatisticsPanel : PanelContainer
 
     private LightLevelOption selectedLightLevelOption = LightLevelOption.Current;
 
-    private EnergyBalanceInfo? energyBalanceInfo;
+    private EnergyBalanceInfoFull? energyBalanceInfo;
 
     [Signal]
     public delegate void OnLightLevelChangedEventHandler(int option);
@@ -192,7 +192,7 @@ public partial class OrganismStatisticsPanel : PanelContainer
         tutorial.AtpBalanceIntroduction.ATPBalanceBarControl = atpBalancePanel;
     }
 
-    public void UpdateEnergyBalance(EnergyBalanceInfo energyBalance)
+    public void UpdateEnergyBalance(EnergyBalanceInfoFull energyBalance)
     {
         energyBalanceInfo = energyBalance;
 
@@ -221,7 +221,7 @@ public partial class OrganismStatisticsPanel : PanelContainer
         UpdateEnergyBalanceToolTips(energyBalance);
     }
 
-    public void UpdateEnergyBalanceToolTips(EnergyBalanceInfo energyBalance)
+    public void UpdateEnergyBalanceToolTips(EnergyBalanceInfoFull energyBalance)
     {
         var simulationParameters = SimulationParameters.Instance;
 

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -204,7 +204,7 @@ public partial class CellEditorComponent :
 
     private OrganelleDefinition cytoplasm = null!;
 
-    private EnergyBalanceInfo? energyBalanceInfo;
+    private EnergyBalanceInfoFull? energyBalanceInfo;
 
     private string? bestPatchName;
 
@@ -1854,7 +1854,7 @@ public partial class CellEditorComponent :
                 conditionsData);
         }
 
-        var energyBalance = new EnergyBalanceInfo();
+        var energyBalance = new EnergyBalanceInfoFull();
         energyBalance.SetupTrackingForRequiredCompounds();
 
         ProcessSystem.ComputeEnergyBalance(organelles, conditionsData, membrane, moving, true,
@@ -1893,8 +1893,8 @@ public partial class CellEditorComponent :
     }
 
     private Dictionary<Compound, CompoundBalance> CalculateCompoundBalanceWithMethod(BalanceDisplayType calculationType,
-        CompoundAmountType amountType, IReadOnlyList<OrganelleTemplate> organelles,
-        IBiomeConditions biome, EnergyBalanceInfo energyBalance, ref Dictionary<Compound, float>? specificStorages,
+        CompoundAmountType amountType, IReadOnlyList<OrganelleTemplate> organelles, IBiomeConditions biome,
+        EnergyBalanceInfoFull energyBalance, ref Dictionary<Compound, float>? specificStorages,
         ref float nominalStorage)
     {
         var compoundBalanceData = new Dictionary<Compound, CompoundBalance>();
@@ -1917,7 +1917,7 @@ public partial class CellEditorComponent :
         return ProcessSystem.ComputeCompoundFillTimes(compoundBalanceData, nominalStorage, specificStorages);
     }
 
-    private void HandleProcessList(EnergyBalanceInfo energyBalance, IBiomeConditions biome)
+    private void HandleProcessList(EnergyBalanceInfoFull energyBalance, IBiomeConditions biome)
     {
         var processes = new List<TweakedProcess>();
 

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1857,8 +1857,11 @@ public partial class CellEditorComponent :
         var energyBalance = new EnergyBalanceInfoFull();
         energyBalance.SetupTrackingForRequiredCompounds();
 
-        ProcessSystem.ComputeEnergyBalance(organelles, conditionsData, membrane, moving, true,
-            Editor.CurrentGame.GameWorld.WorldSettings, organismStatisticsPanel.CompoundAmountType, energyBalance);
+        var maximumMovementDirection = MicrobeInternalCalculations.MaximumSpeedDirection(organelles);
+
+        ProcessSystem.ComputeEnergyBalanceFull(organelles, conditionsData, membrane, maximumMovementDirection, moving,
+            true, Editor.CurrentGame.GameWorld.WorldSettings, organismStatisticsPanel.CompoundAmountType, null,
+            energyBalance);
 
         energyBalanceInfo = energyBalance;
 

--- a/src/microbe_stage/organelle_unlocks/IUnlockCondition.cs
+++ b/src/microbe_stage/organelle_unlocks/IUnlockCondition.cs
@@ -40,10 +40,10 @@ public class WorldAndPlayerDataSource : IUnlockStateDataSource
 {
     public readonly Patch CurrentPatch;
     public readonly GameWorld World;
-    public readonly EnergyBalanceInfo? EnergyBalance;
+    public readonly EnergyBalanceInfoSimple? EnergyBalance;
     public readonly ICellDefinition? PlayerData;
 
-    public WorldAndPlayerDataSource(GameWorld world, Patch currentPatch, EnergyBalanceInfo? energyBalance,
+    public WorldAndPlayerDataSource(GameWorld world, Patch currentPatch, EnergyBalanceInfoSimple? energyBalance,
         ICellDefinition? playerData)
     {
         World = world;

--- a/src/microbe_stage/organelle_unlocks/IUnlockCondition.cs
+++ b/src/microbe_stage/organelle_unlocks/IUnlockCondition.cs
@@ -40,10 +40,10 @@ public class WorldAndPlayerDataSource : IUnlockStateDataSource
 {
     public readonly Patch CurrentPatch;
     public readonly GameWorld World;
-    public readonly EnergyBalanceInfoSimple? EnergyBalance;
+    public readonly EnergyBalanceInfoFull? EnergyBalance;
     public readonly ICellDefinition? PlayerData;
 
-    public WorldAndPlayerDataSource(GameWorld world, Patch currentPatch, EnergyBalanceInfoSimple? energyBalance,
+    public WorldAndPlayerDataSource(GameWorld world, Patch currentPatch, EnergyBalanceInfoFull? energyBalance,
         ICellDefinition? playerData)
     {
         World = world;

--- a/src/microbe_stage/systems/ProcessSystem.cs
+++ b/src/microbe_stage/systems/ProcessSystem.cs
@@ -862,11 +862,14 @@ public sealed class ProcessSystem : AEntitySetSystem<float>
         ProcessNode(ref processes, ref storage, delta);
     }
 
-    private static float? MovementCostForOrganelle(bool includeMovementCost, OrganelleTemplate organelle,
-        Vector3 onlyMovementInDirection)
+    private static bool TryGetMovementCostForOrganelle(bool includeMovementCost, OrganelleTemplate organelle,
+        Vector3 onlyMovementInDirection, out float movementCost)
     {
         if (!includeMovementCost || !organelle.Definition.HasMovementComponent)
-            return null;
+        {
+            movementCost = 0;
+            return false;
+        }
 
         float amount;
 
@@ -880,11 +883,15 @@ public sealed class ProcessSystem : AEntitySetSystem<float>
             amount = Constants.FLAGELLA_ENERGY_COST;
         }
 
+        movementCost = amount;
+
         var organelleDirection = MicrobeInternalCalculations.GetOrganelleDirection(organelle);
         if (organelleDirection.Dot(onlyMovementInDirection) > 0)
-            return amount;
+        {
+            return true;
+        }
 
-        return null;
+        return false;
     }
 
     private static float GetAmbientInBiome(Compound compound, IBiomeConditions biome, CompoundAmountType amountType)

--- a/src/microbe_stage/systems/ProcessSystem.cs
+++ b/src/microbe_stage/systems/ProcessSystem.cs
@@ -272,7 +272,7 @@ public sealed class ProcessSystem : AEntitySetSystem<float>
         bool includeMovementCost, bool isPlayerSpecies, WorldGenerationSettings worldSettings,
         CompoundAmountType amountType, SimulationCache? cache, EnergyBalanceInfoFull result)
     {
-        ComputeEnergyBalanceSimple(organelles, biome, membrane, onlyMovementInDirection,
+        CalculateSimplePartOfEnergyBalance(organelles, biome, membrane, onlyMovementInDirection,
             includeMovementCost, isPlayerSpecies, worldSettings, amountType, cache, result);
 
         // Once simple balance is calculated we add the extra info on top, this approach loops the organelles twice

--- a/src/microbe_stage/systems/ProcessSystem.cs
+++ b/src/microbe_stage/systems/ProcessSystem.cs
@@ -6,6 +6,7 @@ namespace Systems;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using AutoEvo;
@@ -232,7 +233,13 @@ public sealed class ProcessSystem : AEntitySetSystem<float>
     {
 #if DEBUG
         if (result is EnergyBalanceInfoFull)
-            throw new ArgumentException("Call the full result variant when you have a full result object");
+        {
+            if (Debugger.IsAttached)
+                Debugger.Break();
+
+            throw new ArgumentException("Call the full result variant when you have a full result object " +
+                "(otherwise it won't be filled correctly)");
+        }
 #endif
 
         CalculateSimplePartOfEnergyBalance(organelles, biome, membrane, onlyMovementInDirection, includeMovementCost,

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
@@ -32,7 +32,7 @@ public partial class CellBodyPlanEditorComponent
     ///   selectable.
     ///   https://github.com/Revolutionary-Games/Thrive/issues/5863
     /// </summary>
-    private void HandleProcessList(IReadOnlyList<HexWithData<CellTemplate>> cells, EnergyBalanceInfo energyBalance,
+    private void HandleProcessList(IReadOnlyList<HexWithData<CellTemplate>> cells, EnergyBalanceInfoFull energyBalance,
         IBiomeConditions biome)
     {
         // Empty list to later fill

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -1118,12 +1118,16 @@ public partial class CellBodyPlanEditorComponent :
         var energyBalance = new EnergyBalanceInfoFull();
         energyBalance.SetupTrackingForRequiredCompounds();
 
+        // Cells can't individually move in the body plan, so this probably makes sense
+        var maximumMovementDirection =
+            MicrobeInternalCalculations.MaximumSpeedDirection(cells[0].Data!.CellType.Organelles);
+
         // TODO: improve performance by calculating the balance per cell type
         foreach (var hex in cells)
         {
-            ProcessSystem.ComputeEnergyBalance(hex.Data!.Organelles, conditionsData, hex.Data.MembraneType, moving,
-                true, Editor.CurrentGame.GameWorld.WorldSettings, organismStatisticsPanel.CompoundAmountType,
-                energyBalance);
+            ProcessSystem.ComputeEnergyBalanceFull(hex.Data!.Organelles, conditionsData, hex.Data.MembraneType,
+                maximumMovementDirection, moving, true, Editor.CurrentGame.GameWorld.WorldSettings,
+                organismStatisticsPanel.CompoundAmountType, null, energyBalance);
         }
 
         energyBalanceInfo = energyBalance;

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -134,7 +134,7 @@ public partial class CellBodyPlanEditorComponent :
 
     private bool forceUpdateCellGraphics;
 
-    private EnergyBalanceInfo? energyBalanceInfo;
+    private EnergyBalanceInfoFull? energyBalanceInfo;
 
     [Signal]
     public delegate void OnCellTypeToEditSelectedEventHandler(string name, bool switchTab);
@@ -1115,7 +1115,7 @@ public partial class CellBodyPlanEditorComponent :
                 conditionsData);
         }
 
-        var energyBalance = new EnergyBalanceInfo();
+        var energyBalance = new EnergyBalanceInfoFull();
         energyBalance.SetupTrackingForRequiredCompounds();
 
         // TODO: improve performance by calculating the balance per cell type
@@ -1159,7 +1159,7 @@ public partial class CellBodyPlanEditorComponent :
 
     private Dictionary<Compound, CompoundBalance> CalculateCompoundBalanceWithMethod(BalanceDisplayType calculationType,
         CompoundAmountType amountType,
-        IReadOnlyList<HexWithData<CellTemplate>> cells, IBiomeConditions biome, EnergyBalanceInfo energyBalance,
+        IReadOnlyList<HexWithData<CellTemplate>> cells, IBiomeConditions biome, EnergyBalanceInfoSimple energyBalance,
         ref Dictionary<Compound, float>? specificStorages, ref float nominalStorage)
     {
         Dictionary<Compound, CompoundBalance> compoundBalanceData = new();

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -1159,7 +1159,7 @@ public partial class CellBodyPlanEditorComponent :
 
     private Dictionary<Compound, CompoundBalance> CalculateCompoundBalanceWithMethod(BalanceDisplayType calculationType,
         CompoundAmountType amountType,
-        IReadOnlyList<HexWithData<CellTemplate>> cells, IBiomeConditions biome, EnergyBalanceInfoSimple energyBalance,
+        IReadOnlyList<HexWithData<CellTemplate>> cells, IBiomeConditions biome, EnergyBalanceInfoFull energyBalance,
         ref Dictionary<Compound, float>? specificStorages, ref float nominalStorage)
     {
         Dictionary<Compound, CompoundBalance> compoundBalanceData = new();

--- a/src/tutorial/TutorialEventArgs.cs
+++ b/src/tutorial/TutorialEventArgs.cs
@@ -136,12 +136,12 @@ public class MicrobeColonyEventArgs : TutorialEventArgs
 
 public class EnergyBalanceEventArgs : TutorialEventArgs
 {
-    public EnergyBalanceEventArgs(EnergyBalanceInfo energyBalanceInfo)
+    public EnergyBalanceEventArgs(EnergyBalanceInfoFull energyBalanceInfo)
     {
         EnergyBalanceInfo = energyBalanceInfo;
     }
 
-    public EnergyBalanceInfo EnergyBalanceInfo { get; }
+    public EnergyBalanceInfoFull EnergyBalanceInfo { get; }
 }
 
 public class OrganellePlacedEventArgs : TutorialEventArgs


### PR DESCRIPTION
**Brief Description of What This PR Does**

Create an `EnergyBalanceInfoSimple` class that doesn't record the consumption and production. This is used for the auto evo since it doesn't require the consumption and production information.

Also add an `EnergyBalanceInfoFull` class that inherits from `EnergyBalanceInfoSimple` but with the dictionaries for consumption and production. This is used for the editor display.

Since there are virtual methods now, this will likely be detrimental to performance. However I wasn't able to test the significance of this compared to removing the dictionary allocations for auto-evo since there doesn't see to be a great way to benchmark auto-evo.

**Related Issues**
Closes #5426

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
