### PR TITLE
Enable specular highlights for cell membranes

### DIFF
--- a/shaders/Membrane.gdshader
+++ b/shaders/Membrane.gdshader
@@ -99,8 +99,10 @@ void fragment(){
 
     // Mix base normals with detail normals in some proportion (0.0 - 1.0)
     adjustedNormals = normalize(mix(NORMAL, adjustedNormals, 0.2f));
-
+    
     ALBEDO = final.rgb;
     ALPHA = fresnel(3.0, adjustedNormals, adjustedView) * round(cutoff);
-    ROUGHNESS = 0.7f;
+    METALLIC = 0.0f;
+    ROUGHNESS = 0.5f;
+    SPECULAR = 1.0f;
 }

--- a/shaders/Membrane.gdshader
+++ b/shaders/Membrane.gdshader
@@ -99,7 +99,7 @@ void fragment(){
 
     // Mix base normals with detail normals in some proportion (0.0 - 1.0)
     adjustedNormals = normalize(mix(NORMAL, adjustedNormals, 0.2f));
-    
+
     ALBEDO = final.rgb;
     ALPHA = fresnel(3.0, adjustedNormals, adjustedView) * round(cutoff);
     METALLIC = 0.0f;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Enables specular highlights (i.e. direct light reflection) for cell membranes. Exact parameters are to be defined because I'm still not sure about the visual style

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fe8e2b44-daf6-4ece-b622-eeeaca0e378b" />

<details>
 <summary>
  Alternate visuals
 </summary>
 
 Metallicity: 0.0
 Roughness: 0.25
 Specularity: 0.85
 <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0cb0d531-e55a-4a58-94cf-3be8f8199c55" />

 Metallicity: 0.4
 Roughness: 0.25
 Specularity: 0.85
 <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c1c5be00-7146-446a-9433-4c0838e8e0aa" />

 
</details>

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
