### PR TITLE
Added player instant kill protection when player has a bit of health

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -512,7 +512,7 @@ public static class Constants
     ///   If the player has more than this much health, a single damage event cannot kill them. Instead, it leaves
     ///   just a bit of health (1% or 0.1 whichever is more).
     /// </summary>
-    public const float PLAYER_INSTANT_KILL_PROTECTION_HEALTH_THRESHOLD = 2.5f;
+    public const float PLAYER_INSTANT_KILL_PROTECTION_HEALTH_THRESHOLD = 5.0f;
 
     /// <summary>
     ///   How much a cell's speed is slowed when travelling through slime

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -509,6 +509,12 @@ public static class Constants
     public const float OXYTOXY_DAMAGE_DEBUFF_MAX = 0.75f;
 
     /// <summary>
+    ///   If the player has more than this much health, a single damage event cannot kill them. Instead, it leaves
+    ///   just a bit of health (1% or 0.1 whichever is more).
+    /// </summary>
+    public const float PLAYER_INSTANT_KILL_PROTECTION_HEALTH_THRESHOLD = 2.5f;
+
+    /// <summary>
     ///   How much a cell's speed is slowed when travelling through slime
     /// </summary>
     public const float MUCILAGE_IMPEDE_FACTOR = 4.0f;

--- a/src/engine/common_systems/DamageOnTouchSystem.cs
+++ b/src/engine/common_systems/DamageOnTouchSystem.cs
@@ -120,23 +120,26 @@ public sealed class DamageOnTouchSystem : AEntitySetSystem<float>
             if (entityExtraData.IsSubShapePilus(subShape))
                 return false;
 
+            // This is fetched here as the protection also applies to the player's cell colony
+            var protection = HealthHelpers.GetInstantKillProtectionThreshold(entity);
+
             if (entity.Has<MicrobeColony>())
             {
                 if (entity.Get<MicrobeColony>().GetMicrobeFromSubShape(ref entityExtraData,
                         subShape, out var hitEntity))
                 {
                     hitEntity.Get<Health>()
-                        .DealMicrobeDamage(ref hitEntity.Get<CellProperties>(), damageValue, damageType);
+                        .DealMicrobeDamage(ref hitEntity.Get<CellProperties>(), damageValue, damageType, protection);
 
                     return true;
                 }
             }
 
-            health.DealMicrobeDamage(ref entity.Get<CellProperties>(), damageValue, damageType);
+            health.DealMicrobeDamage(ref entity.Get<CellProperties>(), damageValue, damageType, protection);
         }
         else
         {
-            health.DealDamage(damageValue, damageType);
+            health.DealDamage(damageValue, damageType, HealthHelpers.GetInstantKillProtectionThreshold(entity));
         }
 
         return true;

--- a/src/microbe_stage/AgentProperties.cs
+++ b/src/microbe_stage/AgentProperties.cs
@@ -1,4 +1,5 @@
 ﻿using Components;
+using DefaultEcs;
 using Newtonsoft.Json;
 
 /// <summary>
@@ -44,18 +45,19 @@ public class AgentProperties
         new LocalizedString("AGENT_NAME",
             new LocalizedString(SimulationParameters.GetCompound(Compound).GetUntranslatedName()));
 
-    public void DealDamage(ref Health health, ref CellProperties hitCellProperties, float toxinAmount)
+    public void DealDamage(ref Health health, ref CellProperties hitCellProperties, in Entity entity, float toxinAmount)
     {
         var damage = CalculateBaseDamage(toxinAmount);
 
-        health.DealMicrobeDamage(ref hitCellProperties, damage, DamageTypeName);
+        health.DealMicrobeDamage(ref hitCellProperties, damage, DamageTypeName,
+            HealthHelpers.GetInstantKillProtectionThreshold(entity));
     }
 
