### PR TITLE
Convert Cases of Hardcoded Light Unit

### DIFF
--- a/simulation_parameters/microbe_stage/compounds.json
+++ b/simulation_parameters/microbe_stage/compounds.json
@@ -222,7 +222,8 @@
       "g": 0.745,
       "b": 0.472
     },
-    "IconPath": "res://assets/textures/gui/bevel/Sunlight.svg"
+    "IconPath": "res://assets/textures/gui/bevel/Sunlight.svg",
+    "Unit": "lx"
   },
   "temperature": {
     "Name": "TEMPERATURE",

--- a/src/gui_common/CompoundAmount.cs
+++ b/src/gui_common/CompoundAmount.cs
@@ -304,7 +304,12 @@ public partial class CompoundAmount : HBoxContainer
         }
 
         string numberPart;
-        if (!string.IsNullOrEmpty(compoundDefinition!.Unit) && ShowUnit)
+        if (!string.IsNullOrEmpty(compoundDefinition!.Unit) && ShowUnit && UsePercentageDisplay)
+        {
+            numberPart = Localization.Translate("VALUE_WITH_UNIT")
+                .FormatSafe(Localization.Translate("PERCENTAGE_VALUE").FormatSafe(Math.Round(amount * 100, 1)), compoundDefinition.Unit);
+        }
+        else if (!string.IsNullOrEmpty(compoundDefinition!.Unit) && ShowUnit)
         {
             // TODO: implement also the small value display here?
 

--- a/src/gui_common/menus/PlanetStatistics.cs
+++ b/src/gui_common/menus/PlanetStatistics.cs
@@ -134,12 +134,12 @@ public partial class PlanetStatistics : VBoxContainer
 
         var temperature = SimulationParameters.Instance.GetCompoundDefinition(Compound.Temperature);
         temperatureLevelLabel.Text =
-            unitFormat.FormatSafe(Math.Round(temperatureLevel)
-                .ToString(CultureInfo.CurrentCulture), temperature.Unit);
-        lightLevelLabel.Text =
-            unitFormat.FormatSafe(Math.Round(lightLevel)
-                .ToString(CultureInfo.CurrentCulture), "lx");
+            unitFormat.FormatSafe(Math.Round(temperatureLevel).ToString(CultureInfo.CurrentCulture), temperature.Unit);
 
+        var sunlight = SimulationParameters.Instance.GetCompoundDefinition(Compound.Sunlight);
+        lightLevelLabel.Text =
+            unitFormat.FormatSafe(percentageFormat.FormatSafe(
+                Math.Round(lightLevel).ToString(CultureInfo.CurrentCulture)), sunlight.Unit);
         carbonOxideLevelLabel.Text =
             percentageFormat.FormatSafe(Math.Round(carbonLevel, Constants.ATMOSPHERIC_COMPOUND_DISPLAY_DECIMALS));
         oxygenLevelLabel.Text =

--- a/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
+++ b/src/microbe_stage/editor/MicrobeEditorReportComponent.cs
@@ -529,8 +529,8 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
         }
 
         var percentageFormat = Localization.Translate("PERCENTAGE_VALUE");
-
-        sunlightChart.TooltipYAxisFormat = percentageFormat + " lx";
+        var sunlight = SimulationParameters.Instance.GetCompoundDefinition(Compound.Sunlight);
+        sunlightChart.TooltipYAxisFormat = percentageFormat + sunlight.Unit;
         atmosphericGassesChart.TooltipYAxisFormat = percentageFormat;
 
         speciesPopulationChart.LegendMode = LineChart.LegendDisplayMode.DropDown;
@@ -565,8 +565,10 @@ public partial class MicrobeEditorReportComponent : EditorComponentBase<IEditorR
             speciesPopulationChart.LegendMode = LineChart.LegendDisplayMode.CustomOrNone;
         }
 
