### PR TITLE
Make fossilization buttons' positioning account for screen distortion

### DIFF
--- a/src/general/utils/ScreenUtils.cs
+++ b/src/general/utils/ScreenUtils.cs
@@ -26,16 +26,45 @@ public static class ScreenUtils
         // Convert from [0, size] to [0; 1]
         screenPos /= viewportSize;
 
-        Vector2 oversizeVector = Distort(new Vector2(1.0f, 1.0f), distortion);
-        oversizeVector = (oversizeVector + new Vector2(1.0f, 1.0f)) / 2.0f;
-        screenPos = RemapVector(screenPos, new Vector2(1.0f, 1.0f) - oversizeVector, oversizeVector);
+        Vector2 oversizeVector = Distort(Vector2.One, distortion);
+        oversizeVector = (oversizeVector + Vector2.One) / 2.0f;
+        screenPos = RemapVector(screenPos, Vector2.One - oversizeVector, oversizeVector);
 
         // Convert from [0, 1] to [-1; 1]
-        screenPos = (screenPos * 2.0f) - new Vector2(1.0f, 1.0f);
+        screenPos = (screenPos * 2.0f) - Vector2.One;
         screenPos = Distort(screenPos, distortion * 0.75f);
 
         // Return to [0, size]
-        screenPos = (screenPos + new Vector2(1.0f, 1.0f)) / 2.0f;
+        screenPos = (screenPos + Vector2.One) / 2.0f;
+        screenPos *= viewportSize;
+
+        return screenPos;
+    }
+
+    public static Vector2 ReverseBarrelDistortion(Vector2 screenPos, float distortion, Vector2 viewportSize)
+    {
+        Vector2 resolution = DisplayServer.WindowGetSize();
+
+        // The constant from shader calculations
+        const float distortionMultiplier = 75.0f;
+
+        distortion /= resolution.X;
+        distortion *= distortionMultiplier;
+
+        // Convert from [0, size] to [-1; 1]
+        screenPos /= viewportSize;
+        screenPos = screenPos * 2.0f - Vector2.One;
+
+        screenPos = ReverseDistort(screenPos, distortion * 0.75f);
+
+        // Convert from [-1; 1] to [0, 1]
+        screenPos = (screenPos + Vector2.One) * 0.5f;
+
+        Vector2 oversizeVector = Distort(Vector2.One, distortion);
+        oversizeVector = (oversizeVector + Vector2.One) / 2.0f;
+        screenPos = ReverseRemapVector(screenPos, Vector2.One - oversizeVector, oversizeVector);
+
+        // Return to [0, size]
         screenPos *= viewportSize;
 
         return screenPos;
@@ -60,5 +89,23 @@ public static class ScreenUtils
         t.X = float.Clamp(t.X, 0.0f, 1.0f);
         t.Y = float.Clamp(t.Y, 0.0f, 1.0f);
         return t;
+    }
+
+    private static Vector2 ReverseDistort(Vector2 pos, float distortion)
+    {
+        float barrelDistortion1 = 0.1f * distortion;
+        float barrelDistortion2 = -0.025f * distortion;
+
+        // This is roughly equal to the original position's dot product
+        float r2 = pos.X * pos.X + pos.Y * pos.Y;
+
+        pos /= 1.0f + barrelDistortion1 * r2 + barrelDistortion2 * r2 * r2;
+
+        return pos;
+    }
+
+    private static Vector2 ReverseRemapVector(Vector2 t, Vector2 a, Vector2 b)
+    {
+        return t * (b - a) + a;
     }
 }

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -267,6 +267,7 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
 
             var button = FossilisationButtonScene.Instantiate<FossilisationButton>();
             button.AttachedEntity = entity;
+            button.IsMicrobeStage = true;
             button.Connect(FossilisationButton.SignalName.OnFossilisationDialogOpened, new Callable(this,
                 nameof(ShowFossilisationDialog)));
 

--- a/src/thriveopedia/fossilisation/FossilisationButton.cs
+++ b/src/thriveopedia/fossilisation/FossilisationButton.cs
@@ -83,8 +83,8 @@ public partial class FossilisationButton : TextureButton
                 canvasPosition.X < 1.1f * viewportSize.X && canvasPosition.Y < 1.1f * viewportSize.Y)
             {
                 canvasPosition = ScreenUtils.InverseBarrelDistortion(
-                new Vector2(canvasPosition.X, viewportSize.Y - canvasPosition.Y), Settings.Instance.ChromaticAmount,
-                viewportSize);
+                    new Vector2(canvasPosition.X, viewportSize.Y - canvasPosition.Y), Settings.Instance.ChromaticAmount,
+                    viewportSize);
 
                 canvasPosition = new Vector2(canvasPosition.X, viewportSize.Y - canvasPosition.Y);
             }

