### PR TITLE
Fix extinction box anchor preset

### DIFF
--- a/src/microbe_stage/gui/ExtinctionBox.tscn
+++ b/src/microbe_stage/gui/ExtinctionBox.tscn
@@ -33,22 +33,20 @@ _data = {
 
 [node name="ExtinctionBox" type="Control" node_paths=PackedStringArray("extinctionMenu", "loadMenu", "continueText", "continueButton")]
 layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+anchors_preset = 0
+offset_right = 1280.0
+offset_bottom = 720.0
 theme = ExtResource("3")
 script = ExtResource("4")
-extinctionMenu = NodePath("ExtinctionBoxMenu")
-loadMenu = NodePath("CenterContainer/LoadMenu")
-continueText = NodePath("ExtinctionBoxMenu/PanelContainer/MarginContainer/VBoxContainer/ContinueText")
-continueButton = NodePath("ExtinctionBoxMenu/Continue")
 Movable = false
 ShowCloseButton = false
 Decorate = false
 ExclusiveAllowCloseOnEscape = false
 FullRect = true
+extinctionMenu = NodePath("ExtinctionBoxMenu")
+loadMenu = NodePath("CenterContainer/LoadMenu")
+continueText = NodePath("ExtinctionBoxMenu/PanelContainer/MarginContainer/VBoxContainer/ContinueText")
+continueButton = NodePath("ExtinctionBoxMenu/Continue")
 
 [node name="CenterContainer" type="CenterContainer" parent="."]
 layout_mode = 0


### PR DESCRIPTION
**Brief Description of What This PR Does**

Changes extinction box anchor preset to prevent uneven anchor warnings

**Related Issues**

Fixes #6432

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
