### PR TITLE
Added an auto-save the first time the editor becomes available

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1175,6 +1175,29 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
 
         if (!Player.Has<MulticellularSpeciesMember>())
             TutorialState.SendEvent(TutorialEventType.MicrobePlayerReadyToEdit, EventArgs.Empty, this);
+
+        if (CurrentGame == null)
+        {
+            GD.PrintErr("Current game is null when player is ready to edit");
+            return;
+        }
+
+        // Trigger an auto-save the first time the editor becomes available
+        if (!CurrentGame.IsBoolSet("edited_microbe") && Settings.Instance.AutoSaveEnabled.Value)
+        {
+            // But not if already triggered, this is important when loading such an auto-save so that an immediate save
+            // isn't triggered
+            if (!CurrentGame.IsBoolSet("first_editor_autosaved"))
+            {
+                CurrentGame.SetBool("first_editor_autosaved", true);
+
+                Invoke.Instance.QueueForObject(() =>
+                {
+                    GD.Print("Auto-saving game for the first time editor is available");
+                    AutoSave();
+                }, this);
+            }
+        }
     }
 
     protected override void OnGameOver()


### PR DESCRIPTION
**Brief Description of What This PR Does**

This will help with potential issues if the game is prone to crashing when trying to load for the editor for the first time on Mac, but all platforms can benefit from this. This just means that there's one more early auto save in the game.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
