### PR TITLE
Stop auto evo placing macroscopic organelles

### DIFF
--- a/src/auto-evo/mutation_strategy/AddOrganelleAnywhere.cs
+++ b/src/auto-evo/mutation_strategy/AddOrganelleAnywhere.cs
@@ -12,7 +12,7 @@ public class AddOrganelleAnywhere : IMutationStrategy<MicrobeSpecies>
     public AddOrganelleAnywhere(Func<OrganelleDefinition, bool> criteria, CommonMutationFunctions.Direction direction
         = CommonMutationFunctions.Direction.Neutral)
     {
-        allOrganelles = SimulationParameters.Instance.GetAllOrganelles().Where(criteria).Where(x => x.AutoEvoCanPlace)
+        allOrganelles = SimulationParameters.Instance.GetAllOrganelles().Where(criteria).Where(IsOrangelleValid)
             .ToArray();
 
         this.direction = direction;
@@ -124,5 +124,16 @@ public class AddOrganelleAnywhere : IMutationStrategy<MicrobeSpecies>
         }
 
         return mutated;
+    }
+
+    /// <summary>
+    ///   Macroscopic, multicellular, and non-placable organelles are invalid and so won't be considered.
+    /// </summary>
+    private static bool IsOrangelleValid(OrganelleDefinition organelle)
+    {
+        // TODO: allow placement of multicellular organelles in the appropriate stages.
+        return organelle.AutoEvoCanPlace &&
+            organelle.EditorButtonGroup != OrganelleDefinition.OrganelleGroup.Multicellular &&
+            organelle.EditorButtonGroup != OrganelleDefinition.OrganelleGroup.Macroscopic;
     }
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

The `AddOrganelleAnywhere` mutation strategy will not place organelles tagged as macroscopic or multicellular.

**Related Issues**

Closes #5853

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
