### PR TITLE
Apply shader to ice chunks

### DIFF
--- a/assets/models/IceChunkLarge1.tscn
+++ b/assets/models/IceChunkLarge1.tscn
@@ -1,25 +1,30 @@
-[gd_scene load_steps=5 format=3 uid="uid://cf7m6tvdm1618"]
+[gd_scene load_steps=7 format=3 uid="uid://cf7m6tvdm1618"]
 
+[ext_resource type="Shader" uid="uid://bxd4cdv4qekba" path="res://shaders/Crystal.gdshader" id="1_v3suj"]
 [ext_resource type="Texture2D" uid="uid://c4lakneio0v00" path="res://assets/textures/IronChunk_normal.png" id="2_2cqno"]
 [ext_resource type="Texture2D" uid="uid://dfw401vxsi10p" path="res://assets/textures/IceChunk.png" id="2_kxdxj"]
+[ext_resource type="Texture2D" uid="uid://baxuoyeo83r2u" path="res://assets/textures/dissolve_noise.tres" id="3_qbtcf"]
 [ext_resource type="ArrayMesh" uid="uid://yj10yvbmr7y5" path="res://assets/models/IceChunkLarge1.mesh" id="5_6qvee"]
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_kjn86"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_v3suj"]
+resource_local_to_scene = true
 render_priority = 18
-transparency = 4
-blend_mode = 1
-cull_mode = 2
-albedo_color = Color(0.917647, 1, 1, 0.772549)
-albedo_texture = ExtResource("2_kxdxj")
-metallic = 0.6
-metallic_specular = 0.78
-roughness = 0.6
-emission_enabled = true
-emission = Color(0.321569, 0.321569, 0.435294, 1)
-emission_energy_multiplier = 0.4
-normal_enabled = true
-normal_texture = ExtResource("2_2cqno")
+shader = ExtResource("1_v3suj")
+shader_parameter/albedo = Color(0.839216, 1, 1, 0.870588)
+shader_parameter/albedoTexture = ExtResource("2_kxdxj")
+shader_parameter/useNormal = true
+shader_parameter/normalTexture = ExtResource("2_2cqno")
+shader_parameter/roughness = 0.55
+shader_parameter/roughnessTextureChannel = Vector4(1, 0, 0, 0)
+shader_parameter/specular = 0.78
+shader_parameter/metallic = 0.65
+shader_parameter/emission = Color(0.321569, 0.321569, 0.435294, 1)
+shader_parameter/emissionEnergy = 0.5
+shader_parameter/dissolveTexture = ExtResource("3_qbtcf")
+shader_parameter/dissolveValue = 0.0
+shader_parameter/dissolveScale = 1.0
+shader_parameter/outlineWidth = 0.0
 
 [node name="IceChunk" type="MeshInstance3D"]
-material_override = SubResource("StandardMaterial3D_kjn86")
+material_override = SubResource("ShaderMaterial_v3suj")
 mesh = ExtResource("5_6qvee")

--- a/assets/models/IceChunkLarge2.mesh
+++ b/assets/models/IceChunkLarge2.mesh
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad1fc052bd4c123b5cebffc1b73ac7c5087ae55930f05c1db0fd6c012e2786b8
-size 23593
+oid sha256:c4853c728d4fc1729a5a9c257aadb6639310c5adb9f59151f5e08578b5e28395
+size 27938

--- a/assets/models/IceChunkLarge2.tscn
+++ b/assets/models/IceChunkLarge2.tscn
@@ -1,25 +1,30 @@
-[gd_scene load_steps=5 format=3 uid="uid://0mbxlwabmmgp"]
+[gd_scene load_steps=7 format=3 uid="uid://0mbxlwabmmgp"]
 
+[ext_resource type="Shader" uid="uid://bxd4cdv4qekba" path="res://shaders/Crystal.gdshader" id="1_hmc82"]
 [ext_resource type="Texture2D" uid="uid://dfw401vxsi10p" path="res://assets/textures/IceChunk.png" id="2_qawph"]
 [ext_resource type="Texture2D" uid="uid://c4lakneio0v00" path="res://assets/textures/IronChunk_normal.png" id="2_rupjp"]
