### PR TITLE
Adjust Engulfing Tutorial

### DIFF
--- a/src/microbe_stage/components/Engulfer.cs
+++ b/src/microbe_stage/components/Engulfer.cs
@@ -189,6 +189,13 @@ public static class EngulferHelpers
             if (!compounds.Compounds.Any(p => usefulCompoundSource.IsUseful(p.Key)))
                 continue;
 
+            // Skip entities that are too small to catch easily
+            // TODO: Does this .4 need to be in a CONSTANT?
+            // TODO: What is a deterministic way to come up with a better guess than .4 the size of the player object
+            // TODO: How is player object and the engulfable objects speed calculated to maybe compare a percentage of that instead?
+            if ((engulfer.EngulfingSize / .4) > engulfable.AdjustedEngulfSize)
+                continue;
+
             if (nearestPoint == null || distance < nearestDistanceSquared)
             {
                 nearestPoint = entityPosition.Position;

--- a/src/microbe_stage/components/Engulfer.cs
+++ b/src/microbe_stage/components/Engulfer.cs
@@ -190,10 +190,7 @@ public static class EngulferHelpers
                 continue;
 
             // Skip entities that are too small to catch easily
-            // TODO: Does this .4 need to be in a CONSTANT?
-            // TODO: What is a deterministic way to come up with a better guess than .4 the size of the player object
-            // TODO: How is player object and the engulfable objects speed calculated to maybe compare a percentage of that instead?
-            if ((engulfer.EngulfingSize / .4) > engulfable.AdjustedEngulfSize)
+            if (engulfer.EngulfingSize / .4 > engulfable.AdjustedEngulfSize)
                 continue;
 
             if (nearestPoint == null || distance < nearestDistanceSquared)


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR adds an additional check to the engulfing tutorial to only select a closest object to engulf if it is bigger than the player object size * .4. 

Hi! As this is my first time contributing I had some questions, hopefully this is the right place for them.
Questions:
- Should the .4 value be in a CONSTANT?
- I took a bit of a guess with .4. I tried using half the player objects size and found that many of the other objects in the beginning of the game are size 2 and the player object is size 5, so with .5 all of the objects are smaller than 2.5 and therefore can't be engulfed. It's also hard that the CanEngulfObject size with the ratio is typically 3. Is there a more deterministic way to come up with a value for this?
- The issue description talks about maybe using the player and cell speed to determine which objects to use, but I can't find where in the codebase speed is calculated.

**Related Issues**

closes #4916 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
