### PR TITLE
Made turning tutorials checkbox off actually only hide tutorials that have been seen already

### DIFF
--- a/locale/af.po
+++ b/locale/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -4762,6 +4762,13 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Beweeg na die wakker stadium. Besikbaar na jy genoeg brain krag het (tiepe selle met \"axons\")."
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4775,9 +4782,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5069,6 +5073,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Beweeg na die wakker stadium. Besikbaar na jy genoeg brain krag het (tiepe selle met \"axons\")."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5544,6 +5552,9 @@ msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
 msgid "TUTORIAL"
+msgstr ""
+
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
 msgstr ""
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/ar.po
+++ b/locale/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2023-03-13 09:01+0000\n"
 "Last-Translator: Xradiation <tamimzain@hotmail.com>\n"
 "Language-Team: Arabic <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ar/>\n"
@@ -4898,6 +4898,13 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "استمر إلا مرحلة الاستيقاظ. يصبح متاحًا بمجرد أن تكون قوة العقل كافية (أنسجة مع محاور)."
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4911,9 +4918,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5207,6 +5211,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "استمر إلا مرحلة الاستيقاظ. يصبح متاحًا بمجرد أن تكون قوة العقل كافية (أنسجة مع محاور)."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5697,6 +5705,9 @@ msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
 msgid "TUTORIAL"
+msgstr ""
+
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
 msgstr ""
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/be.po
+++ b/locale/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2023-09-21 09:24+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Belarusian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/be/>\n"
@@ -4758,6 +4758,13 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Перамясціцца на стадыю Абуджэння. Дасягома толькі калі ў вас ёсць дастатковая колькасць развітасці мозга (Размясціце аксон у які небудзь тып клеткі)."
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4771,9 +4778,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5065,6 +5069,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Перамясціцца на стадыю Абуджэння. Дасягома толькі калі ў вас ёсць дастатковая колькасць развітасці мозга (Размясціце аксон у які небудзь тып клеткі)."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5540,6 +5548,9 @@ msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
 msgid "TUTORIAL"
+msgstr ""
+
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
 msgstr ""
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/bg.po
+++ b/locale/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-07 10:46+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/bg/>\n"
@@ -5440,6 +5440,14 @@ msgid "SHIFT"
 msgstr "Клавиш „Shift“"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Показване на упътването"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Експортиране на данните за всички светове като стойности, разделени с запетая в .csv формат"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Подлежи на уточняване"
 
@@ -5456,9 +5464,6 @@ msgstr "Бележки към изданието"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "{0} — {1}"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Показване на упътването"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Упътване (в текущата игра)"
@@ -5772,6 +5777,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Влезли сте като: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Отваряне на страницата ни в „Patreon“"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6309,6 +6318,10 @@ msgstr "Трябва да направите няколко снимки!"
 
 msgid "TUTORIAL"
 msgstr "Упътване"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(ВНИМАНИЕ: понижава ефективността на фотосинтезата)"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/bn.po
+++ b/locale/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2023-09-10 12:18+0000\n"
 "Last-Translator: Mahbeer Alam Sarker <mahbeeralamsarker@gmail.com>\n"
 "Language-Team: Bengali <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/bn/>\n"
@@ -4801,6 +4801,13 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "বর্তমান থ্রেডসমুূহ:"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4814,9 +4821,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5108,6 +5112,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "একটি নতুন কী বাইন্ডিং যোগ করুন"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5587,6 +5595,10 @@ msgstr ""
 
 msgid "TUTORIAL"
 msgstr ""
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(এআই প্রজাতির পরিবর্তনের গতি)"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ca/>\n"
@@ -5476,6 +5476,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Mostrar tutorials"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Han passat: {0:#,#} anys"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "El flagel (plural: flagels) és uns farcell de proteïnes i fibres, com un petit tentacle que sobresurt de la membrana cel·lular. Mitjançant un moviment ondulatori, permet propulsar la cèl·lula cap endavant a gran velocitat, mentre consumeix ATP. La posició dels flagels determina la direcció en la qual produeix l'impuls per moure la cèl·lula. La direcció de l'impuls és oposada a la direcció cap a la qual el flagel està apuntant. Per exemple, un flagel col·locat a l'esquerra del centre de la cèl·lula produïra impuls quan aquesta es mogui cap a la dreta."
 
@@ -5493,9 +5501,6 @@ msgstr "{0} {1}"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "{0} {1}"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Mostrar tutorials"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Mostrar tutorials (a la partida actual)"
@@ -5817,6 +5822,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Registrat com a: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Pausar el joc"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6354,6 +6363,10 @@ msgstr "Intenta fer algunes captures de pantalla!"
 
 msgid "TUTORIAL"
 msgstr "Tutorial"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(comença cada generació amb un núvol de glucosa gratuït proper)"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-07 10:46+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/cs/>\n"
@@ -5537,6 +5537,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Zobrazit tutoriál"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Připoj se na náš komunitní Discord server"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Bičík (množné číslo bičíky) je svazek proteinových vláken, který vychází z buněčné membrány a může se pomocí ATP vlnit a pohánět buňku v určitém směru. Pozice bičíku určuje směr, ve kterém je rychlost buňky ovlivněna. Například bičík umístěný na levé straně buňky zvýší její rychlost pohybu doprava."
 
@@ -5556,9 +5564,6 @@ msgstr "{0} {1}"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "{0} {1}"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Zobrazit tutoriál"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Zobrazit tutoriály (v aktuální hře)"
@@ -5879,6 +5884,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Přihlášen jako: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Navštivte náš Patreon"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6416,6 +6425,10 @@ msgstr "Zkuste udělat snímek obrazovky!"
 
 msgid "TUTORIAL"
 msgstr "Tutoriál"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(POZOR: fotosyntéza se stává mnohem méně životaschopnou)"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/da.po
+++ b/locale/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2024-06-09 13:22+0000\n"
 "Last-Translator: Magnus Norling Svane <magn665e@icloud.com>\n"
 "Language-Team: Danish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/da/>\n"
@@ -4738,6 +4738,13 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Tag til opvågningsstadiet. Tilgængelig, når du har nok hjernekraft (vævstype med axoner)."
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4751,9 +4758,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5045,6 +5049,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Tag til opvågningsstadiet. Tilgængelig, når du har nok hjernekraft (vævstype med axoner)."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5519,6 +5527,9 @@ msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
 msgid "TUTORIAL"
+msgstr ""
+
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
 msgstr ""
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/de.po
+++ b/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-12 14:39+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: German <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/de/>\n"
@@ -5151,6 +5151,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Einführung anzeigen"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Exportiere die Daten aller Welten im CSV-Format (durch Kommas getrennte Werte)"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Schadensauswirkung anzeigen"
 
@@ -5165,9 +5173,6 @@ msgstr "Neue Patchnotizen automatisch anzeigen"
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Patchnotizen neuer Thrive-Versionen automatisch im Hauptmenü anzeigen"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Einführung anzeigen"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Tutorials anzeigen (im aktuellen Spiel)"
@@ -5473,6 +5478,10 @@ msgstr "Sekunden für"
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Angemeldet als: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Sprint-Modus aktivieren. Im Sprint-Modus bewegen sich Zellen schneller, aber verbrauchen mehr ATP. Je länger die Belastung durch den Sprint dauert, desto mehr ATP wird verbraucht."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr "Belastungsbalken Sichtbarkeit"
@@ -5996,6 +6005,10 @@ msgstr "Versuche ein paar Screenshots zu machen!"
 
 msgid "TUTORIAL"
 msgstr "Anleitung"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(WARNUNG: Photosynthese wird wesentlich weniger effizient)"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/el.po
+++ b/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2022-03-31 05:02+0000\n"
 "Last-Translator: Apostolos Paschidis <tolissius@gmail.com>\n"
 "Language-Team: Greek <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/el/>\n"
@@ -4782,6 +4782,12 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr ""
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4795,9 +4801,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5088,6 +5091,9 @@ msgid "STORAGE_STATISTICS_SECONDS_OF_COMPOUND"
 msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
+msgstr ""
+
+msgid "STRAIN_BAR_TOOLTIP"
 msgstr ""
 
 msgid "STRAIN_BAR_VISIBILITY"
@@ -5562,6 +5568,9 @@ msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
 msgid "TUTORIAL"
+msgstr ""
+
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
 msgstr ""
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/en.po
+++ b/locale/en.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
-"PO-Revision-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
+"PO-Revision-Date: 2025-03-19 10:19+0200\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: English <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/en/>\n"
 "Language: en\n"
@@ -5078,6 +5078,12 @@ msgstr "SFX volume"
 msgid "SHIFT"
 msgstr "Shift"
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Show all tutorials"
+
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Select between always showing all tutorials or only showing tutorials that have not been completed yet in any playthrough"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Show on-screen damage effect"
 
@@ -5092,9 +5098,6 @@ msgstr "Show new patch notes automatically"
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Show patch notes of new Thrive releases automatically in the main menu"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Show tutorials"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Show tutorials (in current game)"
@@ -5395,6 +5398,11 @@ msgstr "seconds of"
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Logged in as: {0}"
+
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr ""
+"This bar shows the current sprinting strain. The higher the bar goes the more ATP it costs to continue to sprint.\n"
+"Recovering from the strain also costs extra ATP until the bar is fully empty."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr "Strain bar visibility"
@@ -5890,6 +5898,9 @@ msgstr "Try taking some screenshots!"
 
 msgid "TUTORIAL"
 msgstr "Tutorial"
+
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "Only tutorials that have not been seen yet in any playthrough will be shown. Tutorials can be completely disabled from the options menu, but it is HIGHLY RECOMMENDED to leave at least new tutorials enabled."
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/eo.po
+++ b/locale/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/eo/>\n"
@@ -5548,6 +5548,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Montru lernilojn"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Aldonunovan funkcion por klavo"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "La flagelo estas vip-simila fasko de proteinaj fibroj etendiĝantaj de la membrano de la ĉelo, kiu povas uzi ATP por ondigi kaj peli la ĉelon en direkto."
 
@@ -5565,9 +5573,6 @@ msgstr "Kaverno"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Kaverno"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Montru lernilojn"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Montru lernilojn (en ĉi tiu ludo)"
@@ -5920,6 +5925,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Aldonunovan funkcion por klavo"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6465,6 +6474,10 @@ msgstr "Prenu ekrankopion"
 #, fuzzy
 msgid "TUTORIAL"
 msgstr "Lernilo"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "Piku aliajn ĉelojn per ĉi tio."
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-12 14:39+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Spanish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/es/>\n"
@@ -5274,6 +5274,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Mostrar tutoriales"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Exportar los datos de todos los mundos en formato de valores separados por comas (csv)"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Los flagelos son grupos de fibras de proteínas en forma de látigo que se extienden desde la membrana de la célula. Usan ATP para propulsar a la célula en la dirección contraria a la que apuntan, efecto similar a la cola de un pez. Así pues, un flagelo del lado izquierdo, dará un impulso hacia la derecha."
 
@@ -5293,9 +5301,6 @@ msgstr "{0} {1}"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "{0} {1}"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Mostrar tutoriales"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Mostrar tutoriales (en la partida actual)"
@@ -5614,6 +5619,10 @@ msgstr "Segundos de"
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Conectado como: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Visita nuestro Patreon"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr "Visibilidad de la barra de fatiga"
@@ -6177,6 +6186,10 @@ msgstr "Intenta tomar algunas capturas de pantalla!"
 
 msgid "TUTORIAL"
 msgstr "Tutorial"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(ADVERTENCIA: la fotosíntesis se vuelve mucho menos viable)"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/es_AR.po
+++ b/locale/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-01-21 12:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Spanish (Argentina) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/es_AR/>\n"
@@ -5236,6 +5236,13 @@ msgstr "Volumen de efectos"
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "\" {0} \" - {1}"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -5251,9 +5258,6 @@ msgstr ""
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "\" {0} \" - {1}"
-
-msgid "SHOW_TUTORIALS"
-msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
@@ -5574,6 +5578,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Logeado como: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Disparar toxina"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6107,6 +6115,10 @@ msgstr ""
 
 msgid "TUTORIAL"
 msgstr ""
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "población:"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/et.po
+++ b/locale/et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Estonian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/et/>\n"
@@ -5618,6 +5618,14 @@ msgid "SHIFT"
 msgstr "SHIFT"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Näita õpetusi"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Möödunud aeg: {0:#,#} aastat"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Lipu (mitmuses: flagella) on piitsataoline valgukiudude kimp, mis ulatub välja rakumembraanist, mis kasutab ATP-d raku lainetamiseks ja liikumiseks teatud suunas. Lipu asend määrab suuna, milles see raku liikumiseks tõukejõu annab. Tõukejõu suund on vastupidine suunale, kuhu lipp on suunatud, näiteks raku vasakule küljele asetatud lipp annab paremale liikumisel tõukejõu."
 
@@ -5635,9 +5643,6 @@ msgstr "{0} {1}"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "{0} {1}"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Näita õpetusi"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Näita õpetusi (praeguses mängus)"
@@ -5968,6 +5973,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Sisse logitud kui: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Peata mäng"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6519,6 +6528,13 @@ msgstr "Proovige teha ekraanipilte!"
 
 msgid "TUTORIAL"
 msgstr "Õpetus"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr ""
+"Keskendunud mikroobid otsivad tükke või saaki suuremate vahemaade tagant\n"
+"ja võib olla tükkide osas palju ambitsioonikam.\n"
+"Reageerivad mikroobid lülituvad varem uutele sihtmärkidele."
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/fi.po
+++ b/locale/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-06 07:27+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Finnish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/fi/>\n"
@@ -5603,6 +5603,14 @@ msgstr "Efektien voimakkuus"
 msgid "SHIFT"
 msgstr "Vaihto"
 
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Näytä tutoriaalit"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Lisää uusi syöte"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -5620,10 +5628,6 @@ msgstr "{0} {1}"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "{0} {1}"
-
-#, fuzzy
-msgid "SHOW_TUTORIALS"
-msgstr "Näytä tutoriaalit"
 
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5961,6 +5965,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Sisäänkirjauduttu käyttäjänä: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Laita peli tauolle"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6510,6 +6518,13 @@ msgstr "Kokeile ottaa ruudunkaappauksia!"
 #, fuzzy
 msgid "TUTORIAL"
 msgstr "Tutoriaali"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr ""
+"Keskittyneet mikrobit etsivät yhdisteitä, kappaleita ja saaliita pidemmän matkan päästä\n"
+"ja voivat olla kunnianhimoisempia löytyvien palasten keruussa.\n"
+"Responssiiviset mikrobit vaihtavat kohdetta nopeammin, jos ei niitä heti saa kiinni."
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-12 14:39+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: French <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/fr/>\n"
@@ -5300,6 +5300,14 @@ msgid "SHIFT"
 msgstr "Maj"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Montrer les tutoriels"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Exporter toutes les donnée des mondes en format Comma-Separated Values (csv)"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Chaque [b]flagelle[/b] exerce une poussée en sens inverse de son orientation. Il fournit également une petite poussée dans les directions proches du sens opposé (plus précisément, les directions pour lesquelles la composante du vecteur opposé est positive). Lorsqu'un [b]flagelle[/b] est actif, il consomme de l'[/thrive:compound type=\"atp\"][/thrive:compound]."
 
@@ -5317,9 +5325,6 @@ msgstr "Afficher automatiquement les nouvelles notes de correctif"
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Afficher automatiquement les notes de correctif des nouvelles versions de Thrive dans le menu principal"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Montrer les tutoriels"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Afficher les tutoriels (dans la partie en cours)"
@@ -5627,6 +5632,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Connecté sous le nom de : {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Visitez notre page Patreon"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6159,6 +6168,10 @@ msgstr "Essayez de prendre une capture d'écran !"
 
 msgid "TUTORIAL"
 msgstr "Tutoriel"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(certains organites auront des conditions de déverrouillage requises pour les placer)"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/frm.po
+++ b/locale/frm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -4706,6 +4706,12 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr ""
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4719,9 +4725,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5010,6 +5013,9 @@ msgid "STORAGE_STATISTICS_SECONDS_OF_COMPOUND"
 msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
+msgstr ""
+
+msgid "STRAIN_BAR_TOOLTIP"
 msgstr ""
 
 msgid "STRAIN_BAR_VISIBILITY"
@@ -5481,6 +5487,9 @@ msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
 msgid "TUTORIAL"
+msgstr ""
+
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
 msgstr ""
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/gsw.po
+++ b/locale/gsw.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-01 13:57+0000\n"
 "Last-Translator: Argakyan <andrinmueller@hotmail.ch>\n"
 "Language-Team: Alemannic <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/gsw/>\n"
@@ -4799,6 +4799,12 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr ""
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4812,9 +4818,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5104,6 +5107,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Fortschritt zum Erwachene-Stadium. Erscht mögli wenn uusriichend Ghirnkapazität z'Verfüegig staht (Hirngwäb mit Axone) ."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5575,6 +5582,9 @@ msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
 msgid "TUTORIAL"
+msgstr ""
+
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
 msgstr ""
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/he.po
+++ b/locale/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/he/>\n"
@@ -5442,6 +5442,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "הצג מדריכים"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "היצטרפו לשרת הדיסטורט הקהילתי שלנו"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "השוטון (ברבים: שוטונים) הוא צרור סיבי חלבון דמוי שוט המשתרע מקרום התא אשר משתמש ב- ATP כדי לגלול ולהניע את התא לכיוון מסוים. מקומו של השוטון קובע את כיוונו שממנו מספק דחף לתנועת התא. כיוון הדחף מנוגד לכיוון שהשוטון פונה, למשל שוטון שמונח בכיוון השמאל של התא יספק דחף לימין."
 
@@ -5459,9 +5467,6 @@ msgstr "{0} {1}"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "{0} {1}"
-
-msgid "SHOW_TUTORIALS"
-msgstr "הצג מדריכים"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "הצג מדריכים (בשמירה נוכחית)"
@@ -5778,6 +5783,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "התחבר כ:{0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "ראו את דף הפטריון שלנו"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6315,6 +6324,10 @@ msgstr "נסה לצלם כמה צילומי מסך!"
 
 msgid "TUTORIAL"
 msgstr "מדריך"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(מתחיל עם ענן גלוקוז חופשי קרוב בכל דור)"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/hr.po
+++ b/locale/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-01-21 12:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Croatian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/hr/>\n"
@@ -4988,6 +4988,13 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Kreni u fazu buđenja. Moguće kada imaš dovoljno moždane snage (vrsta tkiva s aksionima)"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -5001,9 +5008,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5297,6 +5301,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Kreni u fazu buđenja. Moguće kada imaš dovoljno moždane snage (vrsta tkiva s aksionima)"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5789,6 +5797,14 @@ msgstr ""
 
 msgid "TUTORIAL"
 msgstr ""
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr ""
+"Agresivni mikrobi će loviti plijen na većim udaljenostima\n"
+"i veća je šansa da će se braniti kada su napadnuti.\n"
+"Mirni mikrobi neće se baviti s drugima na većim udaljenostima\n"
+"i manja je šansa da će koristiti toksine protiv predatora."
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hungarian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/hu/>\n"
@@ -5536,6 +5536,14 @@ msgstr "SFX hangerő"
 msgid "SHIFT"
 msgstr "Shift"
 
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Tutorial-ok mutatása"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Segítség"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -5553,10 +5561,6 @@ msgstr "{0} {1}"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "{0} {1}"
-
-#, fuzzy
-msgid "SHOW_TUTORIALS"
-msgstr "Tutorial-ok mutatása"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Tutoriálok mutatása (jelenlegi játékban)"
@@ -5885,6 +5889,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Belépve mint: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Játék szüneteltetése"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6416,6 +6424,10 @@ msgstr "Próbálj pár képernyőképet készíteni!"
 
 msgid "TUTORIAL"
 msgstr "Tutorial"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(a szerkesztő elhagyása után egy közeli glükózfelhő mellett lesz a sejted)"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/id.po
+++ b/locale/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/id/>\n"
@@ -5526,6 +5526,14 @@ msgid "SHIFT"
 msgstr ""
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Tampilkan tutorial"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Tambah keybind baru"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Flagela adalah bundelan serat protein yang berbentuk seperti cambuk memanjang dari membran sel yang menggunakan ATP untuk berputar dan mendorong sel ke suatu arah. Posisi flagela menentukan arah mana flagela tersebut memberi daya dorong untuk pergerakan sel. Arah dorongan berlawanan dengan arah flagela tersebut menuju, contohnya sebuah flagela yang di letakkan pada sisi kiri sebuah sel menyediakan daya dorong ketika bergerak ke kanan."
 
@@ -5543,10 +5551,6 @@ msgstr "Gua"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Gua"
-
-#, fuzzy
-msgid "SHOW_TUTORIALS"
-msgstr "Tampilkan tutorial"
 
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5889,6 +5893,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Masuk sebagai {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Tambah keybind baru"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6422,6 +6430,10 @@ msgstr "Ambil tangkapan layar"
 #, fuzzy
 msgid "TUTORIAL"
 msgstr "Tutorial"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "Tusuk sel lain dengan ini."
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/it.po
+++ b/locale/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Italian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/it/>\n"
@@ -5435,6 +5435,14 @@ msgid "SHIFT"
 msgstr "Maiusc [Shift]"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Mostra i tutorial"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Tempo trascorso: {0:#,#} anni"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Il flagello è un fascio di proteine simile a una frusta che si estende a partire dalla membrana cellulare. Consuma [thrive:compound type=\"atp\"][/thrive:compound] per ondulare, fornendo così movimento alla cellula. La direzione di tale movimento è opposta alla direzione in cui il flagello punta: per esempio, un flagello posizionato sul lato sinistro della cellula fornisce spinta nel movimento verso destra."
 
@@ -5452,9 +5460,6 @@ msgstr "{1} {0}o/a"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "{1} {0}o/a"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Mostra i tutorial"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Mostra i tutorial (nella partita attuale)"
@@ -5774,6 +5779,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Hai effettuato l'accesso come: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Metti in pausa il gioco"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6314,6 +6323,10 @@ msgstr "Prova a scattare qualche screenshot!"
 
 msgid "TUTORIAL"
 msgstr "Tutorial"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(comincia ogni generazione vicino a una nuvola di glucosio)"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-23 16:13+0000\n"
 "Last-Translator: grassgrass <r.u.tohohogisu@gmail.com>\n"
 "Language-Team: Japanese <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ja/>\n"
@@ -4716,6 +4716,12 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr ""
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4729,9 +4735,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5020,6 +5023,9 @@ msgid "STORAGE_STATISTICS_SECONDS_OF_COMPOUND"
 msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
+msgstr ""
+
+msgid "STRAIN_BAR_TOOLTIP"
 msgstr ""
 
 msgid "STRAIN_BAR_VISIBILITY"
@@ -5491,6 +5497,9 @@ msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
 msgid "TUTORIAL"
+msgstr ""
+
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
 msgstr ""
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/ka.po
+++ b/locale/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-12 14:39+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Georgian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ka/>\n"
@@ -4840,6 +4840,14 @@ msgstr "SFX ხმა"
 msgid "SHIFT"
 msgstr "Shift"
 
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "სახელმძღვანელოების ჩვენება"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "ყველა სამყაროს მონაცემების გატანა მძიმით გამოყოფილ (csv) ფორმატში"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "დაზიანების ეფექტის ჩვენება ეკრანზე"
 
@@ -4854,9 +4862,6 @@ msgstr "ახალი პაჩის შენიშვნების ავ
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "ახალი Thrive-ის რელიზების პაჩის შენიშვნების ავტომატური ჩვენება მთავარ მენიუში"
-
-msgid "SHOW_TUTORIALS"
-msgstr "სახელმძღვანელოების ჩვენება"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "სახელმძღვანელოების ჩვენება (მიმდინარე თამაშში)"
@@ -5155,6 +5160,10 @@ msgstr "წამი"
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "შესული ბრძანდებით, როგორც: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "სირბილის რეჟიმის გადართვა. სირბილის რეჟიმისას უჯრედები უფრო სწრაფად მოძრაობენ, მაგრამ უფრო მეტ ატფ-ს ხარჯავენ და სახეობის აგება კიდევ უფრო მეტ ატფ-ს."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr "სახეობის პანელის ხილვადობა"
@@ -5637,6 +5646,10 @@ msgstr "სცადეთ, ეკრანის ანაბეჭდები
 
 msgid "TUTORIAL"
 msgstr "სახელმძღვანელო"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(ზოგიერთი ორგანელა განბლოკავს პირობებს, რომელიც მათ დასასმელადაა საჭირო)"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ko/>\n"
@@ -5514,6 +5514,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "튜토리얼 보기"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "새로운 키 배치 추가"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "편모는 ATP를 사용하여 세포를 앞으로 나아가게 하는 세포막에서 이어지는 채찍 모양의 단백질 섬유 다발입니다."
 
@@ -5531,10 +5539,6 @@ msgstr "동굴"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "동굴"
-
-#, fuzzy
-msgid "SHOW_TUTORIALS"
-msgstr "튜토리얼 보기"
 
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5871,6 +5875,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "새로운 키 배치 추가"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6398,6 +6406,10 @@ msgstr "스크린샷 촬영"
 #, fuzzy
 msgid "TUTORIAL"
 msgstr "튜토리얼"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "이것으로 다른 세포를 찌르세요."
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/la.po
+++ b/locale/la.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-01-21 12:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Latin <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/la/>\n"
@@ -4918,6 +4918,15 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr ""
+"Non automatice potest deprehendi si res nominata \"hyperthreading\" habilitata aut non.\n"
+"Hoc usitata fila adficit quia fila rei nominatae \"hyperthreading\" non ut celer ut rei verae nominatae \"CPU\" nuclei sunt."
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4931,9 +4940,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5228,6 +5234,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Addere novum botonem relegationis"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5713,6 +5723,10 @@ msgstr ""
 
 msgid "TUTORIAL"
 msgstr ""
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(velocitas ad quam AI species mutantes)"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/lb_LU.po
+++ b/locale/lb_LU.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-01-21 12:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Luxembourgish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/lb/>\n"
@@ -4979,6 +4979,13 @@ msgstr "SFX Lautstäerkt"
 msgid "SHIFT"
 msgstr "Shift"
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Weis d'Tutorialen (an dësem Spill)"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4992,9 +4999,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5286,6 +5290,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Op d' 'Erwaachen Stuf' weidergoen. Accessibel wann's de genuch Gehier hues (eng Zort Geweebe mat Axonen)."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5782,6 +5790,10 @@ msgstr ""
 
 msgid "TUTORIAL"
 msgstr ""
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(Geschwindegkeet mat der dei kënschtlech Intelligenz hier Arten mutéieren)"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-01-21 12:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Lithuanian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/lt/>\n"
@@ -5122,6 +5122,14 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Pamoka"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Reikšmė, naudojama generuojant pasaulį, kuri turi būti teigiamas sveikas skaičius"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -5136,9 +5144,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5441,6 +5446,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Prisijungęs kaip: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Baigti žaidimą"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5944,6 +5953,10 @@ msgstr ""
 
 msgid "TUTORIAL"
 msgstr "Pamoka"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "Elemento aprašymas:"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/lv.po
+++ b/locale/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2024-10-17 07:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Latvian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/lv/>\n"
@@ -5439,6 +5439,14 @@ msgstr "SFX skaļums"
 msgid "SHIFT"
 msgstr "Shift"
 
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Rādīt tutoriālus"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -5456,10 +5464,6 @@ msgstr "Ala"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Ala"
-
-#, fuzzy
-msgid "SHOW_TUTORIALS"
-msgstr "Rādīt tutoriālus"
 
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5784,6 +5788,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Apskatiet detalizētu informāciju aiz pareģošanas"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6327,6 +6335,13 @@ msgstr ""
 #, fuzzy
 msgid "TUTORIAL"
 msgstr "Tutoriāls"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr ""
+"Koncentrēti mikrobi meklēs gabalus vai upurus tālas distances\n"
+"un visticamāk būs ambiciozāki par gabaliem.\n"
+"Atsaucīgi mikrobi ātrāk pāries uz jauniem mērķiem."
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -557,7 +557,7 @@ msgstr ""
 msgid "BECOME_MULTICELLULAR"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:115
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:134
 msgid "BEGIN_THRIVING"
 msgstr ""
 
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "CONTINUE_AS_SPECIES"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:470
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:489
 msgid "CONTINUE_THRIVING"
 msgstr ""
 
@@ -4870,43 +4870,43 @@ msgstr ""
 msgid "MICROBE_STAGE"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:254
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:273
 msgid "MICROBE_STAGE_BECOME_MULTICELLULAR_TEXT"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:208
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:227
 msgid "MICROBE_STAGE_COLLECT_TEXT"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:137
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:156
 msgid "MICROBE_STAGE_CONTROL_TEXT"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:138
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:157
 msgid "MICROBE_STAGE_CONTROL_TEXT_CONTROLLER"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:224
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:243
 msgid "MICROBE_STAGE_DAY_NIGHT_TEXT"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:269
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:288
 msgid "MICROBE_STAGE_HEALTH_TEXT"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:59
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:62
 msgid "MICROBE_STAGE_INITIAL"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.cs:541
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.cs:563
 msgid "MICROBE_STAGE_INITIAL_PANSPERMIA"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.cs:540
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.cs:562
 msgid "MICROBE_STAGE_INITIAL_POND"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:240
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:259
 msgid "MICROBE_STAGE_ORGANELLE_DIVISION"
 msgstr ""
 
@@ -7080,6 +7080,14 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:118
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:115
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr ""
+
 #: ../src/general/OptionsMenu.tscn:661
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
@@ -7098,10 +7106,6 @@ msgstr ""
 
 #: ../src/general/OptionsMenu.tscn:1851
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:102
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 #: ../src/general/OptionsMenu.tscn:1790
@@ -7523,8 +7527,13 @@ msgstr ""
 msgid "STORAGE_STATISTICS_SECONDS_OF_COMPOUND"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:679
+#: ../src/general/MainMenu.cs:684
 msgid "STORE_LOGGED_IN_AS"
+msgstr ""
+
+#: ../src/macroscopic_stage/MacroscopicHUD.tscn:607
+#: ../src/microbe_stage/MicrobeHUD.tscn:781
+msgid "STRAIN_BAR_TOOLTIP"
 msgstr ""
 
 #: ../src/general/OptionsMenu.tscn:680
@@ -7748,7 +7757,7 @@ msgstr ""
 msgid "TESTING_TEAM"
 msgstr ""
 
-#: ../src/general/MainMenu.cs:293 ../src/general/MainMenu.tscn:941
+#: ../src/general/MainMenu.cs:294 ../src/general/MainMenu.tscn:941
 msgid "THANKS_FOR_BUYING_THRIVE_2"
 msgstr ""
 
@@ -8206,9 +8215,13 @@ msgstr ""
 #: ../src/tutorial/microbe_editor/MicrobeEditorTutorialGUI.tscn:378
 #: ../src/tutorial/microbe_editor/MicrobeEditorTutorialGUI.tscn:423
 #: ../src/tutorial/microbe_editor/MicrobeEditorTutorialGUI.tscn:474
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:62
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:347
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:65
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:366
 msgid "TUTORIAL"
+msgstr ""
+
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:101
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
 msgstr ""
 
 #: ../src/tutorial/microbe_editor/MicrobeEditorTutorialGUI.tscn:473
@@ -8271,43 +8284,43 @@ msgstr ""
 msgid "TUTORIAL_MICROBE_EDITOR_TOLERANCES_TAB"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:309
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:328
 msgid "TUTORIAL_MICROBE_STAGE_EDITOR_BUTTON_TUTORIAL"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:422
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:441
 msgid "TUTORIAL_MICROBE_STAGE_ENGULFED_TEXT"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:390
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:409
 msgid "TUTORIAL_MICROBE_STAGE_ENGULFMENT_FULL_TEXT"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:406
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:425
 msgid "TUTORIAL_MICROBE_STAGE_ENGULFMENT_TEXT"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:344
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:363
 msgid "TUTORIAL_MICROBE_STAGE_HELP_MENU_AND_ZOOM"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:439
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:458
 msgid "TUTORIAL_MICROBE_STAGE_LEAVE_COLONY_TEXT"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:285
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:304
 msgid "TUTORIAL_MICROBE_STAGE_REPRODUCE_TEXT"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:325
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:344
 msgid "TUTORIAL_MICROBE_STAGE_UNBIND_TEXT"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:451
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:470
 msgid "TUTORIAL_MULTICELLULAR_STAGE_WELCOME"
 msgstr ""
 
-#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:374
+#: ../src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn:393
 msgid "TUTORIAL_VIEW_NOW"
 msgstr ""
 

--- a/locale/mk.po
+++ b/locale/mk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2023-09-15 06:55+0000\n"
 "Last-Translator: Kristijan Miracevski <mircevskihristijan30@gmail.com>\n"
 "Language-Team: Macedonian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/mk/>\n"
@@ -4846,6 +4846,13 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Тековни нишки:"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4859,9 +4866,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5153,6 +5157,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Додадете ново врзување на клучот"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5630,6 +5638,9 @@ msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
 msgid "TUTORIAL"
+msgstr ""
+
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
 msgstr ""
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/nb_NO.po
+++ b/locale/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-01-21 12:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/nb_NO/>\n"
@@ -4942,6 +4942,15 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr ""
+"Det kan ikke oppdages automatisk om hyperthreading er aktivert eller ikke.\n"
+"Dette påvirker standard antall tråder ettersom hyperthreading-tråder ikke er like raske som ekte CPU-kjerner."
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4955,9 +4964,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5252,6 +5258,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Legg til en ny nøkkelbinding"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5737,6 +5747,10 @@ msgstr ""
 
 msgid "TUTORIAL"
 msgstr ""
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(hastighet som AI muterer med)"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-12 14:39+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Dutch <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/nl/>\n"
@@ -5302,6 +5302,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Toon instructies"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Exporteer alle data van deze wereld naar een komma-gescheiden waarden (csv) formaat"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Het flagel (meervoud: flagellen) is een zweepachtige bundel van eiwitdraadjes die uit het celmembraan komen. Een flagel gebruikt [thrive:compound type=\"atp\"][/thrive:compound] om te golven en de cel een richting in te duwen. De positie van het flagel bepaalt de richting waar het de cel heen duwt. De richting van de beweging is tegenover de richting waar het flagel heen wijst. Als de flagel bijvoorbeeld aan de linkerkant van de cel wordt geplaatst, dan duwt het de cel richting rechts."
 
@@ -5319,9 +5327,6 @@ msgstr "Toon nieuwe patchnotities automatisch"
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Toon patchnotities van nieuwe Thrive uitgaven automatisch in het hoofdmenu"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Toon instructies"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Toon instructies (in huidige spel)"
@@ -5631,6 +5636,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Ingelogd als: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Bezoek onze Patreonpagina"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6165,6 +6174,10 @@ msgstr "Maak een screenshot!"
 
 msgid "TUTORIAL"
 msgstr "Instructie"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(WAARSCHUWING: fotosynthese wordt veel minder levensvatbaar)"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/nl_BE.po
+++ b/locale/nl_BE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Dutch (Belgium) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/nl_BE/>\n"
@@ -5519,6 +5519,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Toon tutorials"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Voeg een nieuwe sneltoets toe"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Het flagellum (meervoud: flagella) is een zweepachtige bundel van proteïne vezels, dat vasthangt aan het celmembraan, die ATP gebruikt om golven te vormen en zo de cel voort te stuwen in een bepaalde richting. De positie van het flagellum bepaalt de richting waarin het stuwkracht levert voor de cel. De stuwrichting is tegengesteld aan de richting waarin de flagellum wijst, bijvoorbeeld een flagellum die aan de linkerkant van een cel is geplaatst, geeft stuwkracht wanneer hij naar rechts beweegt."
 
@@ -5536,10 +5544,6 @@ msgstr "Grot"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Grot"
-
-#, fuzzy
-msgid "SHOW_TUTORIALS"
-msgstr "Toon tutorials"
 
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5864,6 +5868,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Ingelogd als : {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Pauzeer het spel"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6408,6 +6416,13 @@ msgstr "Probeer wat schermopnamen te nemen!"
 #, fuzzy
 msgid "TUTORIAL"
 msgstr "Tutorial"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr ""
+"Gefocuste microben zullen over grotere afstanden naar brokken of prooien zoeken\n"
+"en misschien veel ambitieuzer over brokken zijn.\n"
+"Responsieve microben zullen sneller overschakelen naar nieuwe doelen."
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-12 14:39+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/pl/>\n"
@@ -5299,6 +5299,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Pokazuj samouczki"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Pokazuj samouczki"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Wić to biczo-podobny zbiór białek wysunięty z błony komórkowej, który zużywa ATP do obracania się i poruszania komórki w danym kierunku. Pozycja wici determinuje kierunek w którym napędza komórkę. Kierunek siły napędowej jest przeciwny do strony po której wić jest umiejscowiona, na przykład wić umieszczona po lewej napędza komórkę w prawo."
 
@@ -5316,9 +5324,6 @@ msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr ""
-
-msgid "SHOW_TUTORIALS"
-msgstr "Pokazuj samouczki"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Pokazuj samouczki (w aktualnej rozgrywce)"
@@ -5635,6 +5640,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Zalogowano jako: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Odwiedź naszego Patreona"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6161,6 +6170,10 @@ msgstr "Spróbuj zrobić kilka zrzutów ekranu!"
 
 msgid "TUTORIAL"
 msgstr "Samouczek"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(Niektóre organelle będą mieć warunki odblokowania wymagane by je postawić)"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-12 14:39+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/pt_BR/>\n"
@@ -5116,6 +5116,14 @@ msgstr "Volume dos efeitos sonoros"
 msgid "SHIFT"
 msgstr "Shift"
 
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Mostrar tutoriais"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Exportar os dados de todos os mundos no formato CSV (comma-separated values)"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Mostrar efeito do dano na tela"
 
@@ -5130,9 +5138,6 @@ msgstr "Mostrar novas notas de atualização automaticamente"
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Mostrar as notas de atualização das novas versões de Thrive automaticamente no menu principal"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Mostrar tutoriais"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Mostrar tutoriais (no jogo atual)"
@@ -5433,6 +5438,10 @@ msgstr "segundos de"
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Entrou como: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Ativar/Desativar correr. Correr faz com que as células se movam mais rápido, mas consomem mais ATP e ainda mais ATP à medida que a tensão se acumula."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr "Visibilidade da barra de tensão"
@@ -5930,6 +5939,10 @@ msgstr "Tente fazer algumas capturas de tela!"
 
 msgid "TUTORIAL"
 msgstr "Tutorial"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(algumas organelas terão condições de desbloqueio para poderem ser colocadas)"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/pt_PT.po
+++ b/locale/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Portuguese (Portugal) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/pt_PT/>\n"
@@ -5288,6 +5288,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Mostrar tutoriais"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Exportar toda a informacão dos mundos em ficheiros .csv"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "O Flagelo (plural: Flagelos) é um feixe de fibras proteicas em forma de chicote que se estende da membrana da célula e que utiliza ATP para ondular e impulsionar a célula numa direção. A posição do flagelo determina a direção em que fornece impulso para movimentar a célula. A direção de impulso é oposta à direção para a qual o flagelo está direcionado, por exemplo, um flagelo posicionado no lado esquerdo de uma célula fornece impulso quando se move para a direita."
 
@@ -5305,9 +5313,6 @@ msgstr "Caverna"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Caverna"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Mostrar tutoriais"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Mostrar tutoriais (no jogo atual)"
@@ -5623,6 +5628,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Entrou como: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Visite a nossa pagina de Patreon"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6161,6 +6170,10 @@ msgstr "Tente tirar algumas capturas de ecrã!"
 
 msgid "TUTORIAL"
 msgstr "Tutorial"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(Alguns organelos terão condições de desbloqueio necessárias para os colocar)"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/ro.po
+++ b/locale/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-01-21 12:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Romanian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ro/>\n"
@@ -4930,6 +4930,15 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr ""
+"Nu poate fi detectat automat dacă hyperthreading-ul este activat sau nu.\n"
+"Acest lucru afectează numărul implicit de thread-uri, deoarece thread-urile hiperthreading nu sunt la fel de rapide ca nucleele CPU reale."
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4943,9 +4952,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5241,6 +5247,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Treceți la etapa de trezire. Disponibil odată ce aveți creierul suficient de dezvoltat (tip de țesut cu axoni)."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5730,6 +5740,10 @@ msgstr ""
 
 msgid "TUTORIAL"
 msgstr ""
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(viteza cu care speciile IA suferă mutații)"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-12 14:39+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Russian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/ru/>\n"
@@ -5139,6 +5139,14 @@ msgstr "Громкость звуковых эффектов"
 msgid "SHIFT"
 msgstr "Shift"
 
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Показать Обучение"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Экспортировать всю информацию мира в csv формат"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Показывать на экране эффекты урона"
 
@@ -5153,9 +5161,6 @@ msgstr "Показывать новые заметки релизов автом
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Показывать заметки обновлений новых релизов Thrive автоматически в главном меню"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Показать Обучение"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Показывать руководства (в текущей игре)"
@@ -5456,6 +5461,10 @@ msgstr "секунд"
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Авторизован как: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Переключает режим спринтинга. Во время спринта клетки двигаются быстрее, но потребляют значительно больше АТФ."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr "Видимость Полоски Усталости"
@@ -5974,6 +5983,10 @@ msgstr "Попробуйте сделать скриншоты!"
 
 msgid "TUTORIAL"
 msgstr "Руководство"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(Некоторые органеллы будут обладать определёнными требованиями для возможности ставить их)"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/si_LK.po
+++ b/locale/si_LK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2022-03-22 18:22+0000\n"
 "Last-Translator: Henri Hyyryläinen <hhyyrylainen@revolutionarygamesstudio.com>\n"
 "Language-Team: Sinhala <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/si/>\n"
@@ -4816,6 +4816,14 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "නිබන්ධන පෙන්වන්න"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "නිබන්ධන පෙන්වන්න"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4831,10 +4839,6 @@ msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr ""
-
-#, fuzzy
-msgid "SHOW_TUTORIALS"
-msgstr "නිබන්ධන පෙන්වන්න"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr ""
@@ -5128,6 +5132,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "තේරූ:"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5613,6 +5621,10 @@ msgstr ""
 
 msgid "TUTORIAL"
 msgstr ""
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "තේරූ:"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/sk.po
+++ b/locale/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovak <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sk/>\n"
@@ -5240,6 +5240,14 @@ msgstr "Hlasitosť SFX"
 msgid "SHIFT"
 msgstr "Shift"
 
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Zobraziť návody"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Uplynulý čas: {0:#,#} rokov"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -5257,10 +5265,6 @@ msgstr "{0} {1}"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "{0} {1}"
-
-#, fuzzy
-msgid "SHOW_TUTORIALS"
-msgstr "Zobraziť návody"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Zobraziť tutoriál (v aktuálnej hre)"
@@ -5575,6 +5579,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Prihlásený ako: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Pozastaviť hru"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6095,6 +6103,10 @@ msgstr "Skús spraviť zopár snímiek obrazovky!"
 
 msgid "TUTORIAL"
 msgstr "Tutoriál"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(začni s oblakom glukózy v blízkosti každou generáciou)"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/sr_Cyrl.po
+++ b/locale/sr_Cyrl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian (Cyrillic script) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sr_Cyrl/>\n"
@@ -5541,6 +5541,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Прикажи туторијале"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Додајте ново везивање тастера"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Бич (множина: бичеви) је сноп протеинских влакана који се протеже од ћелијске мембране која може да користи ATP да би се поваљао и покренуо ћелију у правцу."
 
@@ -5558,9 +5566,6 @@ msgstr "Пећина"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Пећина"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Прикажи туторијале"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Прикажи водиче (у тренутној игри)"
@@ -5913,6 +5918,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Додајте ново везивање тастера"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6452,6 +6461,10 @@ msgstr "Направите снимак екрана"
 
 msgid "TUTORIAL"
 msgstr "Приручник"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "Избодите друге ћелије са ово."
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/sr_Latn.po
+++ b/locale/sr_Latn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian (Latin script) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sr_Latn/>\n"
@@ -5332,6 +5332,13 @@ msgstr "Tom od zvučnih efekata"
 msgid "SHIFT"
 msgstr "Shift"
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Dodajte novo vezivanje tastera"
+
 #, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Bič (množina: bičevi) je snop proteinskih vlakana koji se proteže od ćelijske membrane koja može da koristi ATP da bi se povaljao i pokrenuo ćeliju u pravcu."
@@ -5349,9 +5356,6 @@ msgstr "Pećina"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Pećina"
-
-msgid "SHOW_TUTORIALS"
-msgstr ""
 
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5688,6 +5692,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Dodajte novo vezivanje tastera"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6214,6 +6222,10 @@ msgstr "Napravite snimak ekrana"
 
 msgid "TUTORIAL"
 msgstr ""
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "Izbodite druge ćelije sa ovo."
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/sv/>\n"
@@ -5501,6 +5501,14 @@ msgstr "SFX Volym"
 msgid "SHIFT"
 msgstr "SHIFT"
 
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Visa handledningar"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Hjälp"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -5518,9 +5526,6 @@ msgstr "Grotta"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Grotta"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Visa handledningar"
 
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5858,6 +5863,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Inloggad som: {0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Självmord"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6409,6 +6418,14 @@ msgstr "Testa att ta några screenshots!"
 
 msgid "TUTORIAL"
 msgstr "Handledning"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr ""
+"Aggressiva mikrober jagar byte över större avstånd\n"
+"och har större sannolikhet att kämpa emot när rovdjur attackerar.\n"
+"Fredliga mikrober attackerar inte andra över större avstånd\n"
+"och har lägre sannolikhet att använda gifter mot rovdjur."
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/th_TH.po
+++ b/locale/th_TH.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-02-06 13:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Thai <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/th/>\n"
@@ -5345,6 +5345,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "บทช่วยสอน"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "ดำเนินการต่อ"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "แฟลกเจลลัม (พหูพจน์: แฟลกเจลลา) เป็นกลุ่มเส้นใยโปรตีนคล้ายแส้ที่ยื่นออกมาจากเยื่อหุ้มเซลล์ซึ่งสามารถใช้ ATP เพื่อทำให้เป็นคลื่นและขับเคลื่อนเซลล์ไปในทิศทาง"
 
@@ -5362,9 +5370,6 @@ msgstr "\"{0}\" - {1}"
 #, fuzzy
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "\"{0}\" - {1}"
-
-msgid "SHOW_TUTORIALS"
-msgstr ""
 
 #, fuzzy
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5699,6 +5704,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "ดำเนินการต่อ"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -6240,6 +6249,10 @@ msgstr "จับภาพหน้าจอ"
 #, fuzzy
 msgid "TUTORIAL"
 msgstr "บทช่วยสอน"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "แทงเซลล์อื่นด้วยสิ่งนี้"
 
 #, fuzzy
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/tok.po
+++ b/locale/tok.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2023-02-06 07:13+0000\n"
 "Last-Translator: jan-sopi <jansopi303@genocide.fun>\n"
 "Language-Team: Toki Pona <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/tok/>\n"
@@ -4918,6 +4918,13 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "nanpa pi ijo pali:"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4931,9 +4938,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5228,6 +5232,10 @@ msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr ""
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "open e lipu pi ante lili"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr ""
@@ -5710,6 +5718,10 @@ msgstr ""
 
 msgid "TUTORIAL"
 msgstr ""
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(nanpa ni: sike ante li kama ante kepeken tenpo seme)"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-12 15:26+0000\n"
 "Last-Translator: punctdan <yunusemredilek@hotmail.com>\n"
 "Language-Team: Turkish <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/tr/>\n"
@@ -5080,6 +5080,14 @@ msgstr "Ses efektleri"
 msgid "SHIFT"
 msgstr "Shift"
 
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Rehberi göster"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Tüm dünyaların verilerini virgülle ayrılmış değerler (csv) biçiminde dışa aktarın"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Ekran üzerindeki hasar efektini göster"
 
@@ -5094,9 +5102,6 @@ msgstr "Yeni yama notlarını otomatik olarak göster"
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Yeni Thrive sürümlerinin yama notlarını ana menüde otomatik olarak göster"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Rehberi göster"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Rehberi göster (mevcut oyunda)"
@@ -5397,6 +5402,10 @@ msgstr "saniye hızda"
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "{0} olarak giriş yapıldı"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Hızlanma modunu aç. Hızlanırken, hücreler daha hızlı hareket eder. Ancak bu hücreler daha fazla ATP tüketir ve yorgunluk arttıkça ATP tüketimi daha da artar."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr "Yorgunluk çubuğu görünürlüğü"
@@ -5893,6 +5902,10 @@ msgstr "Bir ekran görüntüsü almayı deneyin!"
 
 msgid "TUTORIAL"
 msgstr "Oyun Rehberi"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(bazı organelleri yerleştirmek için gerekli olan kilit açma koşulları sağlanmalıdır)"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/tt.po
+++ b/locale/tt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Thrive VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -4706,6 +4706,12 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr ""
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4719,9 +4725,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5010,6 +5013,9 @@ msgid "STORAGE_STATISTICS_SECONDS_OF_COMPOUND"
 msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
+msgstr ""
+
+msgid "STRAIN_BAR_TOOLTIP"
 msgstr ""
 
 msgid "STRAIN_BAR_VISIBILITY"
@@ -5481,6 +5487,9 @@ msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
 msgid "TUTORIAL"
+msgstr ""
+
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
 msgstr ""
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-12 14:39+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/uk/>\n"
@@ -5208,6 +5208,14 @@ msgid "SHIFT"
 msgstr "Shift"
 
 #, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "Показувати туторіали"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "Експортувати дані усіх світів у CSV-формат"
+
+#, fuzzy
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "Джгутик є батогоподібнім мішечком з пучків білкових волокон, що тягнуться від мембрани, який використовує [thrive:compound type=\"atp\"][/thrive:compound] для хвилеподібних рухів і пересування клітини в певному напрямі. Положення джгутика визначає напрям, в якому буде забезпечена тяга. Її напрям протилежний напряму джгутика, наприклад якщо джгутик зліва, він забезпечить тягу вправо."
 
@@ -5222,9 +5230,6 @@ msgstr "Показувати нову інформацію про патчі а�
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "Показувати нову інформацію про зміни у нових версіях Thrive автоматично в головному меню"
-
-msgid "SHOW_TUTORIALS"
-msgstr "Показувати туторіали"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "Показати туторіал (в поточній грі)"
@@ -5531,6 +5536,10 @@ msgstr "секунд"
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "Ви увійшли як:{0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "Відвідайте"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr "Видимість деформаційної планки"
@@ -6041,6 +6050,10 @@ msgstr "Спробуйте зробити декілька скріншотів!
 
 msgid "TUTORIAL"
 msgstr "Туторіал"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "(деякі органели матимуть умови відкриття, необхідні для їх розміщення)"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/vi.po
+++ b/locale/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -4706,6 +4706,12 @@ msgstr ""
 msgid "SHIFT"
 msgstr ""
 
+msgid "SHOW_ALL_TUTORIALS"
+msgstr ""
+
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr ""
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr ""
 
@@ -4719,9 +4725,6 @@ msgid "SHOW_NEW_PATCH_NOTES"
 msgstr ""
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
-msgstr ""
-
-msgid "SHOW_TUTORIALS"
 msgstr ""
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
@@ -5010,6 +5013,9 @@ msgid "STORAGE_STATISTICS_SECONDS_OF_COMPOUND"
 msgstr ""
 
 msgid "STORE_LOGGED_IN_AS"
+msgstr ""
+
+msgid "STRAIN_BAR_TOOLTIP"
 msgstr ""
 
 msgid "STRAIN_BAR_VISIBILITY"
@@ -5481,6 +5487,9 @@ msgid "TRY_TAKING_SOME_SCREENSHOTS"
 msgstr ""
 
 msgid "TUTORIAL"
+msgstr ""
+
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
 msgstr ""
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-12 14:39+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/zh_Hans/>\n"
@@ -5195,6 +5195,14 @@ msgstr "音效音量"
 msgid "SHIFT"
 msgstr "Shift"
 
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "显示教程"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "以逗号分隔符（csv）格式导出所有世界数据"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "在屏幕上显示伤害效果"
 
@@ -5212,9 +5220,6 @@ msgstr "自动显示新的补丁说明"
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "在主菜单中自动显示新版Thrive的补丁说明"
-
-msgid "SHOW_TUTORIALS"
-msgstr "显示教程"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "现有游戏中显示教程"
@@ -5516,6 +5521,10 @@ msgstr "秒"
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "已登录为：{0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "切换到冲刺模式。冲刺时细胞移动得更快，但会消耗更多ATP，且随着压力增加ATP消耗会变得更多."
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr "压力值可见性"
@@ -6031,6 +6040,10 @@ msgstr "试着截一些图吧！"
 
 msgid "TUTORIAL"
 msgstr "教程"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "（一些细胞器需要前置解锁条件来放置）"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-17 16:32+0200\n"
+"POT-Creation-Date: 2025-03-19 10:10+0200\n"
 "PO-Revision-Date: 2025-03-12 14:39+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional Han script) <https://translate.revolutionarygamesstudio.com/projects/thrive/thrive-game/zh_Hant/>\n"
@@ -5091,6 +5091,14 @@ msgstr "音效音量"
 msgid "SHIFT"
 msgstr "Shift"
 
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS"
+msgstr "顯示教學"
+
+#, fuzzy
+msgid "SHOW_ALL_TUTORIALS_TOOLTIP"
+msgstr "以逗號分隔值（csv）格式匯出所有世界的數據"
+
 msgid "SHOW_DAMAGE_EFFECT"
 msgstr "在螢幕上顯示傷害效果"
 
@@ -5105,9 +5113,6 @@ msgstr "自動顯示新更新說明"
 
 msgid "SHOW_NEW_PATCH_NOTES_TOOLTIP"
 msgstr "在主選單中自動顯示新 Thrive 版本的更新說明"
-
-msgid "SHOW_TUTORIALS"
-msgstr "顯示教學"
 
 msgid "SHOW_TUTORIALS_IN_NEW_CURRENT_OPTION"
 msgstr "顯示教學（在當前遊戲中）"
@@ -5408,6 +5413,10 @@ msgstr "秒數"
 
 msgid "STORE_LOGGED_IN_AS"
 msgstr "登入身分：{0}"
+
+#, fuzzy
+msgid "STRAIN_BAR_TOOLTIP"
+msgstr "切換衝刺模式。衝刺時細胞移動得更快，但會消耗更多的 ATP，隨著壓力增加會消耗更多的 ATP。"
 
 msgid "STRAIN_BAR_VISIBILITY"
 msgstr "壓力值條可見性"
@@ -5905,6 +5914,10 @@ msgstr "嘗試截一些圖吧！"
 
 msgid "TUTORIAL"
 msgstr "教學"
+
+#, fuzzy
+msgid "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+msgstr "（某些細胞器需要滿足特定解鎖條件才能放置）"
 
 msgid "TUTORIAL_MICROBE_EDITOR_ATP_BALANCE_INTRO"
 msgstr ""

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1546,6 +1546,8 @@ public static class Constants
     public const string FOSSILISED_SPECIES_FOLDER = "user://fossils";
     public const string AUTO_EVO_EXPORT_FOLDER = "user://auto-evo_exports";
 
+    public const string TUTORIAL_DATA_FILE = "user://tutorials.json.gz";
+
     public const string CACHE_FOLDER = "user://cache";
     public const string CACHE_IMAGES_FOLDER = "user://cache/img";
 

--- a/src/engine/PostStartupActions.cs
+++ b/src/engine/PostStartupActions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using Godot;
+using Tutorial;
 
 /// <summary>
 ///   This is the last autoloaded class to perform some actions there
@@ -43,5 +44,7 @@ public partial class PostStartupActions : Node
             GD.Print("This version of Thrive was built at ", time, " from commit ", info.Commit, " on branch ",
                 info.Branch);
         }
+
+        AlreadySeenTutorials.OnGameInit();
     }
 }

--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Godot;
 using Godot.Collections;
 using LauncherThriveShared;
+using Tutorial;
 using Xoshiro.PRNG32;
 
 /// <summary>
@@ -336,6 +337,10 @@ public partial class MainMenu : NodeWithInput
                 }
             }
         }
+
+        // This makes saving seen tutorials work if a tutorial was just closed and the player exited to the main menu
+        // before the delayed save was able to trigger
+        AlreadySeenTutorials.Process(delta);
     }
 
     public override void _Notification(int notification)

--- a/src/macroscopic_stage/MacroscopicHUD.tscn
+++ b/src/macroscopic_stage/MacroscopicHUD.tscn
@@ -604,6 +604,7 @@ offset_right = 125.0
 offset_bottom = 198.0
 grow_horizontal = 2
 grow_vertical = 2
+tooltip_text = "STRAIN_BAR_TOOLTIP"
 theme_type_variation = &"SprintBar"
 max_value = 0.9
 step = 0.001

--- a/src/microbe_stage/MicrobeHUD.tscn
+++ b/src/microbe_stage/MicrobeHUD.tscn
@@ -778,6 +778,7 @@ offset_right = 125.0
 offset_bottom = 198.0
 grow_horizontal = 2
 grow_vertical = 2
+tooltip_text = "STRAIN_BAR_TOOLTIP"
 theme_type_variation = &"SprintBar"
 max_value = 0.9
 step = 0.001

--- a/src/tutorial/AlreadySeenTutorials.cs
+++ b/src/tutorial/AlreadySeenTutorials.cs
@@ -1,0 +1,131 @@
+﻿namespace Tutorial;
+
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using Godot;
+using Newtonsoft.Json;
+using FileAccess = Godot.FileAccess;
+
+/// <summary>
+///   Helper class for saving / loading the global state of all tutorials the player has seen
+/// </summary>
+public static class AlreadySeenTutorials
+{
+    private static readonly HashSet<string> AlreadySeenTutorialsValue = new();
+
+    private static bool dirty;
+
+    private static double elapsedTime;
+
+    public static IReadOnlyCollection<string> SeenTutorials => AlreadySeenTutorialsValue;
+
+    public static void MarkSeen(string tutorialName)
+    {
+        if (!AlreadySeenTutorialsValue.Add(tutorialName))
+            return;
+
+        dirty = true;
+    }
+
+    public static void Process(double delta)
+    {
+        elapsedTime += delta;
+
+        if (elapsedTime > 11)
+        {
+            if (dirty)
+            {
+                // Saving in the background should be fine. And good to avoid random hitching during gameplay.
+                TaskExecutor.Instance.AddTask(new Task(Save));
+            }
+
+            elapsedTime = 0;
+        }
+    }
+
+    public static void ResetAllSeenTutorials()
+    {
+        if (AlreadySeenTutorialsValue.Count < 1)
+            return;
+
+        dirty = true;
+        AlreadySeenTutorialsValue.Clear();
+    }
+
+    public static void OnGameInit()
+    {
+        Load();
+    }
+
+    private static void Load()
+    {
+        dirty = false;
+
+        using var file = FileAccess.Open(Constants.TUTORIAL_DATA_FILE, FileAccess.ModeFlags.Read);
+        if (file == null)
+        {
+            // If the player has not used any tutorials / played before, this is not a problem if missing
+            return;
+        }
+
+        using var fileStream = new GodotFileStream(file);
+        using Stream gzoStream = new GZipStream(fileStream, CompressionMode.Decompress);
+        using TextReader reader = new StreamReader(gzoStream);
+        using var jsonReader = new JsonTextReader(reader);
+
+        var serializer = JsonSerializer.Create();
+        var data = serializer.Deserialize<SerializedData>(jsonReader);
+
+        if (data == null)
+        {
+            GD.PrintErr("Cannot deserialize tutorial data file, won't remember which tutorials have been seen");
+            return;
+        }
+
+        AlreadySeenTutorialsValue.Clear();
+
+        foreach (var item in data.Seen)
+        {
+            AlreadySeenTutorialsValue.Add(item);
+        }
+    }
+
+    private static void Save()
+    {
+        if (!dirty)
+            return;
+
+        dirty = false;
+
+        using var file = FileAccess.Open(Constants.TUTORIAL_DATA_FILE, FileAccess.ModeFlags.Write);
+        if (file == null)
+        {
+            GD.PrintErr("Cannot open tutorial data file for writing, won't remember which tutorials have been seen");
+            return;
+        }
+
+        using var fileStream = new GodotFileStream(file);
+        using Stream gzoStream = new GZipStream(fileStream, CompressionLevel.Optimal);
+        using TextWriter writer = new StreamWriter(gzoStream);
+
+        var serializer = JsonSerializer.Create();
+
+        serializer.Serialize(writer, new SerializedData(AlreadySeenTutorialsValue));
+    }
+
+    /// <summary>
+    ///   A wrapper object for the on-disk representation of the tutorial data. This is used to allow further
+    ///   extensibility to be added.
+    /// </summary>
+    private class SerializedData
+    {
+        public SerializedData(ICollection<string> seen)
+        {
+            Seen = seen;
+        }
+
+        public ICollection<string> Seen { get; set; }
+    }
+}

--- a/src/tutorial/AlreadySeenTutorials.cs.uid
+++ b/src/tutorial/AlreadySeenTutorials.cs.uid
@@ -1,0 +1,1 @@
+uid://cygc10frn0gb2

--- a/src/tutorial/ITutorialGUI.cs
+++ b/src/tutorial/ITutorialGUI.cs
@@ -11,7 +11,7 @@ public interface ITutorialGUI
     public MainGameState AssociatedGameState { get; }
 
     /// <summary>
-    ///   Which object receives events from this tutorial
+    ///   Specifies which object receives events from this tutorial
     /// </summary>
     public ITutorialInput? EventReceiver { get; set; }
 
@@ -21,17 +21,16 @@ public interface ITutorialGUI
     public bool IsClosingAutomatically { get; set; }
 
     /// <summary>
-    ///   True when the tutorial selected boxes have been left untouched (on).
-    ///   Child classes should by default set this to true.
+    ///   True when all tutorials should be shown and not just the new ones.
     /// </summary>
     /// <remarks>
     ///   <para>
     ///     There's a small bug where if the tutorials are turned back on and then displayed, that leaves the checkboxes
-    ///     unchecked, when things become visible all the enable tutorials check boxes would need to read this value
-    ///     to fix this
+    ///     unchecked when things become visible.
+    ///     All the enable tutorials check boxes would need to read this value to fix this
     ///   </para>
     /// </remarks>
-    public bool TutorialEnabledSelected { get; }
+    public bool AllTutorialsDesiredState { get; }
 
     /// <summary>
     ///   The main GUI node
@@ -44,15 +43,15 @@ public interface ITutorialGUI
     public void OnClickedCloseAll();
 
     /// <summary>
-    ///   A button for closing specific tutorial was pressed by the user
+    ///   A button for closing a specific tutorial was pressed by the user
     /// </summary>
     /// <param name="closedThing">Name of the tutorials that should be closed</param>
     public void OnSpecificCloseClicked(string closedThing);
 
     /// <summary>
-    ///   Value for tutorials being on was toggled by the user, and should be applied when the current tutorial is
-    ///   closed
+    ///   The user changed the value for all tutorials being enabled.
+    ///   Should be applied when the current tutorial is closed
     /// </summary>
-    /// <param name="value">Whether tutorials should be on</param>
+    /// <param name="value">Whether all tutorials should be on or not</param>
     public void OnTutorialEnabledValueChanged(bool value);
 }

--- a/src/tutorial/ITutorialInput.cs
+++ b/src/tutorial/ITutorialInput.cs
@@ -6,6 +6,8 @@ public interface ITutorialInput
     public void OnTutorialDisabled();
     public void OnTutorialEnabled();
 
+    public void OnCompleteTutorialsAlreadySeen();
+
     /// <summary>
     ///   Player closed the current tutorial
     /// </summary>

--- a/src/tutorial/TutorialHelper.cs
+++ b/src/tutorial/TutorialHelper.cs
@@ -11,9 +11,11 @@ public static class TutorialHelper
         GUICommon.Instance.PlayButtonPressSound();
         gui.EventReceiver?.OnTutorialClosed();
 
-        if (!gui.TutorialEnabledSelected)
+        if (!gui.AllTutorialsDesiredState)
         {
-            gui.EventReceiver?.OnTutorialDisabled();
+            // TODO: restoring this based on some conditions? Would be pretty hard to make as this would need to
+            // remember which tutorials were disabled due to this
+            gui.EventReceiver?.OnCompleteTutorialsAlreadySeen();
         }
     }
 
