### PR TITLE
Clear cell type selection when the cell type is deleted

### DIFF
--- a/src/macroscopic_stage/editor/MacroscopicEditor.cs
+++ b/src/macroscopic_stage/editor/MacroscopicEditor.cs
@@ -531,6 +531,15 @@ public partial class MacroscopicEditor : EditorBase<EditorAction, MacroscopicSta
             return;
         }
 
+        // If there is a null name, that means there is no selected cell,
+        // so clear the selectedCellTypeToEdit and return early
+        if (string.IsNullOrEmpty(name))
+        {
+            selectedCellTypeToEdit = null;
+            GD.Print("Cleared editing cell type");
+            return;
+        }
+
         var newTypeToEdit = EditedSpecies.CellTypes.First(c => c.TypeName == name);
 
         // Only reinitialize the editor when required

--- a/src/macroscopic_stage/editor/MacroscopicEditor.cs
+++ b/src/macroscopic_stage/editor/MacroscopicEditor.cs
@@ -522,7 +522,7 @@ public partial class MacroscopicEditor : EditorBase<EditorAction, MacroscopicSta
         bodyEditorLight.Visible = bodyEditor;
     }
 
-    private void OnStartEditingCellType(string name)
+    private void OnStartEditingCellType(string? name)
     {
         if (CanCancelAction)
         {

--- a/src/macroscopic_stage/editor/MetaballBodyEditorComponent.cs
+++ b/src/macroscopic_stage/editor/MetaballBodyEditorComponent.cs
@@ -976,6 +976,9 @@ public partial class MetaballBodyEditorComponent :
     {
         activeActionName = null;
         OnCurrentActionChanged();
+
+        // Clear the edited cell type
+        EmitSignal(SignalName.OnCellTypeToEditSelected, default(Variant));
     }
 
     private void OnMetaballsChanged()


### PR DESCRIPTION
**Brief Description of What This PR Does**

Clear the cell type from being edited when it's deleted (in macroscopic editor).

**Related Issues**

Closes #3228

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
