### PR TITLE
Deselect patch extinction move target on GUI open

### DIFF
--- a/src/general/base_stage/CreatureStageHUDBase.cs
+++ b/src/general/base_stage/CreatureStageHUDBase.cs
@@ -608,6 +608,8 @@ public partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSta
             patchExtinctionBox.PlayerSpecies = stage!.GameWorld.PlayerSpecies;
             patchExtinctionBox.Map = stage.GameWorld.Map;
 
+            patchExtinctionBox.ForgetSelectedPatch();
+
             patchExtinctionBox.Show();
         }
     }

--- a/src/microbe_stage/gui/PatchDetailsPanel.cs
+++ b/src/microbe_stage/gui/PatchDetailsPanel.cs
@@ -328,6 +328,10 @@ public partial class PatchDetailsPanel : PanelContainer
             nothingSelected.Visible = true;
             unknownPatch.Visible = false;
 
+            // If no selected patch, the move cannot be valid
+            if (moveToPatchButton != null)
+                moveToPatchButton.Disabled = true;
+
             return;
         }
 

--- a/src/microbe_stage/gui/PatchExtinctionBox.cs
+++ b/src/microbe_stage/gui/PatchExtinctionBox.cs
@@ -2,8 +2,8 @@
 using Godot;
 
 /// <summary>
-///   Shown when player is extinct in the current patch and needs to pick a new patch to play in. When fully extinct in
-///   all patches <see cref="ExtinctionBox"/> is shown instead.
+///   Shown when the player is extinct in the current patch and needs to pick a new patch to play in.
+///   When fully extinct in all patches <see cref="ExtinctionBox"/> is shown instead.
 /// </summary>
 public partial class PatchExtinctionBox : Control
 {
@@ -60,6 +60,16 @@ public partial class PatchExtinctionBox : Control
 
         if (what == NotificationVisibilityChanged && Visible)
             animationPlayer.Play();
+    }
+
+    /// <summary>
+    ///   Forgets the selected patch to make sure a player can't keep a disabled patch selected and thus exploit being
+    ///   able to play indefinitely in a patch they are extinct in.
+    /// </summary>
+    public void ForgetSelectedPatch()
+    {
+        detailsPanel.SelectedPatch = null;
+        mapDrawer.SelectedPatch = null;
     }
 
     protected override void Dispose(bool disposing)


### PR DESCRIPTION
**Brief Description of What This PR Does**

This prevents exploit of infinitely being able to continue in a patch the player is extinct in already

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://community.revolutionarygamesstudio.com/t/selecting-a-new-patch-upon-having-multiple-repeated-patch-extinctions-bug-0-8-2-1-opengl-mode/8437

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
