### PR TITLE
Avoid context specific songs playing in a row

### DIFF
--- a/src/general/Jukebox.cs
+++ b/src/general/Jukebox.cs
@@ -558,7 +558,7 @@ public partial class Jukebox : Node
         if (random.NextFloat() <= Constants.CONTEXTUAL_ONLY_MUSIC_CHANCE)
         {
             var contextMusicOnly = list.GetTracksForContexts(activeContexts)
-                .Where(c => c is { ExclusiveToContexts: not null, PlayedOnce: false })
+                .Where(c => c.ExclusiveToContexts != null && !c.PlayedOnce)
                 .ToArray();
 
             if (contextMusicOnly.Length > 0)

--- a/src/general/Jukebox.cs
+++ b/src/general/Jukebox.cs
@@ -557,15 +557,13 @@ public partial class Jukebox : Node
 
         if (random.NextFloat() <= Constants.CONTEXTUAL_ONLY_MUSIC_CHANCE)
         {
-            var contextMusicOnly = list.GetTracksForContexts(activeContexts).Where(c => c.ExclusiveToContexts != null)
+            var contextMusicOnly = list.GetTracksForContexts(activeContexts)
+                .Where(c => c is { ExclusiveToContexts: not null, PlayedOnce: false })
                 .ToArray();
 
             if (contextMusicOnly.Length > 0)
             {
                 tracks = contextMusicOnly;
-
-                // TODO: it would be nice to ensure that contextual track doesn't cause the same track to play in a row
-                // Currently it is way more likely as most contexts only have one track for them.
             }
         }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Add a check for context specific songs to ensure they are only played once in the category rotation. Once all songs have been played in a category and played once is reset then the context specific song would be played again.

NOTE: It seems like the randomness of this should be removed and always have the context specific song play first and then allow other songs to be played. 

**Related Issues**

closes #5615 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