+[ext_resource type="Texture2D" uid="uid://baxuoyeo83r2u" path="res://assets/textures/dissolve_noise.tres" id="3_y4bye"]
 [ext_resource type="ArrayMesh" uid="uid://dwku0n7qribgu" path="res://assets/models/IceChunkLarge2.mesh" id="5_p5w0v"]
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_pawmm"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_hmc82"]
+resource_local_to_scene = true
 render_priority = 18
-transparency = 4
-blend_mode = 1
-cull_mode = 2
-albedo_color = Color(0.839216, 1, 1, 0.882353)
-albedo_texture = ExtResource("2_qawph")
-metallic = 0.6
-metallic_specular = 0.78
-roughness = 0.6
-emission_enabled = true
-emission = Color(0.321569, 0.321569, 0.435294, 1)
-emission_energy_multiplier = 1.5
-normal_enabled = true
-normal_texture = ExtResource("2_rupjp")
+shader = ExtResource("1_hmc82")
+shader_parameter/albedo = Color(0.839216, 1, 1, 0.882353)
+shader_parameter/albedoTexture = ExtResource("2_qawph")
+shader_parameter/useNormal = true
+shader_parameter/normalTexture = ExtResource("2_rupjp")
+shader_parameter/roughness = 0.5
+shader_parameter/roughnessTextureChannel = Vector4(1, 0, 0, 0)
+shader_parameter/specular = 0.78
+shader_parameter/metallic = 0.65
+shader_parameter/emission = Color(0.321569, 0.321569, 0.435294, 1)
+shader_parameter/emissionEnergy = 1.2
+shader_parameter/dissolveTexture = ExtResource("3_y4bye")
+shader_parameter/dissolveValue = 0.0
+shader_parameter/dissolveScale = 1.2
+shader_parameter/outlineWidth = 0.1
 
 [node name="IceChunk" type="MeshInstance3D"]
-material_override = SubResource("StandardMaterial3D_pawmm")
+material_override = SubResource("ShaderMaterial_hmc82")
 mesh = ExtResource("5_p5w0v")

--- a/assets/models/IceChunkLarge3.tscn
+++ b/assets/models/IceChunkLarge3.tscn
@@ -1,26 +1,31 @@
-[gd_scene load_steps=5 format=3 uid="uid://dntmcvk7uibgs"]
+[gd_scene load_steps=7 format=3 uid="uid://dntmcvk7uibgs"]
 
+[ext_resource type="Shader" uid="uid://bxd4cdv4qekba" path="res://shaders/Crystal.gdshader" id="1_ddthg"]
 [ext_resource type="Texture2D" uid="uid://dfw401vxsi10p" path="res://assets/textures/IceChunk.png" id="2_7fory"]
 [ext_resource type="Texture2D" uid="uid://c4lakneio0v00" path="res://assets/textures/IronChunk_normal.png" id="2_7vrdy"]
+[ext_resource type="Texture2D" uid="uid://baxuoyeo83r2u" path="res://assets/textures/dissolve_noise.tres" id="3_kao0r"]
 [ext_resource type="ArrayMesh" uid="uid://dev5lpvehe254" path="res://assets/models/IceChunkLarge3.mesh" id="4_vi8ht"]
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_5xlso"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_ddthg"]
+resource_local_to_scene = true
 render_priority = 18
-transparency = 4
-blend_mode = 1
-cull_mode = 2
-albedo_color = Color(0.87451, 1, 1, 0.921569)
-albedo_texture = ExtResource("2_7fory")
-metallic = 0.6
-metallic_specular = 0.78
-roughness = 0.6
-emission_enabled = true
-emission = Color(0.321569, 0.321569, 0.435294, 1)
-emission_energy_multiplier = 1.5
-normal_enabled = true
-normal_texture = ExtResource("2_7vrdy")
+shader = ExtResource("1_ddthg")
+shader_parameter/albedo = Color(0.839216, 1, 1, 0.866667)
+shader_parameter/albedoTexture = ExtResource("2_7fory")
+shader_parameter/useNormal = true
+shader_parameter/normalTexture = ExtResource("2_7vrdy")
+shader_parameter/roughness = 0.5
+shader_parameter/roughnessTextureChannel = Vector4(1, 0, 0, 0)
+shader_parameter/specular = 0.78
+shader_parameter/metallic = 0.7
+shader_parameter/emission = Color(0.321569, 0.321569, 0.435294, 1)
+shader_parameter/emissionEnergy = 0.5
+shader_parameter/dissolveTexture = ExtResource("3_kao0r")
+shader_parameter/dissolveValue = 0.0
+shader_parameter/dissolveScale = 1.0
+shader_parameter/outlineWidth = 0.0
 
 [node name="IceChunk" type="MeshInstance3D"]
 transform = Transform3D(1.00374, 0, 0, 0, 1.00374, 0, 0, 0, 1.00374, 0, 0, 0)
