### PR TITLE
Removed an unnecessary enumerator allocation in UpgradeOrganelle

### DIFF
--- a/src/auto-evo/mutation_strategy/UpgradeOrganelle.cs
+++ b/src/auto-evo/mutation_strategy/UpgradeOrganelle.cs
@@ -41,8 +41,14 @@ public class UpgradeOrganelle : IMutationStrategy<MicrobeSpecies>
         }
 
         bool validMutations = false;
-        foreach (OrganelleTemplate organelle in baseSpecies.Organelles)
+
+        // Manual looping to avoid one enumerator allocation per call
+        var organelleList = baseSpecies.Organelles.Organelles;
+        var count = organelleList.Count;
+        for (var i = 0; i < count; ++i)
         {
+            var organelle = organelleList[i];
+
             if (allOrganelles.Contains(organelle.Definition))
             {
                 validMutations = true;
@@ -54,10 +60,14 @@ public class UpgradeOrganelle : IMutationStrategy<MicrobeSpecies>
         {
             var mutated = new List<Tuple<MicrobeSpecies, float>>();
 
-            MicrobeSpecies newSpecies = (MicrobeSpecies)baseSpecies.Clone();
+            var newSpecies = (MicrobeSpecies)baseSpecies.Clone();
 
-            foreach (OrganelleTemplate organelle in newSpecies.Organelles)
+            organelleList = newSpecies.Organelles.Organelles;
+            count = organelleList.Count;
+            for (var i = 0; i < count; ++i)
             {
+                var organelle = organelleList[i];
+
                 if (allOrganelles.Contains(organelle.Definition))
                 {
                     // TODO: Once this is used with an upgrade that costs MP this will need to factor that in


### PR DESCRIPTION
**Brief Description of What This PR Does**

I noticed when reviewing another PR that my IDE plugin caught enumerator allocations so I swapped those out to manual looping to remove the extra allocator calls to reduce generated garbage while auto-evo is running.

This shouldn't affect any functionality.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
