### PR TITLE
Made entities except the player play sounds 30% quieter

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -291,8 +291,6 @@ public static class Constants
 
     public const float CONTEXTUAL_ONLY_MUSIC_CHANCE = 0.33f;
 
-    public const float MICROBE_MOVEMENT_SOUND_EMIT_COOLDOWN = 1.3f;
-
     // Note that the rotation speed is reversed, i.e. lower values mean faster
     public const float CELL_MAX_ROTATION = 8.0f;
     public const float CELL_MIN_ROTATION = 0.10f;
@@ -427,6 +425,7 @@ public static class Constants
     public const string MICROBE_ENGULFING_MODE_SOUND = "res://assets/sounds/soundeffects/engulfment.ogg";
     public const string MICROBE_BINDING_MODE_SOUND = "res://assets/sounds/soundeffects/binding.ogg";
 
+    public const float MICROBE_MOVEMENT_SOUND_EMIT_COOLDOWN = 1.3f;
     public const float MICROBE_MOVEMENT_SOUND_MAX_VOLUME = 0.4f;
 
     // TODO: should this volume be actually 0?
@@ -439,6 +438,12 @@ public static class Constants
 
     public const float MICROBE_SOUND_MAX_DISTANCE = 300;
     public const float MICROBE_SOUND_MAX_DISTANCE_SQUARED = MICROBE_SOUND_MAX_DISTANCE * MICROBE_SOUND_MAX_DISTANCE;
+
+    /// <summary>
+    ///   Makes sounds played by the non-player cell a bit quieter. This is added because death sounds from other
+    ///   entities can get overwhelming otherwise
+    /// </summary>
+    public const float NON_PLAYER_ENTITY_VOLUME_MULTIPLIER = 0.7f;
 
     public const int MAX_CONCURRENT_SOUNDS = 100;
 

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -497,6 +497,7 @@ public static class SpawnHelpers
             entity.Set(new SoundEffectPlayer
             {
                 AbsoluteMaxDistanceSquared = Constants.MICROBE_SOUND_MAX_DISTANCE_SQUARED,
+                SoundVolumeMultiplier = Constants.NON_PLAYER_ENTITY_VOLUME_MULTIPLIER,
             });
         }
         else


### PR DESCRIPTION
**Brief Description of What This PR Does**

Other entities are quieter so that death sounds and other loud sounds from other cells aren't as loud

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
This gets reports every now and then but I think there wasn't any issue open about this

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