-material_override = SubResource("StandardMaterial3D_5xlso")
+material_override = SubResource("ShaderMaterial_ddthg")
 mesh = ExtResource("4_vi8ht")

--- a/assets/models/IceChunkSmall1.tscn
+++ b/assets/models/IceChunkSmall1.tscn
@@ -1,25 +1,30 @@
-[gd_scene load_steps=5 format=3 uid="uid://b468e0b04dot"]
+[gd_scene load_steps=7 format=3 uid="uid://b468e0b04dot"]
 
+[ext_resource type="Shader" uid="uid://bxd4cdv4qekba" path="res://shaders/Crystal.gdshader" id="1_hlsws"]
 [ext_resource type="ArrayMesh" uid="uid://d2jrhrxmkd7dw" path="res://assets/models/IceChunkSmall1.mesh" id="2_3v8mk"]
 [ext_resource type="Texture2D" uid="uid://dfw401vxsi10p" path="res://assets/textures/IceChunk.png" id="2_ayeji"]
 [ext_resource type="Texture2D" uid="uid://c4lakneio0v00" path="res://assets/textures/IronChunk_normal.png" id="2_ruhxd"]
+[ext_resource type="Texture2D" uid="uid://baxuoyeo83r2u" path="res://assets/textures/dissolve_noise.tres" id="3_sb57p"]
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_5iyqp"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_hlsws"]
+resource_local_to_scene = true
 render_priority = 18
-transparency = 4
-blend_mode = 1
-cull_mode = 2
-albedo_color = Color(0.862745, 1, 1, 0.92549)
-albedo_texture = ExtResource("2_ayeji")
-metallic = 0.6
-metallic_specular = 0.78
-roughness = 0.6
-emission_enabled = true
-emission = Color(0.321569, 0.321569, 0.435294, 1)
-emission_energy_multiplier = 0.5
-normal_enabled = true
-normal_texture = ExtResource("2_ruhxd")
+shader = ExtResource("1_hlsws")
+shader_parameter/albedo = Color(0.839216, 1, 1, 0.894118)
+shader_parameter/albedoTexture = ExtResource("2_ayeji")
+shader_parameter/useNormal = true
+shader_parameter/normalTexture = ExtResource("2_ruhxd")
+shader_parameter/roughness = 0.5
+shader_parameter/roughnessTextureChannel = Vector4(1, 0, 0, 0)
+shader_parameter/specular = 0.78
+shader_parameter/metallic = 0.6
+shader_parameter/emission = Color(0.321569, 0.321569, 0.435294, 1)
+shader_parameter/emissionEnergy = 0.5
+shader_parameter/dissolveTexture = ExtResource("3_sb57p")
+shader_parameter/dissolveValue = 0.0
+shader_parameter/dissolveScale = 1.0
+shader_parameter/outlineWidth = 0.0
 
 [node name="IceChunkSmall" type="MeshInstance3D"]
-material_override = SubResource("StandardMaterial3D_5iyqp")
+material_override = SubResource("ShaderMaterial_hlsws")
 mesh = ExtResource("2_3v8mk")

--- a/assets/models/IceChunkSmall2.tscn
+++ b/assets/models/IceChunkSmall2.tscn
@@ -1,25 +1,30 @@
-[gd_scene load_steps=5 format=3 uid="uid://bsida34nrjiis"]
+[gd_scene load_steps=7 format=3 uid="uid://bsida34nrjiis"]
 
