### PR TITLE
Show editor tabs after a few seconds if tutorial is sequence broken

### DIFF
--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -503,7 +503,8 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
             if (!TutorialState.TutorialActive())
             {
                 // Tutorial is likely sequence broken, so it won't continue, show tabs to not get the player stuck
-                GD.Print("Showing tabs as tutorial is not active while it probably should be");
+                if (editorTabSelector == null || !editorTabSelector.Visible)
+                    GD.Print("Showing tabs as tutorial is not active while it probably should be");
                 ShowTabBar(true);
             }
         }

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -13,6 +13,8 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
 {
     private const string ADVANCED_TABS_SHOWN_BEFORE = "editor_advanced_tabs";
 
+    private const double EMERGENCY_SHOW_TABS_AFTER_SECONDS = 4;
+
 #pragma warning disable CA2213
     [JsonProperty]
     [AssignOnlyChildItemsOnDeserialize]
@@ -37,6 +39,9 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
     /// </summary>
     [JsonProperty]
     private MicrobeSpecies? editedSpecies;
+
+    private bool checkingTabVisibility;
+    private double tabCheckVisibilityTimer = 10;
 
     public override bool CanCancelAction => cellEditorTab.Visible && cellEditorTab.CanCancelAction;
 
@@ -99,6 +104,12 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
             TutorialState.AutoEvoPrediction.OnClosed -= ShowTabBarAfterTutorial;
             TutorialState.StaySmallTutorial.OnClosed -= ShowTabBarAfterTutorial;
         }
+    }
+
+    public override void _Process(double delta)
+    {
+        base._Process(delta);
+        CheckTabVisibilityAfterTutorial(delta);
     }
 
     public void SendAutoEvoResultsToReportComponent()
@@ -412,6 +423,8 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
                 cellEditorTab.Show();
                 SetEditorObjectVisibility(true);
                 cellEditorTab.UpdateCamera();
+
+                StartTimerForSafetyTabShow();
                 break;
             }
 
@@ -461,5 +474,43 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
 
         CurrentGame.GameWorld.UnlockProgress.UnlockAll = true;
         cellEditorTab.UnlockAllOrganelles();
+    }
+
+    private void StartTimerForSafetyTabShow()
+    {
+        checkingTabVisibility = true;
+        tabCheckVisibilityTimer = EMERGENCY_SHOW_TABS_AFTER_SECONDS;
+    }
+
+    /// <summary>
+    ///   Makes sure that due to some tutorials not triggering when they have been done out of order in different
+    ///   saves, won't leave editor tabs permanently hidden during some tutorial cycles.
+    /// </summary>
+    private void CheckTabVisibilityAfterTutorial(double delta)
+    {
+        if (!checkingTabVisibility)
+            return;
+
+        tabCheckVisibilityTimer -= delta;
+
+        if (tabCheckVisibilityTimer > 0)
+            return;
+
+        checkingTabVisibility = false;
+
+        if (TutorialState.Enabled)
+        {
+            if (!TutorialState.TutorialActive())
+            {
+                // Tutorial is likely sequence broken, so it won't continue, show tabs to not get the player stuck
+                GD.Print("Showing tabs as tutorial is not active while it probably should be");
+                ShowTabBar(true);
+            }
+        }
+        else
+        {
+            // Make sure tabs are shown if the tutorial is turned off
+            ShowTabBar(true);
+        }
     }
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes tabs visible after a few seconds so that the player is not stuck in the cell editor tab if they haven't played through the entire tutorial and swap saves

**Related Issues**

Reports from people who have played a part of the tutorial and then started a new game

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
