### PR TITLE
Prevent a Macroscopic stage crash

### DIFF
--- a/src/macroscopic_stage/editor/MacroscopicEditor.cs
+++ b/src/macroscopic_stage/editor/MacroscopicEditor.cs
@@ -193,6 +193,15 @@ public partial class MacroscopicEditor : EditorBase<EditorAction, MacroscopicSta
         base.Undo();
     }
 
+    public bool IsNewCellTypeNameValid(string newName)
+    {
+        // Name is invalid if it is empty or a duplicate
+        // TODO: should this ensure the name doesn't have trailing whitespace?
+        // If so, CellTemplate.UpdateNameIfValid should be updated as well
+        return !string.IsNullOrWhiteSpace(newName) && !EditedSpecies.CellTypes.Any(c =>
+            c.TypeName.Equals(newName, StringComparison.InvariantCultureIgnoreCase));
+    }
+
     protected override void ResolveDerivedTypeNodeReferences()
     {
     }
@@ -232,6 +241,7 @@ public partial class MacroscopicEditor : EditorBase<EditorAction, MacroscopicSta
         patchMapTab.OnNextTab = () => SetEditorTab(EditorTab.CellEditor);
         bodyPlanEditorTab.OnFinish = ForwardEditorComponentFinishRequest;
         cellEditorTab.OnNextTab = () => SetEditorTab(EditorTab.CellEditor);
+        cellEditorTab.ValidateNewCellTypeName = IsNewCellTypeNameValid;
 
         foreach (var editorComponent in GetAllEditorComponents())
         {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes the Macroscopic Editor provide a name validation callback to the cell editor component (otherwise it throws an exception).

**Related Issues**

A crash when entering the Macroscopic Editor (regression from #6175)

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
