### PR TITLE
Fix sliders in editor at fast movements or far ranges

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1946,7 +1946,6 @@ public static class Constants
     public const float TOLERANCE_INITIAL_PRESSURE_MIN_FRACTION = 0.8f;
     public const float TOLERANCE_INITIAL_PRESSURE_MAX_FRACTION = 1.2f;
 
-    public const float TOLERANCE_PRESSURE_SCALE = 1000;
     public const float TOLERANCE_PRESSURE_RANGE_MAX = 2000000;
     public const float TOLERANCE_PERFECT_PRESSURE_SCORE = 0.1f;
 
@@ -1959,16 +1958,34 @@ public static class Constants
 
     // How much it costs to edit various tolerances in the editor
     public const float TOLERANCE_CHANGE_MP_PER_TEMPERATURE = 1.0f;
+    public const float TOLERANCE_CHANGE_MP_PER_TEMPERATURE_INVERTED = 1.0f / TOLERANCE_CHANGE_MP_PER_TEMPERATURE;
     public const float TOLERANCE_CHANGE_MP_PER_TEMPERATURE_TOLERANCE = 4.0f;
+
+    public const float TOLERANCE_CHANGE_MP_PER_TEMPERATURE_TOLERANCE_INVERTED = 1.0f
+        / TOLERANCE_CHANGE_MP_PER_TEMPERATURE_TOLERANCE;
+
     public const float TOLERANCE_CHANGE_MP_PER_OXYGEN = 150.0f;
+    public const float TOLERANCE_CHANGE_MP_PER_OXYGEN_INVERTED = 1.0f / TOLERANCE_CHANGE_MP_PER_OXYGEN;
+
     public const float TOLERANCE_CHANGE_MP_PER_UV = 100.0f;
+
+    public const float TOLERANCE_CHANGE_MP_PER_UV_INVERTED = 1.0f
+        / TOLERANCE_CHANGE_MP_PER_UV;
 
     /// <summary>
     ///   As pressure values are massive, this is a double to get reasonable MP costs
     /// </summary>
     public const double TOLERANCE_CHANGE_MP_PER_PRESSURE = 0.000002;
 
+    public const double TOLERANCE_CHANGE_MP_PER_PRESSURE_INVERTED = 1.0f / TOLERANCE_CHANGE_MP_PER_PRESSURE;
+
     public const double TOLERANCE_CHANGE_MP_PER_PRESSURE_TOLERANCE = 0.00005;
+
+    public const double TOLERANCE_CHANGE_MP_PER_PRESSURE_AND_TOLERANCE =
+        TOLERANCE_CHANGE_MP_PER_PRESSURE + TOLERANCE_CHANGE_MP_PER_PRESSURE_TOLERANCE;
+
+    public const double TOLERANCE_CHANGE_MP_PER_PRESSURE_AND_TOLERANCE_INVERTED =
+        1.0f / TOLERANCE_CHANGE_MP_PER_PRESSURE_AND_TOLERANCE;
 
     // Environmental tolerance debuff / buff tweak variables
     public const float TOLERANCE_TEMPERATURE_SPEED_MODIFIER_MIN = 0.8f;

--- a/src/microbe_stage/editor/TolerancesEditorSubComponent.cs
+++ b/src/microbe_stage/editor/TolerancesEditorSubComponent.cs
@@ -270,7 +270,7 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
         if (pressureToolTip != null)
         {
             var pressureCost = pressureMinSlider.Step * Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE *
-                Constants.TOLERANCE_PRESSURE_SCALE * MPDisplayCostMultiplier;
+                MPDisplayCostMultiplier;
 
             pressureToolTip.MPCost = (float)pressureCost;
         }
@@ -498,8 +498,8 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
         temperatureSlider.Value = CurrentTolerances.PreferredTemperature;
         temperatureToleranceRangeSlider.Value = CurrentTolerances.TemperatureTolerance;
-        pressureMinSlider.Value = CurrentTolerances.PressureMinimum / Constants.TOLERANCE_PRESSURE_SCALE;
-        pressureMaxSlider.Value = CurrentTolerances.PressureMaximum / Constants.TOLERANCE_PRESSURE_SCALE;
+        pressureMinSlider.Value = CurrentTolerances.PressureMinimum;
+        pressureMaxSlider.Value = CurrentTolerances.PressureMaximum;
         oxygenResistanceSlider.Value = CurrentTolerances.OxygenResistance;
         uvResistanceSlider.Value = CurrentTolerances.UVResistance;
 
