### PR TITLE
Iron & Chemosynthesis Buff

### DIFF
--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -148,18 +148,18 @@
   "chemoSynthesis": {
     "Name": "CHEMO_SYNTHESIS",
     "Inputs": {
-      "hydrogensulfide": 0.12,
+      "hydrogensulfide": 0.08,
       "carbondioxide": 0.09
     },
     "Outputs": {
-      "glucose": 0.1
+      "glucose": 0.075
     },
     "IsMetabolismProcess": true
   },
   "bacterial_ChemoSynthesis": {
     "Name": "CHEMO_SYNTHESIS",
     "Inputs": {
-      "hydrogensulfide": 0.06,
+      "hydrogensulfide": 0.04,
       "carbondioxide": 0.09
     },
     "Outputs": {
@@ -234,7 +234,7 @@
   "iron_chemolithoautotrophy": {
     "Name": "IRON_OXIDATION",
     "Inputs": {
-      "iron": 0.06
+      "iron": 0.055
     },
     "Outputs": {
       "atp": 5.5
@@ -262,7 +262,7 @@
   "ferrosynthesis": {
     "Name": "IRON_OXIDATION",
     "Inputs": {
-      "iron": 0.04
+      "iron": 0.048
     },
     "Outputs": {
       "atp": 14


### PR DESCRIPTION
**Brief Description of What This PR Does**

Slightly reduces iron input and hydrogen sulfide input. This should hopefully assuage player concerns about chemosynthesis not being very effective, and makes iron's more vapid nature emerge with more of a commitment to the metabolisms tyle rather than being extremely difficult right up the front. Chemosynthesis glucose output was slightly reduced to not make it extremely powerful. I also slightly increased the input for the eukaryotic iron part, though this is less impactful because eukaryotes get a lot more storage straight up. 

This doesn't include any changes to iron chunks, which is what is needed for a more comprehensive iron rebalance. But it should be good for 9.1, and I think will be the last metabolism tweaks I will personally create for 1.0. 

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