+[ext_resource type="Shader" uid="uid://bxd4cdv4qekba" path="res://shaders/Crystal.gdshader" id="1_ajvfr"]
 [ext_resource type="Texture2D" uid="uid://dfw401vxsi10p" path="res://assets/textures/IceChunk.png" id="2_2cj74"]
 [ext_resource type="Texture2D" uid="uid://c4lakneio0v00" path="res://assets/textures/IronChunk_normal.png" id="2_uf5cd"]
+[ext_resource type="Texture2D" uid="uid://baxuoyeo83r2u" path="res://assets/textures/dissolve_noise.tres" id="3_wbve0"]
 [ext_resource type="ArrayMesh" uid="uid://diixv1g5ao2sm" path="res://assets/models/IceChunkSmall2.mesh" id="5_6q7e3"]
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_rktnq"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_ajvfr"]
+resource_local_to_scene = true
 render_priority = 18
-transparency = 4
-blend_mode = 1
-cull_mode = 2
-albedo_color = Color(1, 1, 1, 0.772549)
-albedo_texture = ExtResource("2_2cj74")
-metallic = 0.8
-metallic_specular = 0.78
-roughness = 0.6
-emission_enabled = true
-emission = Color(0.321569, 0.321569, 0.435294, 1)
-emission_energy_multiplier = 0.1
-normal_enabled = true
-normal_texture = ExtResource("2_uf5cd")
+shader = ExtResource("1_ajvfr")
+shader_parameter/albedo = Color(0.839216, 1, 1, 0.858824)
+shader_parameter/albedoTexture = ExtResource("2_2cj74")
+shader_parameter/useNormal = true
+shader_parameter/normalTexture = ExtResource("2_uf5cd")
+shader_parameter/roughness = 0.55
+shader_parameter/roughnessTextureChannel = Vector4(1, 0, 0, 0)
+shader_parameter/specular = 0.78
+shader_parameter/metallic = 0.7
+shader_parameter/emission = Color(0.321569, 0.321569, 0.435294, 1)
+shader_parameter/emissionEnergy = 0.25
+shader_parameter/dissolveTexture = ExtResource("3_wbve0")
+shader_parameter/dissolveValue = 0.0
+shader_parameter/dissolveScale = 1.0
+shader_parameter/outlineWidth = 0.0
 
 [node name="IceChunkSmall" type="MeshInstance3D"]
-material_override = SubResource("StandardMaterial3D_rktnq")
+material_override = SubResource("ShaderMaterial_ajvfr")
 mesh = ExtResource("5_6q7e3")

--- a/assets/models/IceChunkSnowflake.tscn
+++ b/assets/models/IceChunkSnowflake.tscn
@@ -6,27 +6,25 @@
 [ext_resource type="Texture2D" uid="uid://c4lakneio0v00" path="res://assets/textures/IronChunk_normal.png" id="4_mcoj5"]
 [ext_resource type="ArrayMesh" uid="uid://bf3qbqdatru24" path="res://assets/models/IceChunkSnowflake.mesh" id="4_tpouo"]
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_5yag2"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_vhvjp"]
 resource_local_to_scene = true
 render_priority = 18
 shader = ExtResource("1_ah4jf")
-shader_parameter/albedo = Color(0.878431, 1, 1, 0.988235)
+shader_parameter/albedo = Color(0.839216, 1, 1, 0.835294)
 shader_parameter/albedoTexture = ExtResource("2_vhfcg")
 shader_parameter/useNormal = true
 shader_parameter/normalTexture = ExtResource("4_mcoj5")
-shader_parameter/roughness = 0.6
-shader_parameter/roughnessTexture = ExtResource("2_vhfcg")
+shader_parameter/roughness = 0.55
 shader_parameter/roughnessTextureChannel = Vector4(1, 0, 0, 0)
