### PR TITLE
Fix current desync after save load

### DIFF
--- a/src/microbe_stage/FluidCurrentDisplay.cs
+++ b/src/microbe_stage/FluidCurrentDisplay.cs
@@ -64,14 +64,7 @@ public partial class FluidCurrentDisplay : GpuParticles3D
             GlobalPosition = new Vector3(previousParentPosition.X, 1.0f, previousParentPosition.Z);
         }
 
-        if (!PauseManager.Instance.Paused)
-        {
-            SpeedScale = timeScaling.WorldTimeScale;
-
-            time += (float)(delta * SpeedScale);
-
-            material.SetShaderParameter(gameTimeParameterName, time);
-        }
+        SpeedScale = timeScaling.WorldTimeScale;
     }
 
     public void ApplyBiome(Biome biome)
@@ -101,6 +94,13 @@ public partial class FluidCurrentDisplay : GpuParticles3D
 
         material.SetShaderParameter(brightnessParameterName,
             (patch.BiomeTemplate.CompoundCloudBrightness - 1.0f) * lightLevel + 1.0f);
+    }
+
+    public void UpdateTime(float newTime)
+    {
+        time = newTime;
+
+        material.SetShaderParameter(gameTimeParameterName, time);
     }
 
     protected override void Dispose(bool disposing)

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1089,6 +1089,7 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
         // Hook up the simulation to some of the other systems
         WorldSimulation.CameraFollowSystem.Camera = Camera;
         HoverInfo.PhysicalWorld = WorldSimulation.PhysicalWorld;
+        WorldSimulation.FluidCurrentsSystem.FluidCurrentDisplay = fluidCurrentDisplay;
 
         // Init the simulation and finish setting up the systems (for example, cloud init happens here)
         WorldSimulation.InitForCurrentGame(CurrentGame!);

--- a/src/microbe_stage/MicrobeWorldSimulation.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.cs
@@ -58,10 +58,6 @@ public partial class MicrobeWorldSimulation : WorldSimulationWithPhysics
     [AssignOnlyChildItemsOnDeserialize]
     private EntitySignalingSystem entitySignalingSystem = null!;
 
-    [JsonProperty]
-    [AssignOnlyChildItemsOnDeserialize]
-    private FluidCurrentsSystem fluidCurrentsSystem = null!;
-
     private IrradiationSystem irradiationSystem = null!;
     private MicrobeAISystem microbeAI = null!;
     private MicrobeCollisionSoundSystem microbeCollisionSoundSystem = null!;
@@ -131,6 +127,10 @@ public partial class MicrobeWorldSimulation : WorldSimulationWithPhysics
     // TODO: could replace this reference in PatchManager by it just calling ClearPlayerLocationDependentCaches
     [JsonIgnore]
     public TimedLifeSystem TimedLifeSystem { get; private set; } = null!;
+
+    [JsonProperty]
+    [AssignOnlyChildItemsOnDeserialize]
+    public FluidCurrentsSystem FluidCurrentsSystem { get; private set; } = null!;
 
     /// <summary>
     ///   First initialization step which creates all the system objects. When loading from a save objects of this
@@ -286,9 +286,9 @@ public partial class MicrobeWorldSimulation : WorldSimulationWithPhysics
         engulfedDigestionSystem.SetWorld(currentGame.GameWorld);
         microbeAI.SetWorld(currentGame.GameWorld);
         damageSoundSystem.SetWorld(currentGame.GameWorld);
-        fluidCurrentsSystem.SetWorld(currentGame.GameWorld);
+        FluidCurrentsSystem.SetWorld(currentGame.GameWorld);
 
-        CloudSystem.Init(fluidCurrentsSystem);
+        CloudSystem.Init(FluidCurrentsSystem);
     }
 
     public void SetSimulationBiome(BiomeConditions biomeConditions)
@@ -339,7 +339,7 @@ public partial class MicrobeWorldSimulation : WorldSimulationWithPhysics
         }
 
         entitySignalingSystem = new EntitySignalingSystem(EntitySystem, parallelRunner);
-        fluidCurrentsSystem = new FluidCurrentsSystem(EntitySystem, parallelRunner);
+        FluidCurrentsSystem = new FluidCurrentsSystem(EntitySystem, parallelRunner);
 
         SpawnSystem = new SpawnSystem(this);
     }
@@ -463,7 +463,7 @@ public partial class MicrobeWorldSimulation : WorldSimulationWithPhysics
                 engulfedHandlingSystem.Dispose();
                 engulfingSystem.Dispose();
                 entitySignalingSystem.Dispose();
-                fluidCurrentsSystem.Dispose();
+                FluidCurrentsSystem.Dispose();
                 irradiationSystem.Dispose();
                 microbeAI.Dispose();
                 microbeCollisionSoundSystem.Dispose();

--- a/src/microbe_stage/MicrobeWorldSimulation.generated.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.generated.cs
@@ -108,7 +108,7 @@ public partial class MicrobeWorldSimulation
             pathBasedSceneLoader.Update(delta);
             collisionShapeLoaderSystem.Update(delta);
             countLimitedDespawnSystem.Update(delta);
-            fluidCurrentsSystem.Update(delta);
+            FluidCurrentsSystem.Update(delta);
             simpleShapeCreatorSystem.Update(delta);
             strainSystem.Update(delta);
             animationControlSystem.Update(delta);
@@ -288,7 +288,7 @@ public partial class MicrobeWorldSimulation
             soundEffectSystem.Update(delta);
             soundListenerSystem.Update(delta);
             cellBurstEffectSystem.Update(delta);
-            fluidCurrentsSystem.Update(delta);
+            FluidCurrentsSystem.Update(delta);
             microbeRenderPrioritySystem.Update(delta);
             intercellularMatrixSystem.Update(delta);
             CameraFollowSystem.Update(delta);

--- a/src/microbe_stage/systems/FluidCurrentsSystem.cs
+++ b/src/microbe_stage/systems/FluidCurrentsSystem.cs
@@ -26,6 +26,8 @@ using World = DefaultEcs.World;
 [RunsOnMainThread]
 public sealed class FluidCurrentsSystem : AEntitySetSystem<float>
 {
+    public FluidCurrentDisplay? FluidCurrentDisplay;
+
     // The following constants should be the same as in CurrentsParticles.gdshader
     private const float CURRENTS_TIMESCALE = 0.25f;
     private const float POSITION_SCALING = 0.9f;
@@ -109,6 +111,7 @@ public sealed class FluidCurrentsSystem : AEntitySetSystem<float>
         }
 
         currentsTimePassed += delta;
+        FluidCurrentDisplay?.UpdateTime(currentsTimePassed);
 
         if (gameWorld == null)
             throw new InvalidOperationException("GameWorld not set");


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes the current display receive information from the system in order to perfectly sync time between them.

My first approach was to make the display save time, but there was still desynchronization, because systems and in-game objects start to run at slightly different time.

**Related Issues**

Current display's time was reset after save load while current system's time was saved between sessions.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
