### PR TITLE
Increase autoevo diversity

### DIFF
--- a/src/auto-evo/AutoEvoGlobalCache.cs
+++ b/src/auto-evo/AutoEvoGlobalCache.cs
@@ -43,20 +43,20 @@ public class AutoEvoGlobalCache
         EnvironmentalTolerancesPressure = new EnvironmentalTolerancePressure(4);
 
         MinorGlucoseConversionEfficiencyPressure =
-            new CompoundConversionEfficiencyPressure(Compound.Glucose, Compound.ATP, 0.75f);
+            new CompoundConversionEfficiencyPressure(Compound.Glucose, Compound.ATP, 0.75f, true);
         MaintainGlucose = new MaintainCompoundPressure(Compound.Glucose, 1.5f);
 
         GlucoseConversionEfficiencyPressure =
-            new CompoundConversionEfficiencyPressure(Compound.Glucose, Compound.ATP, 1.5f);
+            new CompoundConversionEfficiencyPressure(Compound.Glucose, Compound.ATP, 1.5f, true);
 
-        IronConversionEfficiencyPressure = new CompoundConversionEfficiencyPressure(Compound.Iron, Compound.ATP, 1.5f);
+        IronConversionEfficiencyPressure = new CompoundConversionEfficiencyPressure(Compound.Iron, Compound.ATP, 1.5f, true);
         SmallIronChunkPressure = new ChunkCompoundPressure("ironSmallChunk", new LocalizedString("SMALL_IRON_CHUNK"),
             Compound.Iron, Compound.ATP, 1.0f);
         BigIronChunkPressure = new ChunkCompoundPressure("ironBigChunk", new LocalizedString("BIG_IRON_CHUNK"),
             Compound.Iron, Compound.ATP, 1.0f);
 
         HydrogenSulfideConversionEfficiencyPressure = new CompoundConversionEfficiencyPressure(Compound.Hydrogensulfide,
-            Compound.Glucose, 1.0f);
+            Compound.Glucose, 1.0f, true);
         SmallSulfurChunkPressure = new ChunkCompoundPressure("sulfurSmallChunk",
             new LocalizedString("SMALL_SULFUR_CHUNK"), Compound.Hydrogensulfide, Compound.Glucose, 1.0f);
         MediumSulfurChunkPressure = new ChunkCompoundPressure("sulfurMediumChunk",
@@ -65,16 +65,16 @@ public class AutoEvoGlobalCache
             new LocalizedString("LARGE_SULFUR_CHUNK"), Compound.Hydrogensulfide, Compound.Glucose, 1.0f);
 
         SunlightConversionEfficiencyPressure =
-            new CompoundConversionEfficiencyPressure(Compound.Sunlight, Compound.Glucose, 1.0f);
+            new CompoundConversionEfficiencyPressure(Compound.Sunlight, Compound.Glucose, 1.0f, true);
         SunlightCompoundPressure = new EnvironmentalCompoundPressure(Compound.Sunlight, Compound.Glucose, 20000, 1.0f);
 
         RadiationConversionEfficiencyPressure =
-            new CompoundConversionEfficiencyPressure(Compound.Radiation, Compound.ATP, 1.0f);
+            new CompoundConversionEfficiencyPressure(Compound.Radiation, Compound.ATP, 1.0f, true);
         RadioactiveChunkPressure = new ChunkCompoundPressure("radioactiveChunk",
             new LocalizedString("RADIOACTIVE_CHUNK"), Compound.Radiation, Compound.ATP, 1.0f);
 
         TemperatureConversionEfficiencyPressure =
-            new CompoundConversionEfficiencyPressure(Compound.Temperature, Compound.ATP, 1.0f);
+            new CompoundConversionEfficiencyPressure(Compound.Temperature, Compound.ATP, 1.0f, true);
         TemperatureCompoundPressure = new EnvironmentalCompoundPressure(Compound.Temperature, Compound.ATP, 100, 1.0f);
         HasTemperature = !worldSettings.LAWK;
 

