### PR TITLE
Fix focus jumping after rebinding

### DIFF
--- a/src/engine/input/key_mapping/InputEventItem.cs
+++ b/src/engine/input/key_mapping/InputEventItem.cs
@@ -438,6 +438,11 @@ public partial class InputEventItem : MarginContainer
         return AssociatedEvent?.GetHashCode() ?? 13;
     }
 
+    public void GrabFocusDeferred()
+    {
+        button.CallDeferred(MethodName.GrabFocus);
+    }
+
     internal static InputEventItem BuildGUI(InputActionItem associatedAction, SpecifiedInputKey @event)
     {
         if (associatedAction.GroupList == null)
@@ -496,6 +501,7 @@ public partial class InputEventItem : MarginContainer
                 // because Equals treats it the same with the same AssociatedEvent.
                 AssociatedEvent = null;
                 Delete();
+                associatedAction.Inputs[i].GrabFocusDeferred();
                 return true;
             }
         }

--- a/src/engine/input/key_mapping/InputEventItem.cs
+++ b/src/engine/input/key_mapping/InputEventItem.cs
@@ -416,6 +416,11 @@ public partial class InputEventItem : MarginContainer
         OnKeybindingSuccessfullyChanged();
     }
 
+    public void MakeInputButtonGrabFocus()
+    {
+        button.GrabFocus();
+    }
+
     /// <summary>
     ///   Delete this event from the associated action and update the godot InputMap
     /// </summary>
@@ -436,11 +441,6 @@ public partial class InputEventItem : MarginContainer
     public override int GetHashCode()
     {
         return AssociatedEvent?.GetHashCode() ?? 13;
-    }
-
-    public void GrabFocusDeferred()
-    {
-        button.CallDeferred(MethodName.GrabFocus);
     }
 
     internal static InputEventItem BuildGUI(InputActionItem associatedAction, SpecifiedInputKey @event)
@@ -501,7 +501,7 @@ public partial class InputEventItem : MarginContainer
                 // because Equals treats it the same with the same AssociatedEvent.
                 AssociatedEvent = null;
                 Delete();
-                associatedAction.Inputs[i].GrabFocusDeferred();
+                associatedAction.Inputs[i].MakeInputButtonGrabFocus();
                 return true;
             }
         }

--- a/src/engine/input/key_mapping/InputGroupList.cs
+++ b/src/engine/input/key_mapping/InputGroupList.cs
@@ -21,6 +21,11 @@ public partial class InputGroupList : VBoxContainer
     private InputEventItem? latestDialogCaller;
     private InputEventItem? latestDialogConflict;
     private InputEvent? latestDialogNewEvent;
+
+    [Export]
+    private FocusGrabber focusGrabber = null!;
+
+    private NodePath defaultFocusNode = null!;
 #pragma warning restore CA2213
 
     private FocusFlowDynamicChildrenHelper focusHelper = null!;
@@ -56,6 +61,8 @@ public partial class InputGroupList : VBoxContainer
         focusHelper = new FocusFlowDynamicChildrenHelper(this,
             FocusFlowDynamicChildrenHelper.NavigationToChildrenDirection.VerticalToChildrenOnly,
             FocusFlowDynamicChildrenHelper.NavigationInChildrenDirection.Vertical);
+
+        defaultFocusNode = focusGrabber.NodeToGiveFocusTo!;
     }
 
     public void InitGroupList()
@@ -173,6 +180,16 @@ public partial class InputGroupList : VBoxContainer
 
         // Pass the input event again to have the key be set where it was previously skipped
         latestDialogCaller.Rebind(latestDialogNewEvent);
+
+        latestDialogCaller.GrabFocusDeferred();
+    }
+
+    public void OnConflictCancelled()
+    {
+        if (latestDialogCaller == null)
+            return;
+
+        latestDialogCaller.GrabFocusDeferred();
     }
 
     public bool IsConflictDialogOpen()

--- a/src/engine/input/key_mapping/InputGroupList.cs
+++ b/src/engine/input/key_mapping/InputGroupList.cs
@@ -181,7 +181,7 @@ public partial class InputGroupList : VBoxContainer
         // Pass the input event again to have the key be set where it was previously skipped
         latestDialogCaller.Rebind(latestDialogNewEvent);
 
-        latestDialogCaller.GrabFocusDeferred();
+        latestDialogCaller.MakeInputButtonGrabFocus();
     }
 
     public void OnConflictCancelled()
@@ -189,7 +189,7 @@ public partial class InputGroupList : VBoxContainer
         if (latestDialogCaller == null)
             return;
 
