### PR TITLE
Update auto-evo prediction on patch and behaviour change

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1177,6 +1177,15 @@ public static class Constants
     public const int AUTO_EVO_ORGANELLE_ADD_ATTEMPTS = 15;
     public const int AUTO_EVO_ORGANELLE_REMOVE_ATTEMPTS = 15;
 
+    public const float AUTO_EVO_PREDICTION_UPDATE_INTERVAL = 0.95f;
+
+    /// <summary>
+    ///   When doing an auto-evo prediction, this much free population is placed into the moved-to patch if the player
+    ///   is not in the patch yet.
+    ///   Helps to give some indication on how well adapted the player species is to the target patch.
+    /// </summary>
+    public const int AUTO_EVO_PREDICTION_MOVE_EMPTY_EXTRA_POPULATION = 50;
+
     /// <summary>
     ///   Configures how much auto-evo affects the player species compared to the normal amount
     /// </summary>

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1178,7 +1178,7 @@ public static class Constants
     public const int AUTO_EVO_ORGANELLE_REMOVE_ATTEMPTS = 15;
 
     /// <summary>
-    ///   How much auto-evo affects the player species compared to the normal amount
+    ///   Configures how much auto-evo affects the player species compared to the normal amount
     /// </summary>
     public const float AUTO_EVO_PLAYER_STRENGTH_FRACTION = 0.2f;
 

--- a/src/auto-evo/EditorAutoEvoRun.cs
+++ b/src/auto-evo/EditorAutoEvoRun.cs
@@ -7,19 +7,26 @@ using AutoEvo;
 public class EditorAutoEvoRun : AutoEvoRun
 {
     public EditorAutoEvoRun(GameWorld world, AutoEvoGlobalCache globalCache, Species originalEditedSpecies,
-        Species modifiedProperties) : base(world, globalCache)
+        Species modifiedProperties, Patch? editorTargetPatch) : base(world, globalCache)
     {
         OriginalEditedSpecies = originalEditedSpecies;
         ModifiedProperties = modifiedProperties;
+        EditorTargetPatch = editorTargetPatch;
     }
 
     public Species OriginalEditedSpecies { get; }
     public Species ModifiedProperties { get; }
 
+    /// <summary>
+    ///   Ensures the <see cref="ModifiedProperties"/> is always set to be in this target patch it wants to move to
+    ///   so that the move target also affects the editor auto-evo run.
+    /// </summary>
+    public Patch? EditorTargetPatch { get; }
+
     public bool CollectEnergyInfo { get; set; } = true;
 
     /// <summary>
-    ///   Set to false in order to disable the player species population change cap which can skew the results
+    ///   Set to false in order to disable the player species population change cap, which can skew the results
     ///   depending on the previous population
     /// </summary>
     public bool ApplyPlayerPopulationChangeClamp { get; set; } = true;
@@ -37,9 +44,19 @@ public class EditorAutoEvoRun : AutoEvoRun
             steps.Enqueue(new GenerateMiche(entry.Value, generateMicheCache, globalCache));
         }
 
