### PR TITLE
Ambient reflections

### DIFF
--- a/shaders/SimpleSky.gdshader
+++ b/shaders/SimpleSky.gdshader
@@ -1,0 +1,7 @@
+shader_type sky;
+
+uniform vec3 colour : source_color;
+
+void sky() {
+    COLOR = colour;
+}

--- a/shaders/SimpleSky.gdshader.uid
+++ b/shaders/SimpleSky.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cvvlsk7or1qyk

--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -20,6 +20,12 @@
         "z": 0.75
       }
     },
+    "EnvironmentColour": {
+      "r": 0.141,
+      "g": 0.349,
+      "b": 0.443,
+      "a": 1
+    },
     "WaterCurrents": {
       "Speed": 1.0,
       "Chaoticness": 1.2,
@@ -213,6 +219,12 @@
         "y": -0.3,
         "z": 0.75
       }
+    },
+    "EnvironmentColour": {
+      "r": 0.358,
+      "g": 0.023,
+      "b": 0.035,
+      "a": 1
     },
     "WaterCurrents": {
       "Speed": 0.6,
@@ -546,6 +558,12 @@
         "z": 0.75
       }
     },
+    "EnvironmentColour": {
+      "r": 0.569,
+      "g": 0.78,
+      "b": 0.788,
+      "a": 1
+    },
     "WaterCurrents": {
       "Speed": 1.5,
       "Chaoticness": 1.75,
@@ -806,6 +824,12 @@
         "z": 0.75
       }
     },
+    "EnvironmentColour": {
+      "r": 0.133,
+      "g": 0.271,
+      "b": 0.357,
+      "a": 1
+    },
     "WaterCurrents": {
       "Speed": 0.75,
       "Chaoticness": 0.75,
@@ -1020,6 +1044,12 @@
         "y": -0.3,
         "z": 0.75
       }
+    },
+    "EnvironmentColour": {
+      "r": 0.027,
+      "g": 0.027,
+      "b": 0.075,
+      "a": 1
     },
     "WaterCurrents": {
       "Speed": 0.65,
@@ -1285,6 +1315,12 @@
         "y": -0.3,
         "z": 0.75
       }
+    },
+    "EnvironmentColour": {
+      "r": 0.133,
+      "g": 0.271,
+      "b": 0.357,
+      "a": 1
     },
     "WaterCurrents": {
       "Speed": 0.8,
@@ -1591,6 +1627,12 @@
         "z": 0.75
       }
     },
+    "EnvironmentColour": {
+      "r": 0.298,
+      "g": 0.937,
+      "b": 0.909,
+      "a": 1
+    },
     "WaterCurrents": {
       "Speed": 1.5,
       "Chaoticness": 2.0,
@@ -1847,6 +1889,12 @@
         "y": -0.3,
         "z": 0.75
       }
+    },
+    "EnvironmentColour": {
+      "r": 0.035,
+      "g": 0.035,
+      "b": 0.078,
+      "a": 1
     },
     "WaterCurrents": {
       "Speed": 0.5,
@@ -2188,6 +2236,12 @@
         "z": 0.75
       }
     },
+    "EnvironmentColour": {
+      "r": 0.243,
+      "g": 0.306,
+      "b": 0.357,
+      "a": 1
+    },
     "WaterCurrents": {
       "Speed": 0.6,
       "Chaoticness": 0.75,
@@ -2489,6 +2543,12 @@
         "a": 0.5
       }
     },
+    "EnvironmentColour": {
+      "r": 0.684,
+      "g": 0.725,
+      "b": 0.596,
+      "a": 1
+    },
     "CompoundCloudBrightness": 2.5,
     "GasVolume": 1,
     "TemperatureVarianceScale": 18,
@@ -2782,6 +2842,12 @@
         "y": -0.3,
         "z": 0.75
       }
+    },
+    "EnvironmentColour": {
+      "r": 0.039,
+      "g": 0.114,
+      "b": 0.133,
+      "a": 1
     },
     "WaterCurrents": {
       "Speed": 0.75,
@@ -3136,6 +3202,12 @@
         "y": -0.3,
         "z": 0.75
       }
