### PR TITLE
Added current trail alpha scaling constant

### DIFF
--- a/shaders/FluidCurrentTrail.gdshader
+++ b/shaders/FluidCurrentTrail.gdshader
@@ -1,6 +1,8 @@
 shader_type spatial;
 render_mode blend_mix, depth_draw_opaque, particle_trails;
 
+const float alphaScaling = 0.25f;
+
 void fragment() {
     float uvR = (UV.r * 2.0f - 1.0f);
     vec3 normal = normalize(BINORMAL * vec3(-1.0f, -1.0f, 0.0f)) * uvR
@@ -8,7 +10,7 @@ void fragment() {
     NORMAL = normal;
 
     ALBEDO = COLOR.rgb;
-    ALPHA = (1.0f - abs(uvR)) * COLOR.a;
+    ALPHA = (1.0f - abs(uvR)) * COLOR.a * alphaScaling;
 
     SPECULAR = 1.0f;
     ROUGHNESS = 0.4f;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Reduces the opacity of the current trails, based on feedback from the community.

I set it to 25% as that seemed like a good compromise to my eye, but the community does seem to have somewhat preferred the 12.5% screenshot I showed, so it could be changed further. If anyone wants to play around with the constant a bit to see what your preferred value is, then that would be good info to have.

100%:
<img width="1908" height="1116" alt="Screenshot from 2025-10-25 13-10-02" src="https://github.com/user-attachments/assets/fab6c14c-f513-468e-a269-e1369d677d19" />

25%:
<img width="1908" height="1116" alt="Screenshot from 2025-10-25 13-08-58" src="https://github.com/user-attachments/assets/c108e48c-2d1b-4efb-853f-1ee0fdd9392d" />

12.5%:
<img width="1908" height="1116" alt="Screenshot from 2025-10-25 13-24-16" src="https://github.com/user-attachments/assets/c3fa5c3b-8532-462d-97f8-9c0c8148a8ed" />

Do note that in-game, the currents are somewhat more visible than a static screenshot would suggest because they are moving.

**Related Issues**

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
