### PR TITLE
Fixed major terrain overlap math mistake and added sliding

### DIFF
--- a/src/general/utils/MathUtils.cs
+++ b/src/general/utils/MathUtils.cs
@@ -177,6 +177,17 @@ public static class MathUtils
         return distance <= Math.PI ? distance : (float)(2 * Math.PI) - distance;
     }
 
+    /// <summary>
+    ///   Squares a number, faster alterative to <c>Math.Pow(x, 2)</c>
+    /// </summary>
+    /// <param name="value">Value to square</param>
+    /// <returns>Squared result</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Square(float value)
+    {
+        return value * value;
+    }
+
     public static Vector3 CalculateCameraVisiblePosition(Node3D camera, float distance = 25)
     {
         var forward = camera.Transform.Basis.GetRotationQuaternion() * Vector3.Forward;

--- a/src/microbe_stage/TerrainConfiguration.cs
+++ b/src/microbe_stage/TerrainConfiguration.cs
@@ -178,6 +178,13 @@ public class TerrainConfiguration : RegistryType
         [JsonProperty]
         public readonly bool RandomizeRotation;
 
+        /// <summary>
+        ///   When true, the terrain will slide around other terrain to fit and spawn.
+        ///   If false, only exact positions are tested, and even if it doesn't fit, no adjustment will be done.
+        /// </summary>
+        [JsonProperty]
+        public readonly bool SlideToFit = true;
+
         public float OverallRadius;
         public float OverallOverlapRadius;
 

--- a/src/microbe_stage/systems/SpawnSystem.cs
+++ b/src/microbe_stage/systems/SpawnSystem.cs
@@ -79,7 +79,7 @@ public partial class SpawnSystem : BaseSystem<World, float>, ISpawnSystem, IArch
     private float spawnedEntityWeight;
     private int despawnedCount;
 
-    private float spawnRadiusSquaredCheck = 5 * 5;
+    private float spawnRadiusCheck = 5.5f;
     private int maxDifferentPositionsCheck = 10;
 
     public SpawnSystem(IWorldSimulation worldSimulation, World world, IsSpawnPositionBad badSpawnPositionCheck) :
@@ -93,7 +93,7 @@ public partial class SpawnSystem : BaseSystem<World, float>, ISpawnSystem, IArch
         spawnTypes = new ShuffleBag<Spawner>(random);
     }
 
-    public delegate bool IsSpawnPositionBad(Vector3 position, float spawnRadiusSquared);
+    public delegate bool IsSpawnPositionBad(Vector3 position, float spawnRadius);
 
     public bool IsEnabled { get; set; } = true;
 
@@ -521,7 +521,7 @@ public partial class SpawnSystem : BaseSystem<World, float>, ISpawnSystem, IArch
                 var finalPosition = sectorCenter + displacement;
 
                 // Skip spawning stuff into the terrain
-                if (badSpawnPositionCheck.Invoke(finalPosition, spawnRadiusSquaredCheck))
+                if (badSpawnPositionCheck.Invoke(finalPosition, spawnRadiusCheck))
                     continue;
 
                 spawned = true;
@@ -553,7 +553,7 @@ public partial class SpawnSystem : BaseSystem<World, float>, ISpawnSystem, IArch
                     var position = playerLocation + new Vector3(MathF.Cos(angle) * Constants.SPAWN_SECTOR_SIZE * 2, 0,
                         MathF.Sin(angle) * Constants.SPAWN_SECTOR_SIZE * 2);
 
-                    if (badSpawnPositionCheck.Invoke(position, spawnRadiusSquaredCheck))
+                    if (badSpawnPositionCheck.Invoke(position, spawnRadiusCheck))
                         continue;
 
                     spawns += SpawnWithSpawner(spawnType, position, ref spawnsLeftThisFrame);


### PR DESCRIPTION
**Brief Description of What This PR Does**

for placing more chunks if position is not found, though that might need further tweaking with the position checks being fixed

Turns out I had made a serious math mistake and this makes the terrain system actually correctly calculate overlaps. And that has the effect that the system acts quite differently now.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
