### PR TITLE
Fixed art gallery sound cards resuming on modal close

### DIFF
--- a/src/gui_common/PlaybackControls.cs
+++ b/src/gui_common/PlaybackControls.cs
@@ -57,6 +57,14 @@ public partial class PlaybackControls : HBoxContainer
         UpdateSlider();
     }
 
+    public override void _EnterTree()
+    {
+        base._EnterTree();
+
+        // Stop an engine bug from resuming this player when our parent modal is closed
+        StopPlayback();
+    }
+
     public override void _ExitTree()
     {
         base._ExitTree();
@@ -84,6 +92,7 @@ public partial class PlaybackControls : HBoxContainer
         }
 
         AudioPlayer.StreamPaused = false;
+        AudioPlayer.VolumeLinear = 1;
         AudioPlayer.Play(PlaybackPosFromProgress(playbackProgress));
     }
 
@@ -99,8 +108,11 @@ public partial class PlaybackControls : HBoxContainer
         }
 
         AudioPlayer.StreamPaused = true;
-        AudioPlayer.Playing = false;
+        AudioPlayer.Stop();
         AudioPlayer.Seek(0);
+
+        // Prevent engine bugs from sounding bad when the sound is resumed for like a fraction of a second
+        AudioPlayer.VolumeLinear = 0;
     }
 
     private float ProgressFromPlaybackPos(float value)
@@ -164,6 +176,7 @@ public partial class PlaybackControls : HBoxContainer
             return;
 
         AudioPlayer.StreamPaused = paused;
+        AudioPlayer.VolumeLinear = paused ? 0 : 1;
 
         if (!paused && !Playing)
             StartPlayback();

--- a/src/gui_common/art_gallery/GalleryCardAudio.cs
+++ b/src/gui_common/art_gallery/GalleryCardAudio.cs
@@ -70,7 +70,7 @@ public partial class GalleryCardAudio : GalleryCard, IGalleryCardPlayback
     {
         if (ownPlayer == null)
         {
-            ownPlayer = new AudioStreamPlayer { Stream = GD.Load<AudioStream>(Asset.ResourcePath) };
+            ownPlayer = new AudioStreamPlayer { Stream = GD.Load<AudioStream>(Asset.ResourcePath), VolumeLinear = 0 };
             UpdatePlaybackBar();
             AddChild(ownPlayer);
         }

--- a/src/gui_common/art_gallery/GalleryViewer.cs
+++ b/src/gui_common/art_gallery/GalleryViewer.cs
@@ -458,7 +458,7 @@ public partial class GalleryViewer : CustomWindow
         if (sender == null)
             throw new ArgumentException("Invalid event sender");
 
-        // Assume sender is of playback type, as it should be
+        // Assume the sender is of the playback type, as it should be
         var playback = (IGalleryCardPlayback)sender;
 
         slideScreen.CurrentSlideIndex = CurrentCards.IndexOf((GalleryCard)playback);


### PR DESCRIPTION
this seems like an engine bug where the player is resumed when reparented back into the scene, so now this force stops and disables sound level when we don't want the card playing

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
I think the related issue was closed already but I was able to just reproduce the problem again

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
