### PR TITLE
Fixed different behaviour changes combining

### DIFF
--- a/src/microbe_stage/editor/action_data/BehaviourActionData.cs
+++ b/src/microbe_stage/editor/action_data/BehaviourActionData.cs
@@ -68,7 +68,11 @@ public class BehaviourActionData : EditorCombinableActionData
 
     protected override bool CanMergeWithInternal(CombinableActionData other)
     {
-        return other is BehaviourActionData;
+        if (other is not BehaviourActionData otherBehaviour)
+            return false;
+
+        // Only combine the same type. Otherwise, terrible bugs happen.
+        return otherBehaviour.Type == Type;
     }
 
     protected override void MergeGuaranteed(CombinableActionData other)

--- a/test/code_tests/MicrobeStage.Tests/EditorActionTests.cs
+++ b/test/code_tests/MicrobeStage.Tests/EditorActionTests.cs
@@ -90,4 +90,77 @@ public class EditorActionTests
         Assert.Equal(initialTolerances, castedData.OldTolerances);
         Assert.Equal(changedTolerances2, castedData.NewTolerances);
     }
+
+    [Fact]
+    public void EditorAction_SubsequentBehaviourChangesCombine()
+    {
+        var history = new EditorActionHistory<EditorAction>();
+
+        var behaviourAction1 = new BehaviourActionData(50, 1, BehaviouralValueType.Activity);
+
+        bool done = false;
+
+        history.AddAction(new SingleEditorAction<BehaviourActionData>(_ => done = true, _ => { }, behaviourAction1));
+        Assert.True(done);
+        done = false;
+
+        var behaviourAction2 = new BehaviourActionData(100, 50, BehaviouralValueType.Activity);
+
+        history.AddAction(new SingleEditorAction<BehaviourActionData>(_ => done = true, _ => { }, behaviourAction2));
+
+        Assert.True(history.CanUndo());
+        Assert.True(done);
+
+        var action = history.PopTopAction();
+        var combinedAction = Assert.IsAssignableFrom<SingleEditorAction<BehaviourActionData>>(action);
+
+        var data = combinedAction.Data.ToList();
+        Assert.Single(data);
+
+        var castedData = Assert.IsAssignableFrom<BehaviourActionData>(data[0]);
+        Assert.Equal(1, castedData.OldValue);
+        Assert.Equal(100, castedData.NewValue);
+        Assert.Equal(BehaviouralValueType.Activity, castedData.Type);
+
+        Assert.False(history.CanUndo());
+
+        // There's no easy way to verify the history is completely empty, so we misuse an API here and expect an error
+        Assert.Throws<ArgumentOutOfRangeException>(() => history.PopTopAction());
+    }
+
+    [Fact]
+    public void EditorAction_DifferentBehaviourChangeStatsDoNotCombine()
+    {
+        var history = new EditorActionHistory<EditorAction>();
+
+        var behaviourAction1 = new BehaviourActionData(50, 1, BehaviouralValueType.Activity);
+
+        bool done = false;
+
+        history.AddAction(new SingleEditorAction<BehaviourActionData>(_ => done = true, _ => { }, behaviourAction1));
+        Assert.True(done);
+        done = false;
+
+        var behaviourAction2 = new BehaviourActionData(100, 50, BehaviouralValueType.Aggression);
+
+        history.AddAction(new SingleEditorAction<BehaviourActionData>(_ => done = true, _ => { }, behaviourAction2));
+
+        Assert.True(history.CanUndo());
+        Assert.True(done);
+
+        Assert.NotNull(history.PopTopAction());
+
+        var action = history.PopTopAction();
+        var combinedAction = Assert.IsAssignableFrom<SingleEditorAction<BehaviourActionData>>(action);
+
+        var data = combinedAction.Data.ToList();
+        Assert.Single(data);
+
+        var castedData = Assert.IsAssignableFrom<BehaviourActionData>(data[0]);
+        Assert.Equal(1, castedData.OldValue);
+        Assert.Equal(50, castedData.NewValue);
+        Assert.Equal(BehaviouralValueType.Activity, castedData.Type);
+
+        Assert.False(history.CanUndo());
+    }
 }


### PR DESCRIPTION
causing other sliders to jump around when changing a different one

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/464846402732687391/465937305849298956/1418564831715528815

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
