### PR TITLE
Fixed hydrogenosome not being available through endosymbiosis

### DIFF
--- a/simulation_parameters/microbe_stage/organelles.json
+++ b/simulation_parameters/microbe_stage/organelles.json
@@ -440,7 +440,8 @@
     "ConsumptionColour": "#ff5649",
     "IconPath": "res://assets/textures/gui/bevel/parts/HydrogenaseIcon.svg",
     "EditorButtonGroup": "Protein",
-    "EditorButtonOrder": 0
+    "EditorButtonOrder": 0,
+    "EndosymbiosisUnlocks": "hydrogenosome"
   },
   "hydrogenosome": {
     "MPCost": 45,

--- a/src/microbe_stage/editor/MicrobePartSelection.tscn
+++ b/src/microbe_stage/editor/MicrobePartSelection.tscn
@@ -127,7 +127,7 @@ vertical_alignment = 1
 
 [node name="Name" type="Label" parent="VBoxContainer"]
 editor_description = "PLACEHOLDER"
-custom_minimum_size = Vector2(85, 0)
+custom_minimum_size = Vector2(88, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_constants/line_spacing = -3


### PR DESCRIPTION
also slightly widened the text on the selection part buttons as otherwise the text "hydrogenosome" would very ugglily split across lines

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://community.revolutionarygamesstudio.com/t/0-8-3-general-feedback-thread/8599/40?u=hhyyrylainen

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
