### PR TITLE
Engulfment Rebalancing

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -883,7 +883,7 @@ public static class Constants
     /// <summary>
     ///   The minimum size ratio between a cell and a possible engulfing victim.
     /// </summary>
-    public const float ENGULF_SIZE_RATIO_REQ = 1.5f;
+    public const float ENGULF_SIZE_RATIO_REQ = 2.5f;
 
     public const float EUKARYOTIC_ENGULF_SIZE_MULTIPLIER = 2.0f;
 
@@ -915,12 +915,12 @@ public static class Constants
     /// <summary>
     ///   The speed of which a cell can absorb compounds from digestible engulfed objects.
     /// </summary>
-    public const float ENGULF_COMPOUND_ABSORBING_PER_SECOND = 0.3f;
+    public const float ENGULF_COMPOUND_ABSORBING_PER_SECOND = 0.5f;
 
     /// <summary>
     ///   How much compounds in relation to real compound amount can be absorbed from digestible engulfed objects.
     /// </summary>
-    public const float ENGULF_BASE_COMPOUND_ABSORPTION_YIELD = 0.5f;
+    public const float ENGULF_BASE_COMPOUND_ABSORPTION_YIELD = 0.3f;
 
     /// <summary>
     ///   How long can cell be in engulf mode after activating without ATP
@@ -958,7 +958,7 @@ public static class Constants
     /// <summary>
     ///   Each enzyme addition grants a fraction, set by this variable, increase in digestion speed.
     /// </summary>
-    public const float ENZYME_DIGESTION_SPEED_UP_FRACTION = 0.1f;
+    public const float ENZYME_DIGESTION_SPEED_UP_FRACTION = 0.05f;
 
     /// <summary>
     ///   Each enzyme addition grants this fraction increase in compounds yield.


### PR DESCRIPTION

**Brief Description of What This PR Does**

Current changes include:

* Increased size discrepancy needed to engulf something 
* Slightly sped up the rate at which engulfed chunks are turned into compounds 
* Slightly reduced amount of compounds retrieved from engulfed items 
* Slightly debuffed amount of digestion time decrease from enzymes

This makes baseline engulfment just a touch less powerful, making lysosomes more of a worthy investment. The effort I'm going for is to make your ingested material go away quicker, so that you get the bonus you deserve for a successful hunt, but don't get to survive off of one or two hunts for the entire generation. This incentivizes adaptations to become a more voracious hunter - incentivizing pulling cilia, lysosomes, etc. -  instead of utilizing digestion as a one-and-done sort of thing. 

I'm experimenting a bit with the compound digested percentage and speed, so that could be subjected to change - regardless, a change to the size discrepancy ratio is needed.


**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