@@ -27,7 +29,7 @@ public static class TutorialHelper
     }
 
     /// <summary>
-    ///   Handles process for all tutorial GUI derived classes.
+    ///   Handles processing for all tutorial GUI-derived classes.
     ///   This passes time to the TutorialState as the tutorial GUI Node shouldn't stop processing on pause
     /// </summary>
     public static void ProcessTutorialGUI(ITutorialGUI gui, float delta)

--- a/src/tutorial/microbe_editor/MicrobeEditorTutorialGUI.cs
+++ b/src/tutorial/microbe_editor/MicrobeEditorTutorialGUI.cs
@@ -92,7 +92,7 @@ public partial class MicrobeEditorTutorialGUI : Control, ITutorialGUI
     public MainGameState AssociatedGameState => MainGameState.MicrobeEditor;
     public ITutorialInput? EventReceiver { get; set; }
     public bool IsClosingAutomatically { get; set; }
-    public bool TutorialEnabledSelected { get; private set; } = true;
+    public bool AllTutorialsDesiredState { get; private set; } = true;
     public Node GUINode => this;
 
     public ControlHighlight? CellEditorUndoHighlight { get; private set; }
@@ -104,7 +104,7 @@ public partial class MicrobeEditorTutorialGUI : Control, ITutorialGUI
     public ControlHighlight? AtpBalanceBarHighlight { get; private set; }
 
     /// <summary>
