### PR TITLE
Thrive Photosythesis balance patch

### DIFF
--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -38,7 +38,7 @@
       "carbondioxide": 0.27
     },
     "Outputs": {
-      "glucose": 0.36,
+      "glucose": 0.13,
       "oxygen": 0.27
     }
   },
@@ -214,11 +214,11 @@
     "Name": "PHOTOSYNTHESIS",
     "Inputs": {
       "sunlight": 1,
-      "carbondioxide": 0.081
+      "carbondioxide": 0.27
     },
     "Outputs": {
-      "glucose": 0.03,
-      "oxygen": 0.081
+      "glucose": 0.08,
+      "oxygen": 0.27
     }
   },
   "iron_chemolithoautotrophy": {

--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -38,7 +38,7 @@
       "carbondioxide": 0.27
     },
     "Outputs": {
-      "glucose": 0.13,
+      "glucose": 0.18,
       "oxygen": 0.27
     }
   },

--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -217,7 +217,7 @@
       "carbondioxide": 0.27
     },
     "Outputs": {
-      "glucose": 0.08,
+      "glucose": 0.1,
       "oxygen": 0.27
     }
   },


### PR DESCRIPTION
**What This Does**

Reduces the efficiency of photosynthesis making it less unbalanced. This pull request does not change the code, it just changes the parameters in the JSON file. This is make in order to make heterotrophic-phototrophic less overpowered..

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
