### PR TITLE
Fix ATP flickering

### DIFF
--- a/src/engine/common_systems/PlayerATPRecorderSystem.cs
+++ b/src/engine/common_systems/PlayerATPRecorderSystem.cs
@@ -1,0 +1,36 @@
+﻿namespace Systems;
+
+using Components;
+using DefaultEcs;
+using DefaultEcs.System;
+
+/// <summary>
+///   Records the player ATP for easy access. Run before osmoregulation to ensure it doesn't flicker.
+/// </summary>
+[With(typeof(PlayerMarker))]
+[With(typeof(CompoundStorage))]
+[RunsAfter(typeof(ProcessSystem))]
+[RunsBefore(typeof(OsmoregulationAndHealingSystem))]
+[RunsBefore(typeof(MicrobeMovementSystem))]
+[RuntimeCost(0.5f)]
+[RunsOnMainThread]
+public sealed class PlayerATPRecorderSystem(World world) : AEntitySetSystem<float>(world, null)
+{
+    public static float ATP { get; private set; } = 0;
+    public static float ATPCapacity { get; private set; } = 0;
+
+    protected override void PreUpdate(float delta)
+    {
+        // Reset values
+        ATP = 0;
+        ATPCapacity = 0;
+    }
+
+    protected override void Update(float delta, in Entity entity)
+    {
+        // Update values for the player
+        ref var storage = ref entity.Get<CompoundStorage>();
+        ATP = storage.Compounds.GetCompoundAmount(Compound.ATP);
+        ATPCapacity = storage.Compounds.GetCapacityForCompound(Compound.ATP);
+    }
+}

--- a/src/engine/common_systems/PlayerATPRecorderSystem.cs.uid
+++ b/src/engine/common_systems/PlayerATPRecorderSystem.cs.uid
@@ -1,0 +1,1 @@
+uid://ckfaxqffngtjv

--- a/src/general/base_stage/CreatureStageHUDBase.cs
+++ b/src/general/base_stage/CreatureStageHUDBase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Components;
 using Godot;
 using Newtonsoft.Json;
