### PR TITLE
Increased played volume of radiation damage effect

### DIFF
--- a/src/microbe_stage/systems/DamageSoundSystem.cs
+++ b/src/microbe_stage/systems/DamageSoundSystem.cs
@@ -99,7 +99,7 @@ public sealed class DamageSoundSystem : AEntitySetSystem<float>
                     // Doesn't make a ton of sense if other cells play Geiger-counter sounds...
                     if (isPlayer)
                     {
-                        soundEffectPlayer.PlaySoundEffect("res://assets/sounds/soundeffects/radiation.ogg");
+                        soundEffectPlayer.PlaySoundEffect("res://assets/sounds/soundeffects/radiation.ogg", 40.0f);
                     }
                 }
             }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Changed the played volume to 40.0 to make radiation damage sound audible in-game. To me 40.0 seemed roughly in-line with other sound effects in the game while minimizing distortion, although I can't say I'm familiar with proper sound balancing.

**Related Issues**
<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

Fixes #5854  

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
