### PR TITLE
Fixed special storage not working correctly for compound lasting time

### DIFF
--- a/src/microbe_stage/editor/CompoundStorageStatistics.cs
+++ b/src/microbe_stage/editor/CompoundStorageStatistics.cs
@@ -58,7 +58,9 @@ public partial class CompoundStorageStatistics : VBoxContainer
             if (compoundDefinition.IsGas)
                 continue;
 
-            var storage = specialCapacities.GetValueOrDefault(entry.Key, nominalStorage);
+            var storage = nominalStorage;
+
+            storage += specialCapacities.GetValueOrDefault(entry.Key, 0);
 
             if (nightBalance.TryGetValue(entry.Key, out var nightEntry) && nightEntry.Balance < 0)
             {
@@ -114,7 +116,7 @@ public partial class CompoundStorageStatistics : VBoxContainer
             {
                 // Compound that doesn't change during the night (or not negative during the night), show still a
                 // depletion time if valid (balance is negative)
-                // It should be the case that not many compounds would ever fall into this category but for
+                // It should be the case that not many compounds would ever fall into this category, but for
                 // completeness this is handled as well
 
                 if (entry.Value.Balance < 0)


### PR DESCRIPTION
calculations as it accidentally replaced the nominal storage amount entirely

**Brief Description of What This PR Does**

This PR does some stuff...

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
