### PR TITLE
Fix backgrounds being darker in compatibility mode (with blur enabled)

### DIFF
--- a/shaders/GaussianBlur.gdshader
+++ b/shaders/GaussianBlur.gdshader
@@ -20,5 +20,9 @@ void fragment() {
         0.017919583599443834 * texture(textureAlbedo, UV + 4.8f * s).rgb +
         0.0019076926935783702 * texture(textureAlbedo, UV + 6.4f * s).rgb;
 
+#if CURRENT_RENDERER == RENDERER_COMPATIBILITY
+    COLOR.rgb = COLOR.rgb + 0.05f;
+#endif
+
     COLOR.a = 1.0f;
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes backgrounds look less dark in OpenGL mode.

It seems like the compatibility mode collapses low brightness values to zero, so to circumvent this, this PR offsets the output value by 0.05

**Related Issues**

Fixes #6119

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