--- a/src/auto-evo/AutoEvoGlobalCache.cs
+++ b/src/auto-evo/AutoEvoGlobalCache.cs
@@ -13,14 +13,12 @@ public class AutoEvoGlobalCache
     public readonly MaintainCompoundPressure MaintainGlucose;
 
     public readonly CompoundConversionEfficiencyPressure GlucoseConversionEfficiencyPressure;
-    public readonly CompoundCloudPressure GlucoseCloudPressure;
 
     public readonly CompoundConversionEfficiencyPressure IronConversionEfficiencyPressure;
     public readonly ChunkCompoundPressure SmallIronChunkPressure;
     public readonly ChunkCompoundPressure BigIronChunkPressure;
 
     public readonly CompoundConversionEfficiencyPressure HydrogenSulfideConversionEfficiencyPressure;
-    public readonly CompoundCloudPressure HydrogenSulfideCloudPressure;
     public readonly ChunkCompoundPressure SmallSulfurChunkPressure;
     public readonly ChunkCompoundPressure MediumSulfurChunkPressure;
     public readonly ChunkCompoundPressure LargeSulfurChunkPressure;
@@ -50,7 +48,6 @@ public class AutoEvoGlobalCache
 
         GlucoseConversionEfficiencyPressure =
             new CompoundConversionEfficiencyPressure(Compound.Glucose, Compound.ATP, 1.5f);
