### PR TITLE
Metabolism & Playstyle Balancing

### DIFF
--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "respiration": {
     "Name": "RESPIRATION",
     "Inputs": {
@@ -6,7 +6,7 @@
       "glucose": 0.10
     },
     "Outputs": {
-      "atp": 110,
+      "atp": 40,
       "carbondioxide": 1
     },
     "IsMetabolismProcess": true
@@ -195,7 +195,7 @@
       "glucose": 0.09
     },
     "Outputs": {
-      "atp": 45,
+      "atp": 20,
       "carbondioxide": 1
     },
     "IsMetabolismProcess": true
@@ -206,7 +206,7 @@
       "glucose": 0.013
     },
     "Outputs": {
-      "atp": 5
+      "atp": 4
     },
     "IsMetabolismProcess": true
   },
@@ -216,7 +216,7 @@
       "glucose": 0.02
     },
     "Outputs": {
-      "atp": 13
+      "atp": 7
     },
     "IsMetabolismProcess": true
   },
@@ -234,7 +234,7 @@
   "iron_chemolithoautotrophy": {
     "Name": "IRON_OXIDATION",
     "Inputs": {
-      "iron": 0.02
+      "iron": 0.2
     },
     "Outputs": {
       "atp": 5.5
@@ -253,16 +253,16 @@
   "bacterial_thermosynthesis": {
     "Name": "THERMOSYNTHESIS",
     "Inputs": {
-      "temperature": 0.2
+      "temperature": 0.4
     },
     "Outputs": {
-      "atp": 4
+      "atp": 6
     }
   },
   "ferrosynthesis": {
     "Name": "IRON_OXIDATION",
     "Inputs": {
-      "iron": 0.033
+      "iron": 0.14
     },
     "Outputs": {
       "atp": 14
@@ -272,7 +272,7 @@
   "radiosynthesis": {
     "name": "RADIOSYNTHESIS",
     "inputs": {
-      "radiation": 0.4
+      "radiation": 0.2
     },
     "outputs": {
       "atp": 35

--- a/simulation_parameters/microbe_stage/organelles.json
+++ b/simulation_parameters/microbe_stage/organelles.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "pilus": {
     "MPCost": 30,
     "InitialComposition": {
@@ -339,7 +339,7 @@
       "UV": 0.03,
       "Oxygen": 0.01
     },
-    "Density": 1200,
+    "Density": 1600,
     "Graphics": {
       "ScenePath": "res://assets/models/organelles/Chromatophore.tscn"
     },
@@ -937,7 +937,7 @@
       "UV": 0.08,
       "Oxygen": 0.02
     },
-    "Density": 1200,
+    "Density": 1800,
     "Graphics": {
       "ScenePath": "res://assets/models/organelles/Chloroplast.tscn"
     },
@@ -979,7 +979,7 @@
         "Capacity": 0.5
       }
     },
-    "Density": 1000,
+    "Density": 800,
     "CorpseChunkGraphics": {
       "ScenePath": "res://assets/models/organelles/Cytoplasm.tscn"
     },
@@ -1050,7 +1050,7 @@
       "Nucleus"
     ],
     "ShouldScale": false,
-    "Density": 1200,
+    "Density": 500,
     "RelativeDensityVolume": 1,
     "Graphics": {
       "ScenePath": "res://assets/models/organelles/Nucleus.tscn"

--- a/src/general/world_effects/PhotosynthesisProductionEffect.cs
+++ b/src/general/world_effects/PhotosynthesisProductionEffect.cs
@@ -29,11 +29,11 @@ public class PhotosynthesisProductionEffect : IWorldEffect
     private void ApplyCompoundsAddition()
     {
         // These affect the final balance
-        var outputModifier = 1.5f;
-        var inputModifier = 1.0f;
+        var outputModifier = 1.2f;
+        var inputModifier = 0.8f;
 
         // This affects how fast the conditions change, but also the final balance somewhat
-        var modifier = 0.00015f;
+        var modifier = 0.000010f;
 
         List<TweakedProcess> microbeProcesses = [];
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Tweaking balance across multiple areas that I think are relevant to the various playstyles and metabolisms in game, including the various anaerobic and aerobic respiration methods, pacing of how quickly the atmosphere changes, and predation. 


- Slowed down the speed at which oxygen accumulates, and lowered how much oxygen is build up on average, while pacing carbon dioxide build up as well. This should make it take longer for aerobic respiration to become the clear dominant form of progression.
- Reduced the ATP output of metabolosomes and mitochondria, as it was quite extreme. 
- Slightly nerfed the ATP output of hydrogenase and hydrogenosomes to produce less ATP since they are unaffected by any atmospheric compounds. 
- Made iron respiration burn through iron quicker since it also is unaffected by any atmospheric compounds. This incentivizes players who utilize iron respiration to hang around iron chunks, and makes storage more important to these builds. 
Increased the mass of chloroplasts and thylakoids to make predation harder as a photoautotroph.
Reduced the mass of the nucleus so that predation is a bit easier for eukaryotes.
- Bumped up thermosynthesis ATP production, but increased amount of temperature needed. Should hopefully make it so that hot spots are more important, but rewarding. 
- Radiation should be more efficient, increasing how long you can go on without touching a radioactive zone.

Mitochondria and metabolosomes could arguably be bumped, but I do like the pacing of oxygen accumulation in the atmosphere currently. I also am not 100% how the densities work, so I'm going to investigate the .json file and might bump up density even more. 

Overall, this should slightly incentivize forms of respiration other than just burning glucose while maintaining the power of aerobic respiration. Iron and photo-autotrophy remain powerful but face more constraints altering strategy, thermosynthesis is made powerful but slightly fickle, and radiation is slightly buffed. Reducing the impact of the nucleus on speed should also hopefully make it a bit easier for predation to occur.

Sulfur is notably omitted from this pull request. I want dligr's pull request on sulfur damage to be implemented before tweaking balancing significantly there. 


**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
