### PR TITLE
Made hydrogen sulfide diffuse between patches and buffed generation events

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1345,8 +1345,9 @@ public static class Constants
     public const float VOLCANISM_FLOOR_CO2_STRENGTH = 0.010f;
     public const float VOLCANISM_FLOOR_CO2_THRESHOLD = 0.1f;
 
-    public const float MIN_HYDROGEN_SULFIDE_FRACTION = 0.496f;
-    public const double HYDROGEN_SULFIDE_ENVIRONMENT_EATING_MULTIPLIER = 0.00000002;
+    public const float MIN_HYDROGEN_SULFIDE_FRACTION = 0.517f;
+    public const double HYDROGEN_SULFIDE_ENVIRONMENT_EATING_MULTIPLIER = 0.00000001;
+    public const float HYDROGEN_SULFIDE_NATURAL_DECAY_FACTOR = 0.3f;
 
     /// <summary>
     ///   Below this value oxygen doesn't cause iron chunks to become less common
@@ -1368,7 +1369,7 @@ public static class Constants
 
     // Patch event variables
     public const int VENT_ERUPTION_CHANCE = 15;
-    public const float VENT_ERUPTION_HYDROGEN_SULFIDE_INCREASE = 0.00004f;
+    public const float VENT_ERUPTION_HYDROGEN_SULFIDE_INCREASE = 0.001f;
     public const float VENT_ERUPTION_CARBON_DIOXIDE_INCREASE = 0.3f;
 
     public const float GLOBAL_GLACIATION_OXYGEN_THRESHOLD = 0.07f;

--- a/simulation_parameters/microbe_stage/compounds.json
+++ b/simulation_parameters/microbe_stage/compounds.json
@@ -62,6 +62,7 @@
     "IsEnvironmental": false,
     "CanBeDistributed": true,
     "Digestible": true,
+    "Diffusible": true,
     "Colour": {
       "r": 0.949,
       "g": 0.918,

--- a/simulation_parameters/microbe_stage/meteors.json
+++ b/simulation_parameters/microbe_stage/meteors.json
@@ -39,7 +39,7 @@
     ],
     "Compounds": {
       "Carbondioxide": 0.15,
-      "Hydrogensulfide": 0.00005
+      "Hydrogensulfide": 0.001
     },
     "Probability": 0.1,
     "VisualEffect": "MeteorSulfurImpact"

--- a/src/general/world_effects/CompoundDiffusionEffect.cs
+++ b/src/general/world_effects/CompoundDiffusionEffect.cs
@@ -48,6 +48,10 @@ public class CompoundDiffusionEffect : IWorldEffect
         {
             foreach (var compound in patch.Value.Biome.Compounds)
             {
+                // Skip processing compounds there isn't any of
+                if (compound.Value is { Ambient: <= 0, Density: <= 0 })
+                    continue;
+
                 var definition = simulationParameters.GetCompoundDefinition(compound.Key);
 
                 // If not diffusible, then skip
@@ -106,7 +110,7 @@ public class CompoundDiffusionEffect : IWorldEffect
 
                     AddMove(compound.Key, adjacent, changes, movedAmounts);
 
-                    // Negate for the source patch to keep the same total amount of compounds but just to move it
+                    // Negate for the source patch to keep the same total number of compounds but just to move it
                     if (changes.Ambient != 0)
                         changes.Ambient = -changes.Ambient;
 
@@ -136,7 +140,7 @@ public class CompoundDiffusionEffect : IWorldEffect
                         "incorrect result");
                 }
 
-                // Setup cloud size copying in case it ends up needed
+                // Set up cloud size copying in case it ends up needed
                 if (entry.Value.Amount > 0)
                     cloudSizes[entry.Key] = entry.Value.Amount;
             }

--- a/src/microbe_stage/BiomeConditions.cs
+++ b/src/microbe_stage/BiomeConditions.cs
@@ -209,7 +209,23 @@ public class BiomeConditions : IBiomeConditions, ICloneable
             var definition = simulationParameters.GetCompoundDefinition(entry.Key);
             if (!definition.IsEnvironmental)
             {
+                bool updateCloudSize = false;
+
                 if (!TryGetCompound(entry.Key, CompoundAmountType.Biome, out var existing))
+                {
+                    updateCloudSize = true;
+                }
+                else
+                {
+                    // Make sure the cloud size is set (as the above fetch can succeed but return a value with no
+                    // amount set)
+                    if (existing.Amount <= 0)
+                    {
+                        updateCloudSize = true;
+                    }
+                }
+
+                if (updateCloudSize)
                 {
                     if (!newCloudSizes.TryGetValue(entry.Key, out var cloudSize))
                     {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes hydrogen sulfide move between patches and I tried to buff the events a lot to still have similar impact as before

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
