### PR TITLE
Fixed crash exiting multicellular editor loaded from a save

### DIFF
--- a/src/general/base_stage/WorldSimulation.cs
+++ b/src/general/base_stage/WorldSimulation.cs
@@ -216,6 +216,10 @@ public abstract class WorldSimulation : IWorldSimulation, IGodotEarlyNodeResolve
         // Make sure all commands are flushed if someone added some in the time between updates
         ApplyRecordedCommands();
 
+        // And that all deletes are processed as they can be related to the recorded commands
+        // Fixes a crashing bug when continuing a save made in the multicellular editor
+        ProcessDestroyQueue();
+
         // See the similar check in ProcessAll to see what this is about (this is about special component debug mode)
         bool useNormalPhysics = disableComponentChecking || !GenerateThreadedSystems.UseCheckedComponentAccess;
 

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -24,7 +24,7 @@ public struct MicrobeColony : IArchivableComponent
     public Entity[] ColonyMembers;
 
     /// <summary>
-    ///   Lead cell of the colony. This is the newMember that exists separately in the world, all others are
+    ///   Lead cell of the colony. This is the newMember that exists separately in the world; all others are
     ///   attached to it with <see cref="AttachedToEntity"/> components. Note this is always assumed to be the
     ///   same as the entity that has this <see cref="MicrobeColony"/> component on it.
     /// </summary>
@@ -54,14 +54,14 @@ public struct MicrobeColony : IArchivableComponent
 
     // Note that the following statistics should be accessed through the helpers to ensure that they have been
     // calculated. This is implemented like this to simplify spawning to not require full entities to exist at that
-    // point. Instead only when the properties are used they are calculated when the colony member entities are
+    // point. Instead, only when the properties are used they are calculated when the colony member entities are
     // certainly created.
 
     public int HexCount;
     public bool CanEngulf;
 
     /// <summary>
-    ///   Internal variable don't touch.
+    ///   Internal variable, don't touch.
     /// </summary>
     public bool DerivedStatisticsCalculated;
 

--- a/src/multicellular_stage/systems/IntercellularMatrixSystem.cs
+++ b/src/multicellular_stage/systems/IntercellularMatrixSystem.cs
@@ -158,7 +158,16 @@ public partial class IntercellularMatrixSystem : BaseSystem<World, float>
         {
             if (!matrix.IsConnectionRedundant && matrix.GeneratedConnection == null)
             {
-                ref var colony = ref entity.Get<MicrobeColonyMember>().ColonyLeader.Get<MicrobeColony>();
+                var leader = entity.Get<MicrobeColonyMember>().ColonyLeader;
+
+                if (!leader.IsAliveAndHas<MicrobeColony>())
+                {
+                    GD.PrintErr($"Leader of a colony is missing or missing MicrobeColony component, " +
+                        $"can't generate intercellular matrix for {entity}");
+                    return;
+                }
+
+                ref var colony = ref leader.Get<MicrobeColony>();
 
                 AddIntercellularConnection(entity, ref matrix, ref colony, ref spatialInstance, ref cellProperties);
             }

--- a/src/saving/serializers/IArchivableComponent.cs
+++ b/src/saving/serializers/IArchivableComponent.cs
@@ -1,6 +1,7 @@
 ﻿using Arch.Core;
 using Arch.Core.Extensions;
 using Components;
+using Godot;
 using SharedBase.Archive;
 
 /// <summary>
@@ -59,8 +60,22 @@ public static class ComponentDeserializers
                 entity.Add(MicrobeColonyHelpers.ReadFromArchive(reader, version));
                 return true;
             case ThriveArchiveObjectType.ComponentMicrobeColonyMember:
-                entity.Add(MicrobeColonyMemberHelpers.ReadFromArchive(reader, version));
+            {
+                var member = MicrobeColonyMemberHelpers.ReadFromArchive(reader, version);
+
+                // Skip invalid colony members (apparently this wasn't a reported bug, but probably good to have this
+                // anyway)
+                if (member.ColonyLeader == default || member.ColonyLeader == Entity.Null ||
+                    !member.ColonyLeader.IsAlive())
+                {
+                    GD.PrintErr("Ignoring colony member component that has invalid leader");
+                    return true;
+                }
+
+                entity.Add(member);
                 return true;
+            }
+
             case ThriveArchiveObjectType.ComponentMicrobeControl:
                 entity.Add(MicrobeControlHelpers.ReadFromArchive(reader, version));
                 return true;


### PR DESCRIPTION
that was caused by delayed deletion of cleared player cell colony and was ultimately an oversight in the base WorldSimulation. This also adds some safety code I wrote which I think is still good to have for the future.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/228300288023461893/958598553389903913/1435025603848831147

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
