### PR TITLE
Make the ripple subdivision count static

### DIFF
--- a/src/microbe_stage/Membrane.tscn
+++ b/src/microbe_stage/Membrane.tscn
@@ -67,8 +67,8 @@ shader_parameter/MembraneRadius = 5.0
 [sub_resource type="PlaneMesh" id="PlaneMesh_ripple"]
 resource_local_to_scene = true
 size = Vector2(18, 18)
-subdivide_width = 120
-subdivide_depth = 120
+subdivide_width = 80
+subdivide_depth = 80
 
 [node name="Membrane" type="MeshInstance3D" node_paths=PackedStringArray("engulfAnimationMeshInstance", "mucocystAnimationMeshInstance", "waterRipple")]
 process_priority = 2

--- a/src/microbe_stage/MembraneWaterRipple.cs
+++ b/src/microbe_stage/MembraneWaterRipple.cs
@@ -391,8 +391,6 @@ public partial class MembraneWaterRipple : Node
         {
             planeMesh.Size = new Vector2(desiredSize, desiredSize);
         }
-
-        UpdateDetailLevelSubdivisions();
     }
 
     private float CalculateTimeScale()
@@ -498,35 +496,6 @@ public partial class MembraneWaterRipple : Node
             lastCameraPosition = cameraPos;
             lastCameraDistance = FollowTargetNode.GlobalPosition.DistanceTo(cameraPos);
             isCameraPositionValid = true;
-
-            // Update detail level based on distance
-            UpdateDetailLevelSubdivisions();
-        }
-    }
-
-    /// <summary>
-    ///   Updates the mesh subdivisions based on camera distance
-    /// </summary>
-    private void UpdateDetailLevelSubdivisions()
-    {
-        if (!isCameraPositionValid)
-            return;
-
-        float sizeScale = Math.Clamp(EffectRadius / 5.0f, 1.0f, 2.0f);
-        float scaledDistance = lastCameraDistance / sizeScale;
-
-        // Map distance (0-120) to subdivision (120-40) with a non-linear curve
-        float t = Math.Clamp(scaledDistance / 120.0f, 0.0f, 1.0f);
-        t = MathF.Pow(t, 1.5f);
-
-        // Calculate subdivision from min (40) to max (120)
-        // TODO: optimize how often subdivisions are updated
-        int subdivision = (int)Mathf.Lerp(120, 40, t);
-
-        if (planeMesh.SubdivideWidth != subdivision || planeMesh.SubdivideDepth != subdivision)
-        {
-            planeMesh.SubdivideWidth = subdivision;
-            planeMesh.SubdivideDepth = subdivision;
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

I noticed some lag in the game due to ripple effect subdivision change calls - according to the profiler, they were using about 20% of the game's total CPU time. To address this, this PR makes the subdivision count static. The 80x80 count is arbitrary and can be made higher or lower if necessary.

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
