### PR TITLE
Converted MP calculations to use doubles

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1027,6 +1027,14 @@ public static class Constants
 
     public const int BASE_MUTATION_POINTS = 100;
 
+    /// <summary>
+    ///   As mutation points are now calculated with floats, there can be situations where the player just barely
+    ///   cannot afford something they should be able to afford, so we allow going negative by this much.
+    /// </summary>
+    public const double ALLOWED_MP_OVERSHOOT = -0.0001;
+
+    public const double SMALL_MP_COST = 0.1;
+
     public const int MUTATION_POINTS_DECIMALS = 1;
 
     public const int ORGANELLE_REMOVE_COST = 10;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1027,6 +1027,8 @@ public static class Constants
 
     public const int BASE_MUTATION_POINTS = 100;
 
+    public const int MUTATION_POINTS_DECIMALS = 1;
+
     public const int ORGANELLE_REMOVE_COST = 10;
     public const int ORGANELLE_MOVE_COST = 5;
 

--- a/src/auto-evo/mutation_strategy/AddOrganelleAnywhere.cs
+++ b/src/auto-evo/mutation_strategy/AddOrganelleAnywhere.cs
@@ -74,7 +74,7 @@ public class AddOrganelleAnywhere : IMutationStrategy<MicrobeSpecies>
         return ThatConvertBetweenCompounds(fromCompoundResolved, toCompoundResolved, direction);
     }
 
