### PR TITLE
Disabled tolerance warnings in multicellular

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -773,38 +773,43 @@ public partial class CellEditorComponent
 
     private void CalculateAndDisplayToleranceWarnings()
     {
-        var tolerances = CalculateRawTolerances();
-
         usedToleranceWarnings = 0;
 
-        void AddToleranceWarning(string text)
+        // Tolerances with the cell editor are not used in multicellular, rather the body plan editor will display
+        // the warnings (once they are done)
+        if (!IsMulticellularEditor)
         {
-            if (usedToleranceWarnings < activeToleranceWarnings.Count)
+            var tolerances = CalculateRawTolerances();
+
+            void AddToleranceWarning(string text)
             {
-                var warning = activeToleranceWarnings[usedToleranceWarnings];
-                warning.Text = text;
-            }
-            else if (usedToleranceWarnings < MaxToleranceWarnings)
-            {
-                var warning = new Label
+                if (usedToleranceWarnings < activeToleranceWarnings.Count)
                 {
-                    HorizontalAlignment = HorizontalAlignment.Center,
-                    AutowrapMode = TextServer.AutowrapMode.WordSmart,
-                    CustomMinimumSize = new Vector2(150, 0),
-                    LabelSettings = toleranceWarningsFont,
-                };
+                    var warning = activeToleranceWarnings[usedToleranceWarnings];
+                    warning.Text = text;
+                }
+                else if (usedToleranceWarnings < MaxToleranceWarnings)
+                {
+                    var warning = new Label
+                    {
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        AutowrapMode = TextServer.AutowrapMode.WordSmart,
+                        CustomMinimumSize = new Vector2(150, 0),
+                        LabelSettings = toleranceWarningsFont,
+                    };
 
-                warning.Text = text;
-                activeToleranceWarnings.Add(warning);
-                toleranceWarningContainer.AddChild(warning);
+                    warning.Text = text;
+                    activeToleranceWarnings.Add(warning);
+                    toleranceWarningContainer.AddChild(warning);
+                }
+
+                ++usedToleranceWarnings;
             }
 
-            ++usedToleranceWarnings;
+            // This allocates a delegate, but it's probably not a significant amount of garbage
+            MicrobeEnvironmentalToleranceCalculations.GenerateToleranceProblemList(tolerances,
+                MicrobeEnvironmentalToleranceCalculations.ResolveToleranceValues(tolerances), AddToleranceWarning);
         }
-
-        // This allocates a delegate, but it's probably not a significant amount of garbage
-        MicrobeEnvironmentalToleranceCalculations.GenerateToleranceProblemList(tolerances,
-            MicrobeEnvironmentalToleranceCalculations.ResolveToleranceValues(tolerances), AddToleranceWarning);
 
         // Remove excess text that is no longer used
         while (usedToleranceWarnings < activeToleranceWarnings.Count)

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -315,6 +315,8 @@ public partial class CellEditorComponent :
 
     private bool showGrowthOrderNumbers;
 
+    private bool multicellularTolerancesPrinted;
+
     private TutorialState? tutorialState;
 
     public enum SelectionMenuTab
@@ -1085,9 +1087,12 @@ public partial class CellEditorComponent :
         CalculateOrganelleEffectivenessInCurrentPatch();
         UpdatePatchDependentBalanceData();
 
-        // Refresh tolerances data for the new patch
-        tolerancesEditor.OnPatchChanged();
-        OnTolerancesChanged(tolerancesEditor.CurrentTolerances);
+        if (!IsMulticellularEditor)
+        {
+            // Refresh tolerances data for the new patch
+            tolerancesEditor.OnPatchChanged();
+            OnTolerancesChanged(tolerancesEditor.CurrentTolerances);
+        }
 
         // Redo suggestion calculations as they could depend on the patch data (though at the time of writing this is
         // not really changing)
@@ -1923,6 +1928,24 @@ public partial class CellEditorComponent :
 
     private ResolvedMicrobeTolerances CalculateLatestTolerances()
     {
+        if (IsMulticellularEditor)
+        {
+            if (!multicellularTolerancesPrinted)
+            {
+                GD.Print("TODO: implement tolerances data coming from the multicellular editor");
+                multicellularTolerancesPrinted = true;
+            }
+
+            // TODO: this should use info from the cell body plan editor regarding tolerances and remove this dummy
+            // return
+            return new ResolvedMicrobeTolerances
+            {
+                HealthModifier = 1,
+                OsmoregulationModifier = 1,
+                ProcessSpeedModifier = 1,
+            };
+        }
+
         return MicrobeEnvironmentalToleranceCalculations.ResolveToleranceValues(CalculateRawTolerances());
     }
 


### PR DESCRIPTION
as the tolerances shouldn't do anything there, and they can no longer be changed anyway. Also fixed an error coming from the tolerances editor when moving patches in multicellular.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
this was finally brought to my attention that this was a less serious bug in multicellular *after* I had just made the 0.8.1.1 patch...

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