-    ///   This is used to ensure scroll position shows elements related to active tutorials
+    ///   This is used to ensure the scroll position shows elements related to active tutorials
     /// </summary>
     public ScrollContainer RightPanelScrollContainer { get; set; } = null!;
 
@@ -492,7 +492,7 @@ public partial class MicrobeEditorTutorialGUI : Control, ITutorialGUI
 
     public void OnTutorialEnabledValueChanged(bool value)
     {
-        TutorialEnabledSelected = value;
+        AllTutorialsDesiredState = value;
     }
 
     public void HandleShowingATPBarHighlight()

--- a/src/tutorial/microbe_stage/MicrobeTutorialGUI.cs
+++ b/src/tutorial/microbe_stage/MicrobeTutorialGUI.cs
@@ -493,11 +493,9 @@ public partial class MicrobeTutorialGUI : Control, ITutorialGUI
             if (tutorialDisabledExplanation.Visible)
             {
                 // Scroll down to ensure the new text is visible
-                // Need to invoke to make sure this
-                // Invoke.Instance.QueueForObject(() => welcomeTutorialScrollContainer.ScrollVertical = 500, welcomeTutorialScrollContainer);
-
-                // TODO: test
-                welcomeTutorialScrollContainer.ScrollVertical = 500;
+                // Need to invoke to make sure this happens after the new text appears
+                Invoke.Instance.QueueForObject(() => welcomeTutorialScrollContainer.ScrollVertical = 500,
+                    welcomeTutorialScrollContainer);
             }
         }
     }