-    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp, bool lawk,
+    public List<Tuple<MicrobeSpecies, double>>? MutationsOf(MicrobeSpecies baseSpecies, double mp, bool lawk,
         Random random, BiomeConditions biomeToConsider)
     {
         // If a cheaper organelle gets added, this will need to be updated
@@ -90,7 +90,7 @@ public class AddOrganelleAnywhere : IMutationStrategy<MicrobeSpecies>
         var organelles = allOrganelles.OrderBy(_ => random.Next())
             .Take(Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS);
 
-        var mutated = new List<Tuple<MicrobeSpecies, float>>();
+        var mutated = new List<Tuple<MicrobeSpecies, double>>();
 
         // TODO: reuse this memory somehow
         var workMemory1 = new List<Hex>();

--- a/src/auto-evo/mutation_strategy/ChangeBehaviorScore.cs
+++ b/src/auto-evo/mutation_strategy/ChangeBehaviorScore.cs
@@ -26,7 +26,7 @@ public class ChangeBehaviorScore : IMutationStrategy<MicrobeSpecies>
     // As it cost no MP the mutation code could just repeat this forever
     public bool Repeatable => false;
 
-    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp, bool lawk,
+    public List<Tuple<MicrobeSpecies, double>>? MutationsOf(MicrobeSpecies baseSpecies, double mp, bool lawk,
         Random random, BiomeConditions biomeToConsider)
     {
         // TODO: Make random something passed in

--- a/src/auto-evo/mutation_strategy/ChangeMembraneRigidity.cs
+++ b/src/auto-evo/mutation_strategy/ChangeMembraneRigidity.cs
@@ -14,7 +14,7 @@ public class ChangeMembraneRigidity : IMutationStrategy<MicrobeSpecies>
 
     public bool Repeatable => true;
 
-    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp, bool lawk,
+    public List<Tuple<MicrobeSpecies, double>>? MutationsOf(MicrobeSpecies baseSpecies, double mp, bool lawk,
         Random random, BiomeConditions biomeToConsider)
     {
         const float change = Constants.AUTO_EVO_MUTATION_RIGIDITY_STEP;

--- a/src/auto-evo/mutation_strategy/ChangeMembraneType.cs
+++ b/src/auto-evo/mutation_strategy/ChangeMembraneType.cs
@@ -14,7 +14,7 @@ public class ChangeMembraneType : IMutationStrategy<MicrobeSpecies>
 
     public bool Repeatable => false;
 
-    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp, bool lawk,
+    public List<Tuple<MicrobeSpecies, double>>? MutationsOf(MicrobeSpecies baseSpecies, double mp, bool lawk,
         Random random, BiomeConditions biomeToConsider)
     {
         if (baseSpecies.MembraneType == membraneType)

--- a/src/auto-evo/mutation_strategy/IMutationStrategy.cs
+++ b/src/auto-evo/mutation_strategy/IMutationStrategy.cs
@@ -16,12 +16,12 @@ public interface IMutationStrategy<T>
     /// <param name="baseSpecies">The species to start from</param>
     /// <param name="mp">How much MP there is to do the mutations</param>
     /// <param name="lawk">
-    ///     The game LAWK status, when the game was started in LAWK mode, affects which mutations are valid
+    ///   The game LAWK status, when the game was started in LAWK mode, affects which mutations are valid
     /// </param>
     /// <param name="random">The random object</param>
     /// <param name="biomeToConsider">
-    ///     Gives environment to consider the mutations to be suitable for. At the time of writing,
-    ///     this only biases environmental tolerance changes.
+    ///   Gives environment to consider the mutations to be suitable for. At the time of writing,
+    ///   this only biases environmental tolerance changes.
     /// </param>
     /// <returns>
     ///   List of mutated species, null if no possible mutations are found (some strategies may return an empty list

--- a/src/auto-evo/mutation_strategy/IMutationStrategy.cs
+++ b/src/auto-evo/mutation_strategy/IMutationStrategy.cs
@@ -16,17 +16,17 @@ public interface IMutationStrategy<T>
     /// <param name="baseSpecies">The species to start from</param>
     /// <param name="mp">How much MP there is to do the mutations</param>
     /// <param name="lawk">
-    ///   The game LAWK status, when the game was started in LAWK mode, affects which mutations are valid
+    ///     The game LAWK status, when the game was started in LAWK mode, affects which mutations are valid
     /// </param>
     /// <param name="random">The random object</param>
     /// <param name="biomeToConsider">
-    ///   Gives environment to consider the mutations to be suitable for. At the time of writing,
-    ///   this only biases environmental tolerance changes.
+    ///     Gives environment to consider the mutations to be suitable for. At the time of writing,
+    ///     this only biases environmental tolerance changes.
     /// </param>
     /// <returns>
     ///   List of mutated species, null if no possible mutations are found (some strategies may return an empty list
     ///   instead in this case)
     /// </returns>
-    public List<Tuple<T, float>>? MutationsOf(T baseSpecies, float mp, bool lawk, Random random,
+    public List<Tuple<T, double>>? MutationsOf(T baseSpecies, double mp, bool lawk, Random random,
         BiomeConditions biomeToConsider);
 }

--- a/src/auto-evo/mutation_strategy/ModifyEnvironmentalTolerance.cs
+++ b/src/auto-evo/mutation_strategy/ModifyEnvironmentalTolerance.cs
@@ -12,7 +12,7 @@ public class ModifyEnvironmentalTolerance : IMutationStrategy<MicrobeSpecies>
     /// </summary>
     public bool Repeatable => false;
 
-    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp, bool lawk,
+    public List<Tuple<MicrobeSpecies, double>>? MutationsOf(MicrobeSpecies baseSpecies, double mp, bool lawk,
         Random random, BiomeConditions biomeToConsider)
     {
         if (mp <= 0)
@@ -53,11 +53,13 @@ public class ModifyEnvironmentalTolerance : IMutationStrategy<MicrobeSpecies>
 
                 if (score.PerfectTemperatureAdjustment < 0)
                 {
-                    change = Math.Max(score.PerfectTemperatureAdjustment, -maxChange);
+                    // Round here so that we don't accidentally round the max change upwards inflating how much change
+                    // is allowed to happen
+                    change = (float)Math.Max(score.PerfectTemperatureAdjustment, -maxChange);
                 }
                 else
                 {
-                    change = Math.Min(score.PerfectTemperatureAdjustment, maxChange);
+                    change = (float)Math.Min(score.PerfectTemperatureAdjustment, maxChange);
                 }
 
                 newTolerances.PreferredTemperature += change;
@@ -68,7 +70,7 @@ public class ModifyEnvironmentalTolerance : IMutationStrategy<MicrobeSpecies>
             else
             {
                 // Trying to perfect this
-                var maxChange = mp / Constants.TOLERANCE_CHANGE_MP_PER_TEMPERATURE_TOLERANCE;
+                var maxChange = (float)(mp / Constants.TOLERANCE_CHANGE_MP_PER_TEMPERATURE_TOLERANCE);
 
                 // To perfect temperature it needs to be always negative
 #if DEBUG
@@ -175,7 +177,7 @@ public class ModifyEnvironmentalTolerance : IMutationStrategy<MicrobeSpecies>
             }
 #endif
 
-            newTolerances.UVResistance += change;
+            newTolerances.UVResistance += (float)change;
 
             mp -= change * Constants.TOLERANCE_CHANGE_MP_PER_OXYGEN;
             changes = true;
@@ -196,7 +198,7 @@ public class ModifyEnvironmentalTolerance : IMutationStrategy<MicrobeSpecies>
             }
 #endif
 
-            newTolerances.UVResistance += change;
+            newTolerances.UVResistance += (float)change;
 
             mp -= change * Constants.TOLERANCE_CHANGE_MP_PER_UV;
             changes = true;

--- a/src/auto-evo/mutation_strategy/MoveOrganelleBack.cs
+++ b/src/auto-evo/mutation_strategy/MoveOrganelleBack.cs
@@ -15,13 +15,13 @@ internal class MoveOrganelleBack : IMutationStrategy<MicrobeSpecies>
 
     public bool Repeatable => true;
 
-    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp, bool lawk,
+    public List<Tuple<MicrobeSpecies, double>>? MutationsOf(MicrobeSpecies baseSpecies, double mp, bool lawk,
         Random random, BiomeConditions biomeToConsider)
     {
         if (mp < Constants.ORGANELLE_MOVE_COST)
             return null;
 
-        var mutated = new List<Tuple<MicrobeSpecies, float>>();
+        var mutated = new List<Tuple<MicrobeSpecies, double>>();
 
         // TODO: try to avoid these temporary list allocations
         var workMemory1 = new List<Hex>();

--- a/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
+++ b/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
@@ -46,7 +46,7 @@ public class RemoveOrganelle : IMutationStrategy<MicrobeSpecies>
 
     // ReSharper restore InvokeAsExtensionMethod
 
-    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp, bool lawk,
+    public List<Tuple<MicrobeSpecies, double>>? MutationsOf(MicrobeSpecies baseSpecies, double mp, bool lawk,
         Random random, BiomeConditions biomeToConsider)
     {
         if (mp < Constants.ORGANELLE_REMOVE_COST)
@@ -55,7 +55,7 @@ public class RemoveOrganelle : IMutationStrategy<MicrobeSpecies>
         var organelles = baseSpecies.Organelles.Where(x => Criteria(x.Definition))
             .OrderBy(_ => random.Next()).Take(Constants.AUTO_EVO_ORGANELLE_REMOVE_ATTEMPTS);
 
-        List<Tuple<MicrobeSpecies, float>>? mutated = null;
+        List<Tuple<MicrobeSpecies, double>>? mutated = null;
 
         MutationWorkMemory? workMemory = null;
 
@@ -90,7 +90,7 @@ public class RemoveOrganelle : IMutationStrategy<MicrobeSpecies>
 
             CommonMutationFunctions.AttachIslandHexes(newSpecies.Organelles, workMemory);
 
-            mutated ??= new List<Tuple<MicrobeSpecies, float>>();
+            mutated ??= new List<Tuple<MicrobeSpecies, double>>();
             mutated.Add(Tuple.Create(newSpecies, mp - Constants.ORGANELLE_REMOVE_COST));
         }
 

--- a/src/auto-evo/mutation_strategy/UpgradeOrganelle.cs
+++ b/src/auto-evo/mutation_strategy/UpgradeOrganelle.cs
@@ -32,7 +32,7 @@ public class UpgradeOrganelle : IMutationStrategy<MicrobeSpecies>
 
     public bool Repeatable => false;
 
-    public List<Tuple<MicrobeSpecies, float>>? MutationsOf(MicrobeSpecies baseSpecies, float mp, bool lawk,
+    public List<Tuple<MicrobeSpecies, double>>? MutationsOf(MicrobeSpecies baseSpecies, double mp, bool lawk,
         Random random, BiomeConditions biomeToConsider)
     {
         if (allOrganelles.Count == 0)
@@ -58,7 +58,7 @@ public class UpgradeOrganelle : IMutationStrategy<MicrobeSpecies>
 
         if (validMutations)
         {
-            var mutated = new List<Tuple<MicrobeSpecies, float>>();
+            var mutated = new List<Tuple<MicrobeSpecies, double>>();
 
             var newSpecies = (MicrobeSpecies)baseSpecies.Clone();
 
@@ -84,7 +84,7 @@ public class UpgradeOrganelle : IMutationStrategy<MicrobeSpecies>
                 }
             }
 
-            mutated.Add(new Tuple<MicrobeSpecies, float>(newSpecies, mp));
+            mutated.Add(new Tuple<MicrobeSpecies, double>(newSpecies, mp));
 
             return mutated;
         }

--- a/src/auto-evo/mutations/CommonMutationFunctions.cs
+++ b/src/auto-evo/mutations/CommonMutationFunctions.cs
@@ -71,7 +71,7 @@ public static class CommonMutationFunctions
     }
 
     public static MicrobeSpecies GenerateRandomSpecies(MicrobeSpecies mutated, Patch forPatch,
-        MutationWorkMemory workMemory, Random random, float mp = 300)
+        MutationWorkMemory workMemory, Random random, double mp = 300)
     {
         var mutationStrategy = new AddOrganelleAnywhere(_ => true);
 

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -37,8 +37,8 @@ public class ModifyExistingSpecies : IRunStep
     private readonly List<IMutationStrategy<MicrobeSpecies>> tempMutationStrategies = new();
 
     // TODO: switch to named tuple elements
-    private readonly List<Tuple<MicrobeSpecies, float>> temporaryMutations1 = new();
-    private readonly List<Tuple<MicrobeSpecies, float>> temporaryMutations2 = new();
+    private readonly List<Tuple<MicrobeSpecies, double>> temporaryMutations1 = new();
+    private readonly List<Tuple<MicrobeSpecies, double>> temporaryMutations2 = new();
 
     private readonly List<MicrobeSpecies> lastGeneratedMutations = new();
 
@@ -46,7 +46,7 @@ public class ModifyExistingSpecies : IRunStep
 
     private readonly List<SelectionPressure> temporaryPressures = new();
 
-    private readonly List<Tuple<MicrobeSpecies, float>> temporaryResultForTopMutations = new();
+    private readonly List<Tuple<MicrobeSpecies, double>> temporaryResultForTopMutations = new();
 
     private readonly MutationSorter mutationSorter;
     private readonly Random random;
@@ -238,8 +238,8 @@ public class ModifyExistingSpecies : IRunStep
         return false;
     }
 
-    private static void PruneMutations(List<Tuple<MicrobeSpecies, float>> addResultsTo, MicrobeSpecies baseSpecies,
-        List<Tuple<MicrobeSpecies, float>> mutated, Patch patch, SimulationCache cache,
+    private static void PruneMutations(List<Tuple<MicrobeSpecies, double>> addResultsTo, MicrobeSpecies baseSpecies,
+        List<Tuple<MicrobeSpecies, double>> mutated, Patch patch, SimulationCache cache,
         List<SelectionPressure> selectionPressures)
     {
         foreach (var potentialVariant in mutated)
@@ -250,7 +250,7 @@ public class ModifyExistingSpecies : IRunStep
                 var newScore = cache.GetPressureScore(pastPressure, patch, potentialVariant.Item1);
                 var oldScore = cache.GetPressureScore(pastPressure, patch, baseSpecies);
 
-                // Break if mutation fails a new pressure
+                // Break if the mutation fails a new pressure check
                 if (newScore <= 0 && oldScore > 0)
                 {
                     combinedScores = -1;
@@ -267,8 +267,8 @@ public class ModifyExistingSpecies : IRunStep
         }
     }
 
-    private static void GetTopMutations(List<Tuple<MicrobeSpecies, float>> result,
-        List<Tuple<MicrobeSpecies, float>> mutated, int amount, MutationSorter sorter)
+    private static void GetTopMutations(List<Tuple<MicrobeSpecies, double>> result,
+        List<Tuple<MicrobeSpecies, double>> mutated, int amount, MutationSorter sorter)
     {
         result.Clear();
 
@@ -385,11 +385,11 @@ public class ModifyExistingSpecies : IRunStep
     ///   Returns a new list of all possible species that might emerge in response to the provided pressures,
     ///   as well as a copy of the original species.
     /// </summary>
-    /// <returns>List of viable variants, and the provided species</returns>
+    /// <returns>List of viable variants and the provided species</returns>
     private List<MicrobeSpecies> GenerateMutations(MicrobeSpecies baseSpecies, int amount,
         List<SelectionPressure> selectionPressures)
     {
-        float totalMP = 100 * worldSettings.AIMutationMultiplier;
+        double totalMP = 100 * worldSettings.AIMutationMultiplier;
 
         temporaryMutations1.Clear();
         temporaryMutations1.Add(Tuple.Create(baseSpecies, totalMP));
@@ -449,7 +449,7 @@ public class ModifyExistingSpecies : IRunStep
                 else
                 {
                     // TODO: switch to a set of rotating buffers to avoid memory allocations here
-                    inputSpecies = new List<Tuple<MicrobeSpecies, float>>();
+                    inputSpecies = new List<Tuple<MicrobeSpecies, double>>();
                     PruneMutations(inputSpecies, baseSpecies, temporaryMutations2, patch, cache, selectionPressures);
                 }
 
@@ -506,7 +506,7 @@ public class ModifyExistingSpecies : IRunStep
     private record struct Mutation(MicrobeSpecies ParentSpecies, MicrobeSpecies MutatedSpecies,
         RunResults.NewSpeciesType AddType);
 
-    private class MutationSorter(Patch patch, SimulationCache cache) : IComparer<Tuple<MicrobeSpecies, float>>
+    private class MutationSorter(Patch patch, SimulationCache cache) : IComparer<Tuple<MicrobeSpecies, double>>
     {
         // This isn't the cleanest but this class is just optimized for performance so if someone forgets to set up
         // this then bad things will happen
@@ -519,7 +519,7 @@ public class ModifyExistingSpecies : IRunStep
             baseSpecies = species;
         }
 
-        public int Compare(Tuple<MicrobeSpecies, float>? x, Tuple<MicrobeSpecies, float>? y)
+        public int Compare(Tuple<MicrobeSpecies, double>? x, Tuple<MicrobeSpecies, double>? y)
         {
             if (ReferenceEquals(x, y))
                 return 0;

--- a/src/general/CombinableActionData.cs
+++ b/src/general/CombinableActionData.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 
 /// <summary>
-///   A combinable action data can be combined with other actions.
-///   For example two separate movements of the same object can be combined into one larger movement action.
-///   This is implemented as an aid for the player so that they do not have to think about optimizing their actions
+///   Combinable action data that can be combined with other actions.
+///   For example, two separate movements of the same object can be combined into one larger movement action.
+///   This is implemented as aid for the player so that they do not have to think about optimizing their actions
 ///   to cost the least amount of MP. And reduce how many steps need to be undone when doing repetitive actions.
 /// </summary>
 public abstract class CombinableActionData
@@ -34,7 +34,7 @@ public abstract class CombinableActionData
     /// </summary>
     /// <param name="other">The action this should be combined with</param>
     /// <returns>Returns the combined action</returns>
-    /// <exception cref="NotSupportedException">Thrown when combination is not possible</exception>
+    /// <exception cref="NotSupportedException">Thrown when the combination is not possible</exception>
     public virtual CombinableActionData Combine(CombinableActionData other)
     {
         if (GetInterferenceModeWith(other) != ActionInterferenceMode.Combinable)

--- a/src/general/base_stage/EditorBase.cs
+++ b/src/general/base_stage/EditorBase.cs
@@ -84,7 +84,7 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
     private Control editorGUIBaseNode = null!;
 #pragma warning restore CA2213
 
-    private int? mutationPointsCache;
+    private double? mutationPointsCache;
 
     /// <summary>
     ///   The fraction of daylight the editor is previewing things at
@@ -107,7 +107,7 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
     public bool TransitionFinished { get; protected set; }
 
     [JsonIgnore]
-    public int MutationPoints
+    public double MutationPoints
     {
         get => mutationPointsCache ?? CalculateMutationPointsLeft();
         set
@@ -416,7 +416,7 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
         throw new GodotAbstractMethodNotOverriddenException();
     }
 
-    public virtual int WhatWouldActionsCost(IEnumerable<EditorCombinableActionData> actions)
+    public virtual double WhatWouldActionsCost(IEnumerable<EditorCombinableActionData> actions)
     {
         // TODO: determine if it is better to use extra memory here or if enumerating multiple times is better (or
         // there's a way to redo this method interface to not need either workaround). Right now this is set to use
@@ -462,7 +462,7 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
         throw new GodotAbstractMethodNotOverriddenException();
     }
 
-    public bool CheckEnoughMPForAction(int cost)
+    public bool CheckEnoughMPForAction(double cost)
     {
         // Freebuilding check is here because in freebuild we are allowed to make edits that consume more than the max
         // MP in a single go, and those wouldn't work without this freebuilding check here
@@ -931,7 +931,7 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
     ///   Calculates the remaining MP from the action history
     /// </summary>
     /// <returns>The remaining MP</returns>
-    private int CalculateMutationPointsLeft()
+    private double CalculateMutationPointsLeft()
     {
         if (FreeBuilding || CheatManager.InfiniteMP)
             return Constants.BASE_MUTATION_POINTS;

--- a/src/general/base_stage/EditorComponentBase.cs
+++ b/src/general/base_stage/EditorComponentBase.cs
@@ -23,6 +23,8 @@ public partial class EditorComponentBase<TEditor> : ControlWithInput, IEditorCom
 
     private TEditor? editor;
 
+    private double invalidSoundCooldown;
+
     protected EditorComponentBase()
     {
     }
@@ -106,6 +108,13 @@ public partial class EditorComponentBase<TEditor> : ControlWithInput, IEditorCom
         Init((TEditor)owningEditor, fresh);
     }
 
+    public override void _Process(double delta)
+    {
+        base._Process(delta);
+
+        invalidSoundCooldown -= delta;
+    }
+
     public virtual void OnEditorReady()
     {
         // Late initialisation stuff can go here (usually overridden by component types that need that)
@@ -182,7 +191,12 @@ public partial class EditorComponentBase<TEditor> : ControlWithInput, IEditorCom
 
     internal void PlayInvalidActionSound()
     {
-        GUICommon.Instance.PlayCustomSound(unableToPerformActionSound, 0.4f);
+        // To avoid multiple sounds overlapping, there's a cooldown
+        if (invalidSoundCooldown <= 0)
+        {
+            GUICommon.Instance.PlayCustomSound(unableToPerformActionSound, 0.4f);
+            invalidSoundCooldown = 0.4f;
+        }
     }
 
     /// <summary>

--- a/src/general/base_stage/EditorComponentBase.cs
+++ b/src/general/base_stage/EditorComponentBase.cs
@@ -171,7 +171,7 @@ public partial class EditorComponentBase<TEditor> : ControlWithInput, IEditorCom
     {
     }
 
-    public virtual void OnMutationPointsChanged(int mutationPoints)
+    public virtual void OnMutationPointsChanged(double mutationPoints)
     {
         throw new GodotAbstractMethodNotOverriddenException();
     }

--- a/src/general/base_stage/EditorComponentWithActionsBase.cs
+++ b/src/general/base_stage/EditorComponentWithActionsBase.cs
@@ -75,7 +75,7 @@ public partial class EditorComponentWithActionsBase<TEditor, TAction> : EditorCo
 
     public void UpdateMutationPointsBar(bool tween = true)
     {
-        float possibleMutationPoints = Editor.FreeBuilding ?
+        var possibleMutationPoints = Editor.FreeBuilding ?
             Constants.BASE_MUTATION_POINTS :
             Editor.MutationPoints - CalculateCurrentActionCost();
 
@@ -85,7 +85,7 @@ public partial class EditorComponentWithActionsBase<TEditor, TAction> : EditorCo
             Editor.MutationPoints, possibleMutationPoints);
     }
 
-    public override void OnMutationPointsChanged(int mutationPoints)
+    public override void OnMutationPointsChanged(double mutationPoints)
     {
         UpdateMutationPointsBar(true);
     }
@@ -189,7 +189,7 @@ public partial class EditorComponentWithActionsBase<TEditor, TAction> : EditorCo
     /// <summary>
     ///   Calculates the cost of the current editor action (may be 0 if free or no active action)
     /// </summary>
-    protected virtual int CalculateCurrentActionCost()
+    protected virtual double CalculateCurrentActionCost()
     {
         throw new GodotAbstractMethodNotOverriddenException();
     }

--- a/src/general/base_stage/IEditor.cs
+++ b/src/general/base_stage/IEditor.cs
@@ -9,9 +9,10 @@ using Newtonsoft.Json;
 public interface IEditor : ISaveLoadedTracked
 {
     /// <summary>
-    ///   The number of mutation points left
+    ///   The number of mutation points left. This is a floating point number as a whole number of mutation points is
+    ///   way too restrictive for many edits.
     /// </summary>
-    public int MutationPoints { get; }
+    public double MutationPoints { get; }
 
     /// <summary>
     ///   When true nothing costs MP
@@ -24,7 +25,7 @@ public interface IEditor : ISaveLoadedTracked
     public bool CanCancelAction { get; }
 
     /// <summary>
-    ///   True once fade transition is finished when entering editor
+    ///   True, once fade transition is finished when entering editor
     /// </summary>
     public bool TransitionFinished { get; }
 
@@ -69,7 +70,7 @@ public interface IEditor : ISaveLoadedTracked
     /// <returns>True if canceled</returns>
     public bool CancelCurrentAction();
 
-    public int WhatWouldActionsCost(IEnumerable<EditorCombinableActionData> actions);
+    public double WhatWouldActionsCost(IEnumerable<EditorCombinableActionData> actions);
 
     /// <summary>
     ///   Perform all actions through this to make undo and redo work
@@ -78,13 +79,13 @@ public interface IEditor : ISaveLoadedTracked
     /// <remarks>
     ///   <para>
     ///     This takes in a base action type so that this interface doesn't need to depend on the specific action
-    ///     type of the editor which causes some pretty nasty generic constraint interdependencies
+    ///     type of the editor, which causes some pretty nasty generic constraint interdependencies
     ///   </para>
     /// </remarks>
     public bool EnqueueAction(ReversibleAction action);
 
     /// <summary>
-    ///   Adds editor state specific context to given sequence of actions. <see cref="EnqueueAction"/> and
+    ///   Adds editor-state-specific context to the given sequence of actions. <see cref="EnqueueAction"/> and
     ///   <see cref="WhatWouldActionsCost"/> perform this automatically. Only adds the context if not missing to give
     ///   flexibility for editor components to add their custom action context that is not overridden.
     /// </summary>
@@ -93,7 +94,7 @@ public interface IEditor : ISaveLoadedTracked
 
     public void NotifyUndoRedoStateChanged();
 
-    public bool CheckEnoughMPForAction(int cost);
+    public bool CheckEnoughMPForAction(double cost);
 
     public void OnInsufficientMP(bool playSound = true);
 

--- a/src/general/base_stage/IEditorComponent.cs
+++ b/src/general/base_stage/IEditorComponent.cs
@@ -49,10 +49,10 @@ public interface IEditorComponent
     public void OnInvalidAction();
 
     /// <summary>
-    ///   Triggered when a valid action occurs. Can be used to implement sounds for example or other GUI feedback.
+    ///   Triggered when a valid action occurs. Can be used to implement sounds, for example or other GUI feedback.
     /// </summary>
     /// <param name="actions">
-    ///   The valid actions, can be used to filter when something special should happen based on the action type
+    ///   The valid actions. Can be used to filter when something special should happen based on the action type
     /// </param>
     public void OnValidAction(IEnumerable<CombinableActionData> actions);
 
@@ -63,7 +63,7 @@ public interface IEditorComponent
     /// <param name="freeBuilding">True if freebuild mode is on</param>
     public void NotifyFreebuild(bool freeBuilding);
 
-    public void OnMutationPointsChanged(int mutationPoints);
+    public void OnMutationPointsChanged(double mutationPoints);
 
     /// <summary>
     ///   Called when <see cref="IEditor.DayLightFraction"/> is changed.

--- a/src/general/base_stage/IEditorWithActions.cs
+++ b/src/general/base_stage/IEditorWithActions.cs
@@ -1,6 +1,6 @@
 ﻿public interface IEditorWithActions : IEditor
 {
-    public new int MutationPoints { get; set; }
+    public new double MutationPoints { get; set; }
 
     public void Undo();
     public void Redo();

--- a/src/macroscopic_stage/editor/MetaballBodyEditorComponent.cs
+++ b/src/macroscopic_stage/editor/MetaballBodyEditorComponent.cs
@@ -403,7 +403,7 @@ public partial class MetaballBodyEditorComponent :
     {
     }
 
-    protected override int CalculateCurrentActionCost()
+    protected override double CalculateCurrentActionCost()
     {
         if (activeActionName == null || !Editor.ShowHover)
             return 0;

--- a/src/macroscopic_stage/editor/MetaballPopupMenu.cs
+++ b/src/macroscopic_stage/editor/MetaballPopupMenu.cs
@@ -99,9 +99,12 @@ public partial class MetaballPopupMenu : HexPopupMenu
 
         mpCost = Math.Round(mpCost, Constants.MUTATION_POINTS_DECIMALS);
 
+        if (mpCost != 0)
+            mpCost = -mpCost;
+
         var mpLabel = moveButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
 
-        mpLabel.Text = new LocalizedString("MP_COST", -mpCost).ToString();
+        mpLabel.Text = new LocalizedString("MP_COST", mpCost).ToString();
 
         moveButton.Disabled = !EnableMoveOption;
     }

--- a/src/macroscopic_stage/editor/MetaballPopupMenu.cs
+++ b/src/macroscopic_stage/editor/MetaballPopupMenu.cs
@@ -78,6 +78,8 @@ public partial class MetaballPopupMenu : HexPopupMenu
                     (EditorCombinableActionData)new MetaballRemoveActionData<MacroscopicMetaball>(o, null))) ??
             throw new ArgumentException($"{nameof(GetActionPrice)} not set");
 
+        mpCost = Math.Round(mpCost, Constants.MUTATION_POINTS_DECIMALS);
+
         var mpLabel = deleteButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
 
         mpLabel.Text = new LocalizedString("MP_COST", -mpCost).ToString();
@@ -94,6 +96,8 @@ public partial class MetaballPopupMenu : HexPopupMenu
             (EditorCombinableActionData)new MetaballMoveActionData<MacroscopicMetaball>(o, o.Position,
                 o.Position + Vector3.One, o.Parent,
                 o.Parent, null))) ?? throw new ArgumentException($"{nameof(GetActionPrice)} not set");
+
+        mpCost = Math.Round(mpCost, Constants.MUTATION_POINTS_DECIMALS);
 
         var mpLabel = moveButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
 

--- a/src/macroscopic_stage/editor/action_data/MetaballMoveActionData.cs
+++ b/src/macroscopic_stage/editor/action_data/MetaballMoveActionData.cs
@@ -76,7 +76,7 @@ public class MetaballMoveActionData<TMetaball> : EditorCombinableActionData
             m.NewPosition + offset, m.OldParent, m.NewParent, null)).ToList();
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         if (OldPosition.DistanceSquaredTo(NewPosition) < MathUtils.EPSILON && OldParent == NewParent)
             return 0;

--- a/src/macroscopic_stage/editor/action_data/MetaballPlacementActionData.cs
+++ b/src/macroscopic_stage/editor/action_data/MetaballPlacementActionData.cs
@@ -26,7 +26,7 @@ public class MetaballPlacementActionData<TMetaball> : EditorCombinableActionData
         Parent = metaball.Parent;
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         return Constants.METABALL_ADD_COST;
     }

--- a/src/macroscopic_stage/editor/action_data/MetaballRemoveActionData.cs
+++ b/src/macroscopic_stage/editor/action_data/MetaballRemoveActionData.cs
@@ -106,7 +106,7 @@ public class MetaballRemoveActionData<TMetaball> : EditorCombinableActionData
         return result;
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         return Constants.METABALL_REMOVE_COST;
     }

--- a/src/macroscopic_stage/editor/action_data/MetaballResizeActionData.cs
+++ b/src/macroscopic_stage/editor/action_data/MetaballResizeActionData.cs
@@ -14,9 +14,9 @@ public class MetaballResizeActionData<TMetaball> : EditorCombinableActionData
         NewSize = newSize;
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
-        if (MathF.Abs(OldSize - NewSize) < MathUtils.EPSILON)
+        if (Math.Abs(OldSize - NewSize) < MathUtils.EPSILON)
             return 0;
 
         return Constants.METABALL_RESIZE_COST;

--- a/src/microbe_stage/editor/BehaviourEditorSubComponent.cs
+++ b/src/microbe_stage/editor/BehaviourEditorSubComponent.cs
@@ -94,7 +94,7 @@ public partial class BehaviourEditorSubComponent : EditorComponentBase<ICellEdit
     {
     }
 
-    public override void OnMutationPointsChanged(int mutationPoints)
+    public override void OnMutationPointsChanged(double mutationPoints)
     {
     }
 

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1218,10 +1218,12 @@ public partial class CellEditorComponent :
 
         // In some cases "theoreticalCost" might get rounded improperly
         var theoreticalCost = Editor.WhatWouldActionsCost(new[] { data });
-        var cost = (int)Math.Ceiling(Math.Ceiling(theoreticalCost / costPerStep) * costPerStep);
+
+        // Removed cast to int here doesn't solve https://github.com/Revolutionary-Games/Thrive/issues/5821
+        var cost = Math.Ceiling(Math.Ceiling(theoreticalCost / costPerStep) * costPerStep);
 
         // Cases where mutation points are equal 0 are handled below in the next "if" statement
-        if (cost > Editor.MutationPoints && Editor.MutationPoints != 0)
+        if (cost > Editor.MutationPoints && Editor.MutationPoints > 0)
         {
             int stepsToCutOff = (int)Math.Ceiling((cost - Editor.MutationPoints) / costPerStep);
             data.NewRigidity -= (desiredRigidity - previousRigidity > 0 ? 1 : -1) * stepsToCutOff /
@@ -1232,9 +1234,9 @@ public partial class CellEditorComponent :
             return;
         }
 
-        // Make sure that if there are no mutation points the player cannot drag the slider
+        // Make sure that if there are no mutation points, the player cannot drag the slider
         // when the cost is rounded to zero
-        if (theoreticalCost >= 0 && (Editor.MutationPoints - cost < 0 || costPerStep > Editor.MutationPoints))
+        if (theoreticalCost >= 0 && (Editor.MutationPoints - cost <= 0 || costPerStep > Editor.MutationPoints))
         {
             UpdateRigiditySlider(previousRigidity);
             return;

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1362,7 +1362,7 @@ public partial class CellEditorComponent :
             actionData)));
     }
 
