### PR TITLE
Solving the Nucleus Paradox

### DIFF
--- a/src/microbe_stage/systems/OsmoregulationAndHealingSystem.cs
+++ b/src/microbe_stage/systems/OsmoregulationAndHealingSystem.cs
@@ -127,6 +127,18 @@ public sealed class OsmoregulationAndHealingSystem : AEntitySetSystem<float>
             osmoregulationCost *= 20.0f / (20.0f + colonySize);
         }
 
+        // 10% osmoregulation bonus if have nucleus
+        if (!cellProperties.IsBacteria)
+        {
+            osmoregulationCost *= 0.9f;
+        }
+
+        // 30% bioprocess speed bonus if have nucleus
+        if (!cellProperties.IsBacteria)
+        {
+            microbeEnvironmentalEffects.ProcessSpeedModifier *= 1.3f;
+        }
+
         // TODO: remove this check on next save breakage point
         if (entity.Has<MicrobeEnvironmentalEffects>())
         {


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR gives a buff of +30% bioprocess speed and -10% osmoregulation cost. This is done so that the nucleus finally has a meaning other than "this part is needed for more advanced organelles"
As a result, this gives a break-even point for the core when the cell size reaches approximately 25 hexagons.

This has biological justifications in the form of the fact that the nucleus reduces the likelihood of errors in the production of proteins, and also accelerates the production of proteins, which reduces the requirements of osmoregulation, as well as increases the efficiency of organelles (since proteins are used to produce energy, accordingly, increasing the rate of protein production will increase the rate of energy production).

**Related Issues**

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
