### PR TITLE
Fix wrong patch being highlighted after multiple extinctions in a row

### DIFF
--- a/src/microbe_stage/gui/PatchExtinctionBox.cs
+++ b/src/microbe_stage/gui/PatchExtinctionBox.cs
@@ -30,6 +30,8 @@ public partial class PatchExtinctionBox : Control
             mapDrawer.SetPatchEnabledStatuses(value.Patches.Values,
                 p => p.GetSpeciesGameplayPopulation(PlayerSpecies) > 0);
             mapDrawer.MarkDirty();
+
+            mapDrawer.PlayerPatch = value.CurrentPatch;
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes the extinction box always highlighting the first patch the player went extinct in.

Apparently, the highlighted patch was only updated once, in `PatchMapDrawer`'s `Map` setter. This PR makes the extinction box update the highlighted patch each time it's shown.

**Related Issues**

Fixes #3459

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
