### PR TITLE
Make it possible to eject all engulfed objects in a colony

### DIFF
--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -505,7 +505,7 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
             engulfing = colony.ColonyState == MicrobeState.Engulf;
             usingMucocyst = colony.ColonyState == MicrobeState.MucocystShield;
 
-            for (int i = 0; i < colony.ColonyMembers.Length; i++)
+            for (int i = 0; i < colony.ColonyMembers.Length; ++i)
             {
                 if (colony.ColonyMembers[i].Get<Engulfer>().EngulfedObjects is { Count: > 0 })
                 {

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -491,6 +491,7 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
 
         bool engulfing;
         bool usingMucocyst;
+        bool isDigesting = false;
 
         // Multicellularity is not checked here (only colony membership) as that is also not checked when firing toxins
         if (player.Has<MicrobeColony>())
@@ -503,6 +504,15 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
 
             engulfing = colony.ColonyState == MicrobeState.Engulf;
             usingMucocyst = colony.ColonyState == MicrobeState.MucocystShield;
+
+            for (int i = 0; i < colony.ColonyMembers.Length; i++)
+            {
+                if (colony.ColonyMembers[i].Get<Engulfer>().EngulfedObjects is { Count: > 0 })
+                {
+                    isDigesting = true;
+                    break;
+                }
+            }
         }
         else
         {
@@ -514,14 +524,12 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
 
             engulfing = control.State == MicrobeState.Engulf;
             usingMucocyst = control.State == MicrobeState.MucocystShield;
+
+            ref var engulfer = ref stage.Player.Get<Engulfer>();
+
+            if (engulfer.EngulfedObjects is { Count: > 0 })
+                isDigesting = true;
         }
-
-        bool isDigesting = false;
-
-        ref var engulfer = ref stage.Player.Get<Engulfer>();
-
-        if (engulfer.EngulfedObjects is { Count: > 0 })
-            isDigesting = true;
 
         // Read the engulf state from the colony as the player cell might be unable to engulf but some
         // member might be able to

--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -229,6 +229,24 @@ public partial class PlayerMicrobeInput : NodeWithInput
                 engulfer.EjectEngulfable(ref engulfedObject.Get<Engulfable>());
             }
         }
+
+        if (stage.Player.Has<MicrobeColony>())
+        {
+            ref var colony = ref stage.Player.Get<MicrobeColony>();
+
+            for (int i = 1; i < colony.ColonyMembers.Length; i++)
+            {
+                ref var memberEngulfer = ref colony.ColonyMembers[i].Get<Engulfer>();
+
+                if (memberEngulfer.EngulfedObjects is not { Count: > 0 })
+                    continue;
+
+                foreach (var engulfedObject in memberEngulfer.EngulfedObjects)
+                {
+                    memberEngulfer.EjectEngulfable(ref engulfedObject.Get<Engulfable>());
+                }
+            }
+        }
     }
 
     [RunOnKeyDown("g_toggle_binding")]

--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -230,21 +230,22 @@ public partial class PlayerMicrobeInput : NodeWithInput
             }
         }
 
-        if (stage.Player.Has<MicrobeColony>())
+        if (!stage.Player.Has<MicrobeColony>())
+            return;
+
+        ref var colony = ref stage.Player.Get<MicrobeColony>();
+
+        // Skip the first colony member (i.e. the root cell) which was already handled
+        for (int i = 1; i < colony.ColonyMembers.Length; ++i)
         {
-            ref var colony = ref stage.Player.Get<MicrobeColony>();
+            ref var memberEngulfer = ref colony.ColonyMembers[i].Get<Engulfer>();
 
-            for (int i = 1; i < colony.ColonyMembers.Length; i++)
+            if (memberEngulfer.EngulfedObjects is not { Count: > 0 })
+                continue;
+
+            foreach (var engulfedObject in memberEngulfer.EngulfedObjects)
             {
-                ref var memberEngulfer = ref colony.ColonyMembers[i].Get<Engulfer>();
-
-                if (memberEngulfer.EngulfedObjects is not { Count: > 0 })
-                    continue;
-
-                foreach (var engulfedObject in memberEngulfer.EngulfedObjects)
-                {
-                    memberEngulfer.EjectEngulfable(ref engulfedObject.Get<Engulfable>());
-                }
+                memberEngulfer.EjectEngulfable(ref engulfedObject.Get<Engulfable>());
             }
         }
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes the ejection also eject objects engulfed by non-root cells in a colony. 

**Related Issues**

Closes #6285

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
