### PR TITLE
Prevent chunks from spawning too close to the player

### DIFF
--- a/src/general/SpawnQueue.cs
+++ b/src/general/SpawnQueue.cs
@@ -106,12 +106,21 @@ public class SingleItemSpawnQueue : SpawnQueue
 {
     private readonly Factory factory;
 
-    public SingleItemSpawnQueue(Factory factory, Spawner fromSpawnType) : base(fromSpawnType)
+    private readonly CheckTooCloseToPlayer cancelCheck;
+
+    private Vector3 spawnLocation;
+
+    public SingleItemSpawnQueue(Factory factory, Vector3 spawnLocation, CheckTooCloseToPlayer cancelCheck,
+        Spawner fromSpawnType) : base(fromSpawnType)
     {
         this.factory = factory;
+        this.spawnLocation = spawnLocation;
+        this.cancelCheck = cancelCheck;
     }
 
     public delegate (EntityCommandRecorder CommandRecorder, float SpawnedWeight) Factory(out EntityRecord entity);
+
+    public delegate bool CheckTooCloseToPlayer(Vector3 spawnLocation, Vector3 playerPosition);
 
     public override bool Ended { get; protected set; }
 
@@ -119,6 +128,14 @@ public class SingleItemSpawnQueue : SpawnQueue
     {
         Ended = true;
         return factory(out entity);
+    }
+
+    public override void CheckIsSpawningStillPossible(Vector3 playerPosition)
+    {
+        if (cancelCheck(spawnLocation, playerPosition))
+        {
+            Ended = true;
+        }
     }
 }
 

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -1187,7 +1187,7 @@ public class MicrobeSpawner : Spawner
             ModLoader.ModInterface.TriggerOnMicrobeSpawned(entity);
 
             return (recorder, weight);
-        }, this);
+        }, location, SpawnQueue.IsTooCloseToPlayer, this);
 
         if (!bacteria)
         {
@@ -1287,7 +1287,7 @@ public class ChunkSpawner : Spawner
             ModLoader.ModInterface.TriggerOnChunkSpawned(entity, true);
 
             return (recorder, Constants.FLOATING_CHUNK_ENTITY_WEIGHT);
-        }, this);
+        }, location, SpawnQueue.IsTooCloseToPlayer, this);
     }
 
     public override string ToString()


### PR DESCRIPTION
**Brief Description of What This PR Does**

Implements a distance check before chunks are spawned to prevent them from spawning too close to the player or inside the player colony.

**Related Issues**

Fixes #5094

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
