### PR TITLE
Disabled focusing on auto-evo prediction text popup

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.tscn
+++ b/src/microbe_stage/editor/CellEditorComponent.tscn
@@ -36,28 +36,12 @@
 [ext_resource type="PackedScene" uid="uid://bq6aee8pw8y3m" path="res://src/gui_common/CollapsibleList.tscn" id="45"]
 [ext_resource type="PackedScene" uid="uid://jdsjx1iyga8d" path="res://src/microbe_stage/editor/OrganellePopupMenu.tscn" id="47"]
 
-[sub_resource type="StyleBoxFlat" id="11"]
+[sub_resource type="StyleBoxFlat" id="12"]
 content_margin_left = 5.0
 content_margin_top = 5.0
 content_margin_right = 5.0
 content_margin_bottom = 5.0
-bg_color = Color(0.164706, 0.215686, 0.235294, 1)
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
-border_color = Color(0.396078, 0.623529, 0.584314, 1)
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
-
-[sub_resource type="StyleBoxFlat" id="9"]
-content_margin_left = 5.0
-content_margin_top = 5.0
-content_margin_right = 5.0
-content_margin_bottom = 5.0
-bg_color = Color(0, 0.435294, 0.52549, 1)
+bg_color = Color(0.0666667, 0.168627, 0.211765, 1)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
@@ -84,17 +68,33 @@ corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
-[sub_resource type="StyleBoxFlat" id="12"]
+[sub_resource type="StyleBoxFlat" id="9"]
 content_margin_left = 5.0
 content_margin_top = 5.0
 content_margin_right = 5.0
 content_margin_bottom = 5.0
-bg_color = Color(0.0666667, 0.168627, 0.211765, 1)
+bg_color = Color(0, 0.435294, 0.52549, 1)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
 border_color = Color(0.0666667, 1, 0.835294, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id="11"]
+content_margin_left = 5.0
+content_margin_top = 5.0
+content_margin_right = 5.0
+content_margin_bottom = 5.0
+bg_color = Color(0.164706, 0.215686, 0.235294, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.396078, 0.623529, 0.584314, 1)
 corner_radius_top_left = 5
 corner_radius_top_right = 5
 corner_radius_bottom_right = 5
@@ -114,28 +114,12 @@ region_rect = Rect2(0, 0, 258, 1)
 
 [sub_resource type="StyleBoxEmpty" id="36"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_tk5n4"]
+[sub_resource type="StyleBoxFlat" id="25"]
 content_margin_left = 5.0
 content_margin_top = 5.0
 content_margin_right = 5.0
 content_margin_bottom = 5.0
-draw_center = false
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.666667, 1, 0.941176, 1)
-corner_radius_top_left = 3
-corner_radius_top_right = 3
-corner_radius_bottom_right = 3
-corner_radius_bottom_left = 3
-
-[sub_resource type="StyleBoxFlat" id="23"]
-content_margin_left = 5.0
-content_margin_top = 5.0
-content_margin_right = 5.0
-content_margin_bottom = 5.0
-bg_color = Color(0.81, 0.0162, 0.0162, 1)
+bg_color = Color(0.49, 0, 0, 1)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
@@ -162,12 +146,12 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 
-[sub_resource type="StyleBoxFlat" id="25"]
+[sub_resource type="StyleBoxFlat" id="23"]
 content_margin_left = 5.0
 content_margin_top = 5.0
 content_margin_right = 5.0
 content_margin_bottom = 5.0
-bg_color = Color(0.49, 0, 0, 1)
+bg_color = Color(0.81, 0.0162, 0.0162, 1)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
@@ -178,7 +162,7 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 
-[sub_resource type="StyleBoxFlat" id="41"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_tk5n4"]
 content_margin_left = 5.0
 content_margin_top = 5.0
 content_margin_right = 5.0
@@ -189,6 +173,22 @@ border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0.666667, 1, 0.941176, 1)
+corner_radius_top_left = 3
+corner_radius_top_right = 3
+corner_radius_bottom_right = 3
+corner_radius_bottom_left = 3
+
+[sub_resource type="StyleBoxFlat" id="27"]
+content_margin_left = 5.0
+content_margin_top = 5.0
+content_margin_right = 5.0
+content_margin_bottom = 5.0
+bg_color = Color(0, 0.490196, 0.258824, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.0666667, 1, 0.835294, 1)
 corner_radius_top_left = 3
 corner_radius_top_right = 3
 corner_radius_bottom_right = 3
@@ -210,17 +210,17 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 
-[sub_resource type="StyleBoxFlat" id="27"]
+[sub_resource type="StyleBoxFlat" id="41"]
 content_margin_left = 5.0
 content_margin_top = 5.0
 content_margin_right = 5.0
 content_margin_bottom = 5.0
