### PR TITLE
Implement multicellular preview images

### DIFF
--- a/src/gui_common/SpeciesDetailsPanel.cs
+++ b/src/gui_common/SpeciesDetailsPanel.cs
@@ -60,18 +60,7 @@ public partial class SpeciesDetailsPanel : MarginContainer
     {
         SpeciesPreview.PreviewSpecies = PreviewSpecies;
 
-        if (PreviewSpecies == null)
-        {
-            hexesPreview.PreviewSpecies = null;
-        }
-        else if (PreviewSpecies is MicrobeSpecies microbeSpecies)
-        {
-            hexesPreview.PreviewSpecies = microbeSpecies;
-        }
-        else
-        {
-            GD.PrintErr("Unknown species type to preview: ", PreviewSpecies, " (", PreviewSpecies.GetType().Name, ")");
-        }
+        hexesPreview.PreviewSpecies = PreviewSpecies;
 
         speciesDetailsLabel!.ExtendedBbcode = PreviewSpecies?.GetDetailString();
     }

--- a/src/gui_common/SpeciesPreview.cs
+++ b/src/gui_common/SpeciesPreview.cs
@@ -41,6 +41,11 @@ public partial class SpeciesPreview : PhotographablePreview
             return PhotoStudio.Instance.GenerateImage(microbeSpecies, Priority);
         }
 
+        if (previewSpecies is MulticellularSpecies multicellularSpecies)
+        {
+            return PhotoStudio.Instance.GenerateImage(multicellularSpecies, Priority);
+        }
+
         GD.PrintErr("Unknown species type to preview: ", previewSpecies, " (", previewSpecies.GetType().Name, ")");
         return null;
     }

--- a/src/microbe_stage/CellHexesPreview.cs
+++ b/src/microbe_stage/CellHexesPreview.cs
@@ -1,23 +1,24 @@
 ﻿using System;
+using Godot;
 
 /// <summary>
 ///   Shows a visualization of a cell's hexes in the GUI
 /// </summary>
 public partial class CellHexesPreview : PhotographablePreview
 {
-    private MicrobeSpecies? microbeSpecies;
+    private Species? species;
 
-    public MicrobeSpecies? PreviewSpecies
+    public Species? PreviewSpecies
     {
-        get => microbeSpecies;
+        get => species;
         set
         {
             if (PreviewSpecies == value)
                 return;
 
-            microbeSpecies = value;
+            species = value;
 
-            if (microbeSpecies != null)
+            if (species != null)
             {
                 UpdatePreview();
             }
@@ -28,18 +29,36 @@ public partial class CellHexesPreview : PhotographablePreview
         }
     }
 
-    protected override IImageTask SetupImageTask()
+    protected override IImageTask? SetupImageTask()
     {
-        if (microbeSpecies == null)
+        if (species == null)
             throw new InvalidOperationException("No species set to generate image of hexes for");
 
-        var hash = CellHexesPhotoBuilder.GetVisualHash(microbeSpecies);
+        if (species is MicrobeSpecies microbeSpecies)
+        {
+            var hash = CellHexesPhotoBuilder.GetVisualHash(microbeSpecies);
 
-        var task = PhotoStudio.Instance.TryGetFromCache(hash);
+            var task = PhotoStudio.Instance.TryGetFromCache(hash);
 
-        if (task != null)
-            return task;
+            if (task != null)
+                return task;
 
-        return PhotoStudio.Instance.GenerateImage(new CellHexesPhotoBuilder { Species = microbeSpecies }, Priority);
+            return PhotoStudio.Instance.GenerateImage(new CellHexesPhotoBuilder { Species = microbeSpecies }, Priority);
+        }
+
+        if (species is MulticellularSpecies multicellularSpecies)
+        {
+            var hash = ColonyHexPhotoBuilder.GetVisualHash(multicellularSpecies);
+
+            var task = PhotoStudio.Instance.TryGetFromCache(hash);
+
+            if (task != null)
+                return task;
+
+            return PhotoStudio.Instance.GenerateImage(new ColonyHexPhotoBuilder { Species = multicellularSpecies }, Priority);
+        }
+
+        GD.PrintErr("Unknown species type to preview: ", species, " (", species.GetType().Name, ")");
+        return null;
     }
 }

--- a/src/microbe_stage/CellHexesPreview.cs
+++ b/src/microbe_stage/CellHexesPreview.cs
@@ -55,6 +55,12 @@ public partial class CellHexesPreview : PhotographablePreview
             if (task != null)
                 return task;
 
+            if (multicellularSpecies.EditorCellLayout == null)
+            {
+                GD.PrintErr("No cell layout is remembered, the hex preview can't be generated");
+                return null;
+            }
+
             return PhotoStudio.Instance.GenerateImage(new ColonyHexPhotoBuilder { Species = multicellularSpecies }, Priority);
         }
 

