### PR TITLE
Remove unnecessary cache

### DIFF
--- a/src/auto-evo/mutation_strategy/AddOrganelleAnywhere.cs
+++ b/src/auto-evo/mutation_strategy/AddOrganelleAnywhere.cs
@@ -113,7 +113,7 @@ public class AddOrganelleAnywhere : IMutationStrategy<MicrobeSpecies>
                 continue;
 
             // Don't add duplicate unique organelles
-            if (organelle.Unique && baseSpecies.Organelles.Any(x => x.Definition == organelle))
+            if (organelle.Unique && baseSpecies.Organelles.Select(x => x.Definition).Contains(organelle))
                 continue;
 
             var newSpecies = (MicrobeSpecies)baseSpecies.Clone();


### PR DESCRIPTION
**Brief Description of What This PR Does**

Reverts the unnecessary HashSet allocation each call back to the `.Select().Contains()` it was originally.
We could make this non-allocating with a for loop instead of the linq query but with how often this code is even called going off previous investigations, it's not really worth it.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

Discussion on #6527 post merge

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
