### PR TITLE
Remember once tolerance tab has been visible once

### DIFF
--- a/src/general/base_stage/EditorBase.cs
+++ b/src/general/base_stage/EditorBase.cs
@@ -316,7 +316,7 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
     ///   Tries to start editor apply results and exit
     /// </summary>
     /// <returns>True if started. False if something is not good and the editor can't be exited currently.</returns>
-    public bool OnFinishEditing(List<EditorUserOverride>? overrides = null)
+    public virtual bool OnFinishEditing(List<EditorUserOverride>? overrides = null)
     {
         // Prevent exiting when the transition hasn't finished
         if (!TransitionFinished)

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1132,6 +1132,11 @@ public partial class CellEditorComponent :
         toleranceTabButton.Visible = false;
     }
 
+    public bool AreAdvancedTabsVisible()
+    {
+        return growthOrderTabButton.Visible || toleranceTabButton.Visible;
+    }
+
     public void HideAutoEvoPredictionForTutorial()
     {
         autoEvoPredictionPanel.Visible = false;


### PR DESCRIPTION
and don't hide it after that, this should hopefully not make it possible for more bug reports to be made about inconsistent visibility of the tabs between editor cycles

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

Hopefully prevents more feedback about inconsistent tab visibility after 0.8.2 is out

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
