### PR TITLE
Update MulticellularGrowthSystem not to use LINQ Reverse

### DIFF
--- a/src/general/utils/ListUtils.cs
+++ b/src/general/utils/ListUtils.cs
@@ -100,7 +100,7 @@ public static class ListUtils
     {
         var comparer = EqualityComparer<TKey>.Default;
 
-        for (int i = 0; i < list.Count; i++)
+        for (int i = 0; i < list.Count; ++i)
         {
             if (comparer.Equals(key, list[i].Key))
                 return i;

--- a/src/general/utils/ListUtils.cs
+++ b/src/general/utils/ListUtils.cs
@@ -87,6 +87,27 @@ public static class ListUtils
     }
 
     /// <summary>
+    ///   Finds the index of the first pair, the first element of which is equl to <paramref name="key"/>
+    /// </summary>
+    /// <typeparam name="TKey">Type of the pairs' first element</typeparam>
+    /// <typeparam name="TValue">Type of the pairs' second element</typeparam>
+    /// <param name="list">The list to seartch through</param>
+    /// <param name="key">The first element of the pair that needs to be found</param>
+    /// <returns>The index of the found element or -1 if not found</returns>
+    public static int FindIndexByKey<TKey, TValue>(this IReadOnlyList<(TKey Key, TValue Value)> list, TKey key)
+    {
+        var comparer = EqualityComparer<TKey>.Default;
+
+        for (int i = 0; i < list.Count; i++)
+        {
+            if (comparer.Equals(key, list[i].Key))
+                return i;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
     ///   Removes an item from a list at index without preserving the list order, this should be faster than normal
     ///   list remove that preserves order
     /// </summary>

--- a/src/general/utils/ListUtils.cs
+++ b/src/general/utils/ListUtils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Godot;
 using Godot.Collections;
 using Array = Godot.Collections.Array;
@@ -94,6 +95,7 @@ public static class ListUtils
     /// <param name="list">The list to seartch through</param>
     /// <param name="key">The first element of the pair that needs to be found</param>
     /// <returns>The index of the found element or -1 if not found</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int FindIndexByKey<TKey, TValue>(this IReadOnlyList<(TKey Key, TValue Value)> list, TKey key)
     {
         var comparer = EqualityComparer<TKey>.Default;

--- a/src/microbe_stage/ICellDefinition.cs
+++ b/src/microbe_stage/ICellDefinition.cs
@@ -69,7 +69,7 @@ public static class GeneralCellPropertiesHelpers
         {
             foreach (var pair in organelle.Definition.InitialComposition)
             {
-                var index = result.FindIndex(a => a.Compound == pair.Key);
+                var index = result.FindIndexByKey(pair.Key);
                 if (index != -1)
                 {
                     result[index] = (pair.Key, pair.Value + result[index].Amount);

--- a/src/microbe_stage/ICellDefinition.cs
+++ b/src/microbe_stage/ICellDefinition.cs
@@ -58,6 +58,32 @@ public static class GeneralCellPropertiesHelpers
         return result;
     }
 
+    /// <summary>
+    ///   The total compounds in the composition of all organelles
+    /// </summary>
+    public static List<(Compound Compound, float Amount)> CalculateTotalCompositionList(this ICellDefinition definition)
+    {
+        var result = new List<(Compound Compound, float Amount)>();
+
+        foreach (var organelle in definition.Organelles)
+        {
+            foreach (var pair in organelle.Definition.InitialComposition)
+            {
+                var index = result.FindIndex(a => a.Compound == pair.Key);
+                if (index != -1)
+                {
+                    result[index] = (pair.Key, pair.Value + result[index].Amount);
+                }
+                else
+                {
+                    result.Add((pair.Key, pair.Value));
+                }
+            }
+        }
+
+        return result;
+    }
+
     public static void SetupWorldEntities(this ICellDefinition definition, IWorldSimulation worldSimulation)
     {
         // TODO: would there be a way to avoid this temporary memory allocation? This gets used each time the

--- a/src/multicellular_stage/components/MulticellularGrowth.cs
+++ b/src/multicellular_stage/components/MulticellularGrowth.cs
@@ -227,7 +227,7 @@ public static class MulticellularGrowthHelpers
             {
                 var totalUsed = multicellularGrowth.CompoundsUsedForMulticellularGrowth[compound];
 
-                int index = usedForProgress.FindIndex(a => a.Compound == compound);
+                int index = usedForProgress.FindIndexByKey(compound);
 
                 if (index != -1)
                 {

--- a/src/multicellular_stage/components/MulticellularGrowth.cs
+++ b/src/multicellular_stage/components/MulticellularGrowth.cs
@@ -186,12 +186,12 @@ public static class MulticellularGrowthHelpers
 
             foreach (var entry in totalNeededForCurrentlyGrowingCell)
             {
-                var id = multicellularGrowth.CompoundsNeededForNextCell!.FindIndex(a => a.Compound == entry.Compound);
+                var id = multicellularGrowth.CompoundsNeededForNextCell!.FindIndexByKey(entry.Compound);
 
                 if (id != -1)
                 {
                     var alreadyUsed = entry.AmountNeeded
-                        - multicellularGrowth.CompoundsNeededForNextCell[id].AmountNeeded;
+                        - multicellularGrowth.CompoundsNeededForNextCell![id].AmountNeeded;
 
                     if (alreadyUsed > 0)
                         usedForProgress.Add((entry.Compound, alreadyUsed));

--- a/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
+++ b/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
@@ -209,7 +209,8 @@ public sealed class MulticellularGrowthSystem : AEntitySetSystem<float>
             {
                 // As we modify the list, we are content just consuming one type of compound per frame
                 var compound = temporaryWorkData[microbeStatus.ConsumeReproductionCompoundsReverse ?
-                    temporaryWorkData.Count - 1 : 0];
+                    temporaryWorkData.Count - 1 :
+                    0];
                 float amountNeeded = multicellularGrowth.CompoundsNeededForNextCell![compound];
 
                 float usedAmount = 0;

--- a/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
+++ b/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
@@ -200,7 +200,8 @@ public sealed class MulticellularGrowthSystem : AEntitySetSystem<float>
         if (multicellularGrowth.CompoundsNeededForNextCell.Count > 0)
         {
             int index = microbeStatus.ConsumeReproductionCompoundsReverse ?
-                multicellularGrowth.CompoundsNeededForNextCell.Count - 1 : 0;
+                multicellularGrowth.CompoundsNeededForNextCell.Count - 1 :
+                0;
 
             // As we modify the list, we are content just consuming one type of compound per frame
             var pair = multicellularGrowth.CompoundsNeededForNextCell![index];

--- a/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
+++ b/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
@@ -203,17 +203,11 @@ public sealed class MulticellularGrowthSystem : AEntitySetSystem<float>
                 temporaryWorkData.Add(entry.Key);
             }
 
-            if (microbeStatus.ConsumeReproductionCompoundsReverse)
-            {
-                ProcessGrowthCompound(temporaryWorkData[temporaryWorkData.Count - 1], ref compounds,
-                    ref multicellularGrowth, remainingAllowedCompoundUse, remainingFreeCompounds,
-                    ref stillNeedsSomething);
-            }
-            else
-            {
-                ProcessGrowthCompound(temporaryWorkData[0], ref compounds, ref multicellularGrowth,
-                    remainingAllowedCompoundUse, remainingFreeCompounds, ref stillNeedsSomething);
-            }
+            // As we modify the list, we are content just consuming one type of compound per frame
+            var compound = temporaryWorkData[microbeStatus.ConsumeReproductionCompoundsReverse ?
+                temporaryWorkData.Count - 1 : 0];
+            ProcessGrowthCompound(compound, ref compounds, ref multicellularGrowth, remainingAllowedCompoundUse,
+                remainingFreeCompounds, ref stillNeedsSomething);
         }
 
         if (!stillNeedsSomething)

--- a/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
+++ b/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
@@ -203,7 +203,8 @@ public sealed class MulticellularGrowthSystem : AEntitySetSystem<float>
                 multicellularGrowth.CompoundsNeededForNextCell.Count - 1 :
                 0;
 
-            // As we modify the list, we are content just consuming one type of compound per frame
+            // TODO: now that CompoundsNeededForNextCell is a list, it should be possible to consume multiple compounds
+            // per frame
             var pair = multicellularGrowth.CompoundsNeededForNextCell![index];
 
             var compound = pair.Compound;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Updates MulticellularGrowthSystem not to use LINQ reverse. Instead, the compound order is now reversed by using a temporary list.

**Related Issues**

Fixes #4879

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
