### PR TITLE
Fix the background plane occluding the guiding line

### DIFF
--- a/src/microbe_stage/BackgroundPlane.cs
+++ b/src/microbe_stage/BackgroundPlane.cs
@@ -49,7 +49,13 @@ public partial class BackgroundPlane : Node3D
     public float PlaneOffset
     {
         get => backgroundPlane.Position.Z;
-        set => backgroundPlane.Position = new Vector3(0, 0, value);
+        set
+        {
+            backgroundPlane.Position = new Vector3(0, 0, value);
+
+            // Move the result plane too to avoid it occluding something
+            blurResultPlane.Position = new Vector3(0, 0, value);
+        }
     }
 
     public override void _Ready()


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixex the background plane occluding the guidance line by being over it

**Related Issues**

The guidance line being invisible with blur enabled

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
