### PR TITLE
Fixed editor ready flag being set too early

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -703,7 +703,7 @@ public partial class CellEditorComponent :
                 }
             }
         }
-        else
+        else if (Editor.EditorReady)
         {
             CheckRunningAutoEvoPrediction();
         }


### PR DESCRIPTION
**Brief Description of What This PR Does**

and fixed auto-evo run prediction checks being enabled before ready is set, which caused an error about player previous energy being unavailable

This doesn't hopefully have the ability to break anything, but testing would be nice. As basically the only thing that could go wrong is that the scene transition system would fail and never call our callback thus softlocking the game.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Editor printing error about player previous energy not being set (due to a method running too early due to the wrong step)

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
