### PR TITLE
Fix the patch move button not updating correctly

### DIFF
--- a/src/microbe_stage/editor/PatchMapEditorComponent.cs
+++ b/src/microbe_stage/editor/PatchMapEditorComponent.cs
@@ -250,8 +250,8 @@ public partial class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEdi
 
     protected virtual void UpdateShownPatchDetails()
     {
-        detailsPanel.SelectedPatch = mapDrawer.SelectedPatch;
         detailsPanel.IsPatchMoveValid = IsPatchMoveValid(mapDrawer.SelectedPatch);
+        detailsPanel.SelectedPatch = mapDrawer.SelectedPatch;
 
         detailsPanel.OnMicheDetailsRequested = GetMicheSelectionCallback();
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

After #6239, the patch move button was partially broken, because its `IsPatchMoveValid` property was updated after the button status update. This PR fixes that by reordering the patch property change.

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
