### PR TITLE
Changed ATP consumption bar to round to 3 decimal places

### DIFF
--- a/src/microbe_stage/OrganismStatisticsPanel.cs
+++ b/src/microbe_stage/OrganismStatisticsPanel.cs
@@ -341,7 +341,7 @@ public partial class OrganismStatisticsPanel : PanelContainer
             }
 
             tooltip.Description = Localization.Translate("ENERGY_BALANCE_TOOLTIP_CONSUMPTION")
-                .FormatSafe(displayName, Math.Round(energyBalance.Consumption[subBar.Name]));
+                .FormatSafe(displayName, Math.Round(energyBalance.Consumption[subBar.Name], 3));
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Sets the tooltip for the ATP consumption bar to round to three 3 decimal places, like the production bar, as opposed to 0.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Resolves #5918 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