-    protected override int CalculateCurrentActionCost()
+    protected override double CalculateCurrentActionCost()
     {
         if (string.IsNullOrEmpty(ActiveActionName) || !Editor.ShowHover)
             return 0;

--- a/src/microbe_stage/editor/CombinedEditorAction.cs
+++ b/src/microbe_stage/editor/CombinedEditorAction.cs
@@ -58,7 +58,7 @@ public class CombinedEditorAction : EditorAction
             action.UndoAction();
     }
 
-    public override int CalculateCost()
+    public override double CalculateCost()
     {
         return Actions.Sum(a => a.CalculateCost());
     }

--- a/src/microbe_stage/editor/EditorAction.cs
+++ b/src/microbe_stage/editor/EditorAction.cs
@@ -11,7 +11,7 @@ public abstract class EditorAction : ReversibleAction
     [JsonIgnore]
     public abstract IEnumerable<EditorCombinableActionData> Data { get; }
 
-    public abstract int CalculateCost();
+    public abstract double CalculateCost();
 
     /// <summary>
     ///   Used to replace the data in this action with data that has been merged

--- a/src/microbe_stage/editor/EditorActionHistory.cs
+++ b/src/microbe_stage/editor/EditorActionHistory.cs
@@ -230,11 +230,11 @@ public class EditorActionHistory<TAction> : ActionHistory<TAction>
     ///   MinimumCostActionData is the action data to combine with (not yet combined);
     ///   Mode is the interference mode currentData has with MinimumCostActionData.
     /// </returns>
