### PR TITLE
Fixed massive game brightness difference in exported game

### DIFF
--- a/src/microbe_stage/MicrobeWorldEnvironment.tscn
+++ b/src/microbe_stage/MicrobeWorldEnvironment.tscn
@@ -13,6 +13,9 @@ sky_material = SubResource("ShaderMaterial_vkgr4")
 [sub_resource type="Environment" id="Environment_31nh3"]
 background_color = Color(1.63645e-06, 0.558327, 0.809688, 1)
 sky = SubResource("Sky_b4xyi")
+ambient_light_source = 2
+ambient_light_color = Color(0.984375, 0.984375, 0.984375, 1)
+ambient_light_energy = 0.07
 reflected_light_source = 2
 glow_enabled = true
 glow_normalized = true


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes a very major oversight in the exported game that caused the game to be much darker than intended. And this has likely been a problem for a while now.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