--- a/src/microbe_stage/MicrobeVisualOnlySimulation.cs
+++ b/src/microbe_stage/MicrobeVisualOnlySimulation.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Components;
 using DefaultEcs;
-using DefaultEcs.Command;
 using DefaultEcs.Threading;
 using Godot;
 using Systems;

--- a/src/microbe_stage/MicrobeVisualOnlySimulation.cs
+++ b/src/microbe_stage/MicrobeVisualOnlySimulation.cs
@@ -13,8 +13,6 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
 {
     private readonly IMicrobeSpawnEnvironment dummyEnvironment = new DummyMicrobeSpawnEnvironment();
 
-    private readonly ISpawnSystem dummySpawnSystem = new DummySpawnSystem();
-
     private readonly List<Hex> hexWorkData1 = new();
     private readonly List<Hex> hexWorkData2 = new();
 
@@ -139,6 +137,8 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
             throw new Exception("Could not find microbe entity that should have been created");
 
         var recorder = StartRecordingEntityCommands();
+
+        var dummySpawnSystem = new DummySpawnSystem();
 
         int count = species.Cells.Count;
         for (int i = 1; i < count; i++)

--- a/src/microbe_stage/editor/EditorHex.tscn
+++ b/src/microbe_stage/editor/EditorHex.tscn
@@ -3,5 +3,5 @@
 [ext_resource type="ArrayMesh" uid="uid://bb5brfu0kxfmo" path="res://assets/models/EditorHex.mesh" id="1"]
 
 [node name="EditorHex" type="MeshInstance3D"]
-transform = Transform3D(-1.22191e-05, 75, -3.27835e-06, 0, -3.27835e-06, -75, -75, -1.22191e-05, 5.34112e-13, 0, 0, 0)
+transform = Transform3D(-1.22191e-05, 75, -3.27835e-06, 0, -3.27835e-06, -75, -75, -1.22191e-05, 5.34112e-13, 0.00796485, 0, 0)
 mesh = ExtResource("1")

--- a/src/microbe_stage/editor/tooltips/SpeciesPreviewTooltip.cs
+++ b/src/microbe_stage/editor/tooltips/SpeciesPreviewTooltip.cs
@@ -65,14 +65,6 @@ public partial class SpeciesPreviewTooltip : PanelContainer, ICustomToolTip
         DisplayName = PreviewSpecies.FormattedName;
         Description = PreviewSpecies.FormattedName;
 
-        if (PreviewSpecies is MicrobeSpecies microbeSpecies)
-        {
-            hexesPreview.PreviewSpecies = microbeSpecies;
-        }
-        else
-        {
-            GD.PrintErr("Unknown species type to preview: ", PreviewSpecies, " (", PreviewSpecies.GetType().Name, ")");
-            hexesPreview.PreviewSpecies = null;
-        }
+        hexesPreview.PreviewSpecies = PreviewSpecies;
     }
 }

--- a/src/multicellular_stage/ColonyHexPhotoBuilder.cs
+++ b/src/multicellular_stage/ColonyHexPhotoBuilder.cs
@@ -71,9 +71,15 @@ public partial class ColonyHexPhotoBuilder : Node3D, IScenePhotographable
         if (Species == null)
             throw new InvalidOperationException("Species is not initialized");
 