-    private static (int CostDelta, EditorCombinableActionData? MinimumCostActionData, ActionInterferenceMode Mode)
+    private static (double CostDelta, EditorCombinableActionData? MinimumCostActionData, ActionInterferenceMode Mode)
         FindCheapestActionToCombineWith(EditorCombinableActionData currentData,
             IEnumerable<EditorCombinableActionData> previousData)
     {
-        // Get an ordered enumerable sorted by priority and then by cost delta
+        // Get an ordered-enumerable sorted by priority and then by cost delta
         var combinationDataEnumerable = previousData.Select(data =>
         {
             var interferenceMode = currentData.GetInterferenceModeWith(data);
@@ -260,7 +260,7 @@ public class EditorActionHistory<TAction> : ActionHistory<TAction>
         }).OrderByDescending(p => p.Item1.Priority).ThenBy(p => p.Item1.Cost);
 
         // Calculate actual cost delta by adding up all replacement refunds, and if any, the first non-replacement one
-        var costDelta = 0;
+        double costDelta = 0;
 
         // Get the first combination data and its type
         EditorCombinableActionData? firstData = null;

--- a/src/microbe_stage/editor/EditorActionHistory.cs
+++ b/src/microbe_stage/editor/EditorActionHistory.cs
@@ -23,15 +23,21 @@ public class EditorActionHistory<TAction> : ActionHistory<TAction>
     /// <summary>
     ///   Calculates how much MP these actions would cost if performed on top of the current history.
     /// </summary>
-    public int WhatWouldActionsCost(IEnumerable<EditorCombinableActionData> actions)
+    public double WhatWouldActionsCost(IEnumerable<EditorCombinableActionData> actions)
     {
-        return actions.Sum(WhatWouldActionCost);
+        double sum = 0;
+
+        // TODO: somehow avoid the enumerator allocation here
+        foreach (var action in actions)
+            sum += WhatWouldActionCost(action);
+
+        return sum;
     }
 
     /// <summary>
     ///   Calculates how much MP this action would cost if performed on top of the current history.
     /// </summary>
-    public int WhatWouldActionCost(EditorCombinableActionData combinableAction)
+    public double WhatWouldActionCost(EditorCombinableActionData combinableAction)
     {
         if (CheatManager.InfiniteMP)
             return 0;
@@ -42,7 +48,7 @@ public class EditorActionHistory<TAction> : ActionHistory<TAction>
     /// <summary>
     ///   Calculates the remaining MP from the action history.
     /// </summary>
-    public int CalculateMutationPointsLeft()
+    public double CalculateMutationPointsLeft()
     {
         if (CheatManager.InfiniteMP)
             return Constants.BASE_MUTATION_POINTS;
@@ -98,7 +104,7 @@ public class EditorActionHistory<TAction> : ActionHistory<TAction>
                     }
                 }
 
-                // If mode is the following, no more checks are needed.
+                // If the mode is the following, no more checks are needed.
                 if (mode == ActionInterferenceMode.CancelsOut)
                     break;
             }
