### PR TITLE
Fix editor cancel buttons' focused visuals

### DIFF
--- a/src/macroscopic_stage/editor/MetaballBodyEditorComponent.tscn
+++ b/src/macroscopic_stage/editor/MetaballBodyEditorComponent.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=33 format=3 uid="uid://b6at78uxbps1"]
+[gd_scene load_steps=34 format=3 uid="uid://b6at78uxbps1"]
 
 [ext_resource type="Script" uid="uid://caq4oh00j7yin" path="res://src/macroscopic_stage/editor/MetaballBodyEditorComponent.cs" id="1"]
 [ext_resource type="Texture2D" uid="uid://bo70v3237p6iv" path="res://assets/textures/gui/bevel/hSeparatorCentered.png" id="2"]
@@ -88,6 +88,22 @@ corner_radius_bottom_left = 5
 [sub_resource type="StyleBoxEmpty" id="7"]
 
 [sub_resource type="StyleBoxEmpty" id="8"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_foare"]
+content_margin_left = 5.0
+content_margin_top = 5.0
+content_margin_right = 5.0
+content_margin_bottom = 5.0
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.666667, 1, 0.941176, 1)
+corner_radius_top_left = 3
+corner_radius_top_right = 3
+corner_radius_bottom_right = 3
+corner_radius_bottom_left = 3
 
 [sub_resource type="StyleBoxFlat" id="12"]
 content_margin_left = 5.0
@@ -655,6 +671,7 @@ layout_mode = 2
 mouse_force_pass_scroll_events = false
 theme_override_colors/font_disabled_color = Color(0.498039, 0.529412, 0.541176, 1)
 theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+theme_override_styles/focus = SubResource("StyleBoxFlat_foare")
 theme_override_styles/hover = SubResource("12")
 theme_override_styles/pressed = SubResource("13")
 theme_override_styles/normal = SubResource("14")

--- a/src/microbe_stage/editor/CellEditorComponent.tscn
+++ b/src/microbe_stage/editor/CellEditorComponent.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=60 format=3 uid="uid://cwot2e52r7lx0"]
+[gd_scene load_steps=61 format=3 uid="uid://cwot2e52r7lx0"]
 
 [ext_resource type="PackedScene" uid="uid://bwegwjlcioasf" path="res://src/microbe_stage/editor/EditorComponentBottomLeftButtons.tscn" id="3"]
 [ext_resource type="PackedScene" uid="uid://0hb8nq18ljr8" path="res://src/microbe_stage/editor/LightConfigurationPanel.tscn" id="3_yy73o"]
@@ -113,6 +113,22 @@ region_rect = Rect2(0, 0, 258, 1)
 [sub_resource type="StyleBoxEmpty" id="37"]
 
 [sub_resource type="StyleBoxEmpty" id="36"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_tk5n4"]
+content_margin_left = 5.0
+content_margin_top = 5.0
+content_margin_right = 5.0
+content_margin_bottom = 5.0
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.666667, 1, 0.941176, 1)
+corner_radius_top_left = 3
+corner_radius_top_right = 3
+corner_radius_bottom_right = 3
+corner_radius_bottom_left = 3
 
 [sub_resource type="StyleBoxFlat" id="23"]
 content_margin_left = 5.0
@@ -1189,6 +1205,7 @@ focus_next = NodePath("../ConfirmButton")
 mouse_force_pass_scroll_events = false
 theme_override_colors/font_disabled_color = Color(0.498039, 0.529412, 0.541176, 1)
 theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+theme_override_styles/focus = SubResource("StyleBoxFlat_tk5n4")
 theme_override_styles/hover = SubResource("23")
 theme_override_styles/pressed = SubResource("24")
 theme_override_styles/normal = SubResource("25")

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.tscn
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=35 format=3 uid="uid://dylo35brdi0js"]
+[gd_scene load_steps=36 format=3 uid="uid://dylo35brdi0js"]
 
 [ext_resource type="Script" uid="uid://ctqyvjb6wvagi" path="res://src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs" id="1"]
 [ext_resource type="PackedScene" uid="uid://ipvxtakaph16" path="res://src/multicellular_stage/editor/CellPopupMenu.tscn" id="3"]
@@ -87,6 +87,22 @@ corner_radius_bottom_left = 5
 [sub_resource type="StyleBoxEmpty" id="7"]
 
 [sub_resource type="StyleBoxEmpty" id="8"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_55mmr"]
+content_margin_left = 5.0
+content_margin_top = 5.0
+content_margin_right = 5.0
+content_margin_bottom = 5.0
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.666667, 1, 0.941176, 1)
+corner_radius_top_left = 3
+corner_radius_top_right = 3
+corner_radius_bottom_right = 3
+corner_radius_bottom_left = 3
 
 [sub_resource type="StyleBoxFlat" id="12"]
 content_margin_left = 5.0
@@ -614,6 +630,7 @@ layout_mode = 2
 mouse_force_pass_scroll_events = false
 theme_override_colors/font_disabled_color = Color(0.498039, 0.529412, 0.541176, 1)
 theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+theme_override_styles/focus = SubResource("StyleBoxFlat_55mmr")
 theme_override_styles/hover = SubResource("12")
 theme_override_styles/pressed = SubResource("13")
 theme_override_styles/normal = SubResource("14")


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes editor cancel buttons' focused state outline coincide with their rounding.

**Related Issues**

Fixes #5130

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
