### PR TITLE
Fixed organelle suggestion suggesting the nucleus too early

### DIFF
--- a/src/auto-evo/EditorAutoEvoRun.cs
+++ b/src/auto-evo/EditorAutoEvoRun.cs
@@ -18,6 +18,12 @@ public class EditorAutoEvoRun : AutoEvoRun
 
     public bool CollectEnergyInfo { get; set; } = true;
 
+    /// <summary>
+    ///   Set to false in order to disable the player species population change cap which can skew the results
+    ///   depending on the previous population
+    /// </summary>
+    public bool ApplyPlayerPopulationChangeClamp { get; set; } = true;
+
     protected override void GatherInfo(Queue<IRunStep> steps)
     {
         // Custom run setup for editor's use
@@ -35,7 +41,10 @@ public class EditorAutoEvoRun : AutoEvoRun
             new Dictionary<Species, Species>
                 { { OriginalEditedSpecies, ModifiedProperties } }, CollectEnergyInfo));
 
-        AddPlayerSpeciesPopulationChangeClampStep(steps, map,
-            OriginalEditedSpecies.PlayerSpecies ? ModifiedProperties : null, OriginalEditedSpecies);
+        if (ApplyPlayerPopulationChangeClamp)
+        {
+            AddPlayerSpeciesPopulationChangeClampStep(steps, map,
+                OriginalEditedSpecies.PlayerSpecies ? ModifiedProperties : null, OriginalEditedSpecies);
+        }
     }
 }

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -3193,7 +3193,9 @@ public partial class CellEditorComponent :
                     calculatedNoChange = true;
 
                     // This is always calculated first so we can just directly set the result
-                    // TODO: maybe add like 1-2% extra here to ensure that very marginal improvements aren't suggested?
+                    // Maybe add like 1-2% extra here to ensure that very marginal improvements aren't suggested?
+                    // But that's probably not needed anymore with this issue closed:
+                    // https://github.com/Revolutionary-Games/Thrive/issues/5799
                     bestResult = score;
                 }
                 else
@@ -3297,6 +3299,10 @@ public partial class CellEditorComponent :
             currentRun = new EditorAutoEvoRun(currentGameProperties.GameWorld,
                 currentGameProperties.GameWorld.AutoEvoGlobalCache, editorOpenedForSpecies, calculationSpecies)
             {
+                // Needed in order for the suggestion to not suggest slapping down a nucleus just to benefit from the
+                // player population clamp and increase in individual cost (which would unfairly give score in
+                // individual-adjusted scoring mode)
+                ApplyPlayerPopulationChangeClamp = UsePurePopulationScore,
                 CollectEnergyInfo = false,
             };
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

when it isn't actually good. This was caused by the player population clamp step affecting the score.

Thanks to a provided save I was able to easily test this and I came up with this fix idea after a few days of mostly passive thinking about this

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #5799

and probably also #5800 but I'll leave that open for now

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
