### PR TITLE
Fix loaded saves being infected by previous cheated flag and editor not immediately setting the cheated flag

### DIFF
--- a/src/general/achievements/AchievementEvents.cs
+++ b/src/general/achievements/AchievementEvents.cs
@@ -28,11 +28,6 @@ public static class AchievementEvents
         AchievementsManager.Instance.OnEndosymbiosisCompleted();
     }
 
-    public static void ReportPlayerDidNotEditSpecies()
-    {
-        AchievementsManager.Instance.OnPlayerDidNotEditSpecies();
-    }
-
     public static void ReportPlayerInCellColony()
     {
         AchievementsManager.Instance.OnPlayerInCellColony();

--- a/src/general/achievements/AchievementsManager.cs
+++ b/src/general/achievements/AchievementsManager.cs
@@ -475,19 +475,6 @@ public partial class AchievementsManager : Node
         }
     }
 
-    internal void OnPlayerDidNotEditSpecies()
-    {
-        if (preventAchievements)
-            return;
-
-        lock (achievementsDataLock)
-        {
-            statsStore.IncrementIntStat(IAchievementStatStore.STAT_NO_CHANGES_IN_EDITOR);
-
-            ReportStatUpdateToRelevantAchievements([AchievementIds.CANNOT_IMPROVE_PERFECTION]);
-        }
-    }
-
     internal void OnPlayerInCellColony()
     {
         if (preventAchievements)

--- a/src/general/base_stage/StageBase.cs
+++ b/src/general/base_stage/StageBase.cs
@@ -138,6 +138,10 @@ public partial class StageBase : NodeWithInput, IStageBase, IGodotEarlyNodeResol
                         CurrentGame.ReportCheatsUsed();
                     }
                 }
+                else
+                {
+                    GD.PrintErr("Stage base expected current game data to be initialized already");
+                }
             }, this);
         }
 

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -150,7 +150,7 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
             if (!history.CanUndo())
             {
                 // Nothing done in the whole editor cycle
-                AchievementEvents.ReportPlayerDidNotEditSpecies();
+                AchievementEvents.ReportExitEditorWithoutChanges();
             }
         }
 

--- a/src/saving/InProgressLoad.cs
+++ b/src/saving/InProgressLoad.cs
@@ -59,6 +59,10 @@ public class InProgressLoad
     {
         CheatManager.OnCheatsDisabled();
 
+        // Need to early report to achievements that no cheats are used so that previous cheat use does not leak
+        // into loaded saves
+        AchievementsManager.ReportNewGameStarted(false);
+
         IsLoading = true;
         SceneManager.Instance.DetachCurrentScene();
         PauseManager.Instance.AddPause(nameof(InProgressLoad));


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes some cheated flag handling problems that were reported

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
