### PR TITLE
Added workaround for bug that removed player from current patch

### DIFF
--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -385,7 +385,7 @@ public class RunResults
         {
             if (entry.Value.NewlyCreated != null)
             {
-                // Summary creation needs to already have species IDs so it might have already registered this
+                // Summary creation needs to already have species IDs, so it might have already registered this
                 world.RegisterAutoEvoCreatedSpeciesIfNotAlready(entry.Key);
             }
 
@@ -399,8 +399,14 @@ public class RunResults
                 var patch = world.Map.GetPatch(populationEntry.Key.ID);
 
                 // We ignore the return value as population results are added for all existing patches for all
-                // species (if the species is not in the patch the population is 0 in the results)
-                patch.UpdateSpeciesSimulationPopulation(entry.Key, populationEntry.Value);
+                // species (if the species is not in the patch, the population is 0 in the results)
+                if (!patch.UpdateSpeciesSimulationPopulation(entry.Key, populationEntry.Value) &&
+                    populationEntry.Value > 0)
+                {
+                    GD.PrintErr(
+                        $"Failed to apply species ({entry.Key}) population ({populationEntry.Value}) to patch " +
+                        $"({patch.Name}) it should be in");
+                }
             }
 
             if (entry.Value.NewlyCreated != null)
@@ -457,8 +463,8 @@ public class RunResults
             {
                 if (entry.Value.SplitOffPatches != null)
                 {
-                    // Set populations to 0 for the patches that split off and use the populations for the split
-                    // off species
+                    // Set populations to 0 for the patches that split off and use the populations for the split-off
+                    // species
                     foreach (var splitOffPatch in entry.Value.SplitOffPatches)
                     {
                         var patch = world.Map.GetPatch(splitOffPatch.ID);

--- a/src/engine/common_systems/PhysicsCollisionManagementSystem.cs
+++ b/src/engine/common_systems/PhysicsCollisionManagementSystem.cs
@@ -81,9 +81,9 @@ public sealed class PhysicsCollisionManagementSystem : AEntitySetSystem<float>
 
         collisionManagement.StateApplied = true;
 
-        // All collision disable is now in Physics directly and applied by PhysicsUpdateAndPositionSystem
+        // All-collision-disable-flag is now in Physics directly and applied by PhysicsUpdateAndPositionSystem
 
-        // Collision disable against specific bodies
+        // Apply collision disabling against specific bodies
         try
         {
             ref var ignoreCollisions = ref collisionManagement.IgnoredCollisionsWith;
@@ -101,7 +101,7 @@ public sealed class PhysicsCollisionManagementSystem : AEntitySetSystem<float>
 
                 if (ignoreCollisions.Count < 2)
                 {
-                    // When ignoring just one collision use the single body API as that doesn't need to allocate
+                    // When ignoring just one collision, use the single body API as that doesn't need to allocate
                     // any lists
                     var ignoreWith = GetPhysicsForEntity(ignoreCollisions[0], ref collisionManagement);
                     if (ignoreWith != null)

--- a/src/general/base_stage/EditorBase.cs
+++ b/src/general/base_stage/EditorBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using AutoEvo;
@@ -849,6 +850,20 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
         foreach (var editorComponent in GetAllEditorComponents())
         {
             editorComponent.OnEditorReady();
+        }
+
+        // Sanity-check the species status for easier problem reporting during development
+        if (CurrentGame.GameWorld.PlayerSpecies.IsExtinct ||
+            CurrentGame.GameWorld.Map.GetSpeciesGlobalSimulationPopulation(CurrentGame.GameWorld.PlayerSpecies) < 1)
+        {
+            GD.PrintErr("Player species is extinct when starting the editor. This should not happen!");
+            GD.PrintErr("Something has incorrectly killed off the player species" +
+                "even though the player survived to the editor");
+
+#if DEBUG
+            if (Debugger.IsAttached)
+                Debugger.Break();
+#endif
         }
     }
 

--- a/src/microbe_stage/Patch.cs
+++ b/src/microbe_stage/Patch.cs
@@ -38,7 +38,7 @@ public class Patch
     private readonly Dictionary<Species, long> gameplayPopulations = new();
 
     /// <summary>
-    ///   The current effects on patch node (shown in the patch map)
+    ///   The current effects on the patch node (shown in the patch map)
     /// </summary>
     [JsonProperty]
     private readonly List<WorldEffectTypes> activeWorldEffectVisuals = new();
@@ -250,7 +250,7 @@ public class Patch
     }
 
     /// <summary>
-    ///   Looks for a species with the specified name in this patch
+    ///   Looks for a species with the specified id in this patch
     /// </summary>
     public Species? FindSpeciesByID(uint id)
     {
@@ -590,7 +590,7 @@ public class Patch
     /// </summary>
     /// <param name="description">The event's description</param>
     /// <param name="highlight">If true, the event will be highlighted in the timeline UI</param>
-    /// <param name="showInReport">If true, the event will be shown on report tab main page</param>
+    /// <param name="showInReport">If true, the event will be shown on the report tab main page</param>
     /// <param name="iconPath">Resource path to the icon of the event</param>
     public void LogEvent(LocalizedString description, bool highlight = false,
         bool showInReport = false, string? iconPath = null)

--- a/src/microbe_stage/editor/PatchMapEditorComponent.cs
+++ b/src/microbe_stage/editor/PatchMapEditorComponent.cs
@@ -163,6 +163,29 @@ public partial class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEdi
                     Editor.CurrentGame.GameWorld, Editor.EditedBaseSpecies);
             }
         }
+        else
+        {
+            var currentPatch = Editor.CurrentGame.GameWorld.Map.CurrentPatch;
+            if (currentPatch != null)
+            {
+                // Ensure the player is in the current patch when exiting, as otherwise that will not allow player
+                // population to be added to the current patch, and that can cause false extinction events
+                if (currentPatch.FindSpeciesByID(Editor.CurrentGame.GameWorld
+                        .PlayerSpecies.ID) == null)
+                {
+                    // Note: this is just fixing the most serious symptom of the issue, but this doesn't do anything to
+                    // the root cause of the problem
+                    GD.PrintErr("Something has removed the player species from the current patch. " +
+                        "Adding back the player to fix this.");
+                    if (!currentPatch.AddSpecies(Editor.CurrentGame.GameWorld.PlayerSpecies, 0))
+                        GD.PrintErr("Failed to add the player species back");
+                }
+            }
+            else
+            {
+                GD.PrintErr("Player current patch is not set on the map when exiting map editor component");
+            }
+        }
 
         // Migrations
         foreach (var migration in detailsPanel.Migrations)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds a bandaid on player species having been removed from a patch the player should be in

and improved some comment grammar and added safety checking code related to this problem

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Related to #6282

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
