### PR TITLE
Fix the toxin firing conditions

### DIFF
--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -487,6 +487,7 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
         bool showSlime;
         bool showMucocyst;
         bool showSiderophore;
+        bool showSignaling;
 
         bool engulfing;
         bool usingMucocyst;
@@ -496,12 +497,8 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
         {
             ref var colony = ref player.Get<MicrobeColony>();
 
-            // TODO: does this need a variant that just returns a bool and has an early exit?
-            colony.CalculateColonySpecialOrganelles(out var vacuoles, out var slimeJets, out var mucocysts);
+            colony.GetColonySpecialOrganelles(out showToxin, out showSlime, out showMucocyst, out showSignaling);
 
-            showToxin = vacuoles > 0;
-            showSlime = slimeJets > 0;
-            showMucocyst = mucocysts > 0;
             showSiderophore = false;
 
             engulfing = colony.ColonyState == MicrobeState.Engulf;
@@ -513,6 +510,7 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
             showSlime = organelles.SlimeJets is { Count: > 0 };
             showMucocyst = organelles.MucocystCount > 0;
             showSiderophore = organelles.IronBreakdownEfficiency > 0 && stage.WorldSettings.ExperimentalFeatures;
+            showSignaling = organelles.HasSignalingAgent;
 
             engulfing = control.State == MicrobeState.Engulf;
             usingMucocyst = control.State == MicrobeState.MucocystShield;
@@ -528,7 +526,7 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
         // Read the engulf state from the colony as the player cell might be unable to engulf but some
         // member might be able to
         UpdateBaseAbilitiesBar(cellProperties.CanEngulfInColony(player), showToxin, showSlime,
-            organelles.HasSignalingAgent, showMucocyst, true, engulfing, isDigesting, usingMucocyst, control.Sprinting);
+            showSignaling, showMucocyst, true, engulfing, isDigesting, usingMucocyst, control.Sprinting);
 
         siderophoreHotkey.Visible = showSiderophore;
 

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -230,22 +230,26 @@ public static class MicrobeColonyHelpers
     }
 
     /// <summary>
-    ///   Calculates the total counts of special organelles in a colony
+    ///   Returns the information about the presence of special organelles in a colony
     /// </summary>
-    public static void CalculateColonySpecialOrganelles(this ref MicrobeColony colony, out int agentVacuoles,
-        out int slimeJets, out int mucocysts)
+    public static void GetColonySpecialOrganelles(this ref MicrobeColony colony, out bool agentVacuoles,
+        out bool slimeJets, out bool mucocysts, out bool signalingAgents)
     {
-        agentVacuoles = 0;
-        slimeJets = 0;
-        mucocysts = 0;
+        agentVacuoles = false;
+        slimeJets = false;
+        mucocysts = false;
+        signalingAgents = false;
 
         foreach (var colonyMember in colony.ColonyMembers)
         {
             ref var organelles = ref colonyMember.Get<OrganelleContainer>();
 
-            agentVacuoles += organelles.AgentVacuoleCount;
-            slimeJets += organelles.SlimeJets?.Count ?? 0;
-            mucocysts += organelles.MucocystCount;
+            // If the cell has a special organelle, set the according variable to true,
+            // otherwise don't change the value
+            agentVacuoles |= organelles.AgentVacuoleCount > 0;
+            mucocysts |= organelles.MucocystCount > 0;
+            slimeJets |= organelles.SlimeJets != null && organelles.SlimeJets.Count > 0;
+            signalingAgents |= organelles.HasSignalingAgent;
         }
     }
 

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -240,12 +240,11 @@ public static class MicrobeColonyHelpers
         mucocysts = false;
         signalingAgents = false;
 
+        // Check the presence of specieal organelles across colony members
         foreach (var colonyMember in colony.ColonyMembers)
         {
             ref var organelles = ref colonyMember.Get<OrganelleContainer>();
 
-            // If the cell has a special organelle, set the according variable to true,
-            // otherwise don't change the value
             agentVacuoles |= organelles.AgentVacuoleCount > 0;
             mucocysts |= organelles.MucocystCount > 0;
             slimeJets |= organelles.SlimeJets != null && organelles.SlimeJets.Count > 0;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes it possible for colonies to use signaling agents, even if they are placed in a non-core cell.

Also refactors a related function, making it check for special organelles' presence instead of counting them.

**Related Issues**

Closes #3193

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