-    public void DealDamage(ref Health health, float toxinAmount)
+    public void DealDamage(ref Health health, in Entity entity, float toxinAmount)
     {
         var damage = CalculateBaseDamage(toxinAmount);
 
-        health.DealDamage(damage, DamageTypeName);
+        health.DealDamage(damage, DamageTypeName, HealthHelpers.GetInstantKillProtectionThreshold(entity));
     }
 
     /// <summary>

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -867,7 +867,7 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
             health.Invulnerable = false;
 
             // This doesn't use the microbe damage calculation as this damage can't be resisted
-            health.DealDamage(9999.0f, "suicide");
+            health.Kill();
 
             // Force digestion to complete immediately
             if (Player.Has<Engulfable>())

--- a/src/microbe_stage/components/MicrobeControl.cs
+++ b/src/microbe_stage/components/MicrobeControl.cs
@@ -391,8 +391,9 @@ public static class MicrobeControlHelpers
             if (damage >= health.CurrentHealth)
                 return;
 
-            // Need to force this cell into a mode, so deal the damage
-            health.DealDamage(damage, "forcedState");
+            // Need to force this cell into a mode, so cause the damage.
+            // We checked above that damage won't kill, so we don't check for damage protection on the player.
+            health.DealDamage(damage, "forcedState", -1);
 
             control.ForcedStateRemaining = Constants.ENGULF_NO_ATP_TIME;
 

--- a/src/microbe_stage/systems/EngulfedDigestionSystem.cs
+++ b/src/microbe_stage/systems/EngulfedDigestionSystem.cs
@@ -272,7 +272,8 @@ public sealed class EngulfedDigestionSystem : AEntitySetSystem<float>
                         ref var health = ref entity.Get<Health>();
 
                         health.DealMicrobeDamage(ref cellProperties,
-                            health.MaxHealth * Constants.TOXIN_DIGESTION_DAMAGE_FRACTION, "oxytoxy");
+                            health.MaxHealth * Constants.TOXIN_DIGESTION_DAMAGE_FRACTION, "oxytoxy",
+                            HealthHelpers.GetInstantKillProtectionThreshold(entity));
 
                         entity.SendNoticeIfPossible(() => new SimpleHUDMessage(
                             Localization.Translate("NOTICE_ENGULF_DAMAGE_FROM_TOXIN"),

--- a/src/microbe_stage/systems/OsmoregulationAndHealingSystem.cs
+++ b/src/microbe_stage/systems/OsmoregulationAndHealingSystem.cs
@@ -94,7 +94,7 @@ public sealed class OsmoregulationAndHealingSystem : AEntitySetSystem<float>
             if (entity.Get<Engulfable>().PhagocytosisStep != PhagocytosisPhase.None)
                 return;
 
-            ApplyATPDamage(compounds, ref health, ref cellProperties);
+            ApplyATPDamage(compounds, ref health, ref cellProperties, entity);
         }
     }
 
@@ -158,13 +158,14 @@ public sealed class OsmoregulationAndHealingSystem : AEntitySetSystem<float>
     /// <summary>
     ///   Damage the microbe if it's too low on ATP.
     /// </summary>
-    private void ApplyATPDamage(CompoundBag compounds, ref Health health, ref CellProperties cellProperties)
+    private void ApplyATPDamage(CompoundBag compounds, ref Health health, ref CellProperties cellProperties,
+        in Entity entity)
     {
         if (compounds.GetCompoundAmount(Compound.ATP) > Constants.ATP_DAMAGE_THRESHOLD)
             return;
 
         health.DealMicrobeDamage(ref cellProperties, health.MaxHealth * Constants.NO_ATP_DAMAGE_FRACTION,
-            "atpDamage");
+            "atpDamage", HealthHelpers.GetInstantKillProtectionThreshold(entity));
     }
 
     /// <summary>

