### PR TITLE
Make patches store event visuals history

### DIFF
--- a/src/auto-evo/AutoEvoExploringTool.cs
+++ b/src/auto-evo/AutoEvoExploringTool.cs
@@ -668,7 +668,7 @@ public partial class AutoEvoExploringTool : NodeWithInput, ISpeciesDataProvider
         UpdateSpeciesList();
         SpeciesListMenuIndexChanged(0);
         UpdateCurrentWorldStatistics();
-        patchMapDrawer.UpdatePatchEvents();
+        patchMapDrawer.UpdatePatchEvents(world.GameProperties.GameWorld.TotalPassedTime);
 
         if (patchMapDrawer.PlayerPatch != null)
             PatchListMenuUpdate(patchMapDrawer.PlayerPatch);
@@ -693,7 +693,8 @@ public partial class AutoEvoExploringTool : NodeWithInput, ISpeciesDataProvider
         UpdateAutoEvoReport();
         UpdateSpeciesList();
         UpdatePatchDetailPanel(patchMapDrawer);
-        patchMapDrawer.UpdatePatchEvents();
+        patchMapDrawer.UpdatePatchEvents(
+            world.GameProperties.GameWorld.GenerationHistory[generationDisplayed].TimeElapsed);
     }
 
     private void UpdateAutoEvoReport()

--- a/src/general/GameWorld.cs
+++ b/src/general/GameWorld.cs
@@ -421,12 +421,6 @@ public class GameWorld : ISaveLoadable
     /// </summary>
     public void OnTimePassed(double timePassed)
     {
-        // TODO: switch patches to keep an event history and remove this clear
-        foreach (var patch in Map.Patches)
-        {
-            patch.Value.ClearPatchNodeEventVisuals();
-        }
-
         TotalPassedTime = CalculateNextTimeStep(timePassed);
 
         TimedEffects.OnTimePassed(timePassed, TotalPassedTime);

--- a/src/macroscopic_stage/editor/MacroscopicEditor.cs
+++ b/src/macroscopic_stage/editor/MacroscopicEditor.cs
@@ -285,7 +285,7 @@ public partial class MacroscopicEditor : EditorBase<EditorAction, MacroscopicSta
 
         reportTab.UpdateEvents(CurrentGame.GameWorld.EventsLog, CurrentGame.GameWorld.TotalPassedTime);
 
-        patchMapTab.UpdatePatchEvents();
+        patchMapTab.UpdatePatchEvents(CurrentGame.GameWorld.TotalPassedTime);
     }
 
     protected override void OnUndoPerformed()

--- a/src/microbe_stage/Patch.cs
+++ b/src/microbe_stage/Patch.cs
@@ -41,7 +41,7 @@ public class Patch
     ///   The current effects on the patch node (shown in the patch map)
     /// </summary>
     [JsonProperty]
-    private readonly List<WorldEffectTypes> activeWorldEffectVisuals = new();
+    private readonly Dictionary<double, List<WorldEffectTypes>> activeWorldEffectVisuals = new();
 
     [JsonProperty]
     private Deque<PatchSnapshot> history = new();
@@ -637,22 +637,18 @@ public class Patch
 
     public void AddPatchEventRecord(WorldEffectTypes worldEffect, double happenedAt)
     {
-        // TODO: switch this class to have more of the logic for keeping event history together
-        _ = happenedAt;
+        if (!activeWorldEffectVisuals.ContainsKey(happenedAt))
+            activeWorldEffectVisuals[happenedAt] = new();
 
-        activeWorldEffectVisuals.Add(worldEffect);
+        activeWorldEffectVisuals[happenedAt].Add(worldEffect);
     }
 
-    public void ClearPatchNodeEventVisuals()
+    public void ApplyPatchEventVisuals(PatchMapNode node, double generation)
     {
-        // TODO: see the TODO comment in AddPatchEventRecord
-        activeWorldEffectVisuals.Clear();
-    }
+        activeWorldEffectVisuals.TryGetValue(generation, out var eventVisualList);
 
