### PR TITLE
Skip rebuilding evolutionary tree if it is not visible

### DIFF
--- a/src/thriveopedia/pages/ThriveopediaEvolutionaryTreePage.cs
+++ b/src/thriveopedia/pages/ThriveopediaEvolutionaryTreePage.cs
@@ -53,6 +53,13 @@ public partial class ThriveopediaEvolutionaryTreePage : ThriveopediaPage, IThriv
         if (CurrentGame == null)
             return;
 
+        // Do not rebuild the tree if we are not showing it as this causes extra lag upon loading a save
+        if (!IsVisibleInTree())
+        {
+            GD.Print("Skipping evolutionary tree rebuild as not visible in tree");
+            return;
+        }
+
         RebuildTree();
     }
 


### PR DESCRIPTION
as that made loading saves with really long evolutionary histories take extra time after loading for no real reason

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Fixes extra second of so or lag that I noticed when loading a save with really long evolutionary history

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
