### PR TITLE
Suppressed error popup for missing monitors

### DIFF
--- a/src/engine/LogInterceptor.cs
+++ b/src/engine/LogInterceptor.cs
@@ -104,6 +104,12 @@ public partial class LogInterceptor : Logger
             return;
         }
 
+        // Disconnected screens after changing settings can cause these
+        if (code.Contains("p_screen") && code.Contains("is out of bounds"))
+        {
+            return;
+        }
+
         // Ignore unsupported antialiasing modes as it would be very complex to hide the options in the GUI:
         // https://github.com/Revolutionary-Games/Thrive/pull/6535#issuecomment-3611112455
         if ((rationale.Contains("only available when using the") && rationale.Contains("renderer.")) ||


### PR DESCRIPTION
which can happen if the player selects a certain monitor to play on and then disconnects a monitor

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
I noticed this when testing the release with one of my screens disconnected

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
