### PR TITLE
Connections between patches and regions should be shown

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1624,7 +1624,7 @@ public static class Constants
 
     // Constants for procedural patch map
     public const float PATCH_NODE_RECT_LENGTH = 64.0f;
-    public const float PATCH_AND_REGION_MARGIN = 2 * 3.0f;
+    public const float PATCH_AND_REGION_MARGIN = 8 * 3.0f;
     public const float PATCH_REGION_CONNECTION_LINE_WIDTH = 4.0f;
     public const float PATCH_REGION_BORDER_WIDTH = 6.0f;
     public const int PATCH_GENERATION_MAX_RETRIES = 100;

--- a/src/microbe_stage/PatchMapGenerator.cs
+++ b/src/microbe_stage/PatchMapGenerator.cs
@@ -533,6 +533,7 @@ public static class PatchMapGenerator
             {
                 region.Width += offset;
                 region.Height += offset;
+                region.Columns = region.Rows = 1;
 
                 var cave = region.Patches.FirstOrDefault(p => p.BiomeType == BiomeType.Cave);
 
@@ -542,15 +543,22 @@ public static class PatchMapGenerator
                 {
                     --waterPatchCount;
                     region.Width += offset;
+                    region.Columns += 1;
                 }
 
-                // Have 2 columns
+                // Have 3 columns
                 if (waterPatchCount > 1)
+                {
                     region.Width += offset;
+                    region.Columns += 1;
+                }
 
                 // Have 2 rows
                 if (waterPatchCount > 2)
+                {
                     region.Height += offset;
+                    region.Rows += 1;
+                }
 
                 break;
             }
@@ -560,12 +568,17 @@ public static class PatchMapGenerator
                 int verticalPatchCount = region.Patches.Count(IsWaterPatch);
 
                 region.Width += offset;
+                region.Columns += 1;
 
                 // If a cave or vent is present
                 if (verticalPatchCount != region.Patches.Count)
+                {
                     region.Width += offset;
+                    region.Columns += 1;
+                }
 
                 region.Height += verticalPatchCount * offset;
+                region.Rows += verticalPatchCount;
 
                 break;
             }

--- a/src/microbe_stage/PatchRegion.cs
+++ b/src/microbe_stage/PatchRegion.cs
@@ -16,6 +16,8 @@ public class PatchRegion
         Name = name;
         Height = 0;
         Width = 0;
+        Rows = 0;
+        Columns = 0;
         Type = regionType;
         ScreenCoordinates = screenCoordinates;
     }
@@ -101,6 +103,9 @@ public class PatchRegion
 
     [JsonProperty]
     public MapElementVisibility Visibility { get; set; } = MapElementVisibility.Hidden;
+
+    public int Rows { get; set; }
+    public int Columns { get; set; }
 
     /// <summary>
     ///   Adds a connection to region


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR adds connections between the patches and regions sides. I increased the margin between the patches and also changed the color of the connections to gray (subject to change) because otherwise it would get a little bit to crowded with all of the connections.
![image](https://github.com/user-attachments/assets/cd167f4c-18b4-487c-a3d6-50a60bacca4d)
![image](https://github.com/user-attachments/assets/151cde1d-3cf8-47cf-9d0c-b6b598cc08a0)
![Screenshot_20250101_131756](https://github.com/user-attachments/assets/b45d58c3-cdd6-4832-8d3e-6377ee0f028c)


**Related Issues**

Closes #3556

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
