### PR TITLE
Multicellular and colony rotation buff

### DIFF
--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -989,7 +989,7 @@ public static class MicrobeColonyHelpers
                 // fastest cell inside it
                 var memberRotation = MicrobeInternalCalculations
                         .CalculateRotationSpeed(colonyMember.Get<OrganelleContainer>().Organelles!.Organelles)
-                    * (1 + 0.01f * distanceSquared);
+                    * (1 + 0.007f * distanceSquared);
 
                 colonyRotation += memberRotation;
             }


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR slightly changes the calculation of the rotation speed of multicellular organisms, reducing the decrease in rotation speed with organism size.

Why?

Currently, even small multicellular organisms rotate incredibly slowly, as if they were a heavy boulder. And setting a large number of cilia makes almost no difference. It's extremely annoying.
I decided to change this. After testing the values ​​several times, I found a happy medium. Small multicellular organisms, although rotating more slowly than single-celled eukaryotes, still rotate quickly; large multicellular organisms rotate slowly, and the effect of the cilia is much more noticeable.

This became especially relevant after 1.0.0

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).