-        foreach (var cell in Species.Cells)
+        if (Species.EditorCellLayout == null)
         {
-            var pos = Hex.AxialToCartesian(cell.Position) * 0.3f;
+            GD.PrintErr("No cell layout is remembered, the hex preview can't be generated");
+            return;
+        }
+
+        foreach (var cell in Species.EditorCellLayout)
+        {
+            var pos = Hex.AxialToCartesian(cell.Position);
 
             var hexNode = hexScene.Instantiate<MeshInstance3D>();
             AddChild(hexNode);

--- a/src/multicellular_stage/ColonyHexPhotoBuilder.cs
+++ b/src/multicellular_stage/ColonyHexPhotoBuilder.cs
@@ -98,7 +98,13 @@ public partial class ColonyHexPhotoBuilder : Node3D, IScenePhotographable
 
         float farthest = 0;
 
-        foreach (var cell in species.Cells)
+        if (species.EditorCellLayout == null)
+        {
+            GD.PrintErr("No cell layout is remembered, the radius can't be calculated for the hex preview");
+            return;
+        }
+
+        foreach (var cell in species.EditorCellLayout)
         {
             farthest = MathF.Max(farthest, Hex.AxialToCartesian(cell.Position).DistanceTo(Vector3.Zero));
         }

--- a/src/multicellular_stage/ColonyHexPhotoBuilder.cs
+++ b/src/multicellular_stage/ColonyHexPhotoBuilder.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using Godot;
+
+/// <summary>
+///   Generates images of colony hex layouts
+/// </summary>
+public partial class ColonyHexPhotoBuilder : Node3D, IScenePhotographable
+{
+    private readonly List<ShaderMaterial> usedMaterials = new();
+
+    private float radius;
+    private bool radiusDirty;
+    private MulticellularSpecies? species;
+
+    public string SceneToPhotographPath => "res://src/multicellular_stage/ColonyHexPhotoBuilder.tscn";
+
+    public float Radius
+    {
+        get
+        {
+            if (radiusDirty)
+                CalculateRadius();
+
+            return radius;
+        }
+    }
+
+    public MulticellularSpecies? Species
+    {
+        get => species;
+        set
+        {
+            species = value;
+            radiusDirty = true;
+        }
+    }
+
+    public static ulong GetVisualHash(MulticellularSpecies species)
+    {
+        return Constants.VISUAL_HASH_HEX_LAYOUT ^ species.GetVisualHashCode();
+    }
+
+    public void ApplySceneParameters(Node3D instancedScene)
+    {
+        var builder = (ColonyHexPhotoBuilder)instancedScene;
+        builder.Species = Species;
+        builder.BuildHexStruct();
+    }
+
+    public Vector3 CalculatePhotographDistance(Node3D instancedScene)
+    {
+        return new Vector3(0, PhotoStudio.CameraDistanceFromRadiusOfObject(
+            ((ColonyHexPhotoBuilder)instancedScene).Radius *
+            Constants.PHOTO_STUDIO_CELL_RADIUS_MULTIPLIER), 0);
+    }
+
+    public ulong GetVisualHashCode()
+    {
+        return GetVisualHash(species ?? throw new InvalidOperationException("No species set"));
+    }
+
+    private void BuildHexStruct()
+    {
+        var hexScene = GD.Load<PackedScene>("res://src/microbe_stage/editor/EditorHex.tscn");
+        var hexMaterial = GD.Load<Material>("res://src/microbe_stage/editor/ValidHex.material");
+        var modelScene = GD.Load<PackedScene>("res://src/general/SceneDisplayer.tscn");
+
+        this.QueueFreeChildren();
+
+        if (Species == null)
+            throw new InvalidOperationException("Species is not initialized");
+
+        foreach (var cell in Species.Cells)
+        {
+            var pos = Hex.AxialToCartesian(cell.Position) * 0.3f;
+
+            var hexNode = hexScene.Instantiate<MeshInstance3D>();
+            AddChild(hexNode);
+            hexNode.MaterialOverride = hexMaterial;
+            hexNode.Position = pos;
+        }
+    }
+
+    private void CalculateRadius()
+    {
+        if (species == null)
+        {
+            radius = 0;
+            return;
+        }
+
+        float farthest = 0;
+
+        foreach (var cell in species.Cells)
+        {
+            farthest = MathF.Max(farthest, Hex.AxialToCartesian(cell.Position).DistanceTo(Vector3.Zero));
+        }
+
+        radius = farthest + Constants.DEFAULT_HEX_SIZE;
+
+        radiusDirty = false;
+    }
+}

--- a/src/multicellular_stage/ColonyHexPhotoBuilder.cs.uid
+++ b/src/multicellular_stage/ColonyHexPhotoBuilder.cs.uid
@@ -1,0 +1,1 @@
+uid://ur0nd33x8rpt

--- a/src/multicellular_stage/ColonyHexPhotoBuilder.tscn
+++ b/src/multicellular_stage/ColonyHexPhotoBuilder.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://crc7th37dmj8d"]
+
+[ext_resource type="Script" uid="uid://ur0nd33x8rpt" path="res://src/multicellular_stage/ColonyHexPhotoBuilder.cs" id="1_7gtif"]
+
+[node name="ColonyHexPhotoBuilder" type="Node3D"]
+script = ExtResource("1_7gtif")

--- a/src/multicellular_stage/ColonyHexPhotoBuilder.tscn
+++ b/src/multicellular_stage/ColonyHexPhotoBuilder.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://crc7th37dmj8d"]
+[gd_scene load_steps=2 format=3 uid="uid://178s22bf6rsn"]
 
 [ext_resource type="Script" uid="uid://ur0nd33x8rpt" path="res://src/multicellular_stage/ColonyHexPhotoBuilder.cs" id="1_7gtif"]
 

--- a/src/multicellular_stage/MulticellularSpecies.cs
+++ b/src/multicellular_stage/MulticellularSpecies.cs
@@ -29,6 +29,12 @@ public class MulticellularSpecies : Species, ISimulationPhotographable
     [JsonProperty]
     public CellLayout<CellTemplate> Cells { get; private set; } = new();
 
+    /// <summary>
+    ///   The cell layout that this species has in the editor. Is null unless this colony created in the editor.
+    /// </summary>
+    [JsonProperty]
+    public IndividualHexLayout<CellTemplate>? EditorCellLayout { get; set; }
+
     [JsonProperty]
     public List<CellType> CellTypes { get; private set; } = new();
 

--- a/src/multicellular_stage/MulticellularSpecies.cs
+++ b/src/multicellular_stage/MulticellularSpecies.cs
@@ -229,7 +229,16 @@ public class MulticellularSpecies : Species, ISimulationPhotographable
     {
         float radius = 0.0f;
 
+        Vector3 center = Vector3.Zero;
+
         int count = Cells.Count;
+        for (int i = 0; i < count; ++i)
+        {
+            center += Hex.AxialToCartesian(Cells[i].Position);
+        }
+
+        center /= count;
+
         foreach (var entity in worldSimulation.EntitySystem)
         {
             if (!entity.Has<CellProperties>())
@@ -243,7 +252,7 @@ public class MulticellularSpecies : Species, ISimulationPhotographable
 
             var cellRadius = cellProperties.CreatedMembrane!.EncompassingCircleRadius;
 
-            var farthestPoint = entity.Get<WorldPosition>().Position.Length() + cellRadius;
+            var farthestPoint = entity.Get<WorldPosition>().Position.DistanceTo(center) + cellRadius;
 
             if (farthestPoint > radius)
             {
@@ -251,7 +260,7 @@ public class MulticellularSpecies : Species, ISimulationPhotographable
             }
         }
 
-        return new Vector3(0.0f, PhotoStudio.CameraDistanceFromRadiusOfObject(radius), 0.0f);
+        return new Vector3(center.X, PhotoStudio.CameraDistanceFromRadiusOfObject(radius), center.Z);
     }
 
     public override ulong GetVisualHashCode()

--- a/src/multicellular_stage/MulticellularSpecies.cs
+++ b/src/multicellular_stage/MulticellularSpecies.cs
@@ -193,28 +193,6 @@ public class MulticellularSpecies : Species, ISimulationPhotographable
         return totalOrganelles;
     }
 
