### PR TITLE
Added in World Size parameter to World Editor

### DIFF
--- a/src/general/NewGameSettings.cs
+++ b/src/general/NewGameSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
@@ -143,7 +143,10 @@ public partial class NewGameSettings : ControlWithInput
 
     [Export]
     public NodePath GameSeedAdvancedPath = null!;
-
+    
+    [Export]
+    public NodePath WorldSizeButtonPath = null!;
+    
     [Export]
     public NodePath IncludeMulticellularButtonPath = null!;
 
@@ -221,6 +224,7 @@ public partial class NewGameSettings : ControlWithInput
     private VBoxContainer dayLengthContainer = null!;
     private LineEdit gameSeed = null!;
     private LineEdit gameSeedAdvanced = null!;
+    private OptionButton worldSizeButton = null!;
 
     // Misc controls
     private Button includeMulticellularButton = null!;
@@ -316,6 +320,7 @@ public partial class NewGameSettings : ControlWithInput
         dayLengthReadout = GetNode<LineEdit>(DayLengthReadoutPath);
         gameSeed = GetNode<LineEdit>(GameSeedPath);
         gameSeedAdvanced = GetNode<LineEdit>(GameSeedAdvancedPath);
+        worldSizeButton = GetNode<OptionButton>(WorldSizeButtonPath);
         includeMulticellularButton = GetNode<Button>(IncludeMulticellularButtonPath);
         easterEggsButton = GetNode<Button>(EasterEggsButtonPath);
         backButton = GetNode<Button>(BackButtonPath);
@@ -462,6 +467,8 @@ public partial class NewGameSettings : ControlWithInput
         gameSeedAdvanced.Text = seedText;
         SetSeed(seedText);
 
+        worldSizeButton.Selected = (int)settings.WorldSize;
+
         // Always set prototypes to true as the player must have been there to descend
         includeMulticellularButton.ButtonPressed = true;
 
@@ -537,6 +544,7 @@ public partial class NewGameSettings : ControlWithInput
                 DayLengthReadoutPath.Dispose();
                 GameSeedPath.Dispose();
                 GameSeedAdvancedPath.Dispose();
+                WorldSizeButtonPath.Dispose();
                 IncludeMulticellularButtonPath.Dispose();
                 EasterEggsButtonPath.Dispose();
                 BackButtonPath.Dispose();
@@ -656,6 +664,7 @@ public partial class NewGameSettings : ControlWithInput
         settings.DayNightCycleEnabled = dayNightCycleButton.ButtonPressed;
         settings.DayLength = (int)dayLength.Value;
         settings.Seed = latestValidSeed;
+        settings.WorldSize = (WorldGenerationSettings.WorldSizeEnum)worldSizeButton.Selected;
 
         settings.IncludeMulticellular = includeMulticellularButton.ButtonPressed;
         settings.EasterEggs = easterEggsButton.ButtonPressed;
@@ -1040,6 +1049,11 @@ public partial class NewGameSettings : ControlWithInput
         gameSeed.Text = seed;
         gameSeedAdvanced.Text = seed;
         SetSeed(seed);
+    }
+    
+    private void OnWorldSizeSelected(int index)
+    {
+        worldSizeButton.Selected = index;
     }
 
     private void OnIncludeMulticellularToggled(bool pressed)

--- a/src/general/NewGameSettings.tscn
+++ b/src/general/NewGameSettings.tscn
@@ -10,7 +10,7 @@
 [ext_resource type="Texture2D" uid="uid://jm2munbr7078" path="res://assets/textures/gui/bevel/randomizeButtonHover.png" id="8"]
 [ext_resource type="Texture2D" uid="uid://c6pe536xf5ime" path="res://assets/concept_art/planet_generation.jpg" id="10"]
 [ext_resource type="PackedScene" path="res://src/gui_common/CustomRichTextLabel.tscn" id="11"]
