### PR TITLE
Limit unlock tooltip size

### DIFF
--- a/src/microbe_stage/OrganelleDefinition.cs
+++ b/src/microbe_stage/OrganelleDefinition.cs
@@ -791,6 +791,13 @@ public class OrganelleDefinition : IRegistryType
         }
     }
 
+    public float Progress(WorldAndPlayerDataSource worldAndPlayerData)
+    {
+        if (UnlockConditions == null)
+            return 0;
+        return UnlockConditions.Select(entry => entry.Progress(worldAndPlayerData)).Max();
+    }
+
     public void ApplyTranslations()
     {
         TranslationHelper.ApplyTranslations(this);

--- a/src/microbe_stage/organelle_unlocks/ConditionSet.cs
+++ b/src/microbe_stage/organelle_unlocks/ConditionSet.cs
@@ -47,6 +47,14 @@ public class ConditionSet
         }
     }
 
+    public float Progress(WorldAndPlayerDataSource worldAndPlayerData)
+    {
+        var tracker = worldAndPlayerData.World.StatisticsTracker;
+        return Requirements
+            .Select(entry => entry.Progress(entry is WorldBasedUnlockCondition ? worldAndPlayerData : tracker))
+            .Sum() / Requirements.Length;
+    }
+
     public void Check(string name)
     {
         foreach (var requirement in Requirements)

--- a/src/microbe_stage/organelle_unlocks/IUnlockCondition.cs
+++ b/src/microbe_stage/organelle_unlocks/IUnlockCondition.cs
@@ -15,6 +15,16 @@ public interface IUnlockCondition
     public bool Satisfied(IUnlockStateDataSource data);
 
     /// <summary>
+    ///   Gets the current progress on the unlock condition
+    /// </summary>
+    /// <param name="data">
+    ///   The data about the world, if this condition doesn't handle the data of the given type this always
+    ///   returns false
+    /// </param>
+    /// <returns>A value between 0 (no progress) and 1 (complete)</returns>
+    public float Progress(IUnlockStateDataSource data);
+
+    /// <summary>
     ///   Generates a tooltip describing how close this unlock condition is to be unlocked
     /// </summary>
     /// <param name="builder">Where to put the result text</param>


### PR DESCRIPTION
**Brief Description of What This PR Does**
In order to rank the unlocks, we probably need a function to return the progress (0 to 1) of each unlock condition. Where multiple unlock conditions are required, the average is used. Where one is needed, the maximum can be taken.

Unlock conditions can then be sorted by the progress and only the first 4 displayed.

**Related Issues**
Closes #5936

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
