### PR TITLE
Make hover panel display other cells' health

### DIFF
--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -30,7 +30,6 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
 
     private const double SHOW_REVERT_POPUP_FOR = 80;
 
-    private readonly Dictionary<(string Category, LocalizedString Name), int> hoveredEntities = new();
     private readonly Dictionary<CompoundDefinition, InspectedEntityLabel> hoveredCompoundControls = new();
 
     [Export]
@@ -659,23 +658,10 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
         mouseHoverPanel.ClearEntries(FLOATING_CHUNKS_CATEGORY);
         mouseHoverPanel.ClearEntries(AGENTS_CATEGORY);
 
-        // Show the entity's name and count of hovered entities
-        hoveredEntities.Clear();
-
         foreach (var entity in stage.HoverInfo.Entities)
         {
             if (!entity.IsAliveAndHas<ReadableName>())
                 continue;
-
-            var name = entity.Get<ReadableName>().Name;
-
-            if (entity.Has<PlayerMarker>())
-            {
-                // Special handling for player
-                var label = mouseHoverPanel.AddItem(SPECIES_CATEGORY, name.ToString());
-                label.SetDescription(Localization.Translate("PLAYER"));
-                continue;
-            }
 
             string category;
 
@@ -693,17 +679,16 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
                 category = FLOATING_CHUNKS_CATEGORY;
             }
 
-            var key = (category, name);
-            hoveredEntities.TryGetValue(key, out int count);
-            hoveredEntities[key] = count + 1;
-        }
+            var item = mouseHoverPanel.AddItem(category, entity.Get<ReadableName>().Name.ToString());
 
-        foreach (var hoveredEntity in hoveredEntities)
-        {
-            var item = mouseHoverPanel.AddItem(hoveredEntity.Key.Category, hoveredEntity.Key.Name.ToString());
-
-            if (hoveredEntity.Value > 1)
-                item.SetDescription(Localization.Translate("N_TIMES").FormatSafe(hoveredEntity.Value));
+            if (entity.Has<PlayerMarker>())
+            {
+                item.SetDescription(Localization.Translate("PLAYER"));
+            }
+            else if (entity.TryGet<Health>(out var health))
+            {
+                item.SetDescription($"{MathF.Round(health.CurrentHealth, 1)}/{MathF.Round(health.MaxHealth, 1)}");
+            }
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes the hover-over panel display the health of the microbe under cursor. This should make combat a bit more transparent, because I think this information wasn't shown anywhere else before.

This PR also removes the functionality of collapsing multiple of the same items into one because it's kind of incompatible with displaying health. But in general, cases where multiple thing are under cursor should be rare enough for that to be unneeded (unlike some time before when the hover panel displayed things in a certain radius).

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