-[ext_resource type="PackedScene" path="res://src/gui_common/FocusGrabber.tscn" id="12"]
+[ext_resource type="PackedScene" uid="uid://bgeijgq7runaw" path="res://src/gui_common/FocusGrabber.tscn" id="12"]
 [ext_resource type="PackedScene" uid="uid://dw3ubsraoopin" path="res://src/gui_common/TabButtons.tscn" id="13"]
 [ext_resource type="LabelSettings" uid="uid://58teykjxnrdt" path="res://src/gui_common/fonts/Body-Regular-AlmostTiny-Red.tres" id="13_yxxhr"]
 [ext_resource type="LabelSettings" uid="uid://cis0p1u7hveec" path="res://src/gui_common/fonts/Title-SemiBold-Huge.tres" id="14_36v86"]
@@ -79,6 +79,7 @@ DayLengthPath = NodePath("CenterContainer/VBoxContainer/AdvancedOptions/Planet/V
 DayLengthReadoutPath = NodePath("CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer/VBoxContainer4/HBoxContainer/HBoxContainer/DayLengthReadout")
 GameSeedPath = NodePath("CenterContainer/VBoxContainer/BasicOptions/Main/VBoxContainer/HBoxContainer3/HBoxContainer/GameSeed")
 GameSeedAdvancedPath = NodePath("CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer/HBoxContainer3/HBoxContainer/GameSeedAdvanced")
+WorldSizeButtonPath = NodePath("CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer/HBoxContainer4/WorldSize")
 IncludeMulticellularButtonPath = NodePath("CenterContainer/VBoxContainer/AdvancedOptions/Misc/VBoxContainer/VBoxContainer2/IncludeMulticellular")
 EasterEggsButtonPath = NodePath("CenterContainer/VBoxContainer/AdvancedOptions/Misc/VBoxContainer/VBoxContainer3/EasterEggs")
 StartButtonPath = NodePath("CenterContainer/VBoxContainer/HBoxContainer/Start")
@@ -951,6 +952,41 @@ texture_disabled = ExtResource("7")
 ignore_texture_size = true
 stretch_mode = 5
 
+[node name="HBoxContainer4" type="HBoxContainer" parent="CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer/HBoxContainer4"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer/HBoxContainer4/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+mouse_filter = 0
+text = "WORLD_SIZE"
+
+[node name="Label2" type="Label" parent="CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer/HBoxContainer4/VBoxContainer"]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "WORLD_SIZE_EXPLANATION"
+label_settings = ExtResource("5_rnvau")
+autowrap_mode = 3
+
+[node name="WorldSize" type="OptionButton" parent="CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer/HBoxContainer4"]
+custom_minimum_size = Vector2(200, 25)
+layout_mode = 2
+size_flags_vertical = 0
+tooltip_text = "WORLD_SIZE_TOOLTIP"
+selected = 0
+item_count = 3
+popup/item_0/text = "WORLD_SIZE_SMALL"
+popup/item_1/text = "WORLD_SIZE_MEDIUM"
+popup/item_1/id = 1
+popup/item_2/text = "WORLD_SIZE_LARGE"
+popup/item_2/id = 2
+
 [node name="CenterContainer" type="CenterContainer" parent="CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer"]
 custom_minimum_size = Vector2(0, 100)
 layout_mode = 2
@@ -1121,6 +1157,7 @@ text = "START_GAME"
 [connection signal="value_changed" from="CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer/VBoxContainer4/HBoxContainer/HBoxContainer/DayLength" to="." method="OnDayLengthChanged"]
 [connection signal="text_changed" from="CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer/HBoxContainer3/HBoxContainer/GameSeedAdvanced" to="." method="OnGameSeedChangedFromAdvanced"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer/HBoxContainer3/HBoxContainer/RandomizeButtonAdvanced" to="." method="OnRandomisedGameSeedPressed"]
+[connection signal="item_selected" from="CenterContainer/VBoxContainer/AdvancedOptions/Planet/VBoxContainer/HBoxContainer4/WorldSize" to="." method="OnWorldSizeSelected"]
 [connection signal="toggled" from="CenterContainer/VBoxContainer/AdvancedOptions/Misc/VBoxContainer/VBoxContainer2/IncludeMulticellular" to="." method="OnIncludeMulticellularToggled"]
 [connection signal="toggled" from="CenterContainer/VBoxContainer/AdvancedOptions/Misc/VBoxContainer/VBoxContainer3/EasterEggs" to="." method="OnEasterEggsToggled"]
 [connection signal="toggled" from="CenterContainer/VBoxContainer/AdvancedOptions/Misc/VBoxContainer/VBoxContainer4/ExperimentalFeatures" to="." method="OnExperimentalFeaturesChanged"]

--- a/src/general/WorldGenerationSettings.cs
+++ b/src/general/WorldGenerationSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using Godot;
 using Newtonsoft.Json;
@@ -48,6 +48,18 @@ public class WorldGenerationSettings
         [Description("LIFE_ORIGIN_PANSPERMIA")]
         Panspermia = 2,
     }
+    
+    public enum WorldSizeEnum
+    {
+        [Description("WORLD_SIZE_SMALL")]
+        Small = 0,
+
+        [Description("WORLD_SIZE_MEDIUM")]
+        Medium = 1,
+
+        [Description("WORLD_SIZE_LARGE")]
+        Large = 2,
+    }
 
     /// <summary>
     ///   Whether this game is restricted to only LAWK parts and abilities
@@ -73,6 +85,11 @@ public class WorldGenerationSettings
     ///   Random seed for generating this game's planet
     /// </summary>
     public long Seed { get; set; } = new XoShiRo256starstar().Next64();
+    
+    /// <summary>
+    ///   Size of World
+    /// </summary>
+    public WorldSizeEnum WorldSize { get; set; } = WorldSizeEnum.Medium;
 
     // The following are helper proxies to the values from the difficulty
     [JsonIgnore]

--- a/src/microbe_stage/PatchMapGenerator.cs
+++ b/src/microbe_stage/PatchMapGenerator.cs
@@ -19,7 +19,21 @@ public static class PatchMapGenerator
 
         // Initialize the graph's random parameters
         var regionCoordinates = new List<Vector2>();
-        int vertexCount = random.Next(6, 10);
+        //int vertexCount = random.Next(6, 10);
+        int vertexCount = 6;
+        if (settings.WorldSize == WorldGenerationSettings.WorldSizeEnum.Small)
+        {
+            vertexCount = 6;
+        }
+        else if (settings.WorldSize == WorldGenerationSettings.WorldSizeEnum.Medium)
+        {
+            vertexCount = 9;
+        }
+        else if (settings.WorldSize == WorldGenerationSettings.WorldSizeEnum.Large)
+        {
+            vertexCount = 12;
+        }
+
         int minDistance = 180;
 
         int currentPatchId = 0;
@@ -136,7 +150,7 @@ public static class PatchMapGenerator
             }
 
             BuildRegionSize(region);
-            coordinates = GenerateCoordinates(region, map, random, minDistance);
+            coordinates = GenerateCoordinates(region, map, random, minDistance, settings.WorldSize);
 
             // If there is no more place for the current region, abandon it.
             // TODO: modify the algorithm to not need to abandon regions
@@ -368,7 +382,7 @@ public static class PatchMapGenerator
         return region1Rect.Intersects(region2Rect, true);
     }
 