--- a/src/microbe_stage/systems/PilusDamageSystem.cs
+++ b/src/microbe_stage/systems/PilusDamageSystem.cs
@@ -86,7 +86,7 @@ public sealed class PilusDamageSystem : AEntitySetSystem<float>
     private void DealPilusDamage(ref MicrobePhysicsExtraData ourExtraData, ref PhysicsCollision collision,
         in Entity targetEntity)
     {
-        // Skip applying damage while previous damage cooldown is still active
+        // Skip applying damage while the previous damage cooldown is still active
         ref var cooldown = ref collision.SecondEntity.Get<DamageCooldown>();
 
         if (cooldown.IsInCooldown())
@@ -98,7 +98,8 @@ public sealed class PilusDamageSystem : AEntitySetSystem<float>
         {
             // Injectisome attack
             targetHealth.DealMicrobeDamage(ref collision.SecondEntity.Get<CellProperties>(),
-                Constants.INJECTISOME_BASE_DAMAGE, "injectisome");
+                Constants.INJECTISOME_BASE_DAMAGE, "injectisome",
+                HealthHelpers.GetInstantKillProtectionThreshold(targetEntity));
 
             cooldown.StartInjectisomeCooldown();
             return;
@@ -113,7 +114,8 @@ public sealed class PilusDamageSystem : AEntitySetSystem<float>
         if (damage > Constants.PILUS_MAX_DAMAGE)
             damage = Constants.PILUS_MAX_DAMAGE;
 
-        targetHealth.DealMicrobeDamage(ref collision.SecondEntity.Get<CellProperties>(), damage, "pilus");
+        targetHealth.DealMicrobeDamage(ref collision.SecondEntity.Get<CellProperties>(), damage, "pilus",
+            HealthHelpers.GetInstantKillProtectionThreshold(targetEntity));
 
         cooldown.StartDamageScaledCooldown(damage, Constants.PILUS_MIN_DAMAGE_TRIGGER_COOLDOWN,
             Constants.PILUS_MAX_DAMAGE, Constants.PILUS_MIN_COOLDOWN, Constants.PILUS_MAX_COOLDOWN);

--- a/src/microbe_stage/systems/RadiationDamageSystem.cs
+++ b/src/microbe_stage/systems/RadiationDamageSystem.cs
@@ -79,7 +79,8 @@ public sealed class RadiationDamageSystem : AEntitySetSystem<float>
         // Apply damage if there is some to apply
         if (rawDamage > 0 && !health.Dead)
         {
-            health.DealMicrobeDamage(ref entity.Get<CellProperties>(), rawDamage, "radiation");
+            health.DealMicrobeDamage(ref entity.Get<CellProperties>(), rawDamage, "radiation",
+                HealthHelpers.GetInstantKillProtectionThreshold(entity));
 
             entity.SendNoticeIfPossible(() =>
                 new SimpleHUDMessage(Localization.Translate("NOTICE_RADIATION_DAMAGE"), DisplayDuration.Short));

--- a/src/microbe_stage/systems/ToxinCollisionSystem.cs
+++ b/src/microbe_stage/systems/ToxinCollisionSystem.cs
@@ -261,11 +261,12 @@ public sealed class ToxinCollisionSystem : AEntitySetSystem<float>
                 }
 
                 damageSource.ToxinProperties.DealDamage(ref health, ref damageTarget.Get<CellProperties>(),
+                    damageTarget,
                     damageSource.ToxinAmount * modifier);
             }
             else
             {
-                damageSource.ToxinProperties.DealDamage(ref health, damageSource.ToxinAmount);
+                damageSource.ToxinProperties.DealDamage(ref health, damageTarget, damageSource.ToxinAmount);
             }
 
             return true;
@@ -274,7 +275,7 @@ public sealed class ToxinCollisionSystem : AEntitySetSystem<float>
         {
             GD.PrintErr("Error processing toxin collision: ", e);
 
-            // Destroy this toxin to avoid recurring error printing spam
+            // Destroy this toxin to avoid recurring error printing spamming
             return true;
         }
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

To make situations where a player with lowered health can be instantly killed by a pilus even at max health. The threshold might be a bit low right now (above 2.5 health you can't be instantly killed) but at least it gives quite often the option for the player to continue trying to survive once taking lethal damage until the next time they take damage.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