@@ -286,7 +292,7 @@ public class EditorActionHistory<TAction> : ActionHistory<TAction>
         if (!currentActionData.Any())
             return null;
 
-        // For now we allow combining only if all data values can be combined
+        // For now, we allow combining only if all data values can be combined
         bool matches = true;
 
         foreach (var currentData in currentActionData)
@@ -328,7 +334,7 @@ public class EditorActionHistory<TAction> : ActionHistory<TAction>
 
             foreach (var newData in newDataList)
             {
-                // In the cancels out case we still want to merge the data so that the action can stay as a placeholder
+                // In the cancels-out case we still want to merge the data so that the action can stay as a placeholder
                 // in the history keeping the original state
                 if (newData.WantsMergeWith(currentData) &&
                     newData.GetInterferenceModeWith(currentData) is ActionInterferenceMode.CancelsOut or

--- a/src/microbe_stage/editor/HexPopupMenu.cs
+++ b/src/microbe_stage/editor/HexPopupMenu.cs
@@ -47,7 +47,7 @@ public partial class HexPopupMenu : CustomPopupMenu
     [Signal]
     public delegate void ModifyPressedEventHandler();
 
-    public Func<IEnumerable<EditorCombinableActionData>, int>? GetActionPrice { get; set; }
+    public Func<IEnumerable<EditorCombinableActionData>, double>? GetActionPrice { get; set; }
 
     public bool ShowPopup
     {

--- a/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
+++ b/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
@@ -298,7 +298,7 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
     {
     }
 
-    public override void OnMutationPointsChanged(int mutationPoints)
+    public override void OnMutationPointsChanged(double mutationPoints)
     {
     }
 

--- a/src/microbe_stage/editor/MicrobePartSelection.cs
+++ b/src/microbe_stage/editor/MicrobePartSelection.cs
@@ -28,7 +28,7 @@ public partial class MicrobePartSelection : MarginContainer
 
 #pragma warning restore CA2213
 
-    private int mpCost;
+    private double mpCost;
     private string name = "Error: unset";
     private bool locked;
     private bool recentlyUnlocked;
@@ -46,12 +46,12 @@ public partial class MicrobePartSelection : MarginContainer
     public bool Undiscovered { get; set; }
 
     [Export]
-    public int MPCost
+    public double MPCost
     {
         get => mpCost;
         set
         {
-            if (mpCost == value)
+            if (Math.Abs(mpCost - value) < MathUtils.EPSILON)
                 return;
 
             mpCost = value;
@@ -202,13 +202,14 @@ public partial class MicrobePartSelection : MarginContainer
 
         if (mpCost < 0)
         {
-            // Negative MP cost means it actually gives MP, to convey that to the player we need to explicitly
-            // prefix the cost with a positive sign
-            cost = "+" + MathF.Abs(mpCost).ToString(CultureInfo.CurrentCulture);
+            // Negative MP cost means it actually gives MP
+            // To convey that to the player, we need to explicitly prefix the cost with a positive sign
+            cost = "+" + Math.Round(Math.Abs(mpCost), Constants.MUTATION_POINTS_DECIMALS)
+                .ToString(CultureInfo.CurrentCulture);
         }
         else
         {
-            cost = mpCost.ToString(CultureInfo.CurrentCulture);
+            cost = Math.Round(mpCost, Constants.MUTATION_POINTS_DECIMALS).ToString(CultureInfo.CurrentCulture);
         }
 
         mpLabel.Text = cost;

--- a/src/microbe_stage/editor/MutationPointsBar.cs
+++ b/src/microbe_stage/editor/MutationPointsBar.cs
@@ -79,6 +79,10 @@ public partial class MutationPointsBar : HBoxContainer
     public void UpdateMutationPoints(bool freebuilding, bool showResultingPoints, double currentMutationPoints,
         double possibleMutationPoints)
     {
+        // Make sure tiny negative values aren't shown improperly
+        if (currentMutationPoints < 0 && currentMutationPoints > Constants.ALLOWED_MP_OVERSHOOT)
+            currentMutationPoints = 0;
+
         if (freebuilding)
         {
             mutationPointsArrow.Hide();
@@ -94,7 +98,7 @@ public partial class MutationPointsBar : HBoxContainer
                 mutationPointsArrow.Show();
                 resultingMutationPointsLabel.Show();
 
-                currentMutationPointsLabel.Text = $"({currentMutationPoints:F0}";
+                currentMutationPointsLabel.Text = $"({currentMutationPoints:0.#}";
                 resultingMutationPointsLabel.Text = $"{possibleMutationPoints:F0})";
             }
             else
@@ -102,7 +106,7 @@ public partial class MutationPointsBar : HBoxContainer
                 mutationPointsArrow.Hide();
                 resultingMutationPointsLabel.Hide();
 
-                currentMutationPointsLabel.Text = $"{currentMutationPoints:F0}";
+                currentMutationPointsLabel.Text = $"{currentMutationPoints:0.#}";
             }
 
             if (ShowPercentageSymbol)

--- a/src/microbe_stage/editor/MutationPointsBar.cs
+++ b/src/microbe_stage/editor/MutationPointsBar.cs
@@ -6,6 +6,9 @@
 public partial class MutationPointsBar : HBoxContainer
 {
     [Export]
+    public bool ShowPercentageSymbol = true;
+
+    [Export]
     public NodePath? CurrentMutationPointsLabelPath;
 
     [Export]
@@ -93,7 +96,6 @@ public partial class MutationPointsBar : HBoxContainer
 
                 currentMutationPointsLabel.Text = $"({currentMutationPoints:F0}";
                 resultingMutationPointsLabel.Text = $"{possibleMutationPoints:F0})";
-                baseMutationPointsLabel.Text = $"/ {Constants.BASE_MUTATION_POINTS:F0}";
             }
             else
             {
@@ -101,6 +103,17 @@ public partial class MutationPointsBar : HBoxContainer
                 resultingMutationPointsLabel.Hide();
 
                 currentMutationPointsLabel.Text = $"{currentMutationPoints:F0}";
+            }
+
+            if (ShowPercentageSymbol)
+            {
+                // TODO: switch this class to using translation keys properly instead of this approach
+                // We have PERCENTAGE_VALUE translation string, but I didn't add that here as this already uses partial
+                // formatting with plain strings so I just extended the existing solution here -hhyyrylainen
+                baseMutationPointsLabel.Text = $"/ {Constants.BASE_MUTATION_POINTS:F0} %";
+            }
+            else
+            {
                 baseMutationPointsLabel.Text = $"/ {Constants.BASE_MUTATION_POINTS:F0}";
             }
         }

--- a/src/microbe_stage/editor/MutationPointsBar.cs
+++ b/src/microbe_stage/editor/MutationPointsBar.cs
@@ -51,7 +51,7 @@ public partial class MutationPointsBar : HBoxContainer
         freebuildingText = Localization.Translate("FREEBUILDING");
     }
 
-    public void UpdateBar(float currentMutationPoints, float possibleMutationPoints, bool tween = true)
+    public void UpdateBar(double currentMutationPoints, double possibleMutationPoints, bool tween = true)
     {
         if (tween)
         {
@@ -73,8 +73,8 @@ public partial class MutationPointsBar : HBoxContainer
             new Color(0.72f, 0.72f, 0.72f);
     }
 
-    public void UpdateMutationPoints(bool freebuilding, bool showResultingPoints, float currentMutationPoints,
-        float possibleMutationPoints)
+    public void UpdateMutationPoints(bool freebuilding, bool showResultingPoints, double currentMutationPoints,
+        double possibleMutationPoints)
     {
         if (freebuilding)
         {

--- a/src/microbe_stage/editor/OrganellePopupMenu.cs
+++ b/src/microbe_stage/editor/OrganellePopupMenu.cs
@@ -82,6 +82,8 @@ public partial class OrganellePopupMenu : HexPopupMenu
                 })) ??
             throw new ArgumentException($"{nameof(GetActionPrice)} not set");
 
+        mpCost = Math.Round(mpCost, Constants.MUTATION_POINTS_DECIMALS);
+
         var mpLabel = deleteButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
 
         mpLabel.Text = new LocalizedString("MP_COST", -mpCost).ToString();
@@ -101,6 +103,8 @@ public partial class OrganellePopupMenu : HexPopupMenu
             {
                 CostMultiplier = CostMultiplier,
             })) ?? throw new ArgumentException($"{nameof(GetActionPrice)} not set");
+
+        mpCost = Math.Round(mpCost, Constants.MUTATION_POINTS_DECIMALS);
 
         var mpLabel = moveButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
 

--- a/src/microbe_stage/editor/OrganellePopupMenu.cs
+++ b/src/microbe_stage/editor/OrganellePopupMenu.cs
@@ -106,9 +106,12 @@ public partial class OrganellePopupMenu : HexPopupMenu
 
         mpCost = Math.Round(mpCost, Constants.MUTATION_POINTS_DECIMALS);
 
+        if (mpCost != 0)
+            mpCost = -mpCost;
+
         var mpLabel = moveButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
 
-        mpLabel.Text = new LocalizedString("MP_COST", -mpCost).ToString();
+        mpLabel.Text = new LocalizedString("MP_COST", mpCost).ToString();
 
         moveButton.Disabled = !EnableMoveOption;
     }

