### PR TITLE
Make sure player has at least 1 population after external effects

### DIFF
--- a/src/general/base_stage/EditorBase.cs
+++ b/src/general/base_stage/EditorBase.cs
@@ -806,7 +806,7 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
         ElapseEditorEntryTime();
         UpdatePatchDetails();
 
-        // Get summary before applying results in order to get comparisons to the previous populations
+        // Get a summary before applying results in order to get comparisons to the previous populations
         var run = CurrentGame.GameWorld.GetAutoEvoRun();
 
         if (run.Results != null)
@@ -814,6 +814,16 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
             // External effects need to be finalized now before we use them for printing summaries or anything like
             // that
             run.CalculateAndApplyFinalExternalEffectSizes();
+
+            var safetyPatch = CurrentGame.GameWorld.Map.CurrentPatch ??
+                CurrentGame.GameWorld.Map.Patches.Values.First();
+
+            // If the player made it to the editor, it is intended that the player has not lost the game, so ensure
+            // the player species is not without population (and would thus get marked as extinct)
+            if (run.Results.EnsureIsNotExtinct(CurrentGame.GameWorld.PlayerSpecies, safetyPatch))
+            {
+                GD.Print("Rescued player species population from extinction thanks to making it to the editor");
+            }
 
             run.Results.RegisterNewSpeciesForSummary(CurrentGame.GameWorld);
 


### PR DESCRIPTION
so that the player if they made it to the editor won't get stuck with a "soft" game over

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
report from a player that they got marked as extinct when going to the editor, though I'm not fully sure if that was caused by this specifically, but this fixes at least one such condition I was able to trigger

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