-        steps.Enqueue(new CalculatePopulation(configuration, worldSettings, map,
+        var populationCalculation = new CalculatePopulation(configuration, worldSettings, map,
             new Dictionary<Species, Species>
-                { { OriginalEditedSpecies, ModifiedProperties } }, CollectEnergyInfo));
+                { { OriginalEditedSpecies, ModifiedProperties } }, CollectEnergyInfo);
+
+        if (EditorTargetPatch != null)
+        {
+            populationCalculation.EnsurePatchesHaveSpecies = new Dictionary<Patch, Species>
+            {
+                { EditorTargetPatch, ModifiedProperties },
+            };
+        }
+
+        steps.Enqueue(populationCalculation);
 
         if (ApplyPlayerPopulationChangeClamp)
         {

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -7,7 +7,7 @@ using Godot;
 using Xoshiro.PRNG64;
 
 /// <summary>
-///   Main class for miche based population simulation.
+///   Main class for miche-based population simulation.
 ///   This contains the algorithm for determining how much population species gain or lose
 /// </summary>
 public static class MichePopulation
@@ -85,7 +85,7 @@ public static class MichePopulation
     {
         var species = new List<Species>();
 
-        // Copy non excluded species
+        // Copy non-excluded species
         foreach (var candidateSpecies in parameters.OriginalMap.FindAllSpeciesWithPopulation())
         {
             if (parameters.ReplacedSpecies.TryGetValue(candidateSpecies, out var replacement))
@@ -119,6 +119,8 @@ public static class MichePopulation
 
         var results = parameters.Results;
 
+        var ensuredPatches = parameters.EnsurePatchesHaveSpecies;
+
         foreach (var currentSpecies in species)
         {
             var currentResult = results.GetSpeciesResultForInternalUse(currentSpecies);
@@ -127,7 +129,7 @@ public static class MichePopulation
             {
                 long currentPopulation = patch.GetSpeciesSimulationPopulation(currentSpecies);
 
-                // If this is a replacement species, this instead takes the
+                // If this is a replacement species, this instead takes the original species' population
                 if (currentPopulation == 0)
                 {
                     Species? isExtraFor = null;
@@ -163,7 +165,17 @@ public static class MichePopulation
                     }
                 }
 
-                // All species even ones not in a patch need to have their population numbers added
+                // Apply ensured population amounts for the simulation to add species to patches it is not normally in
+                if (ensuredPatches != null)
+                {
+                    if (ensuredPatches.TryGetValue(patch, out var speciesToEnsure) && speciesToEnsure == currentSpecies)
+                    {
+                        currentPopulation = Math.Max(currentPopulation,
+                            Constants.AUTO_EVO_PREDICTION_MOVE_EMPTY_EXTRA_POPULATION);
+                    }
+                }
+
+                // All species, even ones not in a patch, need to have their population numbers added
                 // as the simulation expects to be able to get the populations
                 currentResult.NewPopulationInPatches[patch] = currentPopulation;
             }

--- a/src/auto-evo/simulation/SimulationConfiguration.cs
+++ b/src/auto-evo/simulation/SimulationConfiguration.cs
@@ -46,14 +46,21 @@ public class SimulationConfiguration
     public List<Tuple<Species, SpeciesMigration>> Migrations { get; set; } = new();
 
     /// <summary>
-    ///   If not empty, only the specified patches are ran
+    ///   If not empty, only the specified patches are run
     /// </summary>
     public ISet<Patch> PatchesToRun { get; set; } = new HashSet<Patch>();
 
     /// <summary>
-    ///   If set to true then species energy sources will be stored for display to the player
+    ///   If set to true, then species energy sources will be stored for display to the player
     /// </summary>
     public bool CollectEnergyInformation { get; set; }
+
+    /// <summary>
+    ///   Specifies for a set of patches that species should be ensured it is always in them. If the population is
+    ///   lower than <see cref="Constants.AUTO_EVO_PREDICTION_MOVE_EMPTY_EXTRA_POPULATION"/> ensures it is at least
+    ///   that.
+    /// </summary>
+    public Dictionary<Patch, Species>? EnsurePatchesHaveSpecies { get; set; }
 
     /// <summary>
     ///   Sets the patches to be simulated to be ones where the species is present (population > 0)

--- a/src/auto-evo/steps/CalculatePopulation.cs
+++ b/src/auto-evo/steps/CalculatePopulation.cs
@@ -28,6 +28,12 @@ public class CalculatePopulation : IRunStep
 
     public bool CanRunConcurrently => false;
 
+    /// <summary>
+    ///   Used to overwrite <see cref="SimulationConfiguration.EnsurePatchesHaveSpecies"/> for the population
+    ///   calculation run.
+    /// </summary>
+    public Dictionary<Patch, Species>? EnsurePatchesHaveSpecies { get; set; }
+
     public bool RunStep(RunResults results)
     {
         // ReSharper disable RedundantArgumentDefaultValue
@@ -35,6 +41,7 @@ public class CalculatePopulation : IRunStep
         {
             Results = results,
             CollectEnergyInformation = collectEnergyInfo,
+            EnsurePatchesHaveSpecies = EnsurePatchesHaveSpecies,
         };
 
         // ReSharper restore RedundantArgumentDefaultValue

--- a/src/general/base_stage/EditorBase.cs
+++ b/src/general/base_stage/EditorBase.cs
@@ -431,7 +431,7 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
 
     public virtual bool EnqueueAction(TAction action)
     {
-        // A sanity check to not let an action proceed if we don't have enough mutation points
+        // A sanity-check for an action to not let ot proceed if we don't have enough mutation points
         // It's required to call WhatWouldActionsCost as that will set the right context data
         if (!CheckEnoughMPForAction(WhatWouldActionsCost(action.Data)))
             return false;

--- a/src/general/base_stage/EditorComponentBase.cs
+++ b/src/general/base_stage/EditorComponentBase.cs
@@ -28,7 +28,7 @@ public partial class EditorComponentBase<TEditor> : ControlWithInput, IEditorCom
     }
 
     /// <summary>
-    ///   If this is set then the next / finish button on this tab is the next button.
+    ///   If this is set, then the next / finish button on this tab is the next button.
     ///   This or <see cref="OnFinish"/> must be set before <see cref="Init(TEditor,bool)"/> is called.
     /// </summary>
     public Action? OnNextTab { get; set; }
@@ -36,7 +36,7 @@ public partial class EditorComponentBase<TEditor> : ControlWithInput, IEditorCom
     public Func<List<EditorUserOverride>?, bool>? OnFinish { get; set; }
 
     /// <summary>
-    ///   Sub-editor components don't require all functionality, so they override this to disable some initialization
+    ///   Subeditor components don't require all functionality, so they override this to disable some initialization
     ///   logic
     /// </summary>
     [JsonIgnore]
@@ -83,7 +83,7 @@ public partial class EditorComponentBase<TEditor> : ControlWithInput, IEditorCom
 
         if (OnNextTab != null)
         {
-            // This is the default state so we don't need to do anything here
+            // This is the default state, so we don't need to do anything here
         }
         else if (OnFinish != null)
         {
@@ -108,8 +108,8 @@ public partial class EditorComponentBase<TEditor> : ControlWithInput, IEditorCom
 
     public virtual void OnEditorReady()
     {
-        // Late initialization stuff can go here (usually overridden by component types that need that)
-        // Note that this only happens when not loading a save as when loading a save auto-evo etc. data should be
+        // Late initialisation stuff can go here (usually overridden by component types that need that)
+        // Note that this only happens when not loading a save, as when loading a save auto-evo etc. data should be
         // ready immediately
     }
 
@@ -186,7 +186,7 @@ public partial class EditorComponentBase<TEditor> : ControlWithInput, IEditorCom
     }
 
     /// <summary>
-    ///   Rebuilds and recalculates all value dependent UI elements on language change
+    ///   Rebuilds and recalculates all value-dependent UI elements on language change
     /// </summary>
     protected virtual void OnTranslationsChanged()
     {
@@ -201,7 +201,7 @@ public partial class EditorComponentBase<TEditor> : ControlWithInput, IEditorCom
         if (IsSubComponent)
             return;
 
-        // By default this is the next button
+        // By default, this is the next button
         finishOrNextButton.RegisterToolTipForControl("nextTabButton", "editor");
     }
 

--- a/src/general/base_stage/IEditorWithPatches.cs
+++ b/src/general/base_stage/IEditorWithPatches.cs
@@ -3,7 +3,15 @@
 /// </summary>
 public interface IEditorWithPatches : IEditor
 {
+    /// <summary>
+    ///   Current patch of the player (either where they were before the editor or where they want to move to)
+    /// </summary>
     public Patch CurrentPatch { get; }
+
+    /// <summary>
+    ///   The target patch to move to after editing. Null if no move is intended.
+    /// </summary>
+    public Patch? TargetPatch { get; }
 
     public void OnCurrentPatchUpdated(Patch patch);
 }

--- a/src/microbe_stage/editor/BehaviourEditorSubComponent.cs
+++ b/src/microbe_stage/editor/BehaviourEditorSubComponent.cs
@@ -41,6 +41,9 @@ public partial class BehaviourEditorSubComponent : EditorComponentBase<ICellEdit
     [JsonProperty]
     private Species? editedSpecies;
 
+    [Signal]
+    public delegate void OnBehaviourChangedEventHandler();
+
     [JsonIgnore]
     public override bool IsSubComponent => true;
 
@@ -103,6 +106,7 @@ public partial class BehaviourEditorSubComponent : EditorComponentBase<ICellEdit
     {
         behaviour = new BehaviourDictionary();
         UpdateAllBehaviouralSliders(behaviour);
+        EmitSignal(SignalName.OnBehaviourChanged);
     }
 
     public void SetBehaviouralValue(BehaviouralValueType type, float value)
@@ -201,6 +205,8 @@ public partial class BehaviourEditorSubComponent : EditorComponentBase<ICellEdit
 
         Behaviour[data.Type] = data.NewValue;
         UpdateBehaviourSlider(data.Type, data.NewValue);
+
+        EmitSignal(SignalName.OnBehaviourChanged);
     }
 
     [DeserializedCallbackAllowed]
@@ -211,5 +217,7 @@ public partial class BehaviourEditorSubComponent : EditorComponentBase<ICellEdit
 
         Behaviour[data.Type] = data.OldValue;
         UpdateBehaviourSlider(data.Type, data.OldValue);
+
+        EmitSignal(SignalName.OnBehaviourChanged);
     }
 }

--- a/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
@@ -122,7 +122,7 @@ public partial class CellEditorComponent
         {
             UpdateAlreadyPlacedVisuals();
 
-            // Organelle placement *might* affect auto-evo in the future so this is here for that reason
+            // Organelle placement *might* affect auto-evo in the future, so this is here for that reason
             StartAutoEvoPrediction();
 
             // Suggestion is not restarted as the overall shape / movement speed is likely not significant enough to
@@ -317,7 +317,7 @@ public partial class CellEditorComponent
     [DeserializedCallbackAllowed]
     private void DoEndosymbiontPlaceAction(EndosymbiontPlaceActionData data)
     {
-        // Perform unlock to make the endosymbiont placeable for later
+        // Perform the unlocking to make the endosymbiont placeable for later
         if (Editor.CurrentGame.GameWorld.UnlockProgress.UnlockOrganelle(data.PlacedOrganelle.Definition,
                 Editor.CurrentGame))
         {
@@ -392,8 +392,8 @@ public partial class CellEditorComponent
     }
 
     /// <summary>
-    ///   In the case of the multicellular editor some actions need to work even if the editor has been reinitialized
-    ///   in the meantime since they were performed. For sanity checking sake we throw an exception in those cases
+    ///   In the case of the multicellular editor, some actions need to work even if the editor has been reinitialized
+    ///   in the meantime since they were performed. For sanity checking sake, we throw an exception in those cases
     ///   if they are reached in non-multicellular editor mode.
     /// </summary>
     /// <exception cref="InvalidOperationException">The exception thrown if we aren't in multicellular</exception>

--- a/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
@@ -379,7 +379,7 @@ public partial class CellEditorComponent
                 GD.Print("Resetting active action as it is an organelle type that will be locked now");
             }
 
-            // NOTE: if we ever add support for unlock condition re-check after entering the editor, this needs to be
+            // NOTE: if we ever add support for unlock-condition re-check after entering the editor, this needs to be
             // re-thought out to make sure this doesn't interact badly with such a feature
             Editor.CurrentGame.GameWorld.UnlockProgress.UndoOrganelleUnlock(data.PlacedOrganelle.Definition);
 
@@ -389,6 +389,17 @@ public partial class CellEditorComponent
         // Need to restore the previous endosymbiosis action
         data.OverriddenEndosymbiosisOnUndo =
             Editor.EditedBaseSpecies.Endosymbiosis.ResumeEndosymbiosisProcess(data.RelatedEndosymbiosisAction);
+    }
+
+    private void OnEmbeddedBehaviourEditorChangedData()
+    {
+        if (behaviourEditor.Behaviour == null)
+        {
+            GD.PrintErr("Expected behaviour editor to have a behaviour set, but it didn't");
+            return;
+        }
+
+        OnBehaviourDataUpdated(behaviourEditor.Behaviour);
     }
 
     /// <summary>

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -18,8 +18,6 @@ using UnlockConstraints;
 /// </remarks>
 public partial class CellEditorComponent
 {
-    private const float AUTO_EVO_PREDICTION_START_DELAY = 1.0f;
-
     private readonly Dictionary<int, GrowthOrderLabel> createdGrowthOrderLabels = new();
 
     private StringBuilder atpToolTipTextBuilder = new();
@@ -188,7 +186,7 @@ public partial class CellEditorComponent
     {
         autoEvoPredictionStartTimer += delta;
 
-        if (autoEvoPredictionStartTimer > AUTO_EVO_PREDICTION_START_DELAY)
+        if (autoEvoPredictionStartTimer > Constants.AUTO_EVO_PREDICTION_UPDATE_INTERVAL)
         {
             autoEvoPredictionStartTimer = 0;
 

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -18,6 +18,8 @@ using UnlockConstraints;
 /// </remarks>
 public partial class CellEditorComponent
 {
+    private const float AUTO_EVO_PREDICTION_START_DELAY = 1.0f;
+
     private readonly Dictionary<int, GrowthOrderLabel> createdGrowthOrderLabels = new();
 
     private StringBuilder atpToolTipTextBuilder = new();
@@ -174,10 +176,26 @@ public partial class CellEditorComponent
                 {
                     inProgressSuggestionCheckRunning = true;
 
-                    // This allocates a task each frame, but as this would be hard to workaround and is in the editor,
+                    // This allocates a task each frame, but as this would be hard to work around and is in the editor,
                     // this is just left like this
                     TaskExecutor.Instance.AddTask(new Task(CheckSuggestionProgress));
                 }
+            }
+        }
+    }
+
+    private void TriggerDelayedPredictionUpdateIfNeeded(double delta)
+    {
+        autoEvoPredictionStartTimer += delta;
+
+        if (autoEvoPredictionStartTimer > AUTO_EVO_PREDICTION_START_DELAY)
+        {
+            autoEvoPredictionStartTimer = 0;
+
+            if (autoEvoPredictionDirty)
+            {
+                StartAutoEvoPrediction();
+                autoEvoPredictionDirty = false;
             }
         }
     }

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -2010,7 +2010,7 @@ public partial class CellEditorComponent :
         CopyEditedPropertiesToSpecies(cachedAutoEvoPredictionSpecies);
 
         var run = new EditorAutoEvoRun(Editor.CurrentGame.GameWorld, Editor.CurrentGame.GameWorld.AutoEvoGlobalCache,
-            Editor.EditedBaseSpecies, cachedAutoEvoPredictionSpecies);
+            Editor.EditedBaseSpecies, cachedAutoEvoPredictionSpecies, Editor.TargetPatch);
         run.Start();
         autoEvoPredictionDirty = false;
 
@@ -3171,6 +3171,7 @@ public partial class CellEditorComponent :
 
         private AutoEvoRun? currentRun;
         private BiomeConditions? biome;
+        private Patch? patch;
 
         private bool calculatedNoChange;
         private double bestResult;
@@ -3208,6 +3209,7 @@ public partial class CellEditorComponent :
         public void StartNew(List<OrganelleDefinition> organellesToTry, Patch selectedPatch)
         {
             biome = selectedPatch.Biome;
+            patch = selectedPatch;
 
             if (currentRun != null)
             {
@@ -3377,7 +3379,7 @@ public partial class CellEditorComponent :
             }
 
             currentRun = new EditorAutoEvoRun(currentGameProperties.GameWorld,
-                currentGameProperties.GameWorld.AutoEvoGlobalCache, editorOpenedForSpecies, calculationSpecies)
+                currentGameProperties.GameWorld.AutoEvoGlobalCache, editorOpenedForSpecies, calculationSpecies, patch)
             {
                 // Needed in order for the suggestion to not suggest slapping down a nucleus just to benefit from the
                 // player population clamp and increase in individual cost (which would unfairly give score in

--- a/src/microbe_stage/editor/CellEditorComponent.tscn
+++ b/src/microbe_stage/editor/CellEditorComponent.tscn
@@ -1546,6 +1546,7 @@ layout_mode = 1
 [connection signal="pressed" from="LeftPanel/MainPanel/VBoxContainer/MarginContainer/EditingPanel/Structure/ScrollContainer/MarginContainer/StructureContainer/Endosymbiosis" to="." method="OnEndosymbiosisButtonPressed"]
 [connection signal="value_changed" from="LeftPanel/MainPanel/VBoxContainer/MarginContainer/EditingPanel/Membrane/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/RigiditySlider" to="." method="OnRigidityChanged"]
 [connection signal="color_changed" from="LeftPanel/MainPanel/VBoxContainer/MarginContainer/EditingPanel/Membrane/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer2/TweakedColourPicker" to="." method="OnColorChanged"]
+[connection signal="OnBehaviourChanged" from="LeftPanel/MainPanel/VBoxContainer/MarginContainer/EditingPanel/Behaviour" to="." method="OnEmbeddedBehaviourEditorChangedData"]
 [connection signal="OrderReset" from="LeftPanel/MainPanel/VBoxContainer/MarginContainer/EditingPanel/Growth/ScrollContainer/MarginContainer/GrowthContainer/GrowthOrderPicker" to="." method="OnResetGrowthOrderPressed"]
 [connection signal="toggled" from="LeftPanel/MainPanel/VBoxContainer/MarginContainer/EditingPanel/Growth/ScrollContainer/MarginContainer/GrowthContainer/Coordinates" to="." method="OnGrowthOrderCoordinatesToggled"]
 [connection signal="item_selected" from="RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/ATPBalancePanel/VBoxContainer/ATPBalanceMode" to="." method="SelectATPBalanceMode"]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes auto-evo prediction and organelle suggestion react to some new cell edits. And adds a new feature where small artificial population is added in target patch so that the prediction starts showing stats related to the new patch. This should be at least somewhat accurate thanks to the player getting at least the 50 population in the new patch when getting to the editor and then on the next cycle auto-evo taking it from there. Though maybe if it is confusing more than previous the free population amount could be reduced (maybe even a value of 1 would work).

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #2924
closes #2925

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
