### PR TITLE
Editor components now close all active modals on next press 

### DIFF
--- a/src/general/base_stage/EditorComponentBase.cs
+++ b/src/general/base_stage/EditorComponentBase.cs
@@ -209,6 +209,12 @@ public partial class EditorComponentBase<TEditor> : ControlWithInput, IEditorCom
     {
         GUICommon.Instance.PlayButtonPressSound();
 
+        if (!ModalManager.Instance.TryCancelModals())
+        {
+            GD.PrintErr("Cannot close open modals before continuing, not triggering next / finish action");
+            return;
+        }
+
         if (OnFinish != null)
         {
             if (OnFinish!.Invoke(null))

--- a/src/gui_common/ModalManager.cs
+++ b/src/gui_common/ModalManager.cs
@@ -121,7 +121,7 @@ public partial class ModalManager : NodeWithInput
     }
 
     /// <summary>
-    ///   Closes the top-most modal popup if any.
+    ///   Closes the top-most modal popup, if any.
     /// </summary>
     [RunOnKeyDown("ui_cancel", Priority = Constants.POPUP_CANCEL_PRIORITY)]
     public bool HideTopMostPopup()
@@ -134,15 +134,7 @@ public partial class ModalManager : NodeWithInput
         if (popup.Exclusive && !popup.ExclusiveAllowCloseOnEscape)
             return false;
 
-        // This is emitted before closing to allow window using components to differentiate between "cancel" and
-        // "any other reason for closing" in case some logic can be simplified by handling just those two situations.
-        if (popup is CustomWindow dialog)
-            dialog.EmitSignal(CustomWindow.SignalName.Canceled);
-
-        popup.Close();
-
-        // TODO: make sure removing this is not a problem (looks like this signal no longer exists at all)
-        // popup.Notification(Control.NotificationModalClose);
+        ClosePopupDialog(popup);
 
         return true;
     }
@@ -163,6 +155,35 @@ public partial class ModalManager : NodeWithInput
         return null;
     }
 
+    /// <summary>
+    ///   Tries to cancel all open modals (or close if the modals don't support cancellation)
+    /// </summary>
+    /// <returns>True if all modals are closed, false if some refused to close</returns>
+    public bool TryCancelModals()
+    {
+        // If no modals, we don't need to do anything
+        if (modalStack.Count <= 0)
+            return true;
+
+        while (modalStack.Count > 0)
+        {
+            var modal = modalStack.First();
+
+            // TODO: implement a way for important popups to ignore this close
+            ClosePopupDialog(modal);
+
+            // Fail if modal is still not closed
+            if (modal.IsVisibleInTree())
+            {
+                GD.Print("Modal doesn't want to cancel / close failing close operation of all modals");
+                return false;
+            }
+        }
+
+        // All modals are now closed
+        return true;
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)
@@ -171,6 +192,19 @@ public partial class ModalManager : NodeWithInput
         }
 
         base.Dispose(disposing);
+    }
+
+    private void ClosePopupDialog(TopLevelContainer popup)
+    {
+        // This is emitted before closing to allow window-using components to differentiate between "cancel" and
+        // "any other reason for closing" in case some logic can be simplified by handling just those two situations.
+        if (popup is CustomWindow dialog)
+            dialog.EmitSignal(CustomWindow.SignalName.Canceled);
+
+        popup.Close();
+
+        // TODO: make sure removing this is not a problem (looks like this signal no longer exists at all)
+        // popup.Notification(Control.NotificationModalClose);
     }
 
     /// <summary>


### PR DESCRIPTION
or finish press to not leave them open, which can lead to all kinds of issues

**Brief Description of What This PR Does**

Makes the popup closing when they shouldn't be active anymore more reliable.

This is a slight follow up to: https://github.com/Revolutionary-Games/Thrive/pull/5775 so that popups close earlier and for multicellular editor this will make things safer as a popup from a different component cannot stay open when swapping to a different one (or at least that will be harder to do accidentally)

closes #4486

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