-shader_parameter/specular = 0.783
-shader_parameter/metallic = 0.6
-shader_parameter/emission = Color(0.301341, 0.301345, 0.32086, 0.933333)
-shader_parameter/emissionEnergy = 1.5
+shader_parameter/specular = 0.78
+shader_parameter/metallic = 0.65
+shader_parameter/emission = Color(0.301961, 0.301961, 0.478431, 0.933333)
+shader_parameter/emissionEnergy = 1.0
 shader_parameter/dissolveTexture = ExtResource("3_fe0k2")
 shader_parameter/dissolveValue = 0.0
-shader_parameter/dissolveScale = 1.0
+shader_parameter/dissolveScale = 1.5
 shader_parameter/outlineWidth = 0.0
-shader_parameter/growColor = Color(0.1, 0.1, 0.1, 1)
 
 [node name="IceChunkSnowflake" type="MeshInstance3D"]
-material_override = SubResource("ShaderMaterial_5yag2")
+material_override = SubResource("ShaderMaterial_vhvjp")
 mesh = ExtResource("4_tpouo")

--- a/assets/models/Iceshard1.tscn
+++ b/assets/models/Iceshard1.tscn
@@ -1,22 +1,20 @@
-[gd_scene load_steps=8 format=3 uid="uid://bkkpsrifquemw"]
+[gd_scene load_steps=7 format=3 uid="uid://bkkpsrifquemw"]
 
 [ext_resource type="Shader" uid="uid://bxd4cdv4qekba" path="res://shaders/Crystal.gdshader" id="1_l2xop"]
 [ext_resource type="Texture2D" uid="uid://dfw401vxsi10p" path="res://assets/textures/IceChunk.png" id="2_bunih"]
 [ext_resource type="Texture2D" uid="uid://baxuoyeo83r2u" path="res://assets/textures/dissolve_noise.tres" id="3_1c02q"]
 [ext_resource type="Texture2D" uid="uid://c4lakneio0v00" path="res://assets/textures/IronChunk_normal.png" id="4_ej15h"]
-[ext_resource type="Texture2D" uid="uid://dvp0yex8rwygn" path="res://assets/textures/Crystal_rough_emit.png" id="5_mie8v"]
 [ext_resource type="ArrayMesh" uid="uid://ct6x5q7py2637" path="res://assets/models/IceShard1.mesh" id="5_uu00j"]
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_wdpla"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_mk3rw"]
 resource_local_to_scene = true
 render_priority = 17
 shader = ExtResource("1_l2xop")
-shader_parameter/albedo = Color(1, 1, 1, 1)
+shader_parameter/albedo = Color(0.858824, 1, 1, 0.905882)
 shader_parameter/albedoTexture = ExtResource("2_bunih")
 shader_parameter/useNormal = true
 shader_parameter/normalTexture = ExtResource("4_ej15h")
 shader_parameter/roughness = 0.6
-shader_parameter/roughnessTexture = ExtResource("5_mie8v")
 shader_parameter/roughnessTextureChannel = Vector4(1, 0, 0, 0)
 shader_parameter/specular = 0.784
 shader_parameter/metallic = 0.45
@@ -26,8 +24,7 @@ shader_parameter/dissolveTexture = ExtResource("3_1c02q")
 shader_parameter/dissolveValue = 0.0
 shader_parameter/dissolveScale = 1.0
 shader_parameter/outlineWidth = 0.0
-shader_parameter/growColor = Color(0.756863, 0.878431, 0.890196, 0.847059)
 
 [node name="IceShardTiny" type="MeshInstance3D"]
-material_override = SubResource("ShaderMaterial_wdpla")
+material_override = SubResource("ShaderMaterial_mk3rw")
 mesh = ExtResource("5_uu00j")

--- a/assets/models/PhosphateChunkApatiteLarge1.tscn
+++ b/assets/models/PhosphateChunkApatiteLarge1.tscn
@@ -14,21 +14,20 @@
 resource_local_to_scene = true
 render_priority = 18
 shader = ExtResource("1_0qsxg")
-shader_parameter/albedo = Color(0.262745, 0.309804, 1, 1)
+shader_parameter/albedo = Color(0.368627, 0.466667, 1, 0.745098)
 shader_parameter/albedoTexture = ExtResource("3_hcl7f")
 shader_parameter/useNormal = false
