### PR TITLE
Partially fix blur being too dark in OpenGL rendering mode

### DIFF
--- a/shaders/GaussianBlur.gdshader
+++ b/shaders/GaussianBlur.gdshader
@@ -10,16 +10,15 @@ uniform float blurAmount = 1.0f;
 void fragment() {
     vec2 s = blurAmount * blurStep / vec2(textureSize(textureAlbedo, 0));
     COLOR.rgb =
-        0.0016858046f * texture(textureAlbedo, UV - 6.4f * s).rgb +
-        0.015835322f * texture(textureAlbedo, UV - 4.8f * s).rgb +
-        0.07843286f * texture(textureAlbedo, UV - 3.2f * s).rgb +
-        0.20484284f * texture(textureAlbedo, UV - 1.6f * s).rgb +
-        0.28209478f * texture(textureAlbedo, UV).rgb +
-        0.20484288f * texture(textureAlbedo, UV + 1.6f * s).rgb +
-        0.07843288f * texture(textureAlbedo, UV + 3.2f * s).rgb +
-        0.01583533f * texture(textureAlbedo, UV + 4.8f * s).rgb +
-        0.0016858061f * texture(textureAlbedo, UV + 6.4f * s).rgb;
-
+        0.0021587821843544993 * texture(textureAlbedo, UV - 6.4f * s).rgb +
+        0.017919574546480063 * texture(textureAlbedo, UV - 4.8f * s).rgb +
+        0.08875623000679331 * texture(textureAlbedo, UV - 3.2f * s).rgb +
+        0.23180435116461087 * texture(textureAlbedo, UV - 1.6f * s).rgb +
+        0.3192242279243133 * texture(textureAlbedo, UV).rgb +
+        0.23180439642942974 * texture(textureAlbedo, UV + 1.6f * s).rgb +
+        0.08875625263920274 * texture(textureAlbedo, UV + 3.2f * s).rgb +
+        0.017919583599443834 * texture(textureAlbedo, UV + 4.8f * s).rgb +
+        0.0019076926935783702 * texture(textureAlbedo, UV + 6.4f * s).rgb;
 
     COLOR.a = 1.0f;
 }

--- a/shaders/GaussianBlurSpatial.gdshader
+++ b/shaders/GaussianBlurSpatial.gdshader
@@ -13,13 +13,13 @@ void fragment() {
     // Use SCREEN_UV instead of UV, because otherwise the textureAlbedo is stretched
     // across the plane and only a small part of it is visible on the screen
     ALBEDO =
-        0.0016858046f * texture(textureAlbedo, SCREEN_UV - 6.4f * s).rgb +
-        0.015835322f * texture(textureAlbedo, SCREEN_UV - 4.8f * s).rgb +
-        0.07843286f * texture(textureAlbedo, SCREEN_UV - 3.2f * s).rgb +
-        0.20484284f * texture(textureAlbedo, SCREEN_UV - 1.6f * s).rgb +
-        0.28209478f * texture(textureAlbedo, SCREEN_UV).rgb +
-        0.20484288f * texture(textureAlbedo, SCREEN_UV + 1.6f * s).rgb +
-        0.07843288f * texture(textureAlbedo, SCREEN_UV + 3.2f * s).rgb +
-        0.01583533f * texture(textureAlbedo, SCREEN_UV + 4.8f * s).rgb +
-        0.0016858061f * texture(textureAlbedo, SCREEN_UV + 6.4f * s).rgb;
+        0.0021587821843544993 * texture(textureAlbedo, SCREEN_UV - 6.4f * s).rgb +
+        0.017919574546480063 * texture(textureAlbedo, SCREEN_UV - 4.8f * s).rgb +
+        0.08875623000679331 * texture(textureAlbedo, SCREEN_UV - 3.2f * s).rgb +
+        0.23180435116461087 * texture(textureAlbedo, SCREEN_UV - 1.6f * s).rgb +
+        0.3192242279243133 * texture(textureAlbedo, SCREEN_UV).rgb +
+        0.23180439642942974 * texture(textureAlbedo, SCREEN_UV + 1.6f * s).rgb +
+        0.08875625263920274 * texture(textureAlbedo, SCREEN_UV + 3.2f * s).rgb +
+        0.017919583599443834 * texture(textureAlbedo, SCREEN_UV + 4.8f * s).rgb +
+        0.0019076926935783702 * texture(textureAlbedo, SCREEN_UV + 6.4f * s).rgb;
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Normalizes values in the Gaussian Blur shaders, which makes them add up to 1 (as they should).

This partially fixes blur being too dark in OpenGL rendering mode. Unfortunately, this doesn't fix the issue completely, as there's still something else that makes background darker after blurring, potentially something to do with OpenGL's usage of sRGB color space.

**Related Issues**

Partially addresses #6119

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
