### PR TITLE
Don't dispose heat noise image to stop error on second time playing

### DIFF
--- a/src/microbe_stage/systems/MicrobeHeatAccumulationSystem.cs
+++ b/src/microbe_stage/systems/MicrobeHeatAccumulationSystem.cs
@@ -22,7 +22,10 @@ public class MicrobeHeatAccumulationSystem : AEntitySetSystem<float>
 {
     private readonly NoiseTexture2D noiseSource;
 
+    // Don't dispose: https://github.com/Revolutionary-Games/Thrive/issues/5886
+#pragma warning disable CA2213
     private Image? noiseImage;
+#pragma warning restore CA2213
 
     private int noiseWidth;
     private int noiseHeight;
@@ -68,13 +71,6 @@ public class MicrobeHeatAccumulationSystem : AEntitySetSystem<float>
         var differenceFromMiddle = rawNoise - Constants.MICROBE_HEAT_NOISE_MIDDLE_POINT;
 
         return patchTemperatureMiddle + differenceFromMiddle * Constants.NOISE_EFFECT_ON_LOCAL_TEMPERATURE;
-    }
-
-    public sealed override void Dispose()
-    {
-        Dispose(true);
-        base.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     protected override void PreUpdate(float delta)
@@ -162,14 +158,6 @@ public class MicrobeHeatAccumulationSystem : AEntitySetSystem<float>
             }
 
             properties.Temperature += change;
-        }
-    }
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            noiseImage?.Dispose();
         }
     }
 }


### PR DESCRIPTION
as that causes an error on second time playing the game

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
fixes #5886

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