-        latestDialogCaller.GrabFocusDeferred();
+        latestDialogCaller.MakeInputButtonGrabFocus();
     }
 
     public bool IsConflictDialogOpen()

--- a/src/gui_common/menus/OptionsMenu.tscn
+++ b/src/gui_common/menus/OptionsMenu.tscn
@@ -1958,10 +1958,10 @@ size_flags_horizontal = 3
 size_flags_vertical = 1
 size_flags_stretch_ratio = 2.0
 tooltip_text = "MAX_CACHE_SIZE_TOOLTIP"
-min_value = 1.04858e+08
-max_value = 1.04858e+10
+min_value = 104858000.0
+max_value = 10485800000.0
 step = 1024.0
-value = 1.04858e+08
+value = 104858000.0
 scrollable = false
 
 [node name="MemoryCacheDuration" type="VBoxContainer" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Performance/ScrollContainer/MarginContainer/VBoxContainer"]
@@ -2043,7 +2043,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 5
 size_flags_stretch_ratio = 2.0
 min_value = 1800.0
-max_value = 2.365e+07
+max_value = 23650000.0
 step = 1800.0
 value = 1800.0
 scrollable = false
@@ -2602,7 +2602,7 @@ size_flags_horizontal = 3
 [node name="InputGroupListTop" type="HSeparator" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Inputs/MarginContainer/VBoxContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="InputGroupList" type="VBoxContainer" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Inputs/MarginContainer/VBoxContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer" node_paths=PackedStringArray("conflictDialog", "resetInputsDialog")]
+[node name="InputGroupList" type="VBoxContainer" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Inputs/MarginContainer/VBoxContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer" node_paths=PackedStringArray("conflictDialog", "resetInputsDialog", "focusGrabber")]
 layout_mode = 2
 focus_neighbor_left = NodePath("../../../../../../../../../../HBoxContainer/Back")
 focus_neighbor_top = NodePath("../InputGroupListTop")
@@ -2613,6 +2613,7 @@ theme_override_constants/separation = 30
 script = ExtResource("3")
 conflictDialog = NodePath("../../../../../../../../../../../../ConflictDialog")
 resetInputsDialog = NodePath("../../../../../../../../../../../../DefaultsInputsConfirm")
+focusGrabber = NodePath("../FocusGrabber")
 
 [node name="InputGroupListBottom" type="Control" parent="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Inputs/MarginContainer/VBoxContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
@@ -3369,12 +3370,14 @@ theme_override_font_sizes/font_size = 18
 text = "CLOSE"
 
 [node name="FocusGrabber" parent="CenterContainer/PatchNotesBox" instance=ExtResource("13")]
+layout_mode = 0
 Priority = 4
 NodeToGiveFocusTo = NodePath("../VBoxContainer/HBoxContainer/Close")
 GrabFocusWhenBecomingVisible = true
 SkipOverridingFocusForElements = Array[NodePath]([])
 
 [node name="ControllerDeadzoneConfiguration" parent="." instance=ExtResource("12")]
+layout_mode = 0
 anchors_preset = 0
 anchor_right = 0.0
 anchor_bottom = 0.0
@@ -3492,6 +3495,7 @@ grow_vertical = 1
 [connection signal="pressed" from="CenterContainer/BackConfirm/VBoxContainer/HBoxContainer/SaveButton" to="." method="BackSaveSelected"]
 [connection signal="pressed" from="CenterContainer/BackConfirm/VBoxContainer/HBoxContainer/DiscardButton" to="." method="BackDiscardSelected"]
 [connection signal="pressed" from="CenterContainer/BackConfirm/VBoxContainer/HBoxContainer/CancelButton" to="." method="BackCancelSelected"]
+[connection signal="Canceled" from="CenterContainer/ConflictDialog" to="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Inputs/MarginContainer/VBoxContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/InputGroupList" method="OnConflictCancelled"]
 [connection signal="Confirmed" from="CenterContainer/ConflictDialog" to="CenterContainer/VBoxContainer/VBoxContainer/VBoxContainer/PanelContainer/Inputs/MarginContainer/VBoxContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/InputGroupList" method="OnConflictConfirmed"]
 [connection signal="Confirmed" from="CenterContainer/ConfirmResetAchievements" to="." method="ConfirmResetAchievements"]
 [connection signal="pressed" from="CenterContainer/PatchNotesBox/VBoxContainer/HBoxContainer/Close" to="CenterContainer/PatchNotesBox" method="OnCloseButtonPressed"]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes an issue where the input menu scrolled to the top after rebinding an action

**Related Issues**

Fixes #6206
Closes #4638

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