-bg_color = Color(0, 0.490196, 0.258824, 1)
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
-border_color = Color(0.0666667, 1, 0.835294, 1)
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.666667, 1, 0.941176, 1)
 corner_radius_top_left = 3
 corner_radius_top_right = 3
 corner_radius_bottom_right = 3
@@ -653,14 +653,14 @@ layout_mode = 2
 size_flags_horizontal = 3
 focus_mode = 0
 mouse_filter = 1
-theme_override_colors/font_disabled_color = Color(1, 1, 1, 1)
 theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_disabled_color = Color(1, 1, 1, 1)
 theme_override_fonts/font = ExtResource("8_07qd0")
 theme_override_font_sizes/font_size = 14
-theme_override_styles/disabled = SubResource("11")
-theme_override_styles/hover = SubResource("9")
-theme_override_styles/pressed = SubResource("10")
 theme_override_styles/normal = SubResource("12")
+theme_override_styles/pressed = SubResource("10")
+theme_override_styles/hover = SubResource("9")
+theme_override_styles/disabled = SubResource("11")
 toggle_mode = true
 button_pressed = true
 action_mode = 0
@@ -672,14 +672,14 @@ layout_mode = 2
 size_flags_horizontal = 3
 focus_mode = 0
 mouse_filter = 1
-theme_override_colors/font_disabled_color = Color(1, 1, 1, 1)
 theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_disabled_color = Color(1, 1, 1, 1)
 theme_override_fonts/font = ExtResource("8_07qd0")
 theme_override_font_sizes/font_size = 14
-theme_override_styles/disabled = SubResource("11")
-theme_override_styles/hover = SubResource("9")
-theme_override_styles/pressed = SubResource("10")
 theme_override_styles/normal = SubResource("12")
+theme_override_styles/pressed = SubResource("10")
+theme_override_styles/hover = SubResource("9")
+theme_override_styles/disabled = SubResource("11")
 toggle_mode = true
 action_mode = 0
 button_group = SubResource("ButtonGroup_xodoa")
@@ -690,14 +690,14 @@ layout_mode = 2
 size_flags_horizontal = 3
 focus_mode = 0
 mouse_filter = 1
-theme_override_colors/font_disabled_color = Color(0.870588, 0.870588, 0.870588, 1)
 theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_disabled_color = Color(0.870588, 0.870588, 0.870588, 1)
 theme_override_fonts/font = ExtResource("8_07qd0")
 theme_override_font_sizes/font_size = 14
-theme_override_styles/disabled = SubResource("11")
-theme_override_styles/hover = SubResource("9")
-theme_override_styles/pressed = SubResource("10")
 theme_override_styles/normal = SubResource("12")
+theme_override_styles/pressed = SubResource("10")
+theme_override_styles/hover = SubResource("9")
+theme_override_styles/disabled = SubResource("11")
 toggle_mode = true
 action_mode = 0
 button_group = SubResource("ButtonGroup_xodoa")
@@ -709,14 +709,14 @@ layout_mode = 2
 size_flags_horizontal = 3
 focus_mode = 0
 mouse_filter = 1
-theme_override_colors/font_disabled_color = Color(0.870588, 0.870588, 0.870588, 1)
 theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_disabled_color = Color(0.870588, 0.870588, 0.870588, 1)
 theme_override_fonts/font = ExtResource("8_07qd0")
 theme_override_font_sizes/font_size = 14
-theme_override_styles/disabled = SubResource("11")
-theme_override_styles/hover = SubResource("9")
-theme_override_styles/pressed = SubResource("10")
 theme_override_styles/normal = SubResource("12")
+theme_override_styles/pressed = SubResource("10")
+theme_override_styles/hover = SubResource("9")
+theme_override_styles/disabled = SubResource("11")
 toggle_mode = true
 action_mode = 0
 button_group = SubResource("ButtonGroup_xodoa")
@@ -728,14 +728,14 @@ layout_mode = 2
 size_flags_horizontal = 3
 focus_mode = 0
 mouse_filter = 1
-theme_override_colors/font_disabled_color = Color(0.870588, 0.870588, 0.870588, 1)
 theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_disabled_color = Color(0.870588, 0.870588, 0.870588, 1)
 theme_override_fonts/font = ExtResource("8_07qd0")
 theme_override_font_sizes/font_size = 14
-theme_override_styles/disabled = SubResource("11")
-theme_override_styles/hover = SubResource("9")
-theme_override_styles/pressed = SubResource("10")
 theme_override_styles/normal = SubResource("12")
+theme_override_styles/pressed = SubResource("10")
+theme_override_styles/hover = SubResource("9")
+theme_override_styles/disabled = SubResource("11")
 toggle_mode = true
 action_mode = 0
 button_group = SubResource("ButtonGroup_xodoa")