--- a/src/tutorial/microbe_stage/MicrobeTutorialGUI.cs
+++ b/src/tutorial/microbe_stage/MicrobeTutorialGUI.cs
@@ -78,6 +78,13 @@ public partial class MicrobeTutorialGUI : Control, ITutorialGUI
 
 #pragma warning disable CA2213
     private TutorialDialog microbeWelcomeMessage = null!;
+
+    [Export]
+    private Control tutorialDisabledExplanation = null!;
+
+    [Export]
+    private ScrollContainer welcomeTutorialScrollContainer = null!;
+
     private Control microbeMovementKeyPrompts = null!;
     private Control microbeMovementKeyForward = null!;
     private Control microbeMovementKeyLeft = null!;
@@ -107,7 +114,7 @@ public partial class MicrobeTutorialGUI : Control, ITutorialGUI
 
     public MainGameState AssociatedGameState => MainGameState.MicrobeStage;
 
-    public bool TutorialEnabledSelected { get; private set; } = true;
+    public bool AllTutorialsDesiredState { get; private set; } = true;
 
     public Node GUINode => this;
 
@@ -477,7 +484,22 @@ public partial class MicrobeTutorialGUI : Control, ITutorialGUI
 
     public void OnTutorialEnabledValueChanged(bool value)
     {
-        TutorialEnabledSelected = value;
+        AllTutorialsDesiredState = value;
+
+        if (tutorialDisabledExplanation.Visible != !value)
+        {
+            tutorialDisabledExplanation.Visible = !value;
+
+            if (tutorialDisabledExplanation.Visible)
+            {
+                // Scroll down to ensure the new text is visible
+                // Need to invoke to make sure this
+                // Invoke.Instance.QueueForObject(() => welcomeTutorialScrollContainer.ScrollVertical = 500, welcomeTutorialScrollContainer);
+
+                // TODO: test
+                welcomeTutorialScrollContainer.ScrollVertical = 500;
+            }
+        }
     }
 
     public void SetWelcomeTextForLifeOrigin(WorldGenerationSettings.LifeOrigin gameLifeOrigin)

