### PR TITLE
Fix the engulfing system using capacity information from a wrong cell

### DIFF
--- a/src/microbe_stage/systems/EngulfingSystem.cs
+++ b/src/microbe_stage/systems/EngulfingSystem.cs
@@ -1062,7 +1062,7 @@ public sealed class EngulfingSystem : AEntitySetSystem<float>
                 continue;
 
             // Pili don't block engulfing, check starting engulfing
-            var realEngulfer = entity;
+            var actualEntity = entity;
 
             if (resolveColony)
             {
@@ -1070,7 +1070,7 @@ public sealed class EngulfingSystem : AEntitySetSystem<float>
                 ref var colony = ref entity.Get<MicrobeColony>();
                 if (colony.GetMicrobeFromSubShape(ref ourExtraData, collision.FirstSubShapeData, out var adjusted))
                 {
-                    realEngulfer = adjusted;
+                    actualEntity = adjusted;
                 }
             }
 #if DEBUG
@@ -1081,13 +1081,14 @@ public sealed class EngulfingSystem : AEntitySetSystem<float>
             }
 #endif
 
-            ref var actualEngulfer = ref engulfer;
+            ref var actualEngulfer =
+                ref actualEntity == entity ? ref engulfer : ref actualEntity.Get<Engulfer>();
 
             ref var actualCellProperties =
-                ref realEngulfer == entity ? ref cellProperties : ref realEngulfer.Get<CellProperties>();
+                ref actualEntity == entity ? ref cellProperties : ref actualEntity.Get<CellProperties>();
 
             if (CheckStartEngulfingOnCandidate(ref actualCellProperties, ref actualEngulfer, ref species,
-                    realEngulfer, realTarget))
+                    actualEntity, realTarget))
             {
                 // Engulf at most one thing per update, if further collisions still exist next update we'll pull
                 // it in then


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes the engulfing system use the proper `Engulfer`. That is, the engulfing cell itself, instead of the colony leader.

In addition, this PR renames a variable to prevent confusion between the variable called `realEngulfer` (`Entity` type) and the `Engulfer` type variables.

**Related Issues**

Fixes #5098

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
