### PR TITLE
Made dead signalers clear channel data

### DIFF
--- a/src/microbe_stage/MicrobeWorldSimulation.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.cs
@@ -411,6 +411,7 @@ public partial class MicrobeWorldSimulation : WorldSimulationWithPhysics
 
         engulfingSystem.OnEntityDestroyed(entity);
         colonyStatsUpdateSystem.OnEntityDestroyed(entity);
+        entitySignalingSystem.OnEntityDestroyed(entity);
     }
 
     protected override void OnPlayerPositionSet(Vector3 playerPosition)


### PR DESCRIPTION
**Brief Description of What This PR Does**

This which fixes a game lock up and I slightly tweaked the way the channels are filled to avoid duplicate entries. I'm not sure if this is the optimal approach or we should just do full channel refreshes each game simulation update.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/228300288023461893/958598553389903913/1452222607989674115

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