--- a/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
+++ b/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
@@ -73,7 +73,6 @@ offset_right = 40.0
 offset_bottom = 40.0
 
 [node name="ScrollContainer" type="ScrollContainer" parent="MicrobeWelcome/VBoxContainer"]
-clip_contents = false
 custom_minimum_size = Vector2(230, 235)
 layout_mode = 2
 size_flags_vertical = 3
@@ -112,6 +111,7 @@ layout_mode = 2
 [node name="CheckBox" type="CheckBox" parent="MicrobeWelcome/VBoxContainer/ScrollContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 0
+tooltip_text = "SHOW_ALL_TUTORIALS_TOOLTIP"
 theme_override_font_sizes/font_size = 14
 button_pressed = true
 text = "SHOW_ALL_TUTORIALS"

--- a/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
+++ b/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=12 format=3 uid="uid://d116aks100ulm"]
+[gd_scene load_steps=13 format=3 uid="uid://d116aks100ulm"]
 
 [ext_resource type="Script" uid="uid://3xqb6s7y5nm5" path="res://src/tutorial/microbe_stage/MicrobeTutorialGUI.cs" id="1"]
 [ext_resource type="Theme" uid="uid://b4cx0o110g4b6" path="res://src/gui_common/thrive_theme.tres" id="2"]
 [ext_resource type="PackedScene" uid="uid://ci8b4cca0q55h" path="res://src/gui_common/KeyPrompt.tscn" id="3"]
 [ext_resource type="Script" uid="uid://c22vgu2gpm74j" path="res://src/gui_common/dialogs/TutorialDialog.cs" id="7"]
