### PR TITLE
Increase max zoom out for large cell colonies

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -779,6 +779,17 @@ public static class Constants
 
     public const float SCREEN_DAMAGE_FLASH_DECAY_SPEED = 1.0f;
 
+    public const float MICROBE_CAMERA_MIN_HEGIHT = 3.0f;
+
+    public const float MICROBE_CAMERA_MAX_HEGIHT = 80.0f;
+
+    public const float MULTICELLULAR_CAMERA_MIN_HEGIHT = 8.0f;
+
+    /// <summary>
+    ///   The highest that the dynamic multicellular camera max height can get.
+    /// </summary>
+    public const float MULTICELLULAR_CAMERA_MAX_HEGIHT = 180.0f;
+
     /// <summary>
     ///   Cells need at least this much ATP to regenerate health passively. This is now less than one to allow cells
     ///   with 1 storage to regenerate health. As reaching exactly full storage of ATP is not really possible due to

--- a/src/engine/PhotoStudio.cs
+++ b/src/engine/PhotoStudio.cs
@@ -95,12 +95,7 @@ public partial class PhotoStudio : SubViewport
     /// <returns>The distance to use</returns>
     public static float CameraDistanceFromRadiusOfObject(float radius)
     {
-        if (radius <= 0)
-            throw new ArgumentException("radius needs to be over 0");
-
-        float angle = Constants.PHOTO_STUDIO_CAMERA_HALF_ANGLE;
-
-        return MathF.Tan(MathF.PI * 0.5f - MathUtils.DEGREES_TO_RADIANS * angle) * radius;
+        return MathUtils.CameraDistanceFromRadiusOfObject(radius, Constants.PHOTO_STUDIO_CAMERA_FOV);
     }
 
     public override void _Ready()

--- a/src/general/utils/MathUtils.cs
+++ b/src/general/utils/MathUtils.cs
@@ -183,4 +183,19 @@ public static class MathUtils
 
         return forward * distance;
     }
+
+    /// <summary>
+    ///   Calculates a good camera distance from the radius of an object that is photographed
+    /// </summary>
+    /// <param name="radius">The radius of the object</param>
+    /// <returns>The distance to use</returns>
+    public static float CameraDistanceFromRadiusOfObject(float radius, float fieldOfView)
+    {
+        if (radius <= 0)
+            throw new ArgumentException("radius needs to be over 0");
+
+        float angle = fieldOfView * 0.5f;
+
+        return MathF.Tan(MathF.PI * 0.5f - DEGREES_TO_RADIANS * angle) * radius;
+    }
 }

--- a/src/microbe_stage/MicrobeCamera.cs
+++ b/src/microbe_stage/MicrobeCamera.cs
@@ -33,14 +33,14 @@ public partial class MicrobeCamera : Camera3D, ISaveLoadedTracked, IGameCamera
     /// </summary>
     [Export]
     [JsonProperty]
-    public float MinCameraHeight = 3.0f;
+    public float MinCameraHeight = Constants.MICROBE_CAMERA_MIN_HEGIHT;
 
     /// <summary>
     ///   Maximum height the camera can be scrolled to
     /// </summary>
     [Export]
     [JsonProperty]
-    public float MaxCameraHeight = 80.0f;
+    public float MaxCameraHeight = Constants.MICROBE_CAMERA_MAX_HEGIHT;
 
     [Export]
     [JsonProperty]

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -845,6 +845,8 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
             }
         }
 
+        UpdateZoomLevels(playerIsMulticellular);
+
         Player.Set(environmentalEffects);
 
         var playerCompounds = Player.Get<CompoundStorage>().Compounds;
@@ -1339,6 +1341,41 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         {
             // Don't change lighting for patches without day/night effects
             Camera.LightLevel = 1.0f;
+        }
+    }
+
+    private void UpdateZoomLevels(bool isMulticellular)
+    {
+        if (isMulticellular)
+        {
+            var species = Player.Get<MulticellularSpeciesMember>().Species;
+
+            float maxDistance = 0.0f;
+
+            foreach (var cell in species.Cells)
+            {
+                float distance = Hex.AxialToCartesian(cell.Position).LengthSquared();
+
+                if (distance > maxDistance)
+                {
+                    maxDistance = distance;
+                }
+            }
+
+            maxDistance = MathF.Sqrt(maxDistance);
+
+            // Extra padding, just in case
+            maxDistance += 20.0f;
+
+            Camera.MinCameraHeight = Constants.MULTICELLULAR_CAMERA_MIN_HEGIHT;
+            Camera.MaxCameraHeight = float.Clamp(
+                MathUtils.CameraDistanceFromRadiusOfObject(maxDistance, Camera.Fov),
+                Constants.MICROBE_CAMERA_MAX_HEGIHT, Constants.MULTICELLULAR_CAMERA_MAX_HEGIHT);
+        }
+        else
+        {
+            Camera.MinCameraHeight = Constants.MICROBE_CAMERA_MIN_HEGIHT;
+            Camera.MaxCameraHeight = Constants.MICROBE_CAMERA_MAX_HEGIHT;
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Max zoom out now scales with colony size. There's a hard limit to it though, to prevent the camera from going too far.

Also the max zoom in is now more distant to make cells appear smaller. This is a game feel enchancement, so it's a bit debatable.

**Related Issues**

Closes #2312

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