-    public override object Clone()
-    {
-        var result = new MulticellularSpecies(ID, Genus, Epithet);
-
-        ClonePropertiesTo(result);
-
-        var workMemory1 = new List<Hex>();
-        var workMemory2 = new List<Hex>();
-
-        foreach (var cellTemplate in Cells)
-        {
-            result.Cells.AddFast((CellTemplate)cellTemplate.Clone(), workMemory1, workMemory2);
-        }
-
-        foreach (var cellType in CellTypes)
-        {
-            result.CellTypes.Add((CellType)cellType.Clone());
-        }
-
-        return result;
-    }
-
     public void SetupWorldEntities(IWorldSimulation worldSimulation)
     {
         ((MicrobeVisualOnlySimulation)worldSimulation).CreateVisualisationColony(this);
@@ -261,6 +239,28 @@ public class MulticellularSpecies : Species, ISimulationPhotographable
         }
 
         return new Vector3(center.X, PhotoStudio.CameraDistanceFromRadiusOfObject(radius), center.Z);
+    }
+
+    public override object Clone()
+    {
+        var result = new MulticellularSpecies(ID, Genus, Epithet);
+
+        ClonePropertiesTo(result);
+
+        var workMemory1 = new List<Hex>();
+        var workMemory2 = new List<Hex>();
+
+        foreach (var cellTemplate in Cells)
+        {
+            result.Cells.AddFast((CellTemplate)cellTemplate.Clone(), workMemory1, workMemory2);
+        }
+
+        foreach (var cellType in CellTypes)
+        {
+            result.CellTypes.Add((CellType)cellType.Clone());
+        }
+
+        return result;
     }
 
     public override ulong GetVisualHashCode()

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -327,6 +327,9 @@ public partial class CellBodyPlanEditorComponent :
     {
         var editedSpecies = Editor.EditedSpecies;
 
+        editedSpecies.EditorCellLayout ??= new IndividualHexLayout<CellTemplate>();
+        editedSpecies.EditorCellLayout.Clear();
+
         // Note that for the below calculations to work all cell types need to be positioned correctly. So we need
         // to force that to happen here first. This also ensures that the skipped positioning to origin of the cell
         // editor component (that is used as a special mode in multicellular) is performed.


### PR DESCRIPTION
**Brief Description of What This PR Does**

Implements multicellular preview images.

Also makes the species remember the exact colony layout between editor sessions to make the hex preview work. Though it has no cell pictures for now because I couldn't find a way to implement that.

**Related Issues**

Closes #3899
Closes #3179 (to make the hex layout preview work)

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