+[ext_resource type="LabelSettings" uid="uid://c07qrffjvqfw" path="res://src/gui_common/fonts/Body-Regular-Tiny.tres" id="8_01chk"]
 [ext_resource type="PackedScene" uid="uid://bhpjtbtaeunat" path="res://src/gui_common/CustomRichTextLabel.tscn" id="9"]
 [ext_resource type="FontVariation" uid="uid://cqork3l186w1c" path="res://assets/fonts/variants/Jura-Bold.tres" id="9_s6a8v"]
 [ext_resource type="PackedScene" uid="uid://cy5puaxnv8e2a" path="res://src/gui_common/dialogs/TutorialDialog.tscn" id="10"]
@@ -12,7 +13,7 @@
 [ext_resource type="PackedScene" uid="uid://du8sc8kjirguk" path="res://src/gui_common/dialogs/CustomWindow.tscn" id="13"]
 [ext_resource type="PackedScene" uid="uid://tna206f2gtkv" path="res://src/gui_common/AddWindowReorderingSupportToSiblings.tscn" id="14"]
 
-[node name="MicrobeTutorialGUI" type="Control"]
+[node name="MicrobeTutorialGUI" type="Control" node_paths=PackedStringArray("tutorialDisabledExplanation", "welcomeTutorialScrollContainer")]
 process_mode = 3
 layout_mode = 3
 anchors_preset = 15