-        GlucoseCloudPressure = new CompoundCloudPressure(Compound.Glucose, worldSettings.DayNightCycleEnabled, 1.0f);
 
         IronConversionEfficiencyPressure = new CompoundConversionEfficiencyPressure(Compound.Iron, Compound.ATP, 1.5f);
         SmallIronChunkPressure = new ChunkCompoundPressure("ironSmallChunk", new LocalizedString("SMALL_IRON_CHUNK"),
@@ -60,8 +57,6 @@ public class AutoEvoGlobalCache
 
         HydrogenSulfideConversionEfficiencyPressure = new CompoundConversionEfficiencyPressure(Compound.Hydrogensulfide,
             Compound.Glucose, 1.0f);
-        HydrogenSulfideCloudPressure = new CompoundCloudPressure(Compound.Hydrogensulfide,
-            worldSettings.DayNightCycleEnabled, 1.0f);
         SmallSulfurChunkPressure = new ChunkCompoundPressure("sulfurSmallChunk",
             new LocalizedString("SMALL_SULFUR_CHUNK"), Compound.Hydrogensulfide, Compound.Glucose, 1.0f);
         MediumSulfurChunkPressure = new ChunkCompoundPressure("sulfurMediumChunk",

--- a/src/auto-evo/AutoEvoGlobalCache.cs
+++ b/src/auto-evo/AutoEvoGlobalCache.cs
@@ -43,7 +43,7 @@ public class AutoEvoGlobalCache
         EnvironmentalTolerancesPressure = new EnvironmentalTolerancePressure(4);
 
         MinorGlucoseConversionEfficiencyPressure =
-            new CompoundConversionEfficiencyPressure(Compound.Glucose, Compound.ATP, 0.75f, true);
+            new CompoundConversionEfficiencyPressure(Compound.Glucose, Compound.ATP, 0.45f, true);
         MaintainGlucose = new MaintainCompoundPressure(Compound.Glucose, 1.5f);
 
         GlucoseConversionEfficiencyPressure =

--- a/src/auto-evo/AutoEvoGlobalCache.cs
+++ b/src/auto-evo/AutoEvoGlobalCache.cs
@@ -49,7 +49,8 @@ public class AutoEvoGlobalCache
         GlucoseConversionEfficiencyPressure =
             new CompoundConversionEfficiencyPressure(Compound.Glucose, Compound.ATP, 1.5f, true);
 
-        IronConversionEfficiencyPressure = new CompoundConversionEfficiencyPressure(Compound.Iron, Compound.ATP, 1.5f, true);
+        IronConversionEfficiencyPressure = new CompoundConversionEfficiencyPressure(Compound.Iron, Compound.ATP,
+            1.5f, true);
         SmallIronChunkPressure = new ChunkCompoundPressure("ironSmallChunk", new LocalizedString("SMALL_IRON_CHUNK"),
             Compound.Iron, Compound.ATP, 1.0f);
         BigIronChunkPressure = new ChunkCompoundPressure("ironBigChunk", new LocalizedString("BIG_IRON_CHUNK"),

--- a/src/auto-evo/selection_pressure/CompoundCloudPressure.cs
+++ b/src/auto-evo/selection_pressure/CompoundCloudPressure.cs
@@ -1,9 +1,7 @@
 ﻿namespace AutoEvo;
 
 using System;
-using System.Collections.Generic;
 using Newtonsoft.Json;
-using Systems;
 
 [JSONDynamicTypeAllowed]
 public class CompoundCloudPressure : SelectionPressure

--- a/src/auto-evo/selection_pressure/CompoundCloudPressure.cs
+++ b/src/auto-evo/selection_pressure/CompoundCloudPressure.cs
@@ -65,21 +65,6 @@ public class CompoundCloudPressure : SelectionPressure
                 score *= multiplier;
         }
 
-        var energyBalance = new EnergyBalanceInfoSimple();
-        Dictionary<Compound, CompoundBalance> dayCompoundBalances = new Dictionary<Compound, CompoundBalance>();
-
-        List<OrganelleDefinition> organelleDefinitions = new List<OrganelleDefinition>();
-
-        foreach (OrganelleTemplate template in microbeSpecies.Organelles)
-        {
-            organelleDefinitions.Add(template.Definition);
-        }
-
-        ProcessSystem.ComputeCompoundBalanceAtEquilibrium(organelleDefinitions,
-                patch.Biome, cache.GetEnvironmentalTolerances(microbeSpecies, patch.Biome), CompoundAmountType.Biome, energyBalance, dayCompoundBalances);
-
-        score /= dayCompoundBalances[compound].Balance;
-
         return score;
     }
 

--- a/src/auto-evo/selection_pressure/CompoundConversionEfficiencyPressure.cs
+++ b/src/auto-evo/selection_pressure/CompoundConversionEfficiencyPressure.cs
@@ -1,6 +1,9 @@
 ﻿namespace AutoEvo;
 
+using Godot;
 using Newtonsoft.Json;
+using System.Collections.Generic;
+using Systems;
 
 [JSONDynamicTypeAllowed]
 public class CompoundConversionEfficiencyPressure : SelectionPressure
@@ -24,7 +27,10 @@ public class CompoundConversionEfficiencyPressure : SelectionPressure
     [JsonProperty]
     private readonly Compound outCompound;
 
-    public CompoundConversionEfficiencyPressure(Compound compound, Compound outCompound, float weight) :
+    [JsonProperty]
+    private readonly bool usedForSurvival;
+
+    public CompoundConversionEfficiencyPressure(Compound compound, Compound outCompound, float weight, bool usedForSurvival) :
         base(weight, [
             AddOrganelleAnywhere.ThatConvertBetweenCompounds(compound, outCompound),
             RemoveOrganelle.ThatCreateCompound(outCompound),
@@ -35,6 +41,7 @@ public class CompoundConversionEfficiencyPressure : SelectionPressure
 
         FromCompound = SimulationParameters.GetCompound(compound);
         ToCompound = SimulationParameters.GetCompound(outCompound);
+        this.usedForSurvival = usedForSurvival;
     }
 
     [JsonIgnore]
@@ -45,7 +52,13 @@ public class CompoundConversionEfficiencyPressure : SelectionPressure
         if (species is not MicrobeSpecies microbeSpecies)
             return 0;
 
-        return cache.GetCompoundConversionScoreForSpecies(FromCompound, ToCompound, microbeSpecies, patch.Biome);
+        var score = cache.GetCompoundConversionScoreForSpecies(FromCompound, ToCompound, microbeSpecies, patch.Biome);
+
+        // we need to factor in both conversion from source to output, and energy expenditure time
+        if (usedForSurvival)
+            score /= cache.GetEnergyBalanceForSpecies(microbeSpecies, patch.Biome).TotalConsumptionStationary;
+
+        return score;
     }
 
     public override float GetEnergy(Patch patch)

--- a/src/auto-evo/selection_pressure/CompoundConversionEfficiencyPressure.cs
+++ b/src/auto-evo/selection_pressure/CompoundConversionEfficiencyPressure.cs
@@ -1,9 +1,6 @@
 ﻿namespace AutoEvo;
 
-using Godot;
 using Newtonsoft.Json;
-using System.Collections.Generic;
-using Systems;
 
 [JSONDynamicTypeAllowed]
 public class CompoundConversionEfficiencyPressure : SelectionPressure
@@ -30,7 +27,8 @@ public class CompoundConversionEfficiencyPressure : SelectionPressure
     [JsonProperty]
     private readonly bool usedForSurvival;
 
-    public CompoundConversionEfficiencyPressure(Compound compound, Compound outCompound, float weight, bool usedForSurvival) :
+    public CompoundConversionEfficiencyPressure(Compound compound, Compound outCompound, float weight,
+        bool usedForSurvival) :
         base(weight, [
             AddOrganelleAnywhere.ThatConvertBetweenCompounds(compound, outCompound),
             RemoveOrganelle.ThatCreateCompound(outCompound),

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -387,6 +387,11 @@ public class SimulationCache
         return cached;
     }
 
+    public bool GetDayNightEnabled()
+    {
+        return worldSettings.DayNightCycleEnabled;
+    }
+
     public bool MatchesSettings(WorldGenerationSettings checkAgainst)
     {
         return worldSettings.Equals(checkAgainst);

--- a/src/auto-evo/steps/GenerateMiche.cs
+++ b/src/auto-evo/steps/GenerateMiche.cs
@@ -44,7 +44,8 @@ public class GenerateMiche : IRunStep
             glucoseAmount.Amount > 0)
         {
             var glucoseMiche = new Miche(globalCache.GlucoseConversionEfficiencyPressure);
-            glucoseMiche.AddChild(new Miche(new CompoundCloudPressure(Compound.Glucose, glucoseAmount.Amount, cache.GetDayNightEnabled(), 1.0f)));
+            glucoseMiche.AddChild(new Miche(new CompoundCloudPressure(Compound.Glucose, glucoseAmount.Amount,
+                cache.GetDayNightEnabled(), 1.0f)));
 
             generatedMiche.AddChild(glucoseMiche);
         }

--- a/src/auto-evo/steps/GenerateMiche.cs
+++ b/src/auto-evo/steps/GenerateMiche.cs
@@ -44,7 +44,7 @@ public class GenerateMiche : IRunStep
             glucoseAmount.Amount > 0)
         {
             var glucoseMiche = new Miche(globalCache.GlucoseConversionEfficiencyPressure);
-            glucoseMiche.AddChild(new Miche(globalCache.GlucoseCloudPressure));
+            glucoseMiche.AddChild(new Miche(new CompoundCloudPressure(Compound.Glucose, glucoseAmount.Amount, cache.GetDayNightEnabled(), 1.0f)));
 
             generatedMiche.AddChild(glucoseMiche);
         }
@@ -91,7 +91,10 @@ public class GenerateMiche : IRunStep
             var maintainGlucose = new Miche(globalCache.MaintainGlucose);
 
             if (hydrogenSulfideAmount.Amount > 0)
-                maintainGlucose.AddChild(new Miche(globalCache.HydrogenSulfideCloudPressure));
+            {
+                maintainGlucose.AddChild(new Miche(new CompoundCloudPressure(Compound.Hydrogensulfide,
+                    hydrogenSulfideAmount.Amount, cache.GetDayNightEnabled(), 1.0f)));
+            }
 
             if (hasSmallSulfurChunk)
                 maintainGlucose.AddChild(new Miche(globalCache.SmallSulfurChunkPressure));


### PR DESCRIPTION
**Brief Description of What This PR Does**

The compound conversion score focuses only on the efficiency of conversion of those organelles, without factoring in osmoregulation and time. The problem with this seems to be that a species with one chloroplast is as efficient as a species focused around photosynthesis, for example. This change isn't a perfect simulation, but it is seeming to provide the desired diversity and specialization, particularly among autotrophs.

**Related Issues**

None

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
