### PR TITLE
Removed percentage display from the compounds chart

### DIFF
--- a/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
+++ b/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
@@ -532,7 +532,6 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
 
         sunlightChart.TooltipYAxisFormat = percentageFormat + " lx";
         atmosphericGassesChart.TooltipYAxisFormat = percentageFormat;
-        compoundsChart.TooltipYAxisFormat = percentageFormat;
 
         speciesPopulationChart.LegendMode = LineChart.LegendDisplayMode.DropDown;
 
@@ -573,7 +572,7 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
         speciesPopulationChart.Plot(Localization.Translate("YEARS"), string.Empty, 5,
             Localization.Translate("SPECIES_LIST"), speciesPopDatasetsLegend,
             Editor.CurrentGame.GameWorld.PlayerSpecies.FormattedName, 5);
-        compoundsChart.Plot(Localization.Translate("YEARS"), "%", 5, Localization.Translate("COMPOUNDS"),
+        compoundsChart.Plot(Localization.Translate("YEARS"), string.Empty, 5, Localization.Translate("COMPOUNDS"),
             null, null, 5);
 
         OnPhysicalConditionsChartLegendPressed("temperature");


### PR DESCRIPTION
as this should have been the last place that referred to the conditions as percentages

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

closes #1682

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
