### PR TITLE
Make item icon be on top of windows

### DIFF
--- a/src/awakening_stage/gui/InventorySlot.cs
+++ b/src/awakening_stage/gui/InventorySlot.cs
@@ -124,6 +124,7 @@ public partial class InventorySlot : Button
             StretchMode = TextureRect.StretchModeEnum.Scale,
             Texture = item.Icon,
             CustomMinimumSize = new Vector2(32, 32),
+            ZIndex = 1,
         };
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

It's not eliminating the reason why it happened in the first place but makes dragged icons on top of all else.

**Related Issues**

Closes #5224

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
