### PR TITLE
Added forgotten custom difficulty fields to saves

### DIFF
--- a/src/general/CustomDifficulty.cs
+++ b/src/general/CustomDifficulty.cs
@@ -5,7 +5,7 @@
 /// </summary>
 public class CustomDifficulty : IDifficulty
 {
-    public const ushort SERIALIZATION_VERSION = 1;
+    public const ushort SERIALIZATION_VERSION = 2;
 
     private bool applyGrowthOverride;
     private bool growthLimitOverride;
@@ -60,7 +60,7 @@ public class CustomDifficulty : IDifficulty
         if (version is > SERIALIZATION_VERSION or <= 0)
             throw new InvalidArchiveVersionException(version, SERIALIZATION_VERSION);
 
-        return new CustomDifficulty
+        var instance = new CustomDifficulty
         {
             MPMultiplier = reader.ReadFloat(),
             AIMutationMultiplier = reader.ReadFloat(),
@@ -74,6 +74,15 @@ public class CustomDifficulty : IDifficulty
             ReproductionCompounds = (ReproductionCompoundHandling)reader.ReadInt32(),
             SwitchSpeciesOnExtinction = reader.ReadBool(),
         };
+
+        if (version > 1)
+        {
+            instance.FogOfWarMode = (FogOfWarMode)reader.ReadInt32();
+            instance.OrganelleUnlocksEnabled = reader.ReadBool();
+            instance.limitGrowthRate = reader.ReadBool();
+        }
+
+        return instance;
     }
 
     public void WriteToArchive(ISArchiveWriter writer)
@@ -89,6 +98,11 @@ public class CustomDifficulty : IDifficulty
         writer.Write(FreeGlucoseCloud);
         writer.Write((int)ReproductionCompounds);
         writer.Write(SwitchSpeciesOnExtinction);
+
+        // Version 2 fields that were forgotten in the first version (and caused a map reveal bug)
+        writer.Write((int)FogOfWarMode);
+        writer.Write(OrganelleUnlocksEnabled);
+        writer.Write(limitGrowthRate);
     }
 
     public void SetGrowthRateLimitCheatOverride(bool newLimitSetting)


### PR DESCRIPTION
**Brief Description of What This PR Does**

To fix the map revealing itself on loading save with custom difficulty

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

https://discord.com/channels/228300288023461893/958598553389903913/1435357243385184356

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
