### PR TITLE
Fix iron meteor

### DIFF
--- a/src/general/world_effects/patch_events/MeteorImpactEvent.cs
+++ b/src/general/world_effects/patch_events/MeteorImpactEvent.cs
@@ -192,14 +192,10 @@ public class MeteorImpactEvent : IWorldEffect
 
         foreach (var (compoundName, levelChange) in selectedMeteor.Compounds)
         {
-            bool hasCompound =
-                patch.Biome.ChangeableCompounds.TryGetValue(compoundName, out var currentCompoundLevel);
+            // Add 0 value for compound if it doesn't exist (e.g. for iron)
+            patch.Biome.ChangeableCompounds.TryAdd(compoundName, default);
 
-            if (!hasCompound)
-            {
-                GD.PrintErr($"Meteor impact event encountered patch with unexpectedly no {compoundName.ToString()}");
-                return;
-            }
+            var currentCompoundLevel = patch.Biome.ChangeableCompounds[compoundName];
 
             var definition = SimulationParameters.Instance.GetCompoundDefinition(compoundName);
 
@@ -269,14 +265,10 @@ public class MeteorImpactEvent : IWorldEffect
 
         foreach (var (compoundName, levelChange) in selectedMeteor.Compounds)
         {
-            bool hasCompound =
-                patch.Biome.ChangeableCompounds.TryGetValue(compoundName, out var currentCompoundLevel);
+            // Add 0 value for compound if it doesn't exist (e.g. for iron)
+            patch.Biome.ChangeableCompounds.TryAdd(compoundName, default);
 
-            if (!hasCompound)
-            {
-                GD.PrintErr($"Meteor impact event encountered patch with unexpectedly no {compoundName.ToString()}");
-                return;
-            }
+            var currentCompoundLevel = patch.Biome.ChangeableCompounds[compoundName];
 
             var definition = SimulationParameters.Instance.GetCompoundDefinition(compoundName);
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

The iron meteor previously failed to add iron with the following error:
```
Meteor impact event encountered patch with unexpectedly no Iron
```

This PR aims to fix that by automatically adding iron if it doesn't exist already.

**Related Issues**

Closes #6178

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
