### PR TITLE
Made disable showing seen tutorials flag be saved

### DIFF
--- a/src/tutorial/TutorialState.cs
+++ b/src/tutorial/TutorialState.cs
@@ -30,6 +30,7 @@ public class TutorialState : ITutorialInput, ISaveLoadable
     ///   When this is true, tutorials that have already been seen by the player in any playthrough are automatically
     ///   marked as already complete.
     /// </summary>
+    [JsonProperty]
     public bool DisableShowingAlreadySeenTutorials { get; private set; }
 
     // Tutorial states


### PR DESCRIPTION
**Brief Description of What This PR Does**

hopefully this fixes the tutorials getting wrongly partially re-enabled when loading a save

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

A tutorial inconsistency I noticed today when loading saves while testing an unrelated change

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
