### PR TITLE
Improve ai for running from hydrogen sulfide

### DIFF
--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -330,11 +330,9 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
                 ai.MoveWithRandomTurn(1.5f, 4.5f, position.Position, ref control, speciesActivity, random);
                 return;
             }
-            else
-            {
-                control.SetMoveSpeed(Constants.AI_BASE_MOVEMENT);
-                return;
-            }
+
+            control.SetMoveSpeed(Constants.AI_BASE_MOVEMENT);
+            return;
         }
 
         float atpLevel = compounds.GetCompoundAmount(Compound.ATP);


### PR DESCRIPTION
**Brief Description of What This PR Does**

Seems like if a sessile species hit hydrogen sulfide, it could get stuck in a loop of stopping and starting and just turned randomly forever. 

**Related Issues**

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
