### PR TITLE
Make cell type's hash depend on the type's color

### DIFF
--- a/src/multicellular_stage/CellType.cs
+++ b/src/multicellular_stage/CellType.cs
@@ -150,10 +150,12 @@ public class CellType : ICellDefinition, ICloneable
 
     public ulong GetVisualHashCode()
     {
+        var hash = Colour.GetVisualHashCode();
+
         // This code is copied from MicrobeSpecies
         var count = Organelles.Count;
 
-        ulong hash = PersistentStringHash.GetHash(MembraneType.InternalName) * 5743 ^
+        hash ^= PersistentStringHash.GetHash(MembraneType.InternalName) * 5743 ^
             (ulong)MembraneRigidity.GetHashCode() * 5749 ^ (IsBacteria ? 1UL : 0UL) * 5779UL ^ (ulong)count * 131;
 
         var list = Organelles.Organelles;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes the issue in the multicellular editor where a cell icon doesn't change its color after it is changed.

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
