### PR TITLE
Make the Cell Type editor perform name validation

### DIFF
--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.Callbacks.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.Callbacks.cs
@@ -51,7 +51,7 @@ public partial class CellBodyPlanEditorComponent
         // Renaming a cell doesn't create an editor action, so it's possible for someone to duplicate a cell type, undo
         // the duplication, change another cell type's name to the old duplicate's name, then redo the duplication,
         // which would lead to duplicate names, so this loop ensures the duplicated cell's name will be unique
-        while (!IsNewCellTypeNameValid(data.CellType.TypeName))
+        while (!Editor.IsNewCellTypeNameValid(data.CellType.TypeName))
         {
             data.CellType.TypeName = $"{originalName} {count++}";
         }

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -1300,7 +1300,7 @@ public partial class CellBodyPlanEditorComponent :
 
     private void OnNewCellTypeNameChanged(string newText)
     {
-        if (!IsNewCellTypeNameValid(newText))
+        if (!Editor.IsNewCellTypeNameValid(newText))
         {
             GUICommon.MarkInputAsInvalid(duplicateCellTypeName);
         }
@@ -1308,14 +1308,6 @@ public partial class CellBodyPlanEditorComponent :
         {
             GUICommon.MarkInputAsValid(duplicateCellTypeName);
         }
-    }
-
-    private bool IsNewCellTypeNameValid(string text)
-    {
-        // Name is invalid if it is empty or a duplicate
-        // TODO: should this ensure the name doesn't have trailing whitespace?
-        return !string.IsNullOrWhiteSpace(text) && !Editor.EditedSpecies.CellTypes.Any(c =>
-            c.TypeName.Equals(text, StringComparison.InvariantCultureIgnoreCase));
     }
 
     private void OnNewCellTextAccepted(string text)
@@ -1331,7 +1323,7 @@ public partial class CellBodyPlanEditorComponent :
     {
         var newTypeName = duplicateCellTypeName.Text;
 
-        if (!IsNewCellTypeNameValid(newTypeName))
+        if (!Editor.IsNewCellTypeNameValid(newTypeName))
         {
             GD.Print("Bad name for new cell type");
             Editor.OnInvalidAction();

--- a/src/multicellular_stage/editor/MulticellularEditor.cs
+++ b/src/multicellular_stage/editor/MulticellularEditor.cs
@@ -164,6 +164,15 @@ public partial class MulticellularEditor : EditorBase<EditorAction, MicrobeStage
         base.Redo();
     }
 
+    public bool IsNewCellTypeNameValid(string newName)
+    {
+        // Name is invalid if it is empty or a duplicate
+        // TODO: should this ensure the name doesn't have trailing whitespace?
+        // If so, CellTemplate.UpdateNameIfValid should be updated as well
+        return !string.IsNullOrWhiteSpace(newName) && !EditedSpecies.CellTypes.Any(c =>
+            c.TypeName.Equals(newName, StringComparison.InvariantCultureIgnoreCase));
+    }
+
     public override void Undo()
     {
         var cellType = history.GetUndoContext<CellType>();
@@ -217,6 +226,7 @@ public partial class MulticellularEditor : EditorBase<EditorAction, MicrobeStage
         patchMapTab.OnNextTab = () => SetEditorTab(EditorTab.CellEditor);
         bodyPlanEditorTab.OnFinish = ForwardEditorComponentFinishRequest;
         cellEditorTab.OnNextTab = () => SetEditorTab(EditorTab.CellEditor);
+        cellEditorTab.ValidateNewCellTypeName = IsNewCellTypeNameValid;
 
         foreach (var editorComponent in GetAllEditorComponents())
         {
@@ -517,10 +527,6 @@ public partial class MulticellularEditor : EditorBase<EditorAction, MicrobeStage
         if (selectedCellTypeToEdit == null)
             return;
 
-        // We need to handle the renaming here as the cell editor doesn't really know what other cell types exist
-        // so it can't check if the name is unique or not
-        // TODO: would be nice to re-architecture this so that the cell editor could show if the new name is valid
-        // or not
         var oldName = selectedCellTypeToEdit.TypeName;
 
         cellEditorTab.OnFinishEditing(false);


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes the Cell Type editor (in the multicellular stage) perform name validation, making it check if the entered name is a duplicate of another cell type name.

This PR is based on #3387

**Related Issues**

Closes #3168

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
