### PR TITLE
Fix visual artifacts around toxins when chromatic abberation is enabled

### DIFF
--- a/shaders/Chromatic.gdshader
+++ b/shaders/Chromatic.gdshader
@@ -123,11 +123,6 @@ vec3 render(vec2 uv, sampler2D tex)
     return srgb2lin(texture(tex, uv).rgb);
 }
 
-float nrand( vec2 n )
-{
-    return fract(sin(dot(n.xy, vec2(12.9898, 78.233))) * 43758.5453);
-}
-
 void fragment()
 {
     vec4 px = texture(screenTexture, SCREEN_UV);
@@ -144,8 +139,7 @@ void fragment()
 
     const int num_iter = 7;
     const float stepsiz = 1.0 / (float(num_iter)-1.0);
-    float rnd = nrand(UV + fract(TIME));
-    float t = rnd * stepsiz;
+    float t = stepsiz;
 
     vec3 sumcol = vec3(0.0);
     vec3 sumw = vec3(0.0);
@@ -162,7 +156,6 @@ void fragment()
 
     vec3 outcol = sumcol.rgb;
     outcol = lin2srgb(outcol);
-    outcol += rnd / 255.0f;
 
     COLOR = vec4(outcol,1.0);
 }

--- a/shaders/Chromatic.gdshader
+++ b/shaders/Chromatic.gdshader
@@ -123,6 +123,11 @@ vec3 render(vec2 uv, sampler2D tex)
     return srgb2lin(texture(tex, uv).rgb);
 }
 
+float nrand( vec2 n )
+{
+    return fract(sin(dot(n.xy, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 void fragment()
 {
     vec4 px = texture(screenTexture, SCREEN_UV);
@@ -139,8 +144,7 @@ void fragment()
 
     const int num_iter = 7;
     const float stepsiz = 1.0 / (float(num_iter)-1.0);
-    float rnd = fract(1.61803398875 + texture(screenTexture,
-        FRAGCOORD.xy/vec2(textureSize(screenTexture,0)), -10.0 ).x); // nrand( uv + fract(iTime) );
+    float rnd = nrand(UV + fract(TIME));
     float t = rnd * stepsiz;
 
     vec3 sumcol = vec3(0.0);
@@ -158,7 +162,7 @@ void fragment()
 
     vec3 outcol = sumcol.rgb;
     outcol = lin2srgb(outcol);
-    outcol += rnd/255.0;
+    outcol += rnd / 255.0f;
 
     COLOR = vec4(outcol,1.0);
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes the weird outlines near toxins (and some other objects), which appear when chromatic abberation is enabled.
Apparently, the cause of their appearance was a wrong random number generation method, which used screen texture as a noise texture. This PR uses a different RNG function ([taken from here](https://www.shadertoy.com/view/XssGz8)).

This changes the chromatic aberration visuals, adding flickering noise. If this is undesirable, randomness could be removed and the shader would retain its former look (just without artifacts).

https://github.com/user-attachments/assets/0d792f9a-5172-4bff-bacf-75781ccbb8ff

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
