### PR TITLE
Fix lost click event when opening popup

### DIFF
--- a/src/engine/input/InputAttribute.cs
+++ b/src/engine/input/InputAttribute.cs
@@ -59,6 +59,19 @@ public abstract class InputAttribute : Attribute
     public abstract bool OnInput(InputEvent input);
 
     /// <summary>
+    ///   Called for input that is not processed by the <see cref="OnInput"/> method.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     This is useful for updating state such as HeldDown which would otherwise become incorrect.
+    ///   </para>
+    /// </remarks>
+    /// <param name="input">The event fired by the user</param>
+    public virtual void OnUnprocesedInput(InputEvent input)
+    {
+    }
+
+    /// <summary>
     ///   Processes input actions that aren't triggered on key events directly
     /// </summary>
     /// <param name="delta">The time since the last call of OnProcess</param>

--- a/src/engine/input/InputManager.cs
+++ b/src/engine/input/InputManager.cs
@@ -582,6 +582,10 @@ public partial class InputManager : Node
                         break;
                 }
             }
+            else
+            {
+                attribute.OnUnprocesedInput(@event);
+            }
         }
 
         // Define input as consumed to Godot if something reacted to it

--- a/src/engine/input/RunOnKeyDownAttribute.cs
+++ b/src/engine/input/RunOnKeyDownAttribute.cs
@@ -18,11 +18,8 @@ public class RunOnKeyDownAttribute : RunOnKeyAttribute
 
     public override bool OnInput(InputEvent @event)
     {
-        // Only trigger if the input was pressed this frame. It isn't possible to use !HeldDown since its value is
-        // incorrect if a mouse release event is marked as handled e.g. when opening a popup.
-        // https://github.com/Revolutionary-Games/Thrive/issues/5217
-        var justPressed = Input.IsActionJustPressed(InputName);
-        if (base.OnInput(@event) && justPressed && HeldDown)
+        var before = HeldDown;
+        if (base.OnInput(@event) && !before && HeldDown)
         {
             if (TrackInputMethod)
             {
@@ -41,5 +38,13 @@ public class RunOnKeyDownAttribute : RunOnKeyAttribute
 
     public override void OnProcess(double delta)
     {
+    }
+
+    public override void OnUnprocesedInput(InputEvent @event)
+    {
+        // Update the state when the key is released, even if the event is marked as handled.
+        // This can occur for example when a popup is opened when the key is pressed.
+        if (@event.IsActionReleased(InputName, false))
+            HeldDown = false;
     }
 }

--- a/src/engine/input/RunOnKeyDownAttribute.cs
+++ b/src/engine/input/RunOnKeyDownAttribute.cs
@@ -18,8 +18,11 @@ public class RunOnKeyDownAttribute : RunOnKeyAttribute
 
     public override bool OnInput(InputEvent @event)
     {
-        var before = HeldDown;
-        if (base.OnInput(@event) && !before && HeldDown)
+        // Only trigger if the input was pressed this frame. It isn't possible to use !HeldDown since its value is
+        // incorrect if a mouse release event is marked as handled e.g. when opening a popup.
+        // https://github.com/Revolutionary-Games/Thrive/issues/5217
+        var justPressed = Input.IsActionJustPressed(InputName);
+        if (base.OnInput(@event) && justPressed && HeldDown)
         {
             if (TrackInputMethod)
             {


### PR DESCRIPTION
**Brief Description of What This PR Does**

When opening a popup such as the organelle context menu, the mouse release event will be marked as handled by the popup. This means that the input manager won't call the OnInput function:
https://github.com/Revolutionary-Games/Thrive/blob/dce65afc2961d5c00c1b17b3227a01834f03a15f/src/engine/input/InputManager.cs#L573-L575
This caused the HeldDown field of RunOnKeyAttribute to get stuck in the true state.

I changed the RunOnKeyDownAttribute to rely on `Input.IsActionJustPressed` rather than the `HeldDown` state to avoid this issue.

**Related Issues**
I think this closes #5217?

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
