### PR TITLE
Fix error log from glaciation event

### DIFF
--- a/src/general/world_effects/patch_events/GlobalGlaciationEvent.cs
+++ b/src/general/world_effects/patch_events/GlobalGlaciationEvent.cs
@@ -244,9 +244,9 @@ public class GlobalGlaciationEvent : IWorldEffect
     private void FinishEvent()
     {
         hasEventAlreadyHappened = true;
-        foreach (var patch in targetWorld.Map.Patches.Values)
+        foreach (var patchId in modifiedPatchesIds)
         {
-            if (!modifiedPatchesIds.Contains(patch.ID))
+            if (!targetWorld.Map.Patches.TryGetValue(patchId, out var patch))
             {
                 GD.PrintErr("Patch exited the world in global glaciation event");
                 continue;


### PR DESCRIPTION
**Brief Description of What This PR Does**
The finish event code now iterates over the modified patches and prints an error if they are no longer in the world.

Previously it would iterate through all the patches in the world and print and error if they weren't modified. This occurred for all non-surface patches.

**Related Issues**
Closes #6158

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