@@ -524,7 +524,7 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
         if (!TriggerChangeIfPossible())
         {
-            var extremeTemp = CalculateSliderExtremeValue(Constants.TOLERANCE_CHANGE_MP_PER_TEMPERATURE,
+            var extremeTemp = CalculateSliderExtremeValue(Constants.TOLERANCE_CHANGE_MP_PER_TEMPERATURE_INVERTED,
                 value, CurrentTolerances.PreferredTemperature, temperatureSlider.Step);
 
             reusableTolerances.PreferredTemperature = extremeTemp;
@@ -554,7 +554,7 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
         if (!TriggerChangeIfPossible())
         {
             var extremeTempTolerance = CalculateSliderExtremeValue(
-                Constants.TOLERANCE_CHANGE_MP_PER_TEMPERATURE_TOLERANCE,
+                Constants.TOLERANCE_CHANGE_MP_PER_TEMPERATURE_TOLERANCE_INVERTED,
                 value, CurrentTolerances.TemperatureTolerance, temperatureToleranceRangeSlider.Step);
 
             reusableTolerances.TemperatureTolerance = extremeTempTolerance;
@@ -579,8 +579,7 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
         if (keepSamePressureFlexibility)
         {
-            var previousRange = Math.Abs(CurrentTolerances.PressureMaximum - CurrentTolerances.PressureMinimum)
-                / Constants.TOLERANCE_PRESSURE_SCALE;
+            var previousRange = Math.Abs(CurrentTolerances.PressureMaximum - CurrentTolerances.PressureMinimum);
 
             // Update the other slider to keep the current flexibility range
             var maxShouldBe = value + previousRange;
@@ -612,10 +611,9 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
             var newRange = Math.Abs(pressureMaxSlider.Value - value);
 
             // Ensure flexibility doesn't go above the configured limit
-            if (newRange > Constants.TOLERANCE_PRESSURE_RANGE_MAX / Constants.TOLERANCE_PRESSURE_SCALE)
+            if (newRange > Constants.TOLERANCE_PRESSURE_RANGE_MAX)
             {
-                value = (CurrentTolerances.PressureMaximum - Constants.TOLERANCE_PRESSURE_RANGE_MAX)
-                    / Constants.TOLERANCE_PRESSURE_SCALE;
+                value = CurrentTolerances.PressureMaximum - Constants.TOLERANCE_PRESSURE_RANGE_MAX;
 
                 TryApplyPressureChange(value, (float)pressureMaxSlider.Value, true, true);
 
@@ -638,8 +636,7 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
         if (keepSamePressureFlexibility)
         {
-            var previousRange = Math.Abs(CurrentTolerances.PressureMaximum - CurrentTolerances.PressureMinimum)
-                / Constants.TOLERANCE_PRESSURE_SCALE;
+            var previousRange = Math.Abs(CurrentTolerances.PressureMaximum - CurrentTolerances.PressureMinimum);
 
             // Update the other slider to keep the current flexibility range
             var minShouldBe = value - previousRange;
@@ -667,10 +664,9 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
             }
 
             var newRange = Math.Abs(value - pressureMinSlider.Value);
-            if (newRange > Constants.TOLERANCE_PRESSURE_RANGE_MAX / Constants.TOLERANCE_PRESSURE_SCALE)
+            if (newRange > Constants.TOLERANCE_PRESSURE_RANGE_MAX)
             {
-                value = (CurrentTolerances.PressureMinimum +
-                    Constants.TOLERANCE_PRESSURE_RANGE_MAX) / Constants.TOLERANCE_PRESSURE_SCALE;
+                value = CurrentTolerances.PressureMinimum + Constants.TOLERANCE_PRESSURE_RANGE_MAX;
 
                 TryApplyPressureChange((float)pressureMinSlider.Value, value, false, true);
 
@@ -693,8 +689,8 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
     {
         reusableTolerances ??= new EnvironmentalTolerances();
         reusableTolerances.CopyFrom(CurrentTolerances);
-        reusableTolerances.PressureMinimum = min * Constants.TOLERANCE_PRESSURE_SCALE;
-        reusableTolerances.PressureMaximum = max * Constants.TOLERANCE_PRESSURE_SCALE;
+        reusableTolerances.PressureMinimum = min;
+        reusableTolerances.PressureMaximum = max;
 
         if (force || !TriggerChangeIfPossible())
         {
@@ -702,16 +698,15 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
             if (keepSamePressureFlexibility)
             {
-                var extremeMin = CalculateSliderExtremeValue(
-                    Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE * Constants.TOLERANCE_PRESSURE_SCALE,
+                var extremeMin = CalculateSliderExtremeValue(Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE_INVERTED,
                     min,
-                    CurrentTolerances.PressureMinimum / Constants.TOLERANCE_PRESSURE_SCALE,
+                    CurrentTolerances.PressureMinimum,
                     pressureMinSlider.Step);
 
                 var extremeMax = extremeMin + pressureRange;
 
-                reusableTolerances.PressureMinimum = extremeMin * Constants.TOLERANCE_PRESSURE_SCALE;
-                reusableTolerances.PressureMaximum = extremeMax * Constants.TOLERANCE_PRESSURE_SCALE;
+                reusableTolerances.PressureMinimum = extremeMin;
+                reusableTolerances.PressureMaximum = extremeMax;
 
                 pressureMinSlider.Value = extremeMin;
                 pressureMaxSlider.Value = extremeMax;
@@ -721,24 +716,22 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
                 if (minimumChanging)
                 {
                     var extremeMin = CalculateSliderExtremeValue(
-                        Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE * Constants.TOLERANCE_PRESSURE_SCALE +
-                        Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE_TOLERANCE * Constants.TOLERANCE_PRESSURE_SCALE,
-                        min, CurrentTolerances.PressureMinimum / Constants.TOLERANCE_PRESSURE_SCALE,
+                        Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE_AND_TOLERANCE_INVERTED,
+                        min, CurrentTolerances.PressureMinimum,
                         pressureMinSlider.Step);
 
                     extremeMin = Math.Clamp(extremeMin, max - Constants.TOLERANCE_PRESSURE_RANGE_MAX, max);
 
                     pressureMinSlider.Value = extremeMin;
                     pressureMaxSlider.Value = max;
-                    reusableTolerances.PressureMinimum = extremeMin * Constants.TOLERANCE_PRESSURE_SCALE;
-                    reusableTolerances.PressureMaximum = max * Constants.TOLERANCE_PRESSURE_SCALE;
+                    reusableTolerances.PressureMinimum = extremeMin;
+                    reusableTolerances.PressureMaximum = max;
                 }
                 else
                 {
                     var extremeMax = CalculateSliderExtremeValue(
-                        Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE * Constants.TOLERANCE_PRESSURE_SCALE +
-                        Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE_TOLERANCE * Constants.TOLERANCE_PRESSURE_SCALE,
-                        max, CurrentTolerances.PressureMaximum / Constants.TOLERANCE_PRESSURE_SCALE,
+                        Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE_AND_TOLERANCE_INVERTED,
+                        max, CurrentTolerances.PressureMaximum,
                         pressureMaxSlider.Step);
 
                     extremeMax = Math.Clamp(extremeMax, min, min + Constants.TOLERANCE_PRESSURE_RANGE_MAX);
@@ -746,16 +739,16 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
                     pressureMinSlider.Value = min;
                     pressureMaxSlider.Value = extremeMax;
 
-                    reusableTolerances.PressureMinimum = min * Constants.TOLERANCE_PRESSURE_SCALE;
-                    reusableTolerances.PressureMaximum = extremeMax * Constants.TOLERANCE_PRESSURE_SCALE;
+                    reusableTolerances.PressureMinimum = min;
+                    reusableTolerances.PressureMaximum = extremeMax;
                 }
             }
 
             // Attempt the previous rollback if failed again.
             if (!TriggerChangeIfPossible())
             {
-                pressureMinSlider.Value = CurrentTolerances.PressureMinimum / Constants.TOLERANCE_PRESSURE_SCALE;
-                pressureMaxSlider.Value = CurrentTolerances.PressureMaximum / Constants.TOLERANCE_PRESSURE_SCALE;
+                pressureMinSlider.Value = CurrentTolerances.PressureMinimum;
+                pressureMaxSlider.Value = CurrentTolerances.PressureMaximum;
             }
         }
     }
@@ -773,7 +766,7 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
         if (!TriggerChangeIfPossible())
         {
-            var extremeResistance = CalculateSliderExtremeValue(Constants.TOLERANCE_CHANGE_MP_PER_OXYGEN,
+            var extremeResistance = CalculateSliderExtremeValue(Constants.TOLERANCE_CHANGE_MP_PER_OXYGEN_INVERTED,
                 value, CurrentTolerances.OxygenResistance, oxygenResistanceSlider.Step);
 
             reusableTolerances.OxygenResistance = extremeResistance;
@@ -802,7 +795,7 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
         if (!TriggerChangeIfPossible())
         {
-            var extremeResistance = CalculateSliderExtremeValue(Constants.TOLERANCE_CHANGE_MP_PER_UV,
+            var extremeResistance = CalculateSliderExtremeValue(Constants.TOLERANCE_CHANGE_MP_PER_UV_INVERTED,
                 value, CurrentTolerances.UVResistance, uvResistanceSlider.Step);
 
             reusableTolerances.UVResistance = extremeResistance;
@@ -821,7 +814,7 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
     /// <summary>
     ///   Calculates the extremeties of a slider movement when cost is the limiting factor.
     /// </summary>
-    /// <param name="costPerAction">How much MP does changing this value cost?</param>
+    /// <param name="costPerAction">How much MP does changing this value cost? Inverted</param>
     /// <param name="sliderValue">What the slider value currently is at</param>
     /// <param name="originalValue">What the slider value was originally at</param>
     /// <param name="step">The size of each jump on the slider</param>
@@ -830,7 +823,7 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
         double step)
     {
         var pointsLeft = Editor.MutationPoints;
-        var numActions = Math.Abs(Math.Floor((pointsLeft / step) / costPerAction) * step);
+        var numActions = Math.Abs(Math.Floor((pointsLeft / step) * costPerAction) * step);
 
         if (sliderValue == originalValue)
             return originalValue;
@@ -1097,7 +1090,7 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
             / (float)(temperatureSlider.MaxValue - temperatureSlider.MinValue);
 
         float pressureRangeFraction =
-            ((patchPressure / Constants.TOLERANCE_PRESSURE_SCALE) - (float)pressureMaxSlider.MinValue)
+            (patchPressure - (float)pressureMaxSlider.MinValue)
             / (float)(pressureMaxSlider.MaxValue - pressureMaxSlider.MinValue);
 
         minPressureToleranceMarker.OptimalValue = pressureRangeFraction;

--- a/src/microbe_stage/editor/TolerancesEditorSubComponent.tscn
+++ b/src/microbe_stage/editor/TolerancesEditorSubComponent.tscn
@@ -335,9 +335,9 @@ mouse_filter = 1
 [node name="PressureSliderMin" type="HSlider" parent="Pressure"]
 layout_mode = 2
 mouse_filter = 1
-max_value = 70000.0
-step = 50.0
-value = 50.0
+max_value = 70000000.0
+step = 50000.0
+value = 50000.0
 rounded = true
 scrollable = false
 tick_count = 8
@@ -351,8 +351,8 @@ rotation = 0.00114285
 [node name="PressureSliderMax" type="HSlider" parent="Pressure"]
 layout_mode = 2
 mouse_filter = 1
-max_value = 70000.0
-step = 50.0
+max_value = 70000000.0
+step = 50000.0
 value = 50000.0
 rounded = true
 scrollable = false


### PR DESCRIPTION
**Brief Description of What This PR Does**

Improves all sliders with their handling of costly movements.

Now when dragging a slider if you drag too far it will clamp its value to as far as it can pay.
Scales down pressure values for UI use by a factor of 1000. Then rescales them back up for assigning for use in game.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Closes: #5944

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).

I'm attaching a video demonstration to help explain a bit better!

https://github.com/user-attachments/assets/f6ac1b79-d241-4e81-8e0e-24e9798451a6


https://github.com/user-attachments/assets/41b4e3ab-dcff-4db2-bb18-e199b629fcbc

And a specific video demonstrating the pressure threshold changes

https://github.com/user-attachments/assets/6abc83e3-a8d7-442a-90bc-ff891d93fc02


