### PR TITLE
Add right click to deselect chosen part in cell editor.

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -853,7 +853,14 @@ public partial class CellEditorComponent :
             return true;
         }
 
-        return base.CancelCurrentAction();
+        if (base.CancelCurrentAction())
+            return true;
+
+        if (string.IsNullOrWhiteSpace(activeActionName))
+            return false;
+
+        DeselectOrganelleToPlace();
+        return true;
     }
 
     public override void OnEditorSpeciesSetup(Species species)


### PR DESCRIPTION
**Brief Description of What This PR Does**

In cell editor, when you select an organelle there is no easy way to deselect it. With this, right clicking on an empty are should clear your selection now.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).
