### PR TITLE
Fix an ATP warning visibility bug

### DIFF
--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -942,6 +942,8 @@ public partial class CellBodyPlanEditorComponent :
     {
         UpdateCellTypesCounts();
 
+        hasNegativeATPCells = false;
+
         foreach (var button in cellTypeSelectionButtons.Values)
         {
             var cellType = button.CellType;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds an ATP warning reset before its status is recalculated, to fix it always being visible once being made so.

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
