### PR TITLE
Fix location of population indicator around patch icon

### DIFF
--- a/src/microbe_stage/editor/PatchMapDrawer.cs
+++ b/src/microbe_stage/editor/PatchMapDrawer.cs
@@ -1142,10 +1142,6 @@ public partial class PatchMapDrawer : Control
                     CustomMinimumSize = new Vector2(12.0f, 12.0f),
                 };
 
-                populationIndicatorContainer.Position =
-                    new Vector2((Constants.PATCH_NODE_RECT_LENGTH + Constants.PATCH_REGION_BORDER_WIDTH / 4) / 4,
-                        (Constants.PATCH_NODE_RECT_LENGTH + Constants.PATCH_REGION_BORDER_WIDTH / 4) / 4);
-
                 populationIndicatorContainer.AddChild(lifeIndicator);
             }
         }
@@ -1158,8 +1154,9 @@ public partial class PatchMapDrawer : Control
     {
         var indexModifier = MathF.Sin(dotIndex) * 0.5f + 0.5f;
         var nodeModifier = node.Position.LengthSquared();
-        var nodeCenter = node.Position + new Vector2(Constants.PATCH_NODE_RECT_LENGTH / 2,
-            Constants.PATCH_NODE_RECT_LENGTH / 2) - new Vector2(texture.GetWidth() / 2.0f, texture.GetHeight() / 2.0f);
+        var nodeCenter = node.Position +
+            new Vector2((Constants.PATCH_NODE_RECT_LENGTH + Constants.PATCH_REGION_BORDER_WIDTH / 4) / 4,
+            (Constants.PATCH_NODE_RECT_LENGTH + Constants.PATCH_REGION_BORDER_WIDTH / 4) / 4);
 
         var offset = new Vector2(0,
             indexModifier * Constants.PATCH_LIFE_INDICATOR_RADIUS_SCALE + Constants.PATCH_LIFE_INDICATOR_RADIUS_BASE);


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR places the population indicator circle around the center of the patch icon. It was previously in the corner.

Little warning, you could say that this uses magic numbers and I'm still not _quite_ sure that it's _perfectly_ centered.

**Related Issues**

Closes #6676

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