-    private static Vector2 GenerateCoordinates(PatchRegion region, PatchMap map, Random random, int minDistance)
+    private static Vector2 GenerateCoordinates(PatchRegion region, PatchMap map, Random random, int minDistance, WorldGenerationSettings.WorldSizeEnum worldSize)
     {
         Vector2 coordinate;
 
@@ -379,6 +393,17 @@ public static class PatchMapGenerator
         do
         {
             coordinate = new Vector2(random.Next(3, 16) * 100, random.Next(3, 16) * 100);
+
+            // Uses more area for larger worlds
+            if (worldSize == WorldGenerationSettings.WorldSizeEnum.Medium)
+            {
+                coordinate = new Vector2(random.Next(3, 20) * 100, random.Next(3, 20) * 100);
+            }
+            else if (worldSize == WorldGenerationSettings.WorldSizeEnum.Large)
+            {
+                coordinate = new Vector2(random.Next(3, 24) * 100, random.Next(3, 24) * 100);
+            }
+
             region.ScreenCoordinates = coordinate;
         }
         while (!CheckRegionDistance(region, map, minDistance) && ++i < Constants.PATCH_GENERATION_MAX_RETRIES);


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds in a World Size parameter to the Planet Editor.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

Part of a roadmap item (https://wiki.revolutionarygamesstudio.com/wiki/Release_Roadmap#0.8.x_(world_and_auto-evo_updates))

Reduces problem #3563 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