--- a/src/microbe_stage/editor/PatchMapEditorComponent.cs
+++ b/src/microbe_stage/editor/PatchMapEditorComponent.cs
@@ -174,7 +174,7 @@ public partial class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEdi
         }
     }
 
-    public override void OnMutationPointsChanged(int mutationPoints)
+    public override void OnMutationPointsChanged(double mutationPoints)
     {
     }
 

--- a/src/microbe_stage/editor/action_data/BehaviourActionData.cs
+++ b/src/microbe_stage/editor/action_data/BehaviourActionData.cs
@@ -19,7 +19,7 @@ public class BehaviourActionData : EditorCombinableActionData
         return other is BehaviourActionData;
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         // TODO: should this be free?
         return 0;

--- a/src/microbe_stage/editor/action_data/ColourActionData.cs
+++ b/src/microbe_stage/editor/action_data/ColourActionData.cs
@@ -17,7 +17,7 @@ public class ColourActionData : EditorCombinableActionData<CellType>
         return other is ColourActionData;
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         // Changing membrane colour has no cost
         return 0;

--- a/src/microbe_stage/editor/action_data/EditorCombinableActionData.cs
+++ b/src/microbe_stage/editor/action_data/EditorCombinableActionData.cs
@@ -4,9 +4,9 @@ public abstract class EditorCombinableActionData : CombinableActionData
 {
     public float CostMultiplier { get; set; } = 1.0f;
 
-    public virtual int CalculateCost()
+    public virtual double CalculateCost()
     {
-        return (int)Math.Min(CalculateCostInternal() * CostMultiplier, 100);
+        return Math.Min(CalculateCostInternal() * CostMultiplier, 100);
     }
 
     public override CombinableActionData Combine(CombinableActionData other)
@@ -20,7 +20,7 @@ public abstract class EditorCombinableActionData : CombinableActionData
         return combined;
     }
 
