### PR TITLE
Prevent slow currents from making ripples visible

### DIFF
--- a/src/microbe_stage/MembraneWaterRipple.cs
+++ b/src/microbe_stage/MembraneWaterRipple.cs
@@ -64,13 +64,13 @@ public partial class MembraneWaterRipple : Node
     ///   Minimal movement threshold
     /// </summary>
     [Export]
-    public float MovementThresholdSqr = 0.0001f;
+    public float MovementThresholdSqr = 0.0025f;
 
     /// <summary>
     ///   Threshold for resuming movement
     /// </summary>
     [Export]
-    public float ResumeMovementThresholdSqr = 0.0003f;
+    public float ResumeMovementThresholdSqr = 0.005f;
 
     /// <summary>
     ///   Maximum delta time to prevent jitter


### PR DESCRIPTION
**Brief Description of What This PR Does**

Increases ripple visibility threshold to prevent currents from triggering the ripple effect. Unfortunately, this doesn't work for stronger currents, because raising the threshold further would block the ripple effect for slower cells.

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
