### PR TITLE
Refactored editor auto-evo prediction to full wait for queued runs

### DIFF
--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -112,7 +112,7 @@ public class AutoEvoRun
     public bool WasSuccessful => Finished && !Aborted;
 
     /// <summary>
-    ///   If true the auto evo uses all available executor threads by running more concurrent concurrentStepTasks
+    ///   If true, the auto evo uses all available executor threads by running more concurrent concurrentStepTasks
     /// </summary>
     public bool FullSpeed { get; set; }
 

--- a/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
@@ -124,7 +124,7 @@ public partial class CellEditorComponent
             UpdateAlreadyPlacedVisuals();
 
             // Organelle placement *might* affect auto-evo in the future, so this is here for that reason
-            StartAutoEvoPrediction();
+            autoEvoPredictionDirty = true;
 
             // Suggestion is not restarted as the overall shape / movement speed is likely not significant enough to
             // invalidate the suggestion
@@ -157,8 +157,11 @@ public partial class CellEditorComponent
         data.MovedHex.Orientation = data.OldRotation;
 
         UpdateAlreadyPlacedVisuals();
-        StartAutoEvoPrediction();
         UpdateStats();
+
+        autoEvoPredictionDirty = true;
+
+        // As this is a move, this kind of doesn't need to trigger suggestions again, so this apparently doesn't
 
         // TODO: dynamic MP PR had this line:
         // OnMembraneChanged();
@@ -238,7 +241,7 @@ public partial class CellEditorComponent
         CalculateEnergyAndCompoundBalance(editedMicrobeOrganelles.Organelles, Membrane);
         SetMembraneTooltips(Membrane);
 
-        StartAutoEvoPrediction();
+        autoEvoPredictionDirty = true;
         suggestionDirty = true;
 
         if (previewMicrobeSpecies != null)
@@ -262,7 +265,7 @@ public partial class CellEditorComponent
         organismStatisticsPanel.UpdateSpeed(CalculateSpeed());
         organismStatisticsPanel.UpdateHitpoints(CalculateHitpoints());
 
-        StartAutoEvoPrediction();
+        autoEvoPredictionDirty = true;
         suggestionDirty = true;
 
         if (previewMicrobeSpecies != null)

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -183,22 +183,6 @@ public partial class CellEditorComponent
         }
     }
 