-        sunlightChart.Plot(Localization.Translate("YEARS"), "% lx", 5, null, null, null, 5);
-        temperatureChart.Plot(Localization.Translate("YEARS"), "°C", 5, null, null, null, 5);
+        var temperature = SimulationParameters.Instance.GetCompoundDefinition(Compound.Temperature);
+        temperatureChart.Plot(Localization.Translate("YEARS"), temperature.Unit, 5, null, null, null, 5);
+
+        sunlightChart.Plot(Localization.Translate("YEARS"), percentageFormat + sunlight.Unit, 5, null, null, null, 5);
         atmosphericGassesChart.Plot(Localization.Translate("YEARS"), "%", 5,
             Localization.Translate("ATMOSPHERIC_GASSES"), null, null, 5);
         speciesPopulationChart.Plot(Localization.Translate("YEARS"), string.Empty, 5,

--- a/src/microbe_stage/gui/PatchDetailsPanel.cs
+++ b/src/microbe_stage/gui/PatchDetailsPanel.cs
@@ -381,12 +381,13 @@ public partial class PatchDetailsPanel : PanelContainer
                 temperature.Unit);
         pressureLabel.Text = unitFormat.FormatSafe(Math.Round(SelectedPatch.Biome.Pressure * (1 / 1000.0f)), "kPa");
 
+        var sunlight = SimulationParameters.Instance.GetCompoundDefinition(Compound.Sunlight);
         var maxLightLevel = GetCompoundAmount(SelectedPatch, Compound.Sunlight, CompoundAmountType.Biome);
         lightLabel.Text =
             unitFormat.FormatSafe(percentageFormat.FormatSafe(Math.Round(GetCompoundAmount(SelectedPatch,
-                Compound.Sunlight))), "lx");
+                Compound.Sunlight))), sunlight.Unit);
         lightMax.Text = Localization.Translate("LIGHT_LEVEL_LABEL_AT_NOON").FormatSafe(
-            unitFormat.FormatSafe(percentageFormat.FormatSafe(Math.Round(maxLightLevel, 1)), "lx"));
+            unitFormat.FormatSafe(percentageFormat.FormatSafe(Math.Round(maxLightLevel, 1)), sunlight.Unit));
         lightMax.Visible = maxLightLevel > 0;
 
         oxygenLabel.Text = percentageFormat.FormatSafe(Math.Round(GetCompoundAmount(SelectedPatch, Compound.Oxygen),

--- a/src/microbe_stage/organelle_unlocks/WorldBasedUnlockCondition.cs
+++ b/src/microbe_stage/organelle_unlocks/WorldBasedUnlockCondition.cs
@@ -151,19 +151,20 @@ public class PatchCompound : WorldBasedUnlockCondition
         object? formattedMin;
         object? formattedMax;
 
+        // TODO: automatically handle any compounds with unit set?
+        var unit = compoundDefinition.Unit ?? "MISSING CONFIGURED UNIT";
+
         switch (Compound)
         {
             case Compound.Sunlight:
                 formattedMin = Min.HasValue ?
-                    new LocalizedString("VALUE_WITH_UNIT", new LocalizedString("PERCENTAGE_VALUE", Min), "lx") :
+                    new LocalizedString("VALUE_WITH_UNIT", new LocalizedString("PERCENTAGE_VALUE", Min), unit) :
                     null;
                 formattedMax = Max.HasValue ?
-                    new LocalizedString("VALUE_WITH_UNIT", new LocalizedString("PERCENTAGE_VALUE", Max), "lx") :
+                    new LocalizedString("VALUE_WITH_UNIT", new LocalizedString("PERCENTAGE_VALUE", Max), unit) :
                     null;
                 break;
             case Compound.Temperature:
-                // TODO: automatically handle any compounds with unit set?
-                var unit = compoundDefinition.Unit ?? "MISSING CONFIGURED UNIT";
                 formattedMin = Min.HasValue ? new LocalizedString("VALUE_WITH_UNIT", Min / 100, unit) : null;
                 formattedMax = Max.HasValue ? new LocalizedString("VALUE_WITH_UNIT", Max / 100, unit) : null;
                 break;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Convert all places of the hardcoded "lx" unit for light in the code to instead use a Unit set in a config file.

NOTE: This does not solve the actual problem of unifying all compound unit logic. I didn't go through and attempt to do that full fix for 2 reason .

1. The way localization is handled made it a little difficult for me to see where all the logic is for how these units work and feel confident I wouldn't completely break it. I'd like to eventually do a different PR for creating a percentage format and unit format function in a helper class somewhere, so that if/when we do eventually consolidate handling of Compound Display it's a little simpler.
2. The CompountAmount.cs class seems to have most of the logic I would have wanted to consolidate, but it seems to be very coupled with the MicrobeEditor display, particularly with the equations in the organelle descriptions. I didn't want to mess with this any more than I had to since I'm still learning my way around the project. 

**Related Issues**

closes #4895 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
