### PR TITLE
Fix not detecting colony mucocyst state

### DIFF
--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -577,14 +577,22 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
             showSiderophore = false;
 
             engulfing = colony.ColonyState == MicrobeState.Engulf;
+
+            // We don't set the mucocyst state on the colony as it has quite strict requirements,
+            // so we need to loop them specifically (below this simple check that doesn't really find anything)
             usingMucocyst = colony.ColonyState == MicrobeState.MucocystShield;
 
             for (int i = 0; i < colony.ColonyMembers.Length; ++i)
             {
-                if (colony.ColonyMembers[i].Get<Engulfer>().EngulfedObjects is { Count: > 0 })
+                var member = colony.ColonyMembers[i];
+                if (member.Get<Engulfer>().EngulfedObjects is { Count: > 0 })
                 {
                     isDigesting = true;
-                    break;
+                }
+
+                if (member.Get<MicrobeControl>().State == MicrobeState.MucocystShield)
+                {
+                    usingMucocyst = true;
                 }
             }
         }

--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -178,6 +178,16 @@ public partial class PlayerMicrobeInput : NodeWithInput
             ref var colony = ref player.Get<MicrobeColony>();
 
             colonyMucocyst = colony.ColonyState == MicrobeState.MucocystShield;
+
+            // Colony can have individual members in the mucocyst state, so we must check that here
+            for (int i = 0; i < colony.ColonyMembers.Length; ++i)
+            {
+                var member = colony.ColonyMembers[i];
+                if (member.Get<MicrobeControl>().State == MicrobeState.MucocystShield)
+                {
+                    colonyMucocyst = true;
+                }
+            }
         }
 
         if (control.State == MicrobeState.MucocystShield || colonyMucocyst)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes the case where game would not consider colony state when choosing to activate or deactivate mucocyst on player input. Also added missing applying of the state to the colony

**Related Issues**

Closes #6474

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
