### PR TITLE
Made player spawn rate adjust immediately on death

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1472,7 +1472,7 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
     {
         base.OnGameContinuedAsSpecies(newPlayerSpecies, inPatch);
 
-        // Update spawners if staying in the same patch as otherwise they wouldn't be updated and would spawn the
+        // Update spawners if staying in the same patch as otherwise, they wouldn't be updated and would spawn the
         // obsolete species
         if (inPatch == GameWorld.Map.CurrentPatch)
         {
@@ -1710,6 +1710,16 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
 
         // Don't clear the player object here as we want to wait until the player entity is deleted before creating
         // a new one to avoid having two player entities existing at the same time
+
+        if (GameWorld.Map.CurrentPatch == null)
+        {
+            GD.PrintErr("Current patch is unknown for some reason, can't update player spawn rate");
+            return;
+        }
+
+        // Update player spawn rate to make sure that if their own species is competing against the player, their spawn
+        // rate is reduced and thus makes the last live(s) easier
+        patchManager.UpdateSpawners(GameWorld.Map.CurrentPatch, this);
     }
 
     private bool PlayerIsEngulfed(Entity player)

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -221,7 +221,9 @@ public class PatchManager
         foreach (var entry in patch.SpeciesInPatch.OrderByDescending(s => s.Value))
         {
             var species = entry.Key;
-            var population = entry.Value;
+
+            // To allow player deaths to immediately impact populations, get the gameplay-adjusted population here
+            var population = patch.GetSpeciesGameplayPopulation(species);
 
             if (population <= 0)
             {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Immediate spawn rate update rather than it only updating after the next editor cycle

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #3354

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