-shader_parameter/roughness = 0.261
+shader_parameter/roughness = 0.301
 shader_parameter/roughnessTexture = ExtResource("4_7gni5")
 shader_parameter/roughnessTextureChannel = Vector4(1, 0, 0, 0)
 shader_parameter/specular = 0.65
 shader_parameter/metallic = 0.15
-shader_parameter/emission = Color(0.0195242, 0.00734134, 0.53186, 0.956863)
+shader_parameter/emission = Color(0.177802, 0.174531, 0.380285, 1)
 shader_parameter/emissionEnergy = 0.25
 shader_parameter/dissolveTexture = ExtResource("2_w0d41")
 shader_parameter/dissolveValue = 0.0
 shader_parameter/dissolveScale = 1.5
 shader_parameter/outlineWidth = 0.02
-shader_parameter/growColor = Color(0.1617, 0.293498, 0.77, 1)
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_hsbfc"]
 resource_local_to_scene = true

--- a/assets/models/PhosphateChunkApatiteSmall1.tscn
+++ b/assets/models/PhosphateChunkApatiteSmall1.tscn
@@ -10,7 +10,7 @@
 resource_local_to_scene = true
 render_priority = 18
 shader = ExtResource("1_g5rlt")
-shader_parameter/albedo = Color(9.62615e-07, 0.878612, 0.837866, 0.956863)
+shader_parameter/albedo = Color(0, 0.760784, 0.839216, 0.529412)
 shader_parameter/albedoTexture = ExtResource("2_6ymvq")
 shader_parameter/useNormal = false
 shader_parameter/roughness = 0.6
@@ -24,7 +24,6 @@ shader_parameter/dissolveTexture = ExtResource("3_o04en")
 shader_parameter/dissolveValue = 0.0
 shader_parameter/dissolveScale = 1.0
 shader_parameter/outlineWidth = 0.0
-shader_parameter/growColor = Color(0.0823529, 0.541176, 0.705882, 1)
 
 [node name="Apatite" type="MeshInstance3D"]
 material_override = SubResource("ShaderMaterial_6mvut")

--- a/assets/models/PhosphateChunkStruviteLarge.tscn
+++ b/assets/models/PhosphateChunkStruviteLarge.tscn
@@ -10,10 +10,10 @@
 resource_local_to_scene = true
 render_priority = 17
 shader = ExtResource("1_mufvt")
-shader_parameter/albedo = Color(0.91, 0.867533, 0.6552, 0.956863)
+shader_parameter/albedo = Color(0.909804, 0.882353, 0.756863, 0.6)
 shader_parameter/albedoTexture = ExtResource("2_f47t4")
 shader_parameter/useNormal = false
-shader_parameter/roughness = 0.348
+shader_parameter/roughness = 0.228
 shader_parameter/roughnessTexture = ExtResource("4_udyun")
 shader_parameter/roughnessTextureChannel = Vector4(1, 1, 1, 1)
 shader_parameter/specular = 0.75
@@ -24,7 +24,6 @@ shader_parameter/dissolveTexture = ExtResource("2_jdyqm")
 shader_parameter/dissolveValue = 0.0
 shader_parameter/dissolveScale = 1.5
 shader_parameter/outlineWidth = 0.01
-shader_parameter/growColor = Color(0.924418, 0.903825, 0.890985, 0.933333)
 
 [node name="Struvite" type="MeshInstance3D"]
 material_override = SubResource("ShaderMaterial_8u0ks")

--- a/assets/models/PhosphateChunkStruviteSmall1.tscn
+++ b/assets/models/PhosphateChunkStruviteSmall1.tscn
@@ -10,7 +10,7 @@
 resource_local_to_scene = true
 render_priority = 17
 shader = ExtResource("1_m8qe5")
-shader_parameter/albedo = Color(0.91, 0.879667, 0.8372, 0.729412)
+shader_parameter/albedo = Color(0.964706, 0.952941, 0.921569, 0.431373)
 shader_parameter/albedoTexture = ExtResource("2_3udni")
 shader_parameter/useNormal = false
 shader_parameter/roughness = 0.75
@@ -24,7 +24,6 @@ shader_parameter/dissolveTexture = ExtResource("2_7bo67")
 shader_parameter/dissolveValue = 0.0
 shader_parameter/dissolveScale = 1.0
 shader_parameter/outlineWidth = 0.01
