### PR TITLE
Make input manager always forward key up events

### DIFF
--- a/src/engine/input/InputManager.cs
+++ b/src/engine/input/InputManager.cs
@@ -570,7 +570,10 @@ public partial class InputManager : Node
 
             var attribute = entry.Key;
 
-            if (unhandledInput || !attribute.OnlyUnhandled)
+            // Inputs are passed to the attribute when they should be acted on *or* if the action is a key up action
+            // as up actions must be always processed to avoid attributes getting stuck in down state if they don't
+            // see the key release due to being consumed by something else
+            if (unhandledInput || !attribute.OnlyUnhandled || !isDown)
             {
                 if (attribute.OnInput(@event))
                 {

--- a/src/engine/input/RunOnKeyUpAttribute.cs
+++ b/src/engine/input/RunOnKeyUpAttribute.cs
@@ -1,9 +1,17 @@
 ﻿using Godot;
 
 /// <summary>
-///   Attribute for a method, that gets called when the defined key is released.
-///   Can be applied multiple times.
+///   Attribute for a method, that gets called when the defined key is released. Can be applied multiple times.
+///   Note that this is always run, even for otherwise consumed input. So care must be taken when writing any code
+///   using this attribute.
 /// </summary>
+/// <remarks>
+///   <para>
+///     This should mostly be used to react as an additional step to input by using another input attribute as the
+///     "trigger" that sets this up to do something. That way the problem with this always triggering (even on consumed
+///     input) can be avoided.
+///   </para>
+/// </remarks>
 public class RunOnKeyUpAttribute : RunOnKeyAttribute
 {
     public RunOnKeyUpAttribute(string inputName) : base(inputName)


### PR DESCRIPTION
**Brief Description of What This PR Does**

to prevent key state from being stuck down if something else consumes the key up events

this is a redo of: https://github.com/Revolutionary-Games/Thrive/pull/5788

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #5217

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
