### PR TITLE
Fixed fun screen filters not working in exported game

### DIFF
--- a/src/engine/ScreenFilter.cs
+++ b/src/engine/ScreenFilter.cs
@@ -5,15 +5,9 @@
 /// </summary>
 public partial class ScreenFilter : ColorRect
 {
-#pragma warning disable CA2213
-    private ShaderMaterial? material;
-#pragma warning restore CA2213
-
     public override void _EnterTree()
     {
         base._EnterTree();
-
-        material ??= (ShaderMaterial)Material;
 
         UpdateEffect(Settings.Instance.CurrentScreenEffect);
 
@@ -29,9 +23,12 @@ public partial class ScreenFilter : ColorRect
 
     public void UpdateEffect(ScreenEffect? currentEffect)
     {
+        // Free any previous material
+        Visible = false;
+        Material = null;
+
         if (currentEffect?.ShaderPath == null)
         {
-            material!.Shader = null;
             return;
         }
 
@@ -39,6 +36,11 @@ public partial class ScreenFilter : ColorRect
 
         var effectShader = GD.Load<Shader>(currentEffect.ShaderPath);
 
-        material!.Shader = effectShader;
+        Material = new ShaderMaterial
+        {
+            Shader = effectShader,
+        };
+
+        Visible = true;
     }
 }

--- a/src/engine/ScreenFilter.tscn
+++ b/src/engine/ScreenFilter.tscn
@@ -1,12 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://c10c7kaxjt7xi"]
+[gd_scene load_steps=2 format=3 uid="uid://c10c7kaxjt7xi"]
 
 [ext_resource type="Script" uid="uid://drer7qnr3s3bm" path="res://src/engine/ScreenFilter.cs" id="1"]
 
-[sub_resource type="ShaderMaterial" id="2"]
-resource_local_to_scene = true
-
 [node name="ScreenFilter" type="ColorRect"]
-material = SubResource("2")
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0

--- a/src/engine/ScreenOverlays.tscn
+++ b/src/engine/ScreenOverlays.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://woqh47yetqtm" path="res://src/saving/SaveStatusOverlay.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://d386dbkjbq2rh" path="res://src/engine/LoadingScreen.tscn" id="3"]
 [ext_resource type="PackedScene" uid="uid://cmg6okryq4k0l" path="res://src/engine/ColourblindScreenFilter.tscn" id="4"]
-[ext_resource type="PackedScene" path="res://src/gui_common/QuickLoadHandler.tscn" id="5"]
+[ext_resource type="PackedScene" uid="uid://b5b4oe4lcttdp" path="res://src/gui_common/QuickLoadHandler.tscn" id="5"]
 [ext_resource type="Theme" uid="uid://b4cx0o110g4b6" path="res://src/gui_common/thrive_theme.tres" id="6"]
 [ext_resource type="PackedScene" uid="uid://c4dyrcb6l1u3o" path="res://src/engine/DebugOverlays.tscn" id="7"]
 [ext_resource type="Script" uid="uid://lsmrjt7il0xb" path="res://src/gui_common/TransitionManager.cs" id="8"]
@@ -21,8 +21,12 @@ visible = false
 
 [node name="TransitionManager" type="Control" parent="NormalOverlays"]
 process_mode = 3
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_filter = 2
 script = ExtResource("8")
 
@@ -30,6 +34,8 @@ script = ExtResource("8")
 visible = false
 
 [node name="QuickLoad" parent="NormalOverlays" instance=ExtResource("5")]
+grow_horizontal = 2
+grow_vertical = 2
 theme = ExtResource("6")
 
 [node name="OverlaysOnTopOfModals" type="CanvasLayer" parent="."]
@@ -41,11 +47,7 @@ layer = 127
 layer = 128
 
 [node name="ScreenFilter" parent="Effects" instance=ExtResource("1")]
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_right = 0.0
-offset_bottom = 0.0
-mouse_filter = 2
+visible = false
 
 [node name="ColourblindScreenFilter" parent="Effects" instance=ExtResource("4")]
 visible = false


### PR DESCRIPTION
**Brief Description of What This PR Does**

Seems like an engine bug as I think the fix was to remove a material override from a scene and then that now somehow allows the actual render override material to apply so that it works in exported game

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #6539

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
