### PR TITLE
Alter process indicator speed during speed mode

### DIFF
--- a/src/general/base_stage/CreatureStageHUDBase.cs
+++ b/src/general/base_stage/CreatureStageHUDBase.cs
@@ -1091,6 +1091,14 @@ public partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSta
         processPanel.ShownData = stage is { HasAlivePlayer: true } ? GetPlayerProcessStatistics() : null;
     }
 
+    protected void UpdateProcessPanelExternalSpeedModifier(float newValue)
+    {
+        if (!processPanel.Visible)
+            return;
+
+        processPanel.ExternalSpeedModifier = newValue;
+    }
+
     protected virtual ProcessStatistics? GetPlayerProcessStatistics()
     {
         throw new GodotAbstractMethodNotOverriddenException();

--- a/src/gui_common/ChemicalEquation.cs
+++ b/src/gui_common/ChemicalEquation.cs
@@ -7,8 +7,6 @@ using Godot;
 /// </summary>
 public partial class ChemicalEquation : VBoxContainer
 {
-    public ProcessList ParentList = null!;
-
 #pragma warning disable CA2213
     [Export]
     public LabelSettings DefaultTitleFont = null!;
@@ -126,6 +124,8 @@ public partial class ChemicalEquation : VBoxContainer
     /// </summary>
     public bool ShowPerSecondLabel { get; set; } = true;
 
+    public float ExternalSpeedModifier { get; set; } = 1.0f;
+
     /// <summary>
     ///   Only if this is true, the text "/ second" is shown fully, instead of being abbreviated to ` / s`
     /// </summary>
@@ -175,7 +175,7 @@ public partial class ChemicalEquation : VBoxContainer
     {
         if (ShowSpinner && EquationFromProcess != null)
         {
-            currentSpinnerRotation += (float)delta * EquationFromProcess.CurrentSpeed * SpinnerBaseSpeed * ParentList.ExternalSpeedModifier;
+            currentSpinnerRotation += (float)delta * EquationFromProcess.CurrentSpeed * SpinnerBaseSpeed * ExternalSpeedModifier;
 
             // TODO: should we at some point subtract like 100000*360 from the spinner rotation to avoid float range
             // exceeding?

--- a/src/gui_common/ChemicalEquation.cs
+++ b/src/gui_common/ChemicalEquation.cs
@@ -7,6 +7,8 @@ using Godot;
 /// </summary>
 public partial class ChemicalEquation : VBoxContainer
 {
+    public ProcessList ParentList = null!;
+
 #pragma warning disable CA2213
     [Export]
     public LabelSettings DefaultTitleFont = null!;
@@ -173,7 +175,7 @@ public partial class ChemicalEquation : VBoxContainer
     {
         if (ShowSpinner && EquationFromProcess != null)
         {
-            currentSpinnerRotation += (float)delta * EquationFromProcess.CurrentSpeed * SpinnerBaseSpeed;
+            currentSpinnerRotation += (float)delta * EquationFromProcess.CurrentSpeed * SpinnerBaseSpeed * ParentList.ExternalSpeedModifier;
 
             // TODO: should we at some point subtract like 100000*360 from the spinner rotation to avoid float range
             // exceeding?

--- a/src/gui_common/ChemicalEquation.cs
+++ b/src/gui_common/ChemicalEquation.cs
@@ -175,7 +175,8 @@ public partial class ChemicalEquation : VBoxContainer
     {
         if (ShowSpinner && EquationFromProcess != null)
         {
-            currentSpinnerRotation += (float)delta * EquationFromProcess.CurrentSpeed * SpinnerBaseSpeed * ExternalSpeedModifier;
+            currentSpinnerRotation += (float)delta * EquationFromProcess.CurrentSpeed * SpinnerBaseSpeed
+                * ExternalSpeedModifier;
 
             // TODO: should we at some point subtract like 100000*360 from the spinner rotation to avoid float range
             // exceeding?

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -156,6 +156,8 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
             UpdateMacroscopicButton(stage.Player);
 
             UpdateHeatHelperWidget(stage.Player);
+
+            UpdateProcessPanelExternalSpeedModifier(stage.WorldSimulation.WorldTimeScale);
         }
         else
         {
@@ -250,7 +252,6 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
         var resultingModifier = fastModeEnabled ? 2 : 1;
 
         stage.WorldSimulation.WorldTimeScale = resultingModifier;
-        UpdateProcessPanelExternalSpeedModifier(resultingModifier);
     }
 
     public override bool GetCurrentSpeedMode()

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -247,7 +247,10 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
             return;
         }
 
-        stage.WorldSimulation.WorldTimeScale = fastModeEnabled ? 2 : 1;
+        var resultingModifier = fastModeEnabled ? 2 : 1;
+
+        stage.WorldSimulation.WorldTimeScale = resultingModifier;
+        UpdateProcessPanelExternalSpeedModifier(resultingModifier);
     }
 
     public override bool GetCurrentSpeedMode()

--- a/src/microbe_stage/ProcessList.cs
+++ b/src/microbe_stage/ProcessList.cs
@@ -11,6 +11,8 @@ public partial class ProcessList : VBoxContainer
     private PackedScene chemicalEquationScene = null!;
 #pragma warning restore CA2213
 
+    private float externalSpeedModifier = 1.0f;
+
     private ChildObjectCache<StrictProcessDisplayInfoEquality, ChemicalEquation> createdProcessControls = null!;
     private List<StrictProcessDisplayInfoEquality>? processesToShow;
 
@@ -36,7 +38,17 @@ public partial class ProcessList : VBoxContainer
     /// <summary>
     ///   External, more technical modifiers for speed, like 2x gameplay speed modifier
     /// </summary>
-    public float ExternalSpeedModifier { get; set; } = 1.0f;
+    public float ExternalSpeedModifier
+    {
+        get => externalSpeedModifier;
+
+        set
+        {
+            externalSpeedModifier = value;
+
+            UpdateEquationsExternalSpeedModifier();
+        }
+    }
 
     /// <summary>
     ///   If true the color of one of the process titles in this list will be changed to red
@@ -96,7 +108,7 @@ public partial class ProcessList : VBoxContainer
         equation.ShowToggle = ShowToggles;
         equation.MarkRedOnLimitingCompounds = MarkRedOnLimitingCompounds;
         equation.AutoRefreshProcess = UpdateEquationAutomatically;
-        equation.ParentList = this;
+        equation.ExternalSpeedModifier = ExternalSpeedModifier;
 
         equation.Connect(SignalName.ToggleProcessPressed, new Callable(this, nameof(HandleToggleProcess)));
 
@@ -107,6 +119,14 @@ public partial class ProcessList : VBoxContainer
         equation.EquationFromProcess = process.DisplayInfo;
 
         return equation;
+    }
+
+    private void UpdateEquationsExternalSpeedModifier()
+    {
+        foreach (var equation in createdProcessControls.GetChildren())
+        {
+            equation.ExternalSpeedModifier = ExternalSpeedModifier;
+        }
     }
 
     private void HandleToggleProcess(ChemicalEquation equation, bool enabled)

--- a/src/microbe_stage/ProcessList.cs
+++ b/src/microbe_stage/ProcessList.cs
@@ -127,7 +127,7 @@ public partial class ProcessList : VBoxContainer
 
     private void UpdateEquationsExternalSpeedModifier()
     {
-        if (createdProcessControls == null)
+        if (createdProcessControls == null!)
             return;
 
         if (ExternalSpeedModifier == previousExternalSpeedModifier)

--- a/src/microbe_stage/ProcessList.cs
+++ b/src/microbe_stage/ProcessList.cs
@@ -34,6 +34,11 @@ public partial class ProcessList : VBoxContainer
     public LabelSettings? ProcessesTitleColour { get; set; }
 
     /// <summary>
+    ///   External, more technical modifiers for speed, like 2x gameplay speed modifier
+    /// </summary>
+    public float ExternalSpeedModifier { get; set; } = 1.0f;
+
+    /// <summary>
     ///   If true the color of one of the process titles in this list will be changed to red
     ///   if it has any limiting compounds.
     /// </summary>
@@ -91,6 +96,7 @@ public partial class ProcessList : VBoxContainer
         equation.ShowToggle = ShowToggles;
         equation.MarkRedOnLimitingCompounds = MarkRedOnLimitingCompounds;
         equation.AutoRefreshProcess = UpdateEquationAutomatically;
+        equation.ParentList = this;
 
         equation.Connect(SignalName.ToggleProcessPressed, new Callable(this, nameof(HandleToggleProcess)));
 

--- a/src/microbe_stage/ProcessList.cs
+++ b/src/microbe_stage/ProcessList.cs
@@ -127,9 +127,6 @@ public partial class ProcessList : VBoxContainer
 
     private void UpdateEquationsExternalSpeedModifier()
     {
-        if (createdProcessControls == null)
-            return;
-
         if (ExternalSpeedModifier == previousExternalSpeedModifier)
             return;
 

--- a/src/microbe_stage/ProcessList.cs
+++ b/src/microbe_stage/ProcessList.cs
@@ -12,7 +12,6 @@ public partial class ProcessList : VBoxContainer
 #pragma warning restore CA2213
 
     private float externalSpeedModifier = 1.0f;
-    private float previousExternalSpeedModifier;
 
     private ChildObjectCache<StrictProcessDisplayInfoEquality, ChemicalEquation> createdProcessControls = null!;
     private List<StrictProcessDisplayInfoEquality>? processesToShow;
@@ -119,7 +118,7 @@ public partial class ProcessList : VBoxContainer
         if (ProcessesTitleColour != null)
             equation.DefaultTitleFont = ProcessesTitleColour;
 
-        // This creates processes already so this needs to be done last
+        // This creates processes already, so this needs to be done last
         equation.EquationFromProcess = process.DisplayInfo;
 
         return equation;
@@ -127,18 +126,14 @@ public partial class ProcessList : VBoxContainer
 
     private void UpdateEquationsExternalSpeedModifier()
     {
+        // If _Ready was not called yet, don't try to update anything
         if (createdProcessControls == null!)
-            return;
-
-        if (ExternalSpeedModifier == previousExternalSpeedModifier)
             return;
 
         foreach (var equation in createdProcessControls.GetChildren())
         {
             equation.ExternalSpeedModifier = ExternalSpeedModifier;
         }
-
-        previousExternalSpeedModifier = ExternalSpeedModifier;
     }
 
     private void HandleToggleProcess(ChemicalEquation equation, bool enabled)

--- a/src/microbe_stage/ProcessList.cs
+++ b/src/microbe_stage/ProcessList.cs
@@ -12,6 +12,7 @@ public partial class ProcessList : VBoxContainer
 #pragma warning restore CA2213
 
     private float externalSpeedModifier = 1.0f;
+    private float previousExternalSpeedModifier;
 
     private ChildObjectCache<StrictProcessDisplayInfoEquality, ChemicalEquation> createdProcessControls = null!;
     private List<StrictProcessDisplayInfoEquality>? processesToShow;
@@ -44,6 +45,9 @@ public partial class ProcessList : VBoxContainer
 
         set
         {
+            if (value == externalSpeedModifier)
+                return;
+
             externalSpeedModifier = value;
 
             UpdateEquationsExternalSpeedModifier();
@@ -123,10 +127,18 @@ public partial class ProcessList : VBoxContainer
 
     private void UpdateEquationsExternalSpeedModifier()
     {
+        if (createdProcessControls == null)
+            return;
+
+        if (ExternalSpeedModifier == previousExternalSpeedModifier)
+            return;
+
         foreach (var equation in createdProcessControls.GetChildren())
         {
             equation.ExternalSpeedModifier = ExternalSpeedModifier;
         }
+
+        previousExternalSpeedModifier = ExternalSpeedModifier;
     }
 
     private void HandleToggleProcess(ChemicalEquation equation, bool enabled)

--- a/src/microbe_stage/ProcessList.cs
+++ b/src/microbe_stage/ProcessList.cs
@@ -127,6 +127,9 @@ public partial class ProcessList : VBoxContainer
 
     private void UpdateEquationsExternalSpeedModifier()
     {
+        if (createdProcessControls == null)
+            return;
+
         if (ExternalSpeedModifier == previousExternalSpeedModifier)
             return;
 

--- a/src/microbe_stage/ProcessPanel.cs
+++ b/src/microbe_stage/ProcessPanel.cs
@@ -34,7 +34,6 @@ public partial class ProcessPanel : CustomWindow
                 return processList.ExternalSpeedModifier;
 
             return 1.0f;
-
         }
 
         set

--- a/src/microbe_stage/ProcessPanel.cs
+++ b/src/microbe_stage/ProcessPanel.cs
@@ -26,6 +26,24 @@ public partial class ProcessPanel : CustomWindow
 
     public ProcessStatistics? ShownData { get; set; }
 
+    public float ExternalSpeedModifier
+    {
+        get
+        {
+            if (processList != null)
+                return processList.ExternalSpeedModifier;
+
+            return 1.0f;
+
+        }
+
+        set
+        {
+            if (processList != null)
+                processList.ExternalSpeedModifier = value;
+        }
+    }
+
     public override void _Ready()
     {
         processList = GetNode<ProcessList>(ProcessListPath);

--- a/src/microbe_stage/ProcessPanel.cs
+++ b/src/microbe_stage/ProcessPanel.cs
@@ -30,16 +30,12 @@ public partial class ProcessPanel : CustomWindow
     {
         get
         {
-            if (processList != null)
-                return processList.ExternalSpeedModifier;
-
-            return 1.0f;
+            return processList.ExternalSpeedModifier;
         }
 
         set
         {
-            if (processList != null)
-                processList.ExternalSpeedModifier = value;
+            processList.ExternalSpeedModifier = value;
         }
     }
 

--- a/src/microbe_stage/ProcessPanel.cs
+++ b/src/microbe_stage/ProcessPanel.cs
@@ -28,15 +28,9 @@ public partial class ProcessPanel : CustomWindow
 
     public float ExternalSpeedModifier
     {
-        get
-        {
-            return processList.ExternalSpeedModifier;
-        }
+        get => processList.ExternalSpeedModifier;
 
-        set
-        {
-            processList.ExternalSpeedModifier = value;
-        }
+        set => processList.ExternalSpeedModifier = value;
     }
 
     public override void _Ready()


### PR DESCRIPTION
**Brief Description of What This PR Does**

CreatureHUDBase now has method for updating process list speed modifier that is called when speed mode is changed.
ChemicalEquations now know their ProcessList parent and said ProcessList has speed modifier property that is read by chemical equations. ProcessPanel uses ProcessList's speed modifier property. It's just ported into seperate one so it can be accessed by HUD.

**Related Issues**

Closes #6048

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
