### PR TITLE
If the chunk damage to deal is zero don't deal damage

### DIFF
--- a/src/engine/common_components/DamageOnTouch.cs
+++ b/src/engine/common_components/DamageOnTouch.cs
@@ -21,7 +21,7 @@ public struct DamageOnTouch
     public float DamageAmount;
 
     /// <summary>
-    ///   If true then this is destroyed when this collides with something this could deal damage to
+    ///   If true, then this is destroyed when this collides with something this could deal damage to
     /// </summary>
     public bool DestroyOnTouch;
 

--- a/src/engine/common_systems/DamageOnTouchSystem.cs
+++ b/src/engine/common_systems/DamageOnTouchSystem.cs
@@ -59,6 +59,15 @@ public sealed class DamageOnTouchSystem : AEntitySetSystem<float>
             if (!collision.SecondEntity.Has<Health>())
                 continue;
 
+            // If this doesn't cause any damage, we can consider this hit here immediately a success
+            if (damageTouch.DamageAmount <= 0)
+            {
+                // TODO: if we don't want a pilus touch to trigger this destroy, then more complex handling here is
+                // needed
+                collided = true;
+                break;
+            }
+
             ref var health = ref collision.SecondEntity.Get<Health>();
 
             if (DealDamage(collision.SecondEntity, ref health, ref damageTouch, delta,

--- a/src/microbe_stage/BiomeConditions.cs
+++ b/src/microbe_stage/BiomeConditions.cs
@@ -454,6 +454,12 @@ public class BiomeConditions : IBiomeConditions, ICloneable
             {
                 throw new InvalidRegistryDataException(name, GetType().Name, "Missing physics density for chunk type");
             }
+
+            if (chunk.Value.Damages > 0 && string.IsNullOrEmpty(chunk.Value.DamageType))
+            {
+                throw new InvalidRegistryDataException(name, GetType().Name,
+                    "Missing damage type for chunk type that deals damage");
+            }
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**
Fixes an oversight in the damage on touch system where it tries to deal 0 damage

Also adds safety check to chunks that deal damage that they must have a source type set

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
probably fixes #6052

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