-shader_parameter/growColor = Color(0.924418, 0.903825, 0.890985, 0.933333)
 
 [node name="Struvite" type="MeshInstance3D"]
 material_override = SubResource("ShaderMaterial_xyp8a")

--- a/assets/models/PhosphateChunkStruviteSmall2.tscn
+++ b/assets/models/PhosphateChunkStruviteSmall2.tscn
@@ -10,7 +10,7 @@
 resource_local_to_scene = true
 render_priority = 17
 shader = ExtResource("1_6d2xb")
-shader_parameter/albedo = Color(0.91, 0.87997, 0.8281, 0.67451)
+shader_parameter/albedo = Color(0.984314, 0.980392, 0.976471, 0.431373)
 shader_parameter/albedoTexture = ExtResource("2_7djkg")
 shader_parameter/useNormal = false
 shader_parameter/roughness = 0.75
@@ -24,7 +24,6 @@ shader_parameter/dissolveTexture = ExtResource("2_145ad")
 shader_parameter/dissolveValue = 0.0
 shader_parameter/dissolveScale = 1.0
 shader_parameter/outlineWidth = 0.01
-shader_parameter/growColor = Color(0.924418, 0.903825, 0.890985, 0.933333)
 
 [node name="Struvite" type="MeshInstance3D"]
 material_override = SubResource("ShaderMaterial_xjgyo")

--- a/assets/models/easter_eggs/GooglyEyeCellMaterial2.material
+++ b/assets/models/easter_eggs/GooglyEyeCellMaterial2.material
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:65bffc08f5e51450036354aaf73d7172c816098c4e7c0317859b5b32815fea03
-size 1330986

--- a/assets/models/easter_eggs/GooglyEyeCellMaterial4.material
+++ b/assets/models/easter_eggs/GooglyEyeCellMaterial4.material
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:990a5d59c1f5080716cd0def0d000b041dcbd0c3f30e014f63f12aeb6dc44340
-size 1383684

--- a/assets/models/easter_eggs/PhosphateRockLittleBanana.tscn
+++ b/assets/models/easter_eggs/PhosphateRockLittleBanana.tscn
@@ -10,7 +10,7 @@
 resource_local_to_scene = true
 render_priority = 17
 shader = ExtResource("1_nhjnn")
-shader_parameter/albedo = Color(0, 0.580392, 1, 0.87451)
+shader_parameter/albedo = Color(0, 0.580392, 1, 0.588235)
 shader_parameter/albedoTexture = ExtResource("2_j40of")
 shader_parameter/useNormal = false
 shader_parameter/roughness = 0.4
@@ -19,12 +19,11 @@ shader_parameter/roughnessTextureChannel = Vector4(1, 0, 0, 0)
 shader_parameter/specular = 0.83
 shader_parameter/metallic = 0.44
 shader_parameter/emission = Color(0.321569, 0.192157, 0.811765, 1)
-shader_parameter/emissionEnergy = 0.25
+shader_parameter/emissionEnergy = 0.0
 shader_parameter/dissolveTexture = ExtResource("3_qqbc0")
 shader_parameter/dissolveValue = 0.0
 shader_parameter/dissolveScale = 1.1
 shader_parameter/outlineWidth = 0.0
-shader_parameter/growColor = Color(0.1, 0.1, 0.1, 1)
 
 [node name="LittleBanan" type="MeshInstance3D"]
 material_override = SubResource("ShaderMaterial_nih3b")

--- a/assets/textures/Crystal.png
+++ b/assets/textures/Crystal.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:da8f88014f6c6573f6e39bc4db9c8f30208ae521d349843ab7c4a2286321ca2f
-size 641206
+oid sha256:4bdd42975fc1abd4c8564a17d7054577d2a49609d9dd26c7a028b4ad77eb7438
+size 593390

--- a/shaders/Crystal.gdshader
+++ b/shaders/Crystal.gdshader
@@ -1,5 +1,5 @@
 shader_type spatial;