@@ -45,6 +46,8 @@ EngulfmentExplanationPath = NodePath("EngulfmentTutorial")
 EngulfedExplanationPath = NodePath("EngulfedTutorial")
 EngulfmentFullCapacityPath = NodePath("EngulfmentFullCapacity")
 EditorButtonHighlightPath = NodePath("EditorButtonHighlight")
+tutorialDisabledExplanation = NodePath("MicrobeWelcome/VBoxContainer/ScrollContainer/VBoxContainer/AllNotEnabledExplanation")
+welcomeTutorialScrollContainer = NodePath("MicrobeWelcome/VBoxContainer/ScrollContainer")
 
 [node name="AddWindowReorderingSupportToSiblings" parent="." instance=ExtResource("14")]
 anchors_preset = 0
@@ -55,7 +58,7 @@ layout_mode = 1
 offset_right = 450.0
 offset_bottom = 430.0
 script = ExtResource("7")
-LabelPath = NodePath("ScrollContainer/VBoxContainer/CustomRichTextLabel")
+LabelPath = NodePath("VBoxContainer/ScrollContainer/VBoxContainer/CustomRichTextLabel")
 Description = "MICROBE_STAGE_INITIAL"
 DescriptionForController = ""
 ShowDelay = 0.0
@@ -63,51 +66,64 @@ WindowTitle = "TUTORIAL"
 Exclusive = true
 ExclusiveAllowCloseOnEscape = false
 