@@ -377,6 +378,13 @@ public partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSta
     {
         if (stage == null)
             return;
+
+        // Introduce occasional random lag spike
+        if (new Random().NextDouble() < 0.01)
+        {
+            Thread.Sleep((int)1000.0);
+            GD.Print(" ======================================================================== Stall");
+        }
 
         var convertedDelta = (float)delta;
 
@@ -1005,19 +1013,11 @@ public partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICreatureSta
         // Update to the player's current ATP, unless the player does not exist
         if (stage!.HasPlayer)
         {
-            var compounds = GetPlayerStorage();
-
-            atpAmount = compounds.GetCompoundAmount(Compound.ATP);
-            maxATP = compounds.GetCapacityForCompound(Compound.ATP);
+            atpAmount = Systems.PlayerATPRecorderSystem.ATP;
+            maxATP = Systems.PlayerATPRecorderSystem.ATPCapacity;
         }
 
         atpBar.MaxValue = maxATP * 10.0f;
-
-        // If the current ATP is close to full, just pretend that it is to keep the bar from flickering
-        if (maxATP - atpAmount < Math.Max(maxATP / 20.0f, 0.1f))
-        {
-            atpAmount = maxATP;
-        }
 
         GUICommon.SmoothlyUpdateBar(atpBar, atpAmount * 10.0f, delta);
 

--- a/src/microbe_stage/MicrobeWorldSimulation.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.cs
@@ -79,6 +79,7 @@ public partial class MicrobeWorldSimulation : WorldSimulationWithPhysics
     private OrganelleComponentFetchSystem organelleComponentFetchSystem = null!;
     private OrganelleTickSystem organelleTickSystem = null!;
     private OsmoregulationAndHealingSystem osmoregulationAndHealingSystem = null!;
+    private PlayerATPRecorderSystem playerATPRecorderSystem = null!;
     private PilusDamageSystem pilusDamageSystem = null!;
     private RadiationDamageSystem radiationDamageSystem = null!;
     private SlimeSlowdownSystem slimeSlowdownSystem = null!;
@@ -226,6 +227,7 @@ public partial class MicrobeWorldSimulation : WorldSimulationWithPhysics
         organelleComponentFetchSystem = new OrganelleComponentFetchSystem(EntitySystem, couldParallelize);
         organelleTickSystem = new OrganelleTickSystem(this, EntitySystem, parallelRunner);
         osmoregulationAndHealingSystem = new OsmoregulationAndHealingSystem(EntitySystem, couldParallelize);
+        playerATPRecorderSystem = new PlayerATPRecorderSystem(EntitySystem);
         pilusDamageSystem = new PilusDamageSystem(EntitySystem, couldParallelize);
         radiationDamageSystem = new RadiationDamageSystem(EntitySystem, parallelRunner);
         slimeSlowdownSystem = new SlimeSlowdownSystem(cloudSystem, EntitySystem, couldParallelize);
@@ -479,6 +481,7 @@ public partial class MicrobeWorldSimulation : WorldSimulationWithPhysics
                 organelleComponentFetchSystem.Dispose();
                 organelleTickSystem.Dispose();
                 osmoregulationAndHealingSystem.Dispose();
+                playerATPRecorderSystem.Dispose();
                 pilusDamageSystem.Dispose();
                 radiationDamageSystem.Dispose();
                 slimeSlowdownSystem.Dispose();

--- a/src/microbe_stage/MicrobeWorldSimulation.generated.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.generated.cs
@@ -22,33 +22,57 @@ public partial class MicrobeWorldSimulation
                 try
                 {
                     // Timeslot 1 on thread 2
-                    irradiationSystem.Update(delta);
+                    simpleShapeCreatorSystem.Update(delta);
                     countLimitedDespawnSystem.Update(delta);
+                    damageCooldownSystem.Update(delta);
+                    irradiationSystem.Update(delta);
                     entitySignalingSystem.Update(delta);
                     barrier1.SignalAndWait();
 
                     // Timeslot 2 on thread 2
-                    strainSystem.Update(delta);
+                    microbePhysicsCreationAndSizeSystem.Update(delta);
+                    colonyCompoundDistributionSystem.Update(delta);
+                    compoundAbsorptionSystem.Update(delta);
                     barrier1.SignalAndWait();
-
-                    // Timeslot 3 on thread 2
-                    simpleShapeCreatorSystem.Update(delta);
                     barrier1.SignalAndWait();
 
                     // Timeslot 4 on thread 2
-                    compoundAbsorptionSystem.Update(delta);
+                    physicsCollisionManagementSystem.Update(delta);
+                    siderophoreSystem.Update(delta);
+                    disallowPlayerBodySleepSystem.Update(delta);
                     barrier1.SignalAndWait();
 
                     // Timeslot 5 on thread 2
-                    colonyCompoundDistributionSystem.Update(delta);
+                    pilusDamageSystem.Update(delta);
                     ProcessSystem.Update(delta);
                     barrier1.SignalAndWait();
+
+                    // Timeslot 6 on thread 2
+                    toxinCollisionSystem.Update(delta);
+                    damageOnTouchSystem.Update(delta);
                     barrier1.SignalAndWait();
 
                     // Timeslot 7 on thread 2
+                    microbeTemporaryEffectsSystem.Update(delta);
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 8 on thread 2
                     multicellularGrowthSystem.Update(delta);
+                    osmoregulationAndHealingSystem.Update(delta);
                     radiationDamageSystem.Update(delta);
-                    unneededCompoundVentingSystem.Update(delta);
+                    barrier1.SignalAndWait();
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 10 on thread 2
+                    engulfedDigestionSystem.Update(delta);
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 11 on thread 2
+                    engulfedHandlingSystem.Update(delta);
+                    barrier1.SignalAndWait();
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 13 on thread 2
                     organelleComponentFetchSystem.Update(delta);
                     if (RunAI)
                     {
@@ -56,30 +80,24 @@ public partial class MicrobeWorldSimulation
                         microbeAI.Update(delta);
                     }
 
-                    slimeSlowdownSystem.Update(delta);
                     microbeEmissionSystem.Update(delta);
+                    slimeSlowdownSystem.Update(delta);
                     microbeMovementSystem.Update(delta);
+                    physicsBodyControlSystem.Update(delta);
+                    colonyBindingSystem.Update(delta);
+                    delayedColonyOperationSystem.Update(delta);
+                    colonyStatsUpdateSystem.Update(delta);
+                    microbeDeathSystem.Update(delta);
                     microbeMovementSoundSystem.Update(delta);
                     barrier1.SignalAndWait();
 
-                    // Timeslot 8 on thread 2
-                    colonyStatsUpdateSystem.Update(delta);
-                    barrier1.SignalAndWait();
-
-                    // Timeslot 9 on thread 2
-                    physicsBodyControlSystem.Update(delta);
-                    microbeDeathSystem.Update(delta);
-                    colonyBindingSystem.Update(delta);
-                    barrier1.SignalAndWait();
-
-                    // Timeslot 10 on thread 2
-                    microbeEventCallbackSystem.Update(delta);
+                    // Timeslot 14 on thread 2
                     microbeFlashingSystem.Update(delta);
-                    damageSoundSystem.Update(delta);
                     barrier1.SignalAndWait();
 
-                    // Timeslot 11 on thread 2
-                    delayedColonyOperationSystem.Update(delta);
+                    // Timeslot 15 on thread 2
+                    microbeEventCallbackSystem.Update(delta);
+                    damageSoundSystem.Update(delta);
                     barrier1.SignalAndWait();
 
                     barrier1.SignalAndWait();
@@ -103,82 +121,85 @@ public partial class MicrobeWorldSimulation
         try
         {
             // Timeslot 1 on thread 1
-            collisionShapeLoaderSystem.Update(delta);
-            damageCooldownSystem.Update(delta);
+            mucocystSystem.Update(delta);
             endosymbiontOrganelleSystem.Update(delta);
             microbeVisualsSystem.Update(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 2 on thread 1
-            microbePhysicsCreationAndSizeSystem.Update(delta);
-            microbeHeatAccumulationSystem.Update(delta);
+            pathBasedSceneLoader.Update(delta);
+            strainSystem.Update(delta);
+            predefinedVisualLoaderSystem.Update(delta);
+            animationControlSystem.Update(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 3 on thread 1
-            mucocystSystem.Update(delta);
+            collisionShapeLoaderSystem.Update(delta);
+            physicsBodyCreationSystem.Update(delta);
+            physicsBodyDisablingSystem.Update(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 4 on thread 1
-            physicsBodyCreationSystem.Update(delta);
-            physicsBodyDisablingSystem.Update(delta);
-            pathBasedSceneLoader.Update(delta);
-            predefinedVisualLoaderSystem.Update(delta);
-            animationControlSystem.Update(delta);
-            disallowPlayerBodySleepSystem.Update(delta);
-            physicsCollisionManagementSystem.Update(delta);
+            microbeHeatAccumulationSystem.Update(delta);
             entityMaterialFetchSystem.Update(delta);
-            toxinCollisionSystem.Update(delta);
-            microbeCollisionSoundSystem.Update(delta);
-            cellBurstEffectSystem.Update(delta);
-            fluidCurrentsSystem.Update(delta);
             microbeRenderPrioritySystem.Update(delta);
-            TimedLifeSystem.Update(delta);
-            pilusDamageSystem.Update(delta);
-            damageOnTouchSystem.Update(delta);
-            siderophoreSystem.Update(delta);
-            microbeTemporaryEffectsSystem.Update(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 5 on thread 1
             physicsUpdateAndPositionSystem.Update(delta);
+            cellBurstEffectSystem.Update(delta);
             attachedEntityPositionSystem.Update(delta);
+            microbeCollisionSoundSystem.Update(delta);
+            soundListenerSystem.Update(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 6 on thread 1
-            allCompoundsVentingSystem.Update(delta);
-            osmoregulationAndHealingSystem.Update(delta);
-            engulfingSystem.Update(delta);
-            microbeReproductionSystem.Update(delta);
+            unneededCompoundVentingSystem.Update(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 7 on thread 1
-            spatialAttachSystem.Update(delta);
-            spatialPositionSystem.Update(delta);
-            soundListenerSystem.Update(delta);
-            CameraFollowSystem.Update(delta);
-            SpawnSystem.Update(delta);
+            playerATPRecorderSystem.Update(delta);
+            allCompoundsVentingSystem.Update(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 8 on thread 1
-            organelleTickSystem.Update(delta);
+            fluidCurrentsSystem.Update(delta);
+            CameraFollowSystem.Update(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 9 on thread 1
-            entityLightSystem.Update(delta);
-            physicsSensorSystem.Update(delta);
+            engulfingSystem.Update(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 10 on thread 1
-            fadeOutActionSystem.Update(delta);
-            engulfedDigestionSystem.Update(delta);
+            spatialAttachSystem.Update(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 11 on thread 1
-            soundEffectSystem.Update(delta);
+            TimedLifeSystem.Update(delta);
+            SpawnSystem.Update(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 12 on thread 1
-            engulfedHandlingSystem.Update(delta);
+            microbeReproductionSystem.Update(delta);
+            barrier1.SignalAndWait();
+
+            // Timeslot 13 on thread 1
+            spatialPositionSystem.Update(delta);
+            barrier1.SignalAndWait();
+
+            // Timeslot 14 on thread 1
+            organelleTickSystem.Update(delta);
+            barrier1.SignalAndWait();
+
+            // Timeslot 15 on thread 1
+            entityLightSystem.Update(delta);
+            fadeOutActionSystem.Update(delta);
+            physicsSensorSystem.Update(delta);
+            barrier1.SignalAndWait();
+
+            // Timeslot 16 on thread 1
+            soundEffectSystem.Update(delta);
 
             barrier1.SignalAndWait();
         }
@@ -244,6 +265,7 @@ public partial class MicrobeWorldSimulation
             irradiationSystem.Update(delta);
             compoundAbsorptionSystem.Update(delta);
             ProcessSystem.Update(delta);
+            playerATPRecorderSystem.Update(delta);
             multicellularGrowthSystem.Update(delta);
             engulfedDigestionSystem.Update(delta);
             engulfedHandlingSystem.Update(delta);


### PR DESCRIPTION
**Brief Description of What This PR Does**

When there is a large lag spike, the ATP bar decreases randomly.

It is difficult to fix this by snapping the APT value to max since with a large lag spike, the ATP value can fall significantly e.g. 0.5 to 0.2.

I initially considered reordering the existing systems as suggested in the issue. This would involve the `ProcessSystem` running after the `OsmoregulationAndHealingSystem` and the `MicrobeMovementSystem`. However this caused many issues since systems like the `MicrobeEmissionSystem` `MicrobeAISystem` etc like to run between these. I found that it was extremly difficult to rearrange the systems. Perhaps a system like [bevy's system sets](https://bevy-cheatbook.github.io/programming/system-sets.html) to more easily rearrange them.

I decided to stick with the current system order. However I made it so that the process system uses the delta time from the previous frame (which is what the osmoregulation would use). This ensures that the ATP value is always set to exactly the right value at the end of the ProcessSystem; even when a large lag spike occurs.

In order to access the ATP value before it is changed further, I added a new system `PlayerATPRecorderSystem` that just records the ATP value.

This new approach removes the need to round the almost full bar, since the APT value is exactly full.

**Related Issues**

Closes #4703

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
