### PR TITLE
Fixed incorrect mouse mode on tolerances tooltip group

### DIFF
--- a/src/engine/ScreenFilter.tscn
+++ b/src/engine/ScreenFilter.tscn
@@ -10,5 +10,6 @@ material = SubResource("2")
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 2
 color = Color(1, 1, 1, 0)
 script = ExtResource("1")

--- a/src/gui_common/tooltip/ToolTipManager.tscn
+++ b/src/gui_common/tooltip/ToolTipManager.tscn
@@ -869,6 +869,7 @@ DisplayDelay = 2.5
 anchors_preset = 0
 offset_right = 40.0
 offset_bottom = 40.0
+mouse_filter = 2
 
 [node name="temperature" parent="GroupHolder/tolerances" instance=ExtResource("14_k78dl")]
 visible = false

--- a/src/thriveopedia/Thriveopedia.tscn
+++ b/src/thriveopedia/Thriveopedia.tscn
@@ -198,8 +198,11 @@ layout_mode = 2
 custom_minimum_size = Vector2(35, 35)
 layout_mode = 2
 tooltip_text = "TOGGLE_NAVIGATION_TREE"
+focus_neighbor_left = NodePath(".")
 focus_neighbor_right = NodePath("../BackButton")
+focus_neighbor_bottom = NodePath("../../HBoxContainer3/MarginContainer2/MarginContainer/VBoxContainer/PageTree")
 focus_next = NodePath("../BackButton")
+focus_previous = NodePath("../../HBoxContainer3/MarginContainer2/MarginContainer/VBoxContainer/PageTree")
 texture_normal = ExtResource("22")
 texture_pressed = ExtResource("24")
 texture_hover = ExtResource("23")
@@ -345,7 +348,7 @@ theme = ExtResource("2")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="MarginContainer/VBoxContainer/HBoxContainer3/MarginContainer2/MarginContainer"]
 libraries = {
-"": SubResource("AnimationLibrary_4nf6r")
+&"": SubResource("AnimationLibrary_4nf6r")
 }
 
 [node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer/HBoxContainer3"]


### PR DESCRIPTION
that made immediate top-left of the screen non-clickable. That caused things like the toggle button for the Thriveopedia sidebar to only have a bit of clickable area.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

https://discord.com/channels/228300288023461893/958598553389903913/1368303664418132099

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