-[node name="ScrollContainer" type="ScrollContainer" parent="MicrobeWelcome"]
-custom_minimum_size = Vector2(230, 250)
+[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeWelcome"]
+custom_minimum_size = Vector2(230, 255)
 layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 15.0
-offset_top = 15.0
-offset_right = 435.0
-offset_bottom = 385.0
+offset_right = 40.0
+offset_bottom = 40.0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeWelcome/ScrollContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MicrobeWelcome/VBoxContainer"]
+clip_contents = false
+custom_minimum_size = Vector2(230, 235)
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MicrobeWelcome/VBoxContainer/ScrollContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="CustomRichTextLabel" parent="MicrobeWelcome/ScrollContainer/VBoxContainer" instance=ExtResource("9")]
+[node name="CustomRichTextLabel" parent="MicrobeWelcome/VBoxContainer/ScrollContainer/VBoxContainer" instance=ExtResource("9")]
 layout_mode = 2
 theme_override_font_sizes/normal_font_size = 16
 fit_content = true
 
-[node name="Control" type="Control" parent="MicrobeWelcome/ScrollContainer/VBoxContainer"]
+[node name="Control" type="Control" parent="MicrobeWelcome/VBoxContainer/ScrollContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MicrobeWelcome/ScrollContainer/VBoxContainer"]
+[node name="AllNotEnabledExplanation" type="Label" parent="MicrobeWelcome/VBoxContainer/ScrollContainer/VBoxContainer"]
+visible = false
+custom_minimum_size = Vector2(150, 0)
+layout_mode = 2
+text = "TUTORIAL_ALL_NOT_ENABLED_EXPLANATION"
+label_settings = ExtResource("8_01chk")
+autowrap_mode = 3
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MicrobeWelcome/VBoxContainer/ScrollContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Control" type="Control" parent="MicrobeWelcome/ScrollContainer/VBoxContainer/HBoxContainer"]
+[node name="Control" type="Control" parent="MicrobeWelcome/VBoxContainer/ScrollContainer/VBoxContainer/HBoxContainer"]
 custom_minimum_size = Vector2(10, 0)
 layout_mode = 2
 
-[node name="CheckBox" type="CheckBox" parent="MicrobeWelcome/ScrollContainer/VBoxContainer/HBoxContainer"]
+[node name="CheckBox" type="CheckBox" parent="MicrobeWelcome/VBoxContainer/ScrollContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 0
 theme_override_font_sizes/font_size = 14
 button_pressed = true
-text = "SHOW_TUTORIALS"
+text = "SHOW_ALL_TUTORIALS"
 
-[node name="FocusGrabber" parent="MicrobeWelcome/ScrollContainer/VBoxContainer/HBoxContainer" instance=ExtResource("12")]
+[node name="FocusGrabber" parent="MicrobeWelcome/VBoxContainer/ScrollContainer/VBoxContainer/HBoxContainer" instance=ExtResource("12")]
 layout_mode = 2
 Priority = 2
-NodeToGiveFocusTo = NodePath("../../Button")
+NodeToGiveFocusTo = NodePath("../../../../Button")
 GrabFocusWhenBecomingVisible = true
 
-[node name="Button" type="Button" parent="MicrobeWelcome/ScrollContainer/VBoxContainer"]
+[node name="Control2" type="Control" parent="MicrobeWelcome/VBoxContainer/ScrollContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Button" type="Button" parent="MicrobeWelcome/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_fonts/font = ExtResource("9_s6a8v")
@@ -470,8 +486,8 @@ theme_override_font_sizes/font_size = 18
 text = "CONTINUE_THRIVING"
 
 [connection signal="hidden" from="MicrobeWelcome" to="." method="OnClickedCloseAll"]
-[connection signal="toggled" from="MicrobeWelcome/ScrollContainer/VBoxContainer/HBoxContainer/CheckBox" to="." method="OnTutorialEnabledValueChanged"]
-[connection signal="pressed" from="MicrobeWelcome/ScrollContainer/VBoxContainer/Button" to="." method="OnClickedCloseAll"]
+[connection signal="toggled" from="MicrobeWelcome/VBoxContainer/ScrollContainer/VBoxContainer/HBoxContainer/CheckBox" to="." method="OnTutorialEnabledValueChanged"]
+[connection signal="pressed" from="MicrobeWelcome/VBoxContainer/Button" to="." method="OnClickedCloseAll"]
 [connection signal="hidden" from="MicrobeMovementTutorial/ExplainingPopup" to="." method="OnSpecificCloseClicked" binds= ["MicrobeMovementExplain"]]
 [connection signal="hidden" from="GlucoseTutorial" to="." method="OnSpecificCloseClicked" binds= ["GlucoseCollecting"]]
 [connection signal="hidden" from="DayNightTutorial" to="." method="OnSpecificCloseClicked" binds= ["DayNightTutorial"]]

--- a/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
+++ b/src/tutorial/microbe_stage/MicrobeTutorialGUI.tscn
@@ -53,7 +53,7 @@ welcomeTutorialScrollContainer = NodePath("MicrobeWelcome/VBoxContainer/ScrollCo
 anchors_preset = 0
 
 [node name="MicrobeWelcome" parent="." instance=ExtResource("13")]
-custom_minimum_size = Vector2(450, 455)
+custom_minimum_size = Vector2(450, 460)
 layout_mode = 1
 offset_right = 450.0
 offset_bottom = 430.0
@@ -67,7 +67,7 @@ Exclusive = true
 ExclusiveAllowCloseOnEscape = false
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MicrobeWelcome"]
-custom_minimum_size = Vector2(230, 255)
+custom_minimum_size = Vector2(230, 265)
 layout_mode = 0
 offset_right = 40.0
 offset_bottom = 40.0
@@ -77,6 +77,8 @@ clip_contents = false
 custom_minimum_size = Vector2(230, 235)
 layout_mode = 2
 size_flags_vertical = 3
+mouse_filter = 0
+mouse_force_pass_scroll_events = false
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MicrobeWelcome/VBoxContainer/ScrollContainer"]
 layout_mode = 2


### PR DESCRIPTION
**Brief Description of What This PR Does**
This way returning players will see new tutorials that they haven't seen before helping explain new game concepts etc.

With the planned almost complete tutorial rework also coming soon this shouldn't annoy existing players as they will see mostly new tutorials in the next release

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