-render_mode blend_add, depth_draw_opaque, cull_disabled, diffuse_lambert_wrap;
+render_mode blend_mix, depth_draw_opaque, cull_back, diffuse_lambert_wrap;
 
 uniform vec4 albedo : source_color = vec4(1.0f, 1.0f, 1.0f, 1.0f);
 uniform sampler2D albedoTexture : source_color, filter_linear_mipmap, repeat_enable;
@@ -21,7 +21,6 @@ uniform float dissolveValue : hint_range(0, 1) = 0.0f;
 uniform float dissolveScale : hint_range(0.5f, 5.0f, 0.1f) = 1.0f;
 
 uniform float outlineWidth : hint_range(0.0f, 0.25f, 0.01f) = 0.0f;
-uniform vec4 growColor : source_color = vec4(0.1f, 0.1f, 0.1f, 1.0f);
 
 void fragment() {
     vec4 albedoUV = texture(albedoTexture, UV);
@@ -30,14 +29,15 @@ void fragment() {
     // Handle dissolve animation
     vec4 dissolveTex = texture(dissolveTexture, (UV * dissolveScale));
 
-    float cutoff = dot(dissolveTex.rgb, vec3(0.3f, 0.3f, 0.3f)) -
-        float(-0.5f + dissolveValue);
+    float cutoff = clamp(dot(dissolveTex.rgb, vec3(0.3f, 0.3f, 0.3f)) -
+        float(dissolveValue) + 0.475f + outlineWidth, 0.0f, 1.0f);
+    float innerCutoff = clamp(dot(dissolveTex.rgb, vec3(0.3f, 0.3f, 0.3f)) -
+        float(dissolveValue) + 0.4f, 0.0f, 1.0f);
 
-    vec3 dissolveOutline = clamp(vec3(round(1.0f - float(cutoff - outlineWidth))) *
-        growColor.rgb, 0.0f, dissolveValue);
+    float dissolveOutline = clamp((round(cutoff) - round(innerCutoff)), 0.0f, dissolveValue);
 
     ALBEDO = final.rgb;
-    ALPHA = round(cutoff) * final.a;
+    ALPHA = final.a * (round(cutoff) - dissolveOutline);
     if (useNormal == true)
     {
         vec4 normalMap = texture(normalTexture, UV);
@@ -50,5 +50,5 @@ void fragment() {
     METALLIC = metallic;
     SPECULAR = specular;
 
-    EMISSION = clamp(((dissolveOutline + emission.rgb) * roughnessUV * emissionEnergy), 0.0f, dissolveValue);
+    EMISSION = emission.rgb * roughnessUV * emissionEnergy;
 }

--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -2163,7 +2163,7 @@
               "IsParticles": true
             }
           ],
-          "Density": 0.00003,
+          "Density": 0.000005,
           "Dissolves": false,
           "Radius": 2,
           "ChunkScale": 1,
@@ -2207,7 +2207,7 @@
               "MissingDefaultShaderSupport": true
             }
           ],
-          "Density": 0.00008,
+          "Density": 0.00009,
           "Dissolves": false,
           "Radius": 2,
           "ChunkScale": 1,
@@ -2237,7 +2237,7 @@
               "MissingDefaultShaderSupport": true
             }
           ],
-          "Density": 0.00003,
+          "Density": 0.00005,
           "Dissolves": false,
           "Radius": 6,
           "ChunkScale": 1,

--- a/src/microbe_stage/systems/DamageSoundSystem.cs
+++ b/src/microbe_stage/systems/DamageSoundSystem.cs
@@ -92,7 +92,7 @@ public sealed class DamageSoundSystem : AEntitySetSystem<float>
                 {
                     // TODO: check the volume here as this was before set to play non-positionally
                     soundEffectPlayer.PlaySoundEffect("res://assets/sounds/soundeffects/microbe-ice-damage.ogg",
-                        0.5f);
+                        0.8f);
                 }
                 else if (damageSource == "radiation")
                 {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Changes the material of ice chunks to use Crystal.gdshader.
Adjusts Crystal.gdshader, removing growColor property.
Adjusts phosphate chunks to shader changes.

Also increases volume of ice damage and removes some unused materials.

**Related Issues**

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
