### PR TITLE
Chemosynthesis buff

### DIFF
--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -148,7 +148,7 @@
   "chemoSynthesis": {
     "Name": "CHEMO_SYNTHESIS",
     "Inputs": {
-      "hydrogensulfide": 0.08,
+      "hydrogensulfide": 0.025,
       "carbondioxide": 0.09
     },
     "Outputs": {
@@ -159,7 +159,7 @@
   "bacterial_ChemoSynthesis": {
     "Name": "CHEMO_SYNTHESIS",
     "Inputs": {
-      "hydrogensulfide": 0.04,
+      "hydrogensulfide": 0.02,
       "carbondioxide": 0.09
     },
     "Outputs": {

--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -148,11 +148,11 @@
   "chemoSynthesis": {
     "Name": "CHEMO_SYNTHESIS",
     "Inputs": {
-      "hydrogensulfide": 0.025,
+      "hydrogensulfide": 0.04,
       "carbondioxide": 0.09
     },
     "Outputs": {
-      "glucose": 0.075
+      "glucose": 0.12
     },
     "IsMetabolismProcess": true
   },


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR increases the efficiency of chemosynthesis severalfold.

Why?

The fact is that chemosynthesis is terribly inefficient; it's barely enough for large prokaryotes to survive. And chemosynthetic eukaryotes starve even standing in a cloud of hydrogen sulfide.

In real life, chemosynthesis is efficient enough to fuel even some macroscopic organisms.

Furthermore, it requires organelles to convert glucose into ATP, which requires more organelles and, consequently, osmoregulation.


- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).
