### PR TITLE
Fix the colony preview not generating because of a zero photographing radius

### DIFF
--- a/src/microbe_stage/MicrobeVisualOnlySimulation.cs
+++ b/src/microbe_stage/MicrobeVisualOnlySimulation.cs
@@ -369,17 +369,19 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
 
             var distanceSquared = entity.Get<WorldPosition>().Position.DistanceSquaredTo(center);
 
-            if (distanceSquared > maxCellDistanceSquared)
+            ref var cellProperties = ref entity.Get<CellProperties>();
+
+            // This uses the membrane as radius is not set as the physics system doesn't run
+            if (!cellProperties.IsMembraneReady())
+                throw new InvalidOperationException("Microbe doesn't have a ready membrane");
+
+            float radius = cellProperties.CreatedMembrane!.EncompassingCircleRadius;
+
+            if (distanceSquared + radius * radius > maxCellDistanceSquared + farthestCellRadius * farthestCellRadius)
             {
                 maxCellDistanceSquared = distanceSquared;
 
-                ref var cellProperties = ref entity.Get<CellProperties>();
-
-                // This uses the membrane as radius is not set as the physics system doesn't run
-                if (!cellProperties.IsMembraneReady())
-                    throw new InvalidOperationException("Microbe doesn't have a ready membrane");
-
-                farthestCellRadius = cellProperties.CreatedMembrane!.EncompassingCircleRadius;
+                farthestCellRadius = radius;
             }
         }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Apparently, the distance calculation for a single cell was returning 0, and an exception was being thrown as a result. 

This PR fixes this issue and also addresses a rarer corner case where the radius might be calculated incorrectly if the farthest cell has a smaller radius than a closer cell with a larger radius.

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