-    public void ApplyPatchEventVisuals(PatchMapNode node)
-    {
         if (Visibility == MapElementVisibility.Shown)
-            node.ShowEventVisuals(activeWorldEffectVisuals);
+            node.ShowEventVisuals(eventVisualList);
     }
 
     public override string ToString()

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -305,7 +305,7 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
 
         reportTab.UpdateEvents(CurrentGame.GameWorld.EventsLog, CurrentGame.GameWorld.TotalPassedTime);
 
-        patchMapTab.UpdatePatchEvents();
+        patchMapTab.UpdatePatchEvents(CurrentGame.GameWorld.TotalPassedTime);
 
         if (TutorialState.Enabled)
         {

--- a/src/microbe_stage/editor/MicrobeEditorPatchMap.cs
+++ b/src/microbe_stage/editor/MicrobeEditorPatchMap.cs
@@ -25,9 +25,9 @@ public partial class MicrobeEditorPatchMap : PatchMapEditorComponent<IEditorWith
         mapDrawer.MarkDirty();
     }
 
-    public void UpdatePatchEvents()
+    public void UpdatePatchEvents(double timePeriod)
     {
-        mapDrawer.UpdatePatchEvents();
+        mapDrawer.UpdatePatchEvents(timePeriod);
     }
 
     protected override void UpdateShownPatchDetails()

--- a/src/microbe_stage/editor/PatchMapDrawer.cs
+++ b/src/microbe_stage/editor/PatchMapDrawer.cs
@@ -269,16 +269,11 @@ public partial class PatchMapDrawer : Control
     ///   Update the patch event visuals on all created patch map nodes. Call if events change after initial graphics
     ///   init for this drawer.
     /// </summary>
-    /// <remarks>
-    ///   <para>
-    ///     TODO: the auto-evo exploring tool needs to call this to show things properly
-    ///   </para>
-    /// </remarks>
-    public void UpdatePatchEvents()
+    public void UpdatePatchEvents(double generation)
     {
         foreach (var (patch, node) in nodes)
         {
-            patch.ApplyPatchEventVisuals(node);
+            patch.ApplyPatchEventVisuals(node, generation);
         }
     }
 
@@ -1097,7 +1092,7 @@ public partial class PatchMapDrawer : Control
 
         node.Enabled = patchEnableStatusesToBeApplied?[patch] ?? true;
 
-        patch.ApplyPatchEventVisuals(node);
+        patch.ApplyPatchEventVisuals(node, patch.TimePeriod);
 
         patchNodeContainer.AddChild(node);
         nodes.Add(node.Patch, node);

--- a/src/microbe_stage/editor/PatchMapNode.cs
+++ b/src/microbe_stage/editor/PatchMapNode.cs
@@ -258,11 +258,14 @@ public partial class PatchMapNode : MarginContainer
         }
     }
 
-    public void ShowEventVisuals(IReadOnlyList<WorldEffectTypes> list)
+    public void ShowEventVisuals(IReadOnlyList<WorldEffectTypes>? list)
     {
         // TODO: check if this had any active events and only then clear
         // TODO: it would be slightly more efficient to only delete no longer required events
         eventIconsContainer.QueueFreeChildren(false);
+
+        if (list == null)
+            return;
 
         // Manual loop to avoid enumerator allocation
         var count = list.Count;

--- a/src/multicellular_stage/editor/MulticellularEditor.cs
+++ b/src/multicellular_stage/editor/MulticellularEditor.cs
@@ -278,7 +278,7 @@ public partial class MulticellularEditor : EditorBase<EditorAction, MicrobeStage
 
         reportTab.UpdateEvents(CurrentGame.GameWorld.EventsLog, CurrentGame.GameWorld.TotalPassedTime);
 
-        patchMapTab.UpdatePatchEvents();
+        patchMapTab.UpdatePatchEvents(CurrentGame.GameWorld.TotalPassedTime);
     }
 
     protected override void OnUndoPerformed()


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds a patch event history to make auto-evo exploring tool display past events correctly

**Related Issues**

Closes #5672

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