-    protected abstract int CalculateCostInternal();
+    protected abstract double CalculateCostInternal();
 }
 
 public abstract class EditorCombinableActionData<TContext> : EditorCombinableActionData
@@ -33,10 +33,10 @@ public abstract class EditorCombinableActionData<TContext> : EditorCombinableAct
 
     public override ActionInterferenceMode GetInterferenceModeWith(CombinableActionData other)
     {
-        // If the other action was performed on a different context, we can't combine with it
+        // If the other action was performed in a different context, we can't combine with it
         if (other is EditorCombinableActionData<TContext> editorActionData)
         {
-            // Null context is the same as another null context but any existing context value doesn't equal null
+            // Null context is the same as another null context, but any existing context value doesn't equal null
             if ((Context is not null && editorActionData.Context is null) ||
                 (Context is null && editorActionData.Context is not null))
             {

--- a/src/microbe_stage/editor/action_data/EndosymbiontPlaceActionData.cs
+++ b/src/microbe_stage/editor/action_data/EndosymbiontPlaceActionData.cs
@@ -37,7 +37,7 @@ public class EndosymbiontPlaceActionData : EditorCombinableActionData<CellType>
     {
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         // Endosymbiosis placement never costs MP
         return 0;

--- a/src/microbe_stage/editor/action_data/HexMoveActionData.cs
+++ b/src/microbe_stage/editor/action_data/HexMoveActionData.cs
@@ -19,7 +19,7 @@ public abstract class HexMoveActionData<THex, TContext> : EditorCombinableAction
         NewRotation = newRotation;
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         if (OldLocation == NewLocation && OldRotation == NewRotation)
             return 0;

--- a/src/microbe_stage/editor/action_data/HexRemoveActionData.cs
+++ b/src/microbe_stage/editor/action_data/HexRemoveActionData.cs
@@ -13,7 +13,7 @@ public abstract class HexRemoveActionData<THex, TContext> : EditorCombinableActi
         Orientation = orientation;
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         return Constants.ORGANELLE_REMOVE_COST;
     }

--- a/src/microbe_stage/editor/action_data/MembraneActionData.cs
+++ b/src/microbe_stage/editor/action_data/MembraneActionData.cs
@@ -10,7 +10,7 @@ public class MembraneActionData : EditorCombinableActionData<CellType>
         NewMembrane = newMembrane;
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         return NewMembrane.EditorCost;
     }

--- a/src/microbe_stage/editor/action_data/NewMicrobeActionData.cs
+++ b/src/microbe_stage/editor/action_data/NewMicrobeActionData.cs
@@ -40,12 +40,12 @@ public class NewMicrobeActionData : EditorCombinableActionData<CellType>
 
     public override bool ResetsHistory => true;
 
-    public override int CalculateCost()
+    public override double CalculateCost()
     {
         return -Constants.BASE_MUTATION_POINTS;
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         throw new NotSupportedException();
     }

--- a/src/microbe_stage/editor/action_data/OrganellePlacementActionData.cs
+++ b/src/microbe_stage/editor/action_data/OrganellePlacementActionData.cs
@@ -10,7 +10,7 @@ public class OrganellePlacementActionData : HexPlacementActionData<OrganelleTemp
     {
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         return PlacedHex.Definition.MPCost;
     }

--- a/src/microbe_stage/editor/action_data/OrganelleRemoveActionData.cs
+++ b/src/microbe_stage/editor/action_data/OrganelleRemoveActionData.cs
@@ -19,7 +19,7 @@ public class OrganelleRemoveActionData : HexRemoveActionData<OrganelleTemplate, 
     {
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         return GotReplaced ? 0 : base.CalculateCostInternal();
     }

--- a/src/microbe_stage/editor/action_data/OrganelleUpgradeActionData.cs
+++ b/src/microbe_stage/editor/action_data/OrganelleUpgradeActionData.cs
@@ -19,7 +19,7 @@ public class OrganelleUpgradeActionData : EditorCombinableActionData<CellType>
         UpgradedOrganelle = upgradedOrganelle;
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         int cost = 0;
 

--- a/src/microbe_stage/editor/action_data/RigidityActionData.cs
+++ b/src/microbe_stage/editor/action_data/RigidityActionData.cs
@@ -17,10 +17,10 @@ public class RigidityActionData : EditorCombinableActionData<CellType>
         return other is RigidityActionData;
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
-        return (int)Math.Round(Math.Abs(NewRigidity - PreviousRigidity) *
-            Constants.MEMBRANE_RIGIDITY_SLIDER_TO_VALUE_RATIO) * Constants.MEMBRANE_RIGIDITY_COST_PER_STEP;
+        return Math.Abs(NewRigidity - PreviousRigidity) * Constants.MEMBRANE_RIGIDITY_SLIDER_TO_VALUE_RATIO *
+            Constants.MEMBRANE_RIGIDITY_COST_PER_STEP;
     }
 
     protected override ActionInterferenceMode GetInterferenceModeWithGuaranteed(CombinableActionData other)

--- a/src/microbe_stage/editor/action_data/ToleranceActionData.cs
+++ b/src/microbe_stage/editor/action_data/ToleranceActionData.cs
@@ -17,7 +17,7 @@ public class ToleranceActionData : EditorCombinableActionData
         return GetInterferenceModeWith(other) != ActionInterferenceMode.NoInterference;
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         // Calculate all changes
         var temperatureChange = Math.Abs(OldTolerances.PreferredTemperature - NewTolerances.PreferredTemperature);
@@ -27,18 +27,20 @@ public class ToleranceActionData : EditorCombinableActionData
         double minPressureChange = Math.Abs(OldTolerances.PressureMinimum - NewTolerances.PressureMinimum);
         double maxPressureChange = Math.Abs(OldTolerances.PressureMaximum - NewTolerances.PressureMaximum);
 
+        // Calculate pressure range change as moving of the middle point (so scale the total change to half as the same
+        // change moves the min and max points at the same time)
         var pressureToleranceChange = (minPressureChange + maxPressureChange) * 0.5;
 
         var oxygenChange = Math.Abs(OldTolerances.OxygenResistance - NewTolerances.OxygenResistance);
         var uvChange = Math.Abs(OldTolerances.UVResistance - NewTolerances.UVResistance);
 
         // Then add up the costs based on the changes
-        return (int)Math.Round(temperatureChange * Constants.TOLERANCE_CHANGE_MP_PER_TEMPERATURE +
+        return temperatureChange * Constants.TOLERANCE_CHANGE_MP_PER_TEMPERATURE +
             temperatureToleranceChange * Constants.TOLERANCE_CHANGE_MP_PER_TEMPERATURE_TOLERANCE +
             pressureChange * Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE +
             pressureToleranceChange * Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE_TOLERANCE +
             oxygenChange * Constants.TOLERANCE_CHANGE_MP_PER_OXYGEN +
-            uvChange * Constants.TOLERANCE_CHANGE_MP_PER_UV);
+            uvChange * Constants.TOLERANCE_CHANGE_MP_PER_UV;
     }
 
     protected override ActionInterferenceMode GetInterferenceModeWithGuaranteed(CombinableActionData other)

