### PR TITLE
Correct the way color is applied to line edits

### DIFF
--- a/src/gui_common/GUICommon.cs
+++ b/src/gui_common/GUICommon.cs
@@ -98,12 +98,12 @@ public partial class GUICommon : Node
 
     public static void MarkInputAsInvalid(LineEdit control)
     {
-        control.Set("custom_colors/font_color", new Color(1.0f, 0.3f, 0.3f));
+        control.AddThemeColorOverride("font_color", new Color(1.0f, 0.3f, 0.3f));
     }
 
     public static void MarkInputAsValid(LineEdit control)
     {
-        control.Set("custom_colors/font_color", new Color(1, 1, 1));
+        control.AddThemeColorOverride("font_color", new Color(1, 1, 1));
     }
 
     public override void _Ready()

--- a/src/saving/NewSaveMenu.cs
+++ b/src/saving/NewSaveMenu.cs
@@ -195,12 +195,12 @@ public partial class NewSaveMenu : Control
     {
         if (IsSaveNameValid(newName))
         {
-            saveNameBox.Set("custom_colors/font_color", new Color(1, 1, 1));
+            GUICommon.MarkInputAsValid(saveNameBox);
             saveButton.Disabled = false;
         }
         else
         {
-            saveNameBox.Set("custom_colors/font_color", new Color(1.0f, 0.3f, 0.3f));
+            GUICommon.MarkInputAsInvalid(saveNameBox);
             saveButton.Disabled = true;
         }
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Corrects the way line edit coloring works (when they are marked as valid/invalid).

**Related Issues**

Line edits' font color wasn't changed when they were marked as valid/invalid (e.g. in fossilisation dialogues).

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