@@ -771,8 +771,8 @@ custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
 focus_mode = 1
 mouse_filter = 1
-theme_override_colors/selection_color = Color(1, 1, 1, 1)
 theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/selection_color = Color(1, 1, 1, 1)
 placeholder_text = "SEARCH_DOT_DOT_DOT"
 selecting_enabled = false
 
@@ -1203,12 +1203,12 @@ layout_mode = 2
 focus_neighbor_right = NodePath("../ConfirmButton")
 focus_next = NodePath("../ConfirmButton")
 mouse_force_pass_scroll_events = false
-theme_override_colors/font_disabled_color = Color(0.498039, 0.529412, 0.541176, 1)
 theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
-theme_override_styles/focus = SubResource("StyleBoxFlat_tk5n4")
-theme_override_styles/hover = SubResource("23")
-theme_override_styles/pressed = SubResource("24")
+theme_override_colors/font_disabled_color = Color(0.498039, 0.529412, 0.541176, 1)
 theme_override_styles/normal = SubResource("25")
+theme_override_styles/pressed = SubResource("24")
+theme_override_styles/hover = SubResource("23")
+theme_override_styles/focus = SubResource("StyleBoxFlat_tk5n4")
 shortcut_in_tooltip = false
 text = "CANCEL_ACTION_CAPITAL"
 
@@ -1217,9 +1217,9 @@ custom_minimum_size = Vector2(140, 40)
 layout_mode = 2
 mouse_force_pass_scroll_events = false
 theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
-theme_override_styles/focus = SubResource("41")
-theme_override_styles/hover = SubResource("26")
 theme_override_styles/normal = SubResource("27")
+theme_override_styles/hover = SubResource("26")
+theme_override_styles/focus = SubResource("41")
 text = "NEXT_CAPITAL"
 
 [node name="MarginContainer" type="MarginContainer" parent="BottomRight/HBoxContainer/ConfirmButton"]
@@ -1252,6 +1252,7 @@ libraries = {
 
 [node name="NegativeAtpWarning" parent="." instance=ExtResource("9")]
 custom_minimum_size = Vector2(500, 0)
+layout_mode = 0
 offset_right = 500.0
 offset_bottom = 85.0
 DialogText = "NEGATIVE_ATP_BALANCE_TEXT"
@@ -1259,6 +1260,7 @@ WindowTitle = "NEGATIVE_ATP_BALANCE"
 
 [node name="CompleteEndosymbiosisWarning" parent="." instance=ExtResource("9")]
 custom_minimum_size = Vector2(500, 0)
+layout_mode = 0
 offset_right = 500.0
 offset_bottom = 85.0
 NodeToGiveFocusOnOpen = NodePath("VBoxContainer/HBoxContainer/ConfirmButton")
@@ -1269,6 +1271,7 @@ WindowTitle = "PENDING_ENDOSYMBIOSIS_TITLE"
 
 [node name="IslandError" parent="." instance=ExtResource("9")]
 custom_minimum_size = Vector2(600, 0)
+layout_mode = 0
 offset_right = 600.0
 offset_bottom = 85.0
 HideCancelButton = true
@@ -1277,6 +1280,7 @@ WindowTitle = "DISCONNECTED_ORGANELLES"
 
 [node name="OrganelleUpgradeGUI" parent="." instance=ExtResource("30")]
 visible = false
+layout_mode = 0
 anchors_preset = 0
 anchor_right = 0.0
 anchor_bottom = 0.0
@@ -1298,6 +1302,7 @@ layout_mode = 1
 
 [node name="ProcessPanel" parent="." instance=ExtResource("39")]
 custom_minimum_size = Vector2(400, 400)
+layout_mode = 0
 offset_left = 10.0
 offset_top = 72.4143
 offset_right = 410.0
@@ -1319,6 +1324,7 @@ ShowToggles = false
 
 [node name="PredictionExplanation" parent="." instance=ExtResource("39")]
 custom_minimum_size = Vector2(550, 515)
+layout_mode = 0
 WindowTitle = "AUTO-EVO_PREDICTION"
 Resizable = true
 
@@ -1349,6 +1355,7 @@ size_flags_vertical = 3
 
 [node name="ExplanationText" parent="PredictionExplanation/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer" instance=ExtResource("11")]
 layout_mode = 2
+focus_mode = 0
 fit_content = true
 
 [node name="Spacer" type="Control" parent="PredictionExplanation/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]


### PR DESCRIPTION
**Brief Description of What This PR Does**

so that a white outline that goes outside the popup box is not drawn. For some reason the screen reader accessibility focus was triggering this, I'm not sure what else could be done besides disabling it entirely on this one node. Also Godot did a lot of random changes that I think are all fully correct.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/228300288023461893/958598553389903913/1432435423505940520

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
