### PR TITLE
Implemented cancelling loading of save list data

### DIFF
--- a/simulation_parameters/VisualResourceData.cs
+++ b/simulation_parameters/VisualResourceData.cs
@@ -32,6 +32,9 @@ public class VisualResourceData : IRegistryType, IResource
     [JsonIgnore]
     public bool RequiresSyncPostProcess => false;
 
+    [JsonIgnore]
+    public bool CancelRequested { get; set; }
+
     [JsonProperty]
     public float EstimatedTimeRequired { get; set; } = 0.02f;
 

--- a/src/engine/IResource.cs
+++ b/src/engine/IResource.cs
@@ -12,6 +12,14 @@ public interface IResource
     public bool RequiresSyncPostProcess { get; }
 
     /// <summary>
+    ///   Set to true if the loading of the resource is no longer desired. For example, loading save data when no
+    ///   longer relevant is cancelled to let the resource manager skip loading.
+    ///   Normal game resources may not have this set as otherwise the loading screen can get stuck waiting infinitely
+    ///   for something to complete.
+    /// </summary>
+    public bool CancelRequested { get; set; }
+
+    /// <summary>
     ///   Should estimate roughly how long loading this resource takes in the usual case. This is used to skip more
     ///   loading work if there isn't that much time budget remaining in a frame. This should be very cheap to ask,
     ///   and if not, then this should be cached by the resource type. This is the estimated time in seconds.

--- a/src/engine/ResourceManager.cs
+++ b/src/engine/ResourceManager.cs
@@ -113,6 +113,13 @@ public partial class ResourceManager : Node
         queuedResources.Add(resource);
     }
 
+    public void CancelLoad(IResource resource)
+    {
+        // TODO: the collection is a blocking one so we cannot immediately remove the resource, so for now we use
+        // this soft cancellation flag to skip most of hte work
+        resource.CancelRequested = true;
+    }
+
     public void OnStageLoadStart(MainGameState gameState)
     {
         if (!gameStateLoaded)
@@ -280,8 +287,8 @@ public partial class ResourceManager : Node
                 {
                     var resource = processingResources[i];
 
-                    // If already loaded, don't need to do anything
-                    if (resource.Loaded)
+                    // If already loaded, don't need to do anything (or if cancelled)
+                    if (resource.Loaded || resource.CancelRequested)
                     {
                         processingResources.RemoveAt(i);
                         --count;
@@ -353,6 +360,10 @@ public partial class ResourceManager : Node
             }
             else if (queuedResources.TryTake(out var queueResource, 0))
             {
+                // Early skip cancelled items
+                if (queueResource.CancelRequested)
+                    continue;
+
                 processingResources.AddToBack(queueResource);
                 hasThingsInQueue = true;
                 progressedLoading = true;

--- a/src/engine/SceneResource.cs
+++ b/src/engine/SceneResource.cs
@@ -24,6 +24,9 @@ public class SceneResource : IResource
     [JsonProperty]
     public bool RequiresSyncPostProcess { get; private set; }
 
+    [JsonIgnore]
+    public bool CancelRequested { get; set; }
+
     [JsonProperty]
     public float EstimatedTimeRequired { get; private set; } = 0.025f;
 

--- a/src/gui_common/art_gallery/TextureThumbnailResource.cs
+++ b/src/gui_common/art_gallery/TextureThumbnailResource.cs
@@ -31,6 +31,9 @@ public class TextureThumbnailResource : ITextureResource
     public bool RequiresSyncLoad => true;
     public bool UsesPostProcessing => false;
     public bool RequiresSyncPostProcess => true;
+
+    public bool CancelRequested { get; set; }
+
     public float EstimatedTimeRequired => 0.015f;
     public bool LoadingPrepared { get; set; }
     public bool Loaded { get; private set; }

--- a/src/saving/SaveListItem.cs
+++ b/src/saving/SaveListItem.cs
@@ -157,6 +157,20 @@ public partial class SaveListItem : PanelContainer
         UpdateHighlighting();
     }
 
+    public override void _ExitTree()
+    {
+        base._ExitTree();
+
+        if (loadingData || (saveInfoLoadTask != null && !saveInfoLoadTask.Loaded))
+        {
+            if (saveInfoLoadTask != null)
+            {
+                // On slower computers the save list loads can clog up the load
+                ResourceManager.Instance.CancelLoad(saveInfoLoadTask);
+            }
+        }
+    }
+
     public override void _Process(double delta)
     {
         if (!loadingData)
@@ -328,8 +342,7 @@ public partial class SaveListItem : PanelContainer
 
     private void UpdateName()
     {
-        if (saveNameLabel != null)
-            saveNameLabel.Text = saveName.Replace(Constants.SAVE_EXTENSION_WITH_DOT, string.Empty);
+        saveNameLabel?.Text = saveName.Replace(Constants.SAVE_EXTENSION_WITH_DOT, string.Empty);
     }
 
     private void LoadSavePressed()
@@ -361,10 +374,7 @@ public partial class SaveListItem : PanelContainer
 
     private void UpdateHighlighting()
     {
-        if (highlightPanel == null)
-            return;
-
-        highlightPanel.Visible = Highlighted || Selected;
+        highlightPanel?.Visible = Highlighted || Selected;
     }
 
     private void DeletePressed()
@@ -390,6 +400,9 @@ public partial class SaveListItem : PanelContainer
 
         // See the TODO comment in PerformPostProcessing
         public bool RequiresSyncPostProcess => true;
+
+        public bool CancelRequested { get; set; }
+
         public float EstimatedTimeRequired => 0.025f;
         public bool LoadingPrepared { get; set; }
         public bool Loaded { get; private set; }


### PR DESCRIPTION
Cancel load tasks when the GUI elements are closed. This should prevent the resource load queue from being filled up of saves if someone has really many and thus causing slow loading screens where saves are loaded first before the stage

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #6613

I couldn't fully test as even copy-pasting my existing saves I couldn't get the processing tiem to go so high but I at least on a basic level verified that this can skip tasks

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