-    private void TriggerDelayedPredictionUpdateIfNeeded(double delta)
-    {
-        autoEvoPredictionStartTimer += delta;
-
-        if (autoEvoPredictionStartTimer > Constants.AUTO_EVO_PREDICTION_UPDATE_INTERVAL)
-        {
-            autoEvoPredictionStartTimer = 0;
-
-            if (autoEvoPredictionDirty)
-            {
-                StartAutoEvoPrediction();
-                autoEvoPredictionDirty = false;
-            }
-        }
-    }
-
     private void CheckSuggestionProgress()
     {
         try
@@ -608,14 +592,26 @@ public partial class CellEditorComponent
     /// <summary>
     ///   Cancels the previous auto-evo prediction run if there is one
     /// </summary>
-    private void CancelPreviousAutoEvoPrediction()
+    /// <returns>True, once there is no active run</returns>
+    private bool CancelPreviousAutoEvoPrediction()
     {
         if (waitingForPrediction == null)
-            return;
+            return true;
 
-        GD.Print("Canceling previous auto-evo prediction run as it didn't manage to finish yet");
-        waitingForPrediction.AutoEvoRun.Abort();
-        waitingForPrediction = null;
+        if (!waitingForPrediction.AutoEvoRun.Aborted)
+        {
+            GD.Print("Canceling previous auto-evo prediction run as it didn't manage to finish yet");
+            waitingForPrediction.AutoEvoRun.Abort();
+        }
+
+        if (waitingForPrediction.Finished)
+        {
+            GD.Print("Previous auto-evo prediction run finished now");
+            waitingForPrediction = null;
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -210,6 +210,8 @@ public partial class CellEditorComponent :
 
     private SelectionMenuTab selectedSelectionMenuTab = SelectionMenuTab.Structure;
 
+    private bool autoEvoPredictionDirty = true;
+    private double autoEvoPredictionStartTimer = 5;
     private bool? autoEvoPredictionRunSuccessful;
     private PendingAutoEvoPrediction? waitingForPrediction;
     private LocalizedStringBuilder? predictionDetailsText;
@@ -220,9 +222,6 @@ public partial class CellEditorComponent :
     private OrganelleSuggestionCalculation? inProgressSuggestion;
     private bool suggestionDirty;
     private double suggestionStartTimer;
-
-    private bool autoEvoPredictionDirty;
-    private double autoEvoPredictionStartTimer;
 
     private bool refreshTolerancesWarnings = true;
 
@@ -687,6 +686,28 @@ public partial class CellEditorComponent :
 
         base._Process(delta);
 
+        // To have a value available earlier, this can run even before the right tab is set
+        autoEvoPredictionStartTimer += delta;
+
+        // But don't start before the editor is ready
+        if (autoEvoPredictionDirty && Editor.EditorReady)
+        {
+            // Don't constantly trigger prediction runs
+            if (autoEvoPredictionStartTimer >= Constants.AUTO_EVO_PREDICTION_UPDATE_INTERVAL)
+            {
+                if (CancelPreviousAutoEvoPrediction())
+                {
+                    // Start a new run once safe to do so
+                    autoEvoPredictionStartTimer = 0;
+                    StartAutoEvoPrediction();
+                }
+            }
+        }
+        else
+        {
+            CheckRunningAutoEvoPrediction();
+        }
+
         if (!Visible)
             return;
 
@@ -698,9 +719,7 @@ public partial class CellEditorComponent :
             debugOverlay.ReportEntities(roughCount);
         }
 
-        CheckRunningAutoEvoPrediction();
         CheckRunningSuggestion(delta);
-        TriggerDelayedPredictionUpdateIfNeeded(delta);
 
         if (organelleDataDirty)
         {
@@ -1972,6 +1991,11 @@ public partial class CellEditorComponent :
             new SingleEditorAction<OrganelleRemoveActionData>(DoOrganelleRemoveAction, UndoOrganelleRemoveAction, o));
     }
 
+    private void OnWantToUpdateAutoEvoPrediction()
+    {
+        autoEvoPredictionDirty = true;
+    }
+
     /// <summary>
     ///   Immediately start a new auto-evo prediction run. For actions that can trigger quickly in a sequence prefer
     ///   setting <see cref="autoEvoPredictionDirty"/> to false to prevent rapid restarts of the prediction.
@@ -1980,9 +2004,13 @@ public partial class CellEditorComponent :
     {
         // For now disabled in the multicellular editor as the microbe logic being used there doesn't make sense
         if (IsMulticellularEditor)
+        {
+            // Don't be dirty to not constantly try to retry the run
+            autoEvoPredictionDirty = false;
             return;
+        }
 
-        // The first prediction can be made only after population numbers from previous run are applied
+        // The first prediction can be made only after population numbers from the previous run are applied,
         // so this is just here to guard against that potential programming mistake that may happen when code is
         // changed
         if (!Editor.EditorReady)
@@ -1990,10 +2018,6 @@ public partial class CellEditorComponent :
             GD.PrintErr("Can't start auto-evo prediction before editor is ready");
             return;
         }
-
-        // Note that in rare cases the auto-evo run doesn't manage to stop before we edit the cached species object,
-        // which may cause occasional background task errors
-        CancelPreviousAutoEvoPrediction();
 
         cachedAutoEvoPredictionSpecies ??= new MicrobeSpecies(Editor.EditedBaseSpecies,
             Editor.EditedCellProperties ??
@@ -2365,7 +2389,7 @@ public partial class CellEditorComponent :
         OnRigidityChanged();
         OnColourChanged();
 
-        StartAutoEvoPrediction();
+        autoEvoPredictionDirty = true;
         suggestionDirty = true;
     }
 
@@ -2468,7 +2492,7 @@ public partial class CellEditorComponent :
 
         UpdateCellVisualization();
 
-        StartAutoEvoPrediction();
+        autoEvoPredictionDirty = true;
         suggestionDirty = true;
 
         UpdateFinishButtonWarningVisibility();


### PR DESCRIPTION
**Brief Description of What This PR Does**

this should fix the intermittent error about modifying an organelle list while auto-evo is running

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