+    },
+    "EnvironmentColour": {
+      "r": 0.341,
+      "g": 0.565,
+      "b": 0.706,
+      "a": 1
     },
     "WaterCurrents": {
       "Speed": 1.5,

--- a/src/microbe_stage/Biome.cs
+++ b/src/microbe_stage/Biome.cs
@@ -37,7 +37,7 @@ public class Biome : IRegistryType
     /// </summary>
     public LightDetails Sunlight = new();
 
-    public Color EnvironmentColour;
+    public Color EnvironmentColour = new(0, 0, 0, 1);
 
     /// <summary>
     ///   How much the temperature in this biome varies on a microscopic scale when moving around
@@ -104,6 +104,12 @@ public class Biome : IRegistryType
         {
             throw new InvalidRegistryDataException(name, GetType().Name,
                 "temperature variance scale needs to be over 0");
+        }
+
+        if (EnvironmentColour.A < 1.0f)
+        {
+            throw new InvalidRegistryDataException(name, GetType().Name,
+                "Environment colour alpha needs to be 1");
         }
 
         TranslationHelper.CopyTranslateTemplatesToTranslateSource(this);

--- a/src/microbe_stage/Biome.cs
+++ b/src/microbe_stage/Biome.cs
@@ -37,6 +37,8 @@ public class Biome : IRegistryType
     /// </summary>
     public LightDetails Sunlight = new();
 
+    public Color EnvironmentColour;
+
     /// <summary>
     ///   How much the temperature in this biome varies on a microscopic scale when moving around
     /// </summary>

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1383,7 +1383,8 @@ public partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorldSimula
             // Normalise by maximum light level in the patch
             Camera.LightLevel = lightModifier;
 
-            microbeWorldEnvironment.UpdateAmbientReflection(currentPatch.BiomeTemplate.EnvironmentColour * lightModifier);
+            microbeWorldEnvironment.UpdateAmbientReflection(
+                currentPatch.BiomeTemplate.EnvironmentColour * lightModifier);
         }
         else
         {

--- a/src/microbe_stage/MicrobeStage.tscn
+++ b/src/microbe_stage/MicrobeStage.tscn
@@ -17,13 +17,14 @@
 [ext_resource type="PackedScene" uid="uid://b5yuo8sj21lnf" path="res://src/engine/GuidanceLine.tscn" id="75"]
 [ext_resource type="PackedScene" uid="uid://dwkek50fju0fu" path="res://src/microbe_stage/PatchNameOverlay.tscn" id="85"]
 
-[node name="MicrobeStage" type="Node" node_paths=PackedStringArray("heatViewOverlay", "fluidCurrentDisplay", "movementModeSelectionPopup", "guidanceLine", "pauseMenu", "hudRoot")]
+[node name="MicrobeStage" type="Node" node_paths=PackedStringArray("heatViewOverlay", "fluidCurrentDisplay", "movementModeSelectionPopup", "guidanceLine", "microbeWorldEnvironment", "pauseMenu", "hudRoot")]
 process_priority = -1
 script = ExtResource("1")
 heatViewOverlay = NodePath("World/PrimaryCamera/HeatGradientPlane")
 fluidCurrentDisplay = NodePath("World/PrimaryCamera/FluidCurrentDisplay")
 movementModeSelectionPopup = NodePath("MovementModeSelectionPopup")
 guidanceLine = NodePath("World/GuidanceLine")
+microbeWorldEnvironment = NodePath("World/MicrobeWorldEnvironment")
 pauseMenu = NodePath("PauseMenu")
 hudRoot = NodePath("MicrobeHUD")
 

--- a/src/microbe_stage/MicrobeWorldEnvironment.cs
+++ b/src/microbe_stage/MicrobeWorldEnvironment.cs
@@ -5,13 +5,21 @@
 /// </summary>
 public partial class MicrobeWorldEnvironment : WorldEnvironment
 {
-    private static StringName skyColorShaderParameter = new("colour");
+    private readonly StringName skyColorShaderParameter = new("colour");
+
+#pragma warning disable CA2213
+    private ShaderMaterial skyMaterial = null!;
+#pragma warning restore CA2213
+
+    private Color lastSkyColour;
 
     public override void _EnterTree()
     {
         Settings.Instance.BloomEnabled.OnChanged += OnBloomChanged;
         Settings.Instance.BloomStrength.OnChanged += OnStrengthChanged;
         ApplyBloom();
+
+        skyMaterial = (ShaderMaterial)Environment.Sky.SkyMaterial;
     }
 
     public override void _ExitTree()
@@ -22,7 +30,21 @@ public partial class MicrobeWorldEnvironment : WorldEnvironment
 
     public void UpdateAmbientReflection(Color colour)
     {
-        ((ShaderMaterial)Environment.Sky.SkyMaterial).SetShaderParameter(skyColorShaderParameter, colour);
+        if (colour == lastSkyColour)
+            return;
+
+        lastSkyColour = colour;
+        skyMaterial.SetShaderParameter(skyColorShaderParameter, colour);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposing)
+        {
+            skyColorShaderParameter.Dispose();
+        }
     }
 
     private void OnBloomChanged(bool value)

--- a/src/microbe_stage/MicrobeWorldEnvironment.cs
+++ b/src/microbe_stage/MicrobeWorldEnvironment.cs
@@ -5,6 +5,8 @@
 /// </summary>
 public partial class MicrobeWorldEnvironment : WorldEnvironment
 {
+    private static StringName skyColorShaderParameter = new("colour");
+
     public override void _EnterTree()
     {
         Settings.Instance.BloomEnabled.OnChanged += OnBloomChanged;
@@ -16,6 +18,11 @@ public partial class MicrobeWorldEnvironment : WorldEnvironment
     {
         Settings.Instance.BloomEnabled.OnChanged -= OnBloomChanged;
         Settings.Instance.BloomStrength.OnChanged -= OnStrengthChanged;
+    }
+
+    public void UpdateAmbientReflection(Color colour)
+    {
+        ((ShaderMaterial)Environment.Sky.SkyMaterial).SetShaderParameter(skyColorShaderParameter, colour);
     }
 
     private void OnBloomChanged(bool value)

--- a/src/microbe_stage/MicrobeWorldEnvironment.tscn
+++ b/src/microbe_stage/MicrobeWorldEnvironment.tscn
@@ -1,8 +1,19 @@
-[gd_scene load_steps=3 format=3 uid="uid://dqpjtfkjeuwmq"]
+[gd_scene load_steps=6 format=3 uid="uid://dqpjtfkjeuwmq"]
 
+[ext_resource type="Shader" uid="uid://cvvlsk7or1qyk" path="res://shaders/SimpleSky.gdshader" id="1_852k6"]
 [ext_resource type="Script" uid="uid://djjshn5bho65x" path="res://src/microbe_stage/MicrobeWorldEnvironment.cs" id="1_gansp"]
 
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_vkgr4"]
+shader = ExtResource("1_852k6")
+shader_parameter/colour = Color(0, 0, 0, 1)
+
+[sub_resource type="Sky" id="Sky_b4xyi"]
+sky_material = SubResource("ShaderMaterial_vkgr4")
+
 [sub_resource type="Environment" id="Environment_31nh3"]
+background_color = Color(1.63645e-06, 0.558327, 0.809688, 1)
+sky = SubResource("Sky_b4xyi")
+reflected_light_source = 2
 glow_normalized = true
 glow_strength = 1.8
 glow_bloom = 1.0


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds ambient reflections. Most noticable reflections are in the surface patches, especially costal (they are also affected by the day/night cycle in those patches).

Technically, reflections were already there, this PR just changes their source and adds variable colors, making them more noticable. Because of this the only performance impact is light level updating.

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
