### PR TITLE
Added safety handling for missing generations for evolutionary tree

### DIFF
--- a/src/auto-evo/records/GenerationRecord.cs
+++ b/src/auto-evo/records/GenerationRecord.cs
@@ -42,9 +42,24 @@ public class GenerationRecord
         var speciesRecord = generationHistory[currentGeneration].AllSpeciesData[speciesID];
         Species? updatedSpecies = null;
 
+        bool warned = false;
+
         // Loop through previous generations until we find a non-null record and update the species
         for (int i = currentGeneration; i >= 0; i--)
         {
+            // As a safety precaution, skip trying to read generations that don't exist
+            if (!generationHistory.ContainsKey(i))
+            {
+                if (!warned)
+                {
+                    warned = true;
+                    GD.PrintErr($"Generation history is missing a generation, this shouldn't happen. " +
+                        $"Skipping generation {i} while looking for full record of species {speciesID}");
+                }
+
+                continue;
+            }
+
             if (generationHistory[i].AllSpeciesData.TryGetValue(speciesID, out var candidateRecord) &&
                 candidateRecord.Species != null)
             {

--- a/src/general/GameWorld.cs
+++ b/src/general/GameWorld.cs
@@ -585,9 +585,18 @@ public class GameWorld : ISaveLoadable
             {
                 GD.PrintErr(
                     $"World history is out of order, expected generation {nextGeneration} but got {generation.Key}");
-            }
 
-            ++nextGeneration;
+                // Force the key to match, even if this causes gaps in the history
+                if (generation.Key > nextGeneration)
+                {
+                    nextGeneration = generation.Key;
+                    GD.PrintErr("Adjusted generation key to match");
+                }
+            }
+            else
+            {
+                ++nextGeneration;
+            }
 
             foreach (var recordSpecies in generation.Value.AllSpeciesData)
             {
@@ -912,9 +921,18 @@ public class GameWorld : ISaveLoadable
             {
                 GD.PrintErr(
                     $"World history is out of order, expected generation {nextGeneration} but got {generation.Key}");
-            }
 
-            ++nextGeneration;
+                // Force the key to match, even if this causes gaps in the history
+                if (generation.Key > nextGeneration)
+                {
+                    nextGeneration = generation.Key;
+                    GD.PrintErr("Adjusted generation key to match");
+                }
+            }
+            else
+            {
+                ++nextGeneration;
+            }
 
             var record = generation.Value;
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

this way the tree can be generated and displayed even with the missing generation

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

adds workaround for: https://community.revolutionarygamesstudio.com/t/evolutionary-tree-not-working/8284

relevant issue: https://github.com/Revolutionary-Games/Thrive/issues/6032

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
