### PR TITLE
Improve photostudio cell positioning

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1306,7 +1306,7 @@ public static class Constants
 
     public const float EDITOR_DEFAULT_CAMERA_HEIGHT = 10;
 
-    public const float CELL_BILLBOARD_DEFAULT_SCALE_MULTIPLIER = 2.50f;
+    public const float CELL_BILLBOARD_DEFAULT_SCALE_MULTIPLIER = 1.8f;
 
     public const float MAX_SPECIES_NAME_LENGTH_PIXELS = 230.0f;
 

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1559,7 +1559,7 @@ public static class Constants
 
     public const float PHOTO_STUDIO_CAMERA_FOV = 70;
     public const float PHOTO_STUDIO_CAMERA_HALF_ANGLE = PHOTO_STUDIO_CAMERA_FOV / 2.0f;
-    public const float PHOTO_STUDIO_CELL_RADIUS_MULTIPLIER = 1.50f;
+    public const float PHOTO_STUDIO_CELL_RADIUS_MULTIPLIER = 1.1f;
 
     public const int RESOURCE_LOAD_TARGET_MIN_FPS = 60;
     public const float RESOURCE_TIME_BUDGET_PER_FRAME = 1.0f / RESOURCE_LOAD_TARGET_MIN_FPS;

--- a/src/early_multicellular_stage/CellBillboard.cs
+++ b/src/early_multicellular_stage/CellBillboard.cs
@@ -6,7 +6,7 @@ using Godot;
 /// </summary>
 /// <remarks>
 ///   <para>
-///     Note that as currently this is only used in top down view, this doesn't have the billboard part that this is
+///     Note that as currently this is only used in top-down view, this doesn't have the billboard part that this is
 ///     always rotated towards the camera. That will be needed if this is to be used in some new context.
 ///   </para>
 /// </remarks>

--- a/src/microbe_stage/MicrobeVisualOnlySimulation.cs
+++ b/src/microbe_stage/MicrobeVisualOnlySimulation.cs
@@ -242,6 +242,8 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
         // Calculate cell center graphics position for more accurate photographing
         if (organelles.CreatedOrganelleVisuals is { Count: > 0 })
         {
+            float squaredRadius = radius * radius;
+
             foreach (var pair in organelles.CreatedOrganelleVisuals)
             {
                 // We don't need to account for internal organelles as they are located within the cell's radius
@@ -256,8 +258,7 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
                 float organelleRadius = 1.0f;
                 float squaredDistance = (pair.Value.GlobalPosition - center).LengthSquared();
 
-                if (squaredDistance <
-                    MathF.Pow(radius, 2) - 2 * organelleRadius * radius + MathF.Pow(organelleRadius, 2))
+                if (squaredDistance < squaredRadius - 2 * organelleRadius * radius + organelleRadius * organelleRadius)
                     continue;
 
                 float distance = MathF.Sqrt(squaredDistance);
@@ -267,6 +268,7 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
 
                 center += normalized * (newRadius - radius);
                 radius = newRadius;
+                squaredRadius = radius * radius;
             }
         }
         else if (organelles.CreatedOrganelleVisuals != null)

--- a/src/microbe_stage/MicrobeVisualOnlySimulation.cs
+++ b/src/microbe_stage/MicrobeVisualOnlySimulation.cs
@@ -259,10 +259,10 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
                 if (distance + organelleRadius < radius)
                     continue;
 
-                var normalized = (pair.Value.GlobalPosition - center).Normalized();
+                var normalized = (pair.Value.GlobalPosition - center) / distance;
                 var newRadius = (radius + organelleRadius + distance) * 0.5f;
 
-                center = center - normalized * radius + normalized * newRadius;
+                center += normalized * (newRadius - radius);
                 radius = newRadius;
             }
         }

--- a/src/microbe_stage/MicrobeVisualOnlySimulation.cs
+++ b/src/microbe_stage/MicrobeVisualOnlySimulation.cs
@@ -253,17 +253,19 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
                 // TODO: is there another way to not need to call so many Godot data access methods here
                 // Organelle positions might be usable as the visual positions are derived from them, but this requires
                 // using the global translation for some reason as translation gives just 0 here and doesn't help.
+                var position = pair.Value.GlobalPosition;
 
                 // Assume that the organelle's radius is 1
-                float organelleRadius = 1.0f;
-                float squaredDistance = (pair.Value.GlobalPosition - center).LengthSquared();
+                const float organelleRadius = 1.0f;
+                float organelleRadiusSquared = organelleRadius * organelleRadius;
+                float squaredDistance = (position - center).LengthSquared();
 
-                if (squaredDistance < squaredRadius - 2 * organelleRadius * radius + organelleRadius * organelleRadius)
+                if (squaredDistance < squaredRadius - 2 * organelleRadius * radius + organelleRadiusSquared)
                     continue;
 
                 float distance = MathF.Sqrt(squaredDistance);
 
-                var normalized = (pair.Value.GlobalPosition - center) / distance;
+                var normalized = (position - center) / distance;
                 var newRadius = (radius + organelleRadius + distance) * 0.5f;
 
                 center += normalized * (newRadius - radius);

--- a/src/microbe_stage/MicrobeVisualOnlySimulation.cs
+++ b/src/microbe_stage/MicrobeVisualOnlySimulation.cs
@@ -254,10 +254,12 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
 
                 // Assume that the organelle's radius is 1
                 float organelleRadius = 1.0f;
-                float distance = (pair.Value.GlobalPosition - center).Length();
+                float squaredDistance = (pair.Value.GlobalPosition - center).LengthSquared();
 
-                if (distance + organelleRadius < radius)
+                if (squaredDistance < MathF.Pow(radius, 2) - 2 * organelleRadius * radius + MathF.Pow(organelleRadius, 2))
                     continue;
+
+                float distance = MathF.Sqrt(squaredDistance);
 
                 var normalized = (pair.Value.GlobalPosition - center) / distance;
                 var newRadius = (radius + organelleRadius + distance) * 0.5f;

--- a/src/microbe_stage/MicrobeVisualOnlySimulation.cs
+++ b/src/microbe_stage/MicrobeVisualOnlySimulation.cs
@@ -256,7 +256,8 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
                 float organelleRadius = 1.0f;
                 float squaredDistance = (pair.Value.GlobalPosition - center).LengthSquared();
 
-                if (squaredDistance < MathF.Pow(radius, 2) - 2 * organelleRadius * radius + MathF.Pow(organelleRadius, 2))
+                if (squaredDistance <
+                    MathF.Pow(radius, 2) - 2 * organelleRadius * radius + MathF.Pow(organelleRadius, 2))
                     continue;
 
                 float distance = MathF.Sqrt(squaredDistance);


### PR DESCRIPTION
**Brief Description of What This PR Does**

Before:
![image](https://github.com/user-attachments/assets/d8db1277-8c2c-4862-a6f5-72d10b1072ea)
(notice the cells being centered on their organelles, sometimes resulting in them being partly out of the picture)
After:
![image](https://github.com/user-attachments/assets/4fa2f538-1f9b-484d-ae08-53954cfdfdee)

**Related Issues**

Cells having weird position in the photostudio's pictures, sometimes being partially cut because of that.
A good example of this:
![image](https://github.com/user-attachments/assets/262f96fa-7a98-4e59-b85b-9f7ea85100b3)

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
