### PR TITLE
Fixed population indicator circle offset

### DIFF
--- a/src/microbe_stage/editor/PatchMapDrawer.cs
+++ b/src/microbe_stage/editor/PatchMapDrawer.cs
@@ -1136,7 +1136,7 @@ public partial class PatchMapDrawer : Control
                 var lifeIndicator = new TextureRect
                 {
                     Texture = IndicatorTexture,
-                    Position = GetIndicatorPosition(node, i, IndicatorTexture),
+                    Position = GetIndicatorPosition(node, i, 12.0f),
                     MouseFilter = MouseFilterEnum.Ignore,
                     ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize,
                     CustomMinimumSize = new Vector2(12.0f, 12.0f),
@@ -1150,12 +1150,14 @@ public partial class PatchMapDrawer : Control
         nodes.Add(node.Patch, node);
     }
 
-    private Vector2 GetIndicatorPosition(PatchMapNode node, int dotIndex, Texture2D texture)
+    private Vector2 GetIndicatorPosition(PatchMapNode node, int dotIndex, float dotSize)
     {
+        var halfDotSize = dotSize * 0.5f;
+
         var indexModifier = MathF.Sin(dotIndex) * 0.5f + 0.5f;
         var nodeModifier = node.Position.LengthSquared();
         var nodeCenter = node.Position + new Vector2(Constants.PATCH_NODE_RECT_LENGTH / 2,
-            Constants.PATCH_NODE_RECT_LENGTH / 2) - new Vector2(texture.GetWidth() / 2.0f, texture.GetHeight() / 2.0f);
+            Constants.PATCH_NODE_RECT_LENGTH / 2) - new Vector2(halfDotSize, halfDotSize);
 
         var offset = new Vector2(0,
             indexModifier * Constants.PATCH_LIFE_INDICATOR_RADIUS_SCALE + Constants.PATCH_LIFE_INDICATOR_RADIUS_BASE);


### PR DESCRIPTION
which was caused by using the texture size to offset them which was way too high now with the new higher resolution texture

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #6676

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
