### PR TITLE
Make shuffle bag work correctly with 2 elements

### DIFF
--- a/src/general/utils/ShuffleBag.cs
+++ b/src/general/utils/ShuffleBag.cs
@@ -128,19 +128,11 @@ public class ShuffleBag<T> : IEnumerable<T?>
     /// </summary>
     private void Shuffle()
     {
-        // TODO: why is there a -2 here? This makes it so that just 2 items in the bag can never be shuffled.
-        for (int i = 0; i < currentContent.Count - 2; ++i)
+        for (int i = 0; i < currentContent.Count - 1; ++i)
         {
             int j = random.Next(i, currentContent.Count);
 
             (currentContent[i], currentContent[j]) = (currentContent[j], currentContent[i]);
-        }
-
-        // Backup shuffle for 2 item bags
-        if (currentContent.Count == 2)
-        {
-            if (random.NextDouble() < 0.5)
-                (currentContent[0], currentContent[1]) = (currentContent[1], currentContent[0]);
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Apparently the condition is supposed to include n - 2, while the `for`'s condition was exclusive. I changed the condition to be consistent with that of `ListUtils.Shuffle()`, i.e. `i < length - 1`

**Related Issues**

Closes #4868

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
