### PR TITLE
Fix stuck digestion

### DIFF
--- a/src/microbe_stage/systems/EngulfedDigestionSystem.cs
+++ b/src/microbe_stage/systems/EngulfedDigestionSystem.cs
@@ -320,7 +320,9 @@ public sealed class EngulfedDigestionSystem : AEntitySetSystem<float>
             }
 
             // If out of stuff to digest, or as a safety check, the engulf size has gone to zero, consider digested
-            if (totalAmountLeft <= 0 || engulfable.DigestedAmount >= Constants.FULLY_DIGESTED_LIMIT ||
+            // Note that the digestion threshold has to be slightly above zero
+            // to avoid https://github.com/Revolutionary-Games/Thrive/issues/4794
+            if (totalAmountLeft <= 0.001f || engulfable.DigestedAmount >= Constants.FULLY_DIGESTED_LIMIT ||
                 engulfable.AdjustedEngulfSize <= 0)
             {
                 engulfable.PhagocytosisStep = PhagocytosisPhase.Digested;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes stuck digestion by increasing the digestion threshold to 0.001

Based on my testing, when the stuck digestion bug happens, Ingested Matter drops to around 0.0001 and even less, so this threshold should work

**Related Issues**

Fixes #4794

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