--- a/src/thriveopedia/fossilisation/FossilisationButton.cs
+++ b/src/thriveopedia/fossilisation/FossilisationButton.cs
@@ -78,7 +78,11 @@ public partial class FossilisationButton : TextureButton
         {
             var viewportSize = GetViewportRect().Size;
 
-            canvasPosition = ScreenUtils.ReverseBarrelDistortion(
+            // Clamping to the range where InverseBarrelDistortion is accurate
+            var tolerance = viewportSize * 0.1f;
+            canvasPosition = canvasPosition.Clamp(Vector2.Zero - tolerance, viewportSize + tolerance);
+
+            canvasPosition = ScreenUtils.InverseBarrelDistortion(
                 new Vector2(canvasPosition.X, viewportSize.Y - canvasPosition.Y), Settings.Instance.ChromaticAmount,
                 viewportSize);
 

--- a/src/thriveopedia/fossilisation/FossilisationButton.cs
+++ b/src/thriveopedia/fossilisation/FossilisationButton.cs
@@ -17,6 +17,8 @@ public partial class FossilisationButton : TextureButton
     /// </summary>
     public Entity AttachedEntity;
 
+    public bool IsMicrobeStage;
+
     /// <summary>
     ///   Whether this species has already been fossilised.
     /// </summary>
@@ -70,7 +72,20 @@ public partial class FossilisationButton : TextureButton
             return;
         }
 
-        GlobalPosition = camera.UnprojectPosition(AttachedEntity.Get<WorldPosition>().Position);
+        var canvasPosition = camera.UnprojectPosition(AttachedEntity.Get<WorldPosition>().Position);
+
+        if (IsMicrobeStage && Settings.Instance.ChromaticEnabled)
+        {
+            var viewportSize = GetViewportRect().Size;
+
+            canvasPosition = ScreenUtils.ReverseBarrelDistortion(
+                new Vector2(canvasPosition.X, viewportSize.Y - canvasPosition.Y), Settings.Instance.ChromaticAmount,
+                viewportSize);
+
+            canvasPosition = new Vector2(canvasPosition.X, viewportSize.Y - canvasPosition.Y);
+        }
+
+        GlobalPosition = canvasPosition;
     }
 
     private void OnPressed()

--- a/src/thriveopedia/fossilisation/FossilisationButton.cs
+++ b/src/thriveopedia/fossilisation/FossilisationButton.cs
@@ -78,15 +78,16 @@ public partial class FossilisationButton : TextureButton
         {
             var viewportSize = GetViewportRect().Size;
 
-            // Clamping to the range where InverseBarrelDistortion is accurate
-            var tolerance = viewportSize * 0.1f;
-            canvasPosition = canvasPosition.Clamp(Vector2.Zero - tolerance, viewportSize + tolerance);
-
-            canvasPosition = ScreenUtils.InverseBarrelDistortion(
+            // Make sure that the button is on the screen before applying the effect
+            if (canvasPosition.X > -0.1f * viewportSize.X && canvasPosition.Y > -0.1f * viewportSize.Y &&
+                canvasPosition.X < 1.1f * viewportSize.X && canvasPosition.Y < 1.1f * viewportSize.Y)
+            {
+                canvasPosition = ScreenUtils.InverseBarrelDistortion(
                 new Vector2(canvasPosition.X, viewportSize.Y - canvasPosition.Y), Settings.Instance.ChromaticAmount,
                 viewportSize);
 
-            canvasPosition = new Vector2(canvasPosition.X, viewportSize.Y - canvasPosition.Y);
+                canvasPosition = new Vector2(canvasPosition.X, viewportSize.Y - canvasPosition.Y);
+            }
         }
 
         GlobalPosition = canvasPosition;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Applies chromatic abberation (barrel distortion) to fossilization buttons' positions, placing them where microbes visually are.

This requires an inverse function. The true inverse function for barrel distortion would be way too complex ([something like this](https://www.wolframalpha.com/input?i=solve+for+a+and+b+%7B+c+%3D+a+*+%28a+*+a+%2B+b+*+b+%2B+%28a+*+a+%2B+b+*+b%29%5E2%29%3B+d+%3D+b+*+%28a+*+a+%2B+b+*+b+%2B+%28a+*+a+%2B+b+*+b%29%5E2%29+%7D)), so this PR uses an approximation, though its inaccuracy seems almost negligible. It breaks when the given position is outside of the screen, but it's fixable with clamping.

**Related Issues**

Fossilization buttons being too far from their microbes

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
