### PR TITLE
Added a command line flag to disable mods

### DIFF
--- a/src/engine/LaunchOptions.cs
+++ b/src/engine/LaunchOptions.cs
@@ -12,6 +12,7 @@ public static class LaunchOptions
     private static readonly Lazy<bool> DisableVideosOption = new(ReadDisableVideo);
     private static readonly Lazy<bool> SkipCPUCheckOption = new(ReadSkipCPUCheck);
     private static readonly Lazy<bool> DisableAvxOption = new(ReadDisableAvx);
+    private static readonly Lazy<bool> DisableModsOption = new(ReadDisableMods);
 
     private static readonly Lazy<bool> LaunchedThroughLauncherHolder = new(ReadLaunchedThroughLauncher);
     private static readonly Lazy<bool> LaunchingLauncherIsHiddenHolder = new(ReadLaunchingLauncherIsHidden);
@@ -31,6 +32,8 @@ public static class LaunchOptions
     public static bool LaunchingLauncherIsHidden => LaunchedThroughLauncher && LaunchingLauncherIsHiddenHolder.Value;
 
     public static string? StoreVersionName => StoreNameHolder.Value;
+
+    public static bool DisableAllMods => DisableModsOption.Value;
 
     /// <summary>
     ///   Unique identifier for the current Thrive launch. Either communicated from the launcher or a random GUID.
@@ -74,6 +77,16 @@ public static class LaunchOptions
 
         if (value)
             GD.Print("AVX CPU feature usage is disabled with a command line option");
+
+        return value;
+    }
+
+    private static bool ReadDisableMods()
+    {
+        bool value = GodotLaunchOptions.Value.Any(o => o == ThriveLauncherSharedConstants.DISABLE_ALL_MODS);
+
+        if (value)
+            GD.Print("Disabling all mods with a command line option");
 
         return value;
     }

--- a/src/modding/ModLoader.cs
+++ b/src/modding/ModLoader.cs
@@ -166,7 +166,15 @@ public partial class ModLoader : Node
 
         modInterface = new ModInterface(GetTree());
 
-        LoadMods();
+        if (LaunchOptions.DisableAllMods)
+        {
+            GD.Print("Skipping initial mod loading due to launch options");
+        }
+        else
+        {
+            LoadMods();
+        }
+
         initialLoad = false;
     }
 
@@ -176,11 +184,14 @@ public partial class ModLoader : Node
 
         if (firstExecute)
         {
-            GD.Print("Loading mod Nodes into the scene tree");
-
-            foreach (var tuple in loadedModAssemblies)
+            if (loadedModAssemblies.Count > 0)
             {
-                RunCodeModFirstRunCallbacks(tuple.Value);
+                GD.Print("Loading mod Nodes into the scene tree");
+
+                foreach (var tuple in loadedModAssemblies)
+                {
+                    RunCodeModFirstRunCallbacks(tuple.Value);
+                }
             }
 
             firstExecute = false;

--- a/src/modding/ModManager.cs
+++ b/src/modding/ModManager.cs
@@ -856,6 +856,11 @@ public partial class ModManager : Control
 
         GD.Print("Applying changes to enabled mods");
 
+        if (LaunchOptions.DisableAllMods)
+        {
+            GD.Print("Started with all mods disabled due to launch option but will apply new mod list now");
+        }
+
         Settings.Instance.EnabledMods.Value = enabledMods.Select(m => m.InternalName).ToList();
 
         var modLoader = ModLoader.Instance;


### PR DESCRIPTION
**Brief Description of What This PR Does**

This has been needed for quite a while to offer a checkbox in the launcher to disable Thrive mods on startup

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #3917

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
