### PR TITLE
Make microbes stop sprinting when engulfed

### DIFF
--- a/src/microbe_stage/components/Engulfable.cs
+++ b/src/microbe_stage/components/Engulfable.cs
@@ -182,6 +182,11 @@ public static class EngulfableHelpers
             entity.Get<MicrobeControl>().State = MicrobeState.Normal;
         }
 
+        if (entity.Has<StrainAffected>())
+        {
+            entity.Get<StrainAffected>().IsUnderStrain = false;
+        }
+
         // Disable compound venting
         if (entity.Has<UnneededCompoundVenter>())
         {

--- a/src/microbe_stage/systems/EngulfingSystem.cs
+++ b/src/microbe_stage/systems/EngulfingSystem.cs
@@ -45,6 +45,7 @@ using World = DefaultEcs.World;
 [WritesToComponent(typeof(TemporaryEndosymbiontInfo))]
 [WritesToComponent(typeof(DamageCooldown))]
 [WritesToComponent(typeof(TimedLife))]
+[WritesToComponent(typeof(StrainAffected))]
 [ReadsComponent(typeof(CollisionManagement))]
 [ReadsComponent(typeof(MicrobePhysicsExtraData))]
 [ReadsComponent(typeof(OrganelleContainer))]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Stops microbes from sprinting after they get engulfed. 
The `IsUnderStrain` marker only gets changed in the movement system, which doesn't run when the microbe gets engulfed. As such, it has to be set to false in the `OnBecomeEngulfed` method.

**Related Issues**

Fixes #5569

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
