### PR TITLE
Fixed the show tutorials in current game toggle not turning off

### DIFF
--- a/src/gui_common/menus/OptionsMenu.cs
+++ b/src/gui_common/menus/OptionsMenu.cs
@@ -588,13 +588,12 @@ public partial class OptionsMenu : ControlWithInput
         // Need a reference to game properties in the current game for later comparisons.
         this.gameProperties = gameProperties;
 
-        // Set the mode to the one we opened with, and show/hide any options that should only be visible
+        // Set the mode to the one we opened with and show/hide any options that should only be visible
         // when the options menu is opened from in-game.
         SwitchMode(OptionsMode.InGame);
 
         // Set the state of the gui controls to match the settings.
-        if (savedTutorialsEnabled)
-            tutorialsEnabled.ButtonPressed = savedTutorialsEnabled;
+        tutorialsEnabled.ButtonPressed = savedTutorialsEnabled;
 
         ApplySettingsToControls(savedSettings);
         UpdateResetSaveButtonState();


### PR DESCRIPTION
**Brief Description of What This PR Does**

when going into a new game after previously putting that option on it didn't turn off correctly. This is most likely a regression from when the singleton pause menu was added

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
