### PR TITLE
Try to make checks ignore generated.cs files

### DIFF
--- a/CIConfiguration.yml
+++ b/CIConfiguration.yml
@@ -82,8 +82,9 @@ jobs:
       - run:
           when: always
           name: Check cleanup changes
+          # Mode changes are ignored as that can cause spurious failures due to hardlink-based caching
           command: |
-            git diff > cleanup_diff.patch
+            git -c core.fileMode=false diff > cleanup_diff.patch
             if grep -q '[^[:space:]]' < cleanup_diff.patch; then
                 echo "Code cleanup found things to be fixed:"
                 cat cleanup_diff.patch
@@ -134,8 +135,9 @@ jobs:
       - run:
           when: always
           name: Check format changes
+          # Mode changes are ignored as that can cause spurious failures due to hardlink-based caching
           command: |
-            git diff > format_diff.patch
+            git -c core.fileMode=false diff > format_diff.patch
             if grep -q '[^[:space:]]' < format_diff.patch; then
                 echo "Formatter found things to be fixed:"
                 cat format_diff.patch

--- a/Scripts/CodeChecks.cs
+++ b/Scripts/CodeChecks.cs
@@ -76,6 +76,8 @@ public class CodeChecks : CodeChecksBase<Program.CheckOptions>
         FilePathsToAlwaysIgnore.Add(new Regex(@"\.godot\/"));
 
         FilePathsToAlwaysIgnore.Add(new Regex(@"Scripts\/GodotAPIData"));
+
+        FilePathsToAlwaysIgnore.Add(new Regex(@"\.generated\.cs$"));
     }
 
     protected override Dictionary<string, CodeCheck> ValidChecks { get; }
@@ -89,6 +91,7 @@ public class CodeChecks : CodeChecksBase<Program.CheckOptions>
         "third_party/**.hpp",
         "Scripts/GodotAPIData/*",
         "addons/**",
+        "*.generated.cs",
     ];
 
     protected override IEnumerable<string> ExtraIgnoredJetbrainsCleanUpWildcards =>
@@ -99,6 +102,7 @@ public class CodeChecks : CodeChecksBase<Program.CheckOptions>
         "third_party/godot-cpp/**",
         "Scripts/GodotAPIData/*",
         "addons/**",
+        "*.generated.cs",
     ];
 
     protected override string MainSolutionFile => "Thrive.sln";


### PR DESCRIPTION
**Brief Description of What This PR Does**

As those probably cause like the JetBrains check at least to take a bunch of extra time, especially as Godot 4 creates a lot more .generated.cs files

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
