### PR TITLE
Fix a crash when entering an editor scene directly from Godot

### DIFF
--- a/src/microbe_stage/editor/TolerancesEditorSubComponent.cs
+++ b/src/microbe_stage/editor/TolerancesEditorSubComponent.cs
@@ -21,6 +21,8 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
     private readonly Dictionary<OrganelleDefinition, float> tempToleranceModifiers = new();
 
+    private CompoundDefinition temperature = null!;
+
 #pragma warning disable CA2213
 
     [Export]
@@ -177,6 +179,8 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
     public override void Init(ICellEditorData owningEditor, bool fresh)
     {
         base.Init(owningEditor, fresh);
+
+        temperature = temperature;
 
         wasFreshInit = fresh;
     }
@@ -351,7 +355,7 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
         // Copy the units here automatically
         if (temperatureRangeToolTip != null)
         {
-            temperatureRangeToolTip.ValueSuffix = SimulationParameters.GetCompound(Compound.Temperature).Unit;
+            temperatureRangeToolTip.ValueSuffix = temperature.Unit;
         }
         else
         {
@@ -730,11 +734,11 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
         temperatureMinLabel.Text =
             unitFormat.FormatSafe(
                 Math.Round(preferredTemperatureWithOrganelles - temperatureToleranceWithOrganelles, 1),
-                SimulationParameters.GetCompound(Compound.Temperature).Unit);
+                temperature.Unit);
         temperatureMaxLabel.Text =
             unitFormat.FormatSafe(
                 Math.Round(preferredTemperatureWithOrganelles + temperatureToleranceWithOrganelles, 1),
-                SimulationParameters.GetCompound(Compound.Temperature).Unit);
+                temperature.Unit);
 
         // Show in red the conditions that are not matching to make them easier to notice
         if (Math.Abs(patchTemperature - preferredTemperatureWithOrganelles) >
@@ -828,10 +832,10 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
         // Temperature
         temperatureToleranceLabel.Text =
             unitFormat.FormatSafe(Math.Round(CurrentTolerances.TemperatureTolerance, 1),
-            SimulationParameters.GetCompound(Compound.Temperature).Unit);
+            temperature.Unit);
 
         var value = unitFormat.FormatSafe(Math.Round(organelleModifiers.TemperatureTolerance, 1),
-            SimulationParameters.GetCompound(Compound.Temperature).Unit);
+            temperature.Unit);
 
         value = organelleModifiers.TemperatureTolerance >= 0 ? "+" + value : value;
 

--- a/src/microbe_stage/editor/TolerancesEditorSubComponent.cs
+++ b/src/microbe_stage/editor/TolerancesEditorSubComponent.cs
@@ -19,8 +19,6 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
     private readonly StringName toleranceFlashName = new("FlashPressureRange");
     private readonly StringName tooWideRangeName = new("PopupPressureRangeWarning");
 
-    private readonly CompoundDefinition temperature = SimulationParameters.GetCompound(Compound.Temperature);
-
     private readonly Dictionary<OrganelleDefinition, float> tempToleranceModifiers = new();
 
 #pragma warning disable CA2213
@@ -732,11 +730,11 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
         temperatureMinLabel.Text =
             unitFormat.FormatSafe(
                 Math.Round(preferredTemperatureWithOrganelles - temperatureToleranceWithOrganelles, 1),
-                temperature.Unit);
+                SimulationParameters.GetCompound(Compound.Temperature).Unit);
         temperatureMaxLabel.Text =
             unitFormat.FormatSafe(
                 Math.Round(preferredTemperatureWithOrganelles + temperatureToleranceWithOrganelles, 1),
-                temperature.Unit);
+                SimulationParameters.GetCompound(Compound.Temperature).Unit);
 
         // Show in red the conditions that are not matching to make them easier to notice
         if (Math.Abs(patchTemperature - preferredTemperatureWithOrganelles) >
@@ -829,9 +827,11 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
         // Temperature
         temperatureToleranceLabel.Text =
-            unitFormat.FormatSafe(Math.Round(CurrentTolerances.TemperatureTolerance, 1), temperature.Unit);
+            unitFormat.FormatSafe(Math.Round(CurrentTolerances.TemperatureTolerance, 1),
+            SimulationParameters.GetCompound(Compound.Temperature).Unit);
 
-        var value = unitFormat.FormatSafe(Math.Round(organelleModifiers.TemperatureTolerance, 1), temperature.Unit);
+        var value = unitFormat.FormatSafe(Math.Round(organelleModifiers.TemperatureTolerance, 1),
+            SimulationParameters.GetCompound(Compound.Temperature).Unit);
 
         value = organelleModifiers.TemperatureTolerance >= 0 ? "+" + value : value;
 

--- a/src/microbe_stage/editor/TolerancesEditorSubComponent.cs
+++ b/src/microbe_stage/editor/TolerancesEditorSubComponent.cs
@@ -180,7 +180,7 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
     {
         base.Init(owningEditor, fresh);
 
-        temperature = temperature;
+        temperature = SimulationParameters.GetCompound(Compound.Temperature);
 
         wasFreshInit = fresh;
     }
@@ -831,11 +831,9 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
         // Temperature
         temperatureToleranceLabel.Text =
-            unitFormat.FormatSafe(Math.Round(CurrentTolerances.TemperatureTolerance, 1),
-            temperature.Unit);
+            unitFormat.FormatSafe(Math.Round(CurrentTolerances.TemperatureTolerance, 1), temperature.Unit);
 
-        var value = unitFormat.FormatSafe(Math.Round(organelleModifiers.TemperatureTolerance, 1),
-            temperature.Unit);
+        var value = unitFormat.FormatSafe(Math.Round(organelleModifiers.TemperatureTolerance, 1), temperature.Unit);
 
         value = organelleModifiers.TemperatureTolerance >= 0 ? "+" + value : value;
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes a crash that happened when an editor scene was entered directly from the Godot Editor. It happened because a field initialization in `TolerancesEditorSubComponent` depended on `SimulationParameters` being initialized, which only happens when the game is started from the main menu.

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
