### PR TITLE
Make high fire-rate toxins consume less per shot

### DIFF
--- a/src/microbe_stage/systems/MicrobeEmissionSystem.cs
+++ b/src/microbe_stage/systems/MicrobeEmissionSystem.cs
@@ -228,7 +228,9 @@ public sealed class MicrobeEmissionSystem : AEntitySetSystem<float>
                 // aren't used per agent type)
 
                 // Emit as much as you have, but don't start if there's way too little toxin
-                float amountEmitted = Math.Min(amountAvailable, Constants.MAXIMUM_AGENT_EMISSION_AMOUNT);
+                float amountEmitted = Math.Min(amountAvailable,
+                    EmissionAmountWithToxicity(organelles.AverageToxinToxicity));
+
                 if (amountEmitted < Constants.MINIMUM_AGENT_EMISSION_AMOUNT)
                     return;
 
@@ -283,6 +285,23 @@ public sealed class MicrobeEmissionSystem : AEntitySetSystem<float>
 
         // No modification from default
         return Constants.AGENT_EMISSION_COOLDOWN / vacuoleCount;
+    }
+
+    private float EmissionAmountWithToxicity(float toxicity)
+    {
+        if (toxicity < 0)
+        {
+            // High-firerate, low emission amount
+            return Constants.MAXIMUM_AGENT_EMISSION_AMOUNT * (1.0f + toxicity * 0.5f);
+        }
+
+        if (toxicity > 0)
+        {
+            // Low-firerate, high emission amount
+            return Constants.MAXIMUM_AGENT_EMISSION_AMOUNT * (1.0f + toxicity);
+        }
+
+        return Constants.MAXIMUM_AGENT_EMISSION_AMOUNT;
     }
 
     private void HandleSlimeSecretion(in Entity entity, ref MicrobeControl control,


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes toxins consume less toxin per shot when they are modified to have a higher fire-rate. This should allow fast-firing microbes to fire more shots making the lower cooldown more meaningful.

**Related Issues**

Closes #5366

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