--- a/src/microbe_stage/editor/tooltips/SelectionMenuToolTip.cs
+++ b/src/microbe_stage/editor/tooltips/SelectionMenuToolTip.cs
@@ -56,7 +56,7 @@ public partial class SelectionMenuToolTip : ControlWithInput, ICustomToolTip
     private string? displayName;
     private string? description;
     private string processesDescription = string.Empty;
-    private int mpCost;
+    private double mpCost;
     private float osmoregulationCost;
     private bool showOsmoregulation = true;
     private bool requiresNucleus;
@@ -114,7 +114,7 @@ public partial class SelectionMenuToolTip : ControlWithInput, ICustomToolTip
     }
 
     [Export]
-    public int MutationPointCost
+    public double MutationPointCost
     {
         get => mpCost;
         set
@@ -436,13 +436,14 @@ public partial class SelectionMenuToolTip : ControlWithInput, ICustomToolTip
 
         if (mpCost < 0)
         {
-            // Negative MP cost means it actually gives MP, to convey that to the player we need to explicitly
-            // prefix the cost with a positive sign
-            cost = "+" + MathF.Abs(mpCost).ToString(CultureInfo.CurrentCulture);
+            // Negative MP cost means it actually gives MP
+            // To convey that to the player, we need to explicitly prefix the cost with a positive sign
+            cost = "+" + Math.Round(Math.Abs(mpCost), Constants.MUTATION_POINTS_DECIMALS)
+                .ToString(CultureInfo.CurrentCulture);
         }
         else
         {
-            cost = mpCost.ToString(CultureInfo.CurrentCulture);
+            cost = Math.Round(mpCost, Constants.MUTATION_POINTS_DECIMALS).ToString(CultureInfo.CurrentCulture);
         }
 
         mpLabel.Text = cost;

--- a/src/microbe_stage/editor/upgrades/SingleEditorAction.cs
+++ b/src/microbe_stage/editor/upgrades/SingleEditorAction.cs
@@ -46,7 +46,7 @@ public class SingleEditorAction<T> : EditorAction
         undo(SingleData);
     }
 
-    public override int CalculateCost()
+    public override double CalculateCost()
     {
         return SingleData.CalculateCost();
     }
@@ -70,7 +70,7 @@ public class SingleEditorAction<T> : EditorAction
 
     public override int ApplyPartialMergedData(List<EditorCombinableActionData> newData, int startIndex)
     {
-        // To support removing actions from combined action we need to skip applying here if the item is wrong data
+        // To support removing actions from combined action, we need to skip applying here if the item is wrong data
         // which indicates that we want to be deleted
         if (newData[startIndex] is T compatibleData)
         {

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -557,7 +557,7 @@ public partial class CellBodyPlanEditorComponent :
         return Editor.EditedSpecies.CellTypes.First(c => c.TypeName == name);
     }
 
-    protected override int CalculateCurrentActionCost()
+    protected override double CalculateCurrentActionCost()
     {
         if (activeActionName == null || !Editor.ShowHover)
             return 0;

--- a/src/multicellular_stage/editor/CellPopupMenu.cs
+++ b/src/multicellular_stage/editor/CellPopupMenu.cs
@@ -98,9 +98,12 @@ public partial class CellPopupMenu : HexPopupMenu
 
         mpCost = Math.Round(mpCost, Constants.MUTATION_POINTS_DECIMALS);
 
+        if (mpCost != 0)
+            mpCost = -mpCost;
+
         var mpLabel = moveButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
 
-        mpLabel.Text = new LocalizedString("MP_COST", -mpCost).ToString();
+        mpLabel.Text = new LocalizedString("MP_COST", mpCost).ToString();
 
         moveButton.Disabled = !EnableMoveOption;
     }

--- a/src/multicellular_stage/editor/CellPopupMenu.cs
+++ b/src/multicellular_stage/editor/CellPopupMenu.cs
@@ -78,6 +78,8 @@ public partial class CellPopupMenu : HexPopupMenu
                     (EditorCombinableActionData)new CellRemoveActionData(o))) ??
             throw new ArgumentException($"{nameof(GetActionPrice)} not set");
 
+        mpCost = Math.Round(mpCost, Constants.MUTATION_POINTS_DECIMALS);
+
         var mpLabel = deleteButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
 
         mpLabel.Text = new LocalizedString("MP_COST", -mpCost).ToString();
@@ -93,6 +95,8 @@ public partial class CellPopupMenu : HexPopupMenu
         var mpCost = GetActionPrice?.Invoke(SelectedCells.Select(o =>
             (EditorCombinableActionData)new CellMoveActionData(o, o.Position, o.Position + new Hex(5, 5), 0,
                 0))) ?? throw new ArgumentException($"{nameof(GetActionPrice)} not set");
+
+        mpCost = Math.Round(mpCost, Constants.MUTATION_POINTS_DECIMALS);
 
         var mpLabel = moveButton.GetNode<Label>("MarginContainer/HBoxContainer/MpCost");
 

--- a/src/multicellular_stage/editor/action_data/CellPlacementActionData.cs
+++ b/src/multicellular_stage/editor/action_data/CellPlacementActionData.cs
@@ -15,7 +15,7 @@ public class CellPlacementActionData : HexPlacementActionData<HexWithData<CellTe
     {
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         return PlacedHex.Data?.CellType.MPCost ?? throw new InvalidOperationException("Hex with no data");
     }

--- a/src/multicellular_stage/editor/action_data/DuplicateDeleteCellTypeData.cs
+++ b/src/multicellular_stage/editor/action_data/DuplicateDeleteCellTypeData.cs
@@ -23,7 +23,7 @@ public class DuplicateDeleteCellTypeData : EditorCombinableActionData<Multicellu
         throw new NotSupportedException();
     }
 
-    protected override int CalculateCostInternal()
+    protected override double CalculateCostInternal()
     {
         return 0;
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

So that really small MP costs can be handled correctly

Also upgrades auto-evo from using floats to doubles in the remaining MP calculations for it to be consistent

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
doesn't solve but should make possible in the future to do #5821

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
