### PR TITLE
Cap all individual edits to 100 MP at most

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1122,6 +1122,11 @@ public static class Constants
     public const int BASE_MUTATION_POINTS = 100;
 
     /// <summary>
+    ///   Used to limit single edit costs to allow doing them even at double the MP cost.
+    /// </summary>
+    public const int MAX_SINGLE_EDIT_MP_COST = 100;
+
+    /// <summary>
     ///   As mutation points are now calculated with floats, there can be situations where the player just barely
     ///   cannot afford something they should be able to afford, so we allow going negative by this much.
     /// </summary>
@@ -1133,6 +1138,8 @@ public static class Constants
 
     public const int ORGANELLE_REMOVE_COST = 10;
     public const int ORGANELLE_MOVE_COST = 5;
+
+    public const int CELL_REMOVE_COST = 5;
 
     public const string ORGANELLE_UPGRADE_SPECIAL_NONE = "none";
 

--- a/src/general/mutation_points/SpeciesComparer.cs
+++ b/src/general/mutation_points/SpeciesComparer.cs
@@ -5,14 +5,15 @@
 /// </summary>
 public static class SpeciesComparer
 {
-    public static double GetRequiredMutationPoints(IReadOnlySpecies speciesA, IReadOnlySpecies speciesB)
+    public static double GetRequiredMutationPoints(IReadOnlySpecies speciesA, IReadOnlySpecies speciesB,
+        double maxSingleActionCost, double costMultiplier = 1)
     {
         // Behaviour comparison once it costs MP
         // speciesA.Behaviour
 
         double cost = 0;
 
-        cost += CalculateToleranceCost(speciesA.Tolerances, speciesB.Tolerances);
+        cost += CalculateToleranceCost(speciesA.Tolerances, speciesB.Tolerances, maxSingleActionCost, costMultiplier);
 
         // Apparently there are no other base species changes that cost MP currently...
 
@@ -20,7 +21,7 @@ public static class SpeciesComparer
     }
 
     public static double CalculateToleranceCost(IReadOnlyEnvironmentalTolerances oldTolerances,
-        IReadOnlyEnvironmentalTolerances newTolerances)
+        IReadOnlyEnvironmentalTolerances newTolerances, double maxSingleActionCost, double costMultiplier = 1)
     {
         // Calculate all changes
         var temperatureChange = Math.Abs(oldTolerances.PreferredTemperature - newTolerances.PreferredTemperature);
@@ -44,11 +45,18 @@ public static class SpeciesComparer
         var pressureToleranceChange = Math.Abs(oldRange - newRange);
 
         // Then add up the costs based on the changes
-        return temperatureChange * Constants.TOLERANCE_CHANGE_MP_PER_TEMPERATURE +
-            temperatureToleranceChange * Constants.TOLERANCE_CHANGE_MP_PER_TEMPERATURE_TOLERANCE +
-            totalPressureChangeAverage * Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE +
-            pressureToleranceChange * Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE_TOLERANCE +
-            oxygenChange * Constants.TOLERANCE_CHANGE_MP_PER_OXYGEN +
-            uvChange * Constants.TOLERANCE_CHANGE_MP_PER_UV;
+        // TODO: this can't apply the max single action cost as otherwise *all* tolerance changes could be done at once
+        // as long as the player sacrificed all of their MP to do it. To fix this we would need to make it so that a
+        // single slider step is clamped to the max cost and then that is multiplied with the change. We don't know
+        // the slider steps here so for now we can't do that. But we need the parameter to be able to implement that
+        // in the future.
+        _ = maxSingleActionCost;
+
+        return temperatureChange * Constants.TOLERANCE_CHANGE_MP_PER_TEMPERATURE * costMultiplier +
+            temperatureToleranceChange * Constants.TOLERANCE_CHANGE_MP_PER_TEMPERATURE_TOLERANCE * costMultiplier +
+            totalPressureChangeAverage * Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE * costMultiplier +
+            pressureToleranceChange * Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE_TOLERANCE * costMultiplier +
+            oxygenChange * Constants.TOLERANCE_CHANGE_MP_PER_OXYGEN * costMultiplier +
+            uvChange * Constants.TOLERANCE_CHANGE_MP_PER_UV * costMultiplier;
     }
 }

--- a/src/macroscopic_stage/editor/MacroscopicEditor.cs
+++ b/src/macroscopic_stage/editor/MacroscopicEditor.cs
@@ -331,7 +331,8 @@ public partial class MacroscopicEditor : EditorBase<EditorAction, MacroscopicSta
 
         editsFacade.SetActiveActions(performedActionData);
 
-        return speciesComparer.Compare(editedSpecies!, editsFacade) * CurrentGame.GameWorld.WorldSettings.MPMultiplier;
+        return speciesComparer.Compare(editedSpecies!, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST,
+            CurrentGame.GameWorld.WorldSettings.MPMultiplier);
     }
 
     protected override GameProperties StartNewGameForEditor()

--- a/src/macroscopic_stage/editor/MetaballBodyEditorComponent.cs
+++ b/src/macroscopic_stage/editor/MetaballBodyEditorComponent.cs
@@ -374,7 +374,12 @@ public partial class MetaballBodyEditorComponent :
         var cellType = CellTypeFromName(activeActionName);
 
         if (MouseHoverPositions == null)
-            return Constants.METABALL_ADD_COST * Symmetry.PositionCount();
+        {
+            var costMultiplier = Editor.CurrentGame.GameWorld.WorldSettings.MPMultiplier;
+
+            return Math.Min(Constants.METABALL_ADD_COST * costMultiplier, Constants.MAX_SINGLE_EDIT_MP_COST) *
+                Symmetry.PositionCount();
+        }
 
         var positions = MouseHoverPositions.ToList();
 
@@ -883,7 +888,7 @@ public partial class MetaballBodyEditorComponent :
                     new Callable(this, nameof(OnCellToPlaceSelected)));
             }
 
-            control.MPCost = Constants.METABALL_ADD_COST * costMultiplier;
+            control.MPCost = Math.Min(Constants.METABALL_ADD_COST * costMultiplier, Constants.MAX_SINGLE_EDIT_MP_COST);
 
             // TODO: remove this line after ATP balance calculations are implemented for this editor
             control.ShowInsufficientATPWarning = false;

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -358,6 +358,9 @@ public partial class CellEditorComponent
 
     private void CreateUndiscoveredOrganellesButtons(bool refresh = false, bool autoUnlock = true)
     {
+        if (allPartSelectionElements.Count < 1)
+            GD.PrintErr("Create undiscovered organelles buttons is called too early");
+
         // Note that if autoUnlock is true and this is called after the editor is initialized there's a potential
         // logic conflict with UndoEndosymbiontPlaceAction in case we ever decide to allow organelle actions to also
         // occur after entering the editor (other than endosymbiosis unlocks)
@@ -488,10 +491,13 @@ public partial class CellEditorComponent
     /// </summary>
     private void UpdateMPCost()
     {
+        if (placeablePartSelectionElements.Count < 1 || membraneSelectionElements.Count < 1)
+            GD.PrintErr("Cannot update MP cost tooltips as they are not initialised");
+
         // Set the cost factor for each organelle button
         foreach (var entry in placeablePartSelectionElements)
         {
-            var cost = (int)Math.Min(entry.Key.MPCost * CostMultiplier, 100);
+            var cost = (int)Math.Min(entry.Key.MPCost * CostMultiplier, Constants.MAX_SINGLE_EDIT_MP_COST);
 
             entry.Value.MPCost = cost;
 
@@ -503,7 +509,7 @@ public partial class CellEditorComponent
         // Set the cost factor for each membrane button
         foreach (var entry in membraneSelectionElements)
         {
-            var cost = (int)Math.Min(entry.Key.EditorCost * CostMultiplier, 100);
+            var cost = (int)Math.Min(entry.Key.EditorCost * CostMultiplier, Constants.MAX_SINGLE_EDIT_MP_COST);
 
             entry.Value.MPCost = cost;
 
@@ -515,7 +521,8 @@ public partial class CellEditorComponent
         // Set the cost factor for the rigidity tooltip
         var rigidityTooltip = GetSelectionTooltip("rigiditySlider", "editor");
         rigidityTooltip?.MutationPointCost =
-            (int)Math.Min(Constants.MEMBRANE_RIGIDITY_COST_PER_STEP * CostMultiplier, 100);
+            (int)Math.Min(Constants.MEMBRANE_RIGIDITY_COST_PER_STEP * CostMultiplier,
+                Constants.MAX_SINGLE_EDIT_MP_COST);
 
         tolerancesEditor.MPDisplayCostMultiplier = CostMultiplier;
         tolerancesEditor.UpdateMPCostInToolTips();
@@ -611,14 +618,15 @@ public partial class CellEditorComponent
         foreach (var entry in placeablePartSelectionElements)
         {
             entry.Value.PartName = entry.Key.Name;
-            entry.Value.MPCost = (int)(entry.Key.MPCost * CostMultiplier);
+            entry.Value.MPCost = (int)Math.Min(entry.Key.MPCost * CostMultiplier, Constants.MAX_SINGLE_EDIT_MP_COST);
             entry.Value.PartIcon = entry.Key.LoadedIcon;
         }
 
         foreach (var entry in membraneSelectionElements)
         {
             entry.Value.PartName = entry.Key.Name;
-            entry.Value.MPCost = (int)(entry.Key.EditorCost * CostMultiplier);
+            entry.Value.MPCost =
+                (int)Math.Min(entry.Key.EditorCost * CostMultiplier, Constants.MAX_SINGLE_EDIT_MP_COST);
             entry.Value.PartIcon = entry.Key.LoadedIcon;
         }
     }

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -555,8 +555,6 @@ public partial class CellEditorComponent :
         cytoplasm = SimulationParameters.Instance.GetOrganelleType("cytoplasm");
         chemoSynthesizingProteins = SimulationParameters.Instance.GetOrganelleType("chemoSynthesizingProteins");
 
-        SetupMicrobePartSelections();
-
         ApplySelectionMenuTab();
         RegisterTooltips();
     }
@@ -580,6 +578,9 @@ public partial class CellEditorComponent :
             // Endosymbiosis is not managed through this component in multicellular
             endosymbiosisButton.Visible = false;
         }
+
+        // These tooltip updates are now here as they take current effective MP costs into account to write into them
+        SetupMicrobePartSelections();
 
         // Visual simulation is needed very early when loading a save
         previewSimulation = new MicrobeVisualOnlySimulation();
@@ -992,6 +993,7 @@ public partial class CellEditorComponent :
         CalculateEnergyAndCompoundBalance(properties.ModifiableOrganelles.Organelles, properties.MembraneType,
             Editor.CurrentPatch.Biome);
 
+        // Checking unlock conditions can happen safely only after the selection buttons are set up
         UpdateOrganelleUnlockTooltips(true);
 
         UpdateGUIAfterLoadingSpecies(Editor.EditedBaseSpecies);
@@ -2689,10 +2691,10 @@ public partial class CellEditorComponent :
             control.PartIcon = organelle.LoadedIcon ?? throw new Exception("Organelle with no icon");
             control.PartName = organelle.UntranslatedName;
             control.SelectionGroup = organelleButtonGroup;
-            control.MPCost = organelle.MPCost;
+            control.MPCost = Math.Min(organelle.MPCost * CostMultiplier, Constants.MAX_SINGLE_EDIT_MP_COST);
             control.Name = organelle.InternalName;
 
-            // Special case with registering the tooltip here for item with no associated organelle
+            // Special case with registering the tooltip here for an item with no associated organelle
             control.RegisterToolTipForControl(organelle.InternalName, "organelleSelection");
 
             group.AddItem(control);
@@ -2702,7 +2704,7 @@ public partial class CellEditorComponent :
             if (organelle.Unimplemented)
                 continue;
 
-            // Only add items with valid organelles to dictionary
+            // Only add items with valid organelles to the dictionary
             placeablePartSelectionElements.Add(organelle, control);
 
             control.Connect(MicrobePartSelection.SignalName.OnPartSelected,
@@ -2715,7 +2717,7 @@ public partial class CellEditorComponent :
             control.PartIcon = membraneType.LoadedIcon;
             control.PartName = membraneType.UntranslatedName;
             control.SelectionGroup = membraneButtonGroup;
-            control.MPCost = membraneType.EditorCost;
+            control.MPCost = Math.Min(membraneType.EditorCost * CostMultiplier, Constants.MAX_SINGLE_EDIT_MP_COST);
             control.Name = membraneType.InternalName;
 
             control.RegisterToolTipForControl(membraneType.InternalName, "membraneSelection");

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -421,7 +421,10 @@ public partial class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEd
 
         editsFacade.SetActiveActions(performedActionData);
 
-        return speciesComparer.Compare(editedSpecies!, editsFacade) * CurrentGame.GameWorld.WorldSettings.MPMultiplier;
+        // This doesn't use the cell editor CostMultiplier as this cost is purely used in the microbe stage, so we
+        //  don't need to apply the additional considerations on top of this
+        return speciesComparer.Compare(editedSpecies!, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST,
+            CurrentGame.GameWorld.WorldSettings.MPMultiplier);
     }
 
     protected override GameProperties StartNewGameForEditor()

--- a/src/microbe_stage/editor/upgrades/OrganelleUpgradeGUI.cs
+++ b/src/microbe_stage/editor/upgrades/OrganelleUpgradeGUI.cs
@@ -109,7 +109,7 @@ public partial class OrganelleUpgradeGUI : Control
 
                 var data = new OrganelleUpgradeActionData(oldUpgrade, newUpgrade, organelle);
 
-                var cost = editorData.WhatWouldActionsCost(new[] { data });
+                var cost = editorData.WhatWouldActionsCost([data]);
 
                 selectionButton.Name = availableUpgrade.Key;
                 selectionButton.SelectionGroup = generalUpgradeButtonGroup;
@@ -139,14 +139,9 @@ public partial class OrganelleUpgradeGUI : Control
                 generalUpgradeSelectorButtons[availableUpgrade.Key] = selectionButton;
             }
 
-            if (organelle.Upgrades != null)
-            {
-                currentlySelectedGeneralUpgrades = new List<string>(organelle.Upgrades.UnlockedFeatures);
-            }
-            else
-            {
-                currentlySelectedGeneralUpgrades = new List<string>();
-            }
+            currentlySelectedGeneralUpgrades = organelle.Upgrades != null ?
+                new List<string>(organelle.Upgrades.UnlockedFeatures) :
+                new List<string>();
 
             UpdateSelectedUpgradeButton();
 

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -1013,7 +1013,8 @@ public partial class CellBodyPlanEditorComponent :
                 }
 
                 tooltip.Name = cellType.CellTypeName;
-                tooltip.MutationPointCost = GetEditedCellDataIfEdited(cellType).MPCost * costMultiplier;
+                tooltip.MutationPointCost = Math.Min(GetEditedCellDataIfEdited(cellType).MPCost * costMultiplier,
+                    Constants.MAX_SINGLE_EDIT_MP_COST);
 
                 control.RegisterToolTipForControl(tooltip, true);
             }
@@ -1022,10 +1023,12 @@ public partial class CellBodyPlanEditorComponent :
                 var tooltip = ToolTipManager.Instance.GetToolTipIfExists<CellTypeTooltip>(cellType.CellTypeName,
                     "cellTypes");
 
-                tooltip?.MutationPointCost = GetEditedCellDataIfEdited(cellType).MPCost * costMultiplier;
+                tooltip?.MutationPointCost = Math.Min(GetEditedCellDataIfEdited(cellType).MPCost * costMultiplier,
+                    Constants.MAX_SINGLE_EDIT_MP_COST);
             }
 
-            control.MPCost = GetEditedCellDataIfEdited(cellType).MPCost * costMultiplier;
+            control.MPCost = Math.Min(GetEditedCellDataIfEdited(cellType).MPCost * costMultiplier,
+                Constants.MAX_SINGLE_EDIT_MP_COST);
         }
 
         bool clearSelection = false;
@@ -1114,7 +1117,8 @@ public partial class CellBodyPlanEditorComponent :
             environmentalTolerances);
 
         tooltip.DisplayName = cellType.CellTypeName;
-        tooltip.MutationPointCost = cellType.MPCost * Editor.CurrentGame.GameWorld.WorldSettings.MPMultiplier;
+        tooltip.MutationPointCost = Math.Min(cellType.MPCost * Editor.CurrentGame.GameWorld.WorldSettings.MPMultiplier,
+            Constants.MAX_SINGLE_EDIT_MP_COST);
         tooltip.DisplayCellTypeBalances(balances);
         tooltip.UpdateATPBalance(energyBalance.TotalProduction, energyBalance.TotalConsumption);
 
@@ -1640,7 +1644,8 @@ public partial class CellBodyPlanEditorComponent :
                 GD.Print($"First edit of cell type {type.CellTypeName}");
                 var control = entry.Value;
                 control.CellType = newType;
-                control.MPCost = newType.MPCost * Editor.CurrentGame.GameWorld.WorldSettings.MPMultiplier;
+                control.MPCost = Math.Min(newType.MPCost * Editor.CurrentGame.GameWorld.WorldSettings.MPMultiplier,
+                    Constants.MAX_SINGLE_EDIT_MP_COST);
 
                 // Name shouldn't be able to change here
 
@@ -1648,7 +1653,9 @@ public partial class CellBodyPlanEditorComponent :
                 var tooltip = ToolTipManager.Instance.GetToolTipIfExists<CellTypeTooltip>(newType.CellTypeName,
                     "cellTypes");
 
-                tooltip?.MutationPointCost = newType.MPCost * Editor.CurrentGame.GameWorld.WorldSettings.MPMultiplier;
+                tooltip?.MutationPointCost =
+                    Math.Min(newType.MPCost * Editor.CurrentGame.GameWorld.WorldSettings.MPMultiplier,
+                        Constants.MAX_SINGLE_EDIT_MP_COST);
 
                 control.ReportTypeChanged();
             }

--- a/src/multicellular_stage/editor/MulticellularEditor.cs
+++ b/src/multicellular_stage/editor/MulticellularEditor.cs
@@ -392,7 +392,8 @@ public partial class MulticellularEditor : EditorBase<EditorAction, MicrobeStage
 
         editsFacade.SetActiveActions(performedActionData);
 
-        return speciesComparer.Compare(editedSpecies!, editsFacade) * CurrentGame.GameWorld.WorldSettings.MPMultiplier;
+        return speciesComparer.Compare(editedSpecies!, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST,
+            CurrentGame.GameWorld.WorldSettings.MPMultiplier);
     }
 
     protected override GameProperties StartNewGameForEditor()

--- a/test/code_tests/MacroscopicStage.Tests/MetaballEditorTests.cs
+++ b/test/code_tests/MacroscopicStage.Tests/MetaballEditorTests.cs
@@ -66,7 +66,8 @@ public class MetaballEditorTests
             _ => { }, _ => { }, resizeActionData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.METABALL_RESIZE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.METABALL_RESIZE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var removeData =
             new MetaballRemoveActionData<MacroscopicMetaball>(metaball, null);
@@ -75,7 +76,8 @@ public class MetaballEditorTests
             new SingleEditorAction<MetaballRemoveActionData<MacroscopicMetaball>>(_ => { }, _ => { }, removeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.METABALL_REMOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.METABALL_REMOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -103,7 +105,8 @@ public class MetaballEditorTests
             moveActionData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.METABALL_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.METABALL_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var removeData =
             new MetaballRemoveActionData<MacroscopicMetaball>(metaball, null);
@@ -113,7 +116,8 @@ public class MetaballEditorTests
 
         // Deleting cancels the move cost, results in just removal cost
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.METABALL_REMOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.METABALL_REMOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -140,7 +144,8 @@ public class MetaballEditorTests
             placementData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.METABALL_ADD_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.METABALL_ADD_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var removeData = new MetaballRemoveActionData<MacroscopicMetaball>(metaball, null);
 
@@ -149,7 +154,7 @@ public class MetaballEditorTests
 
         // Adding and then removing should result in 0 net cost (full refund)
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     private void ApplyFacadeEdits(MacroscopicEditsFacade facade, EditorActionHistory<EditorAction> history)

--- a/test/code_tests/MicrobeStage.Tests/EditorMPTests.cs
+++ b/test/code_tests/MicrobeStage.Tests/EditorMPTests.cs
@@ -111,7 +111,7 @@ public class EditorMPTests
         var history = new EditorActionHistory<EditorAction>();
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -134,7 +134,8 @@ public class EditorMPTests
         Assert.False(undo);
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -163,7 +164,8 @@ public class EditorMPTests
         Assert.NotEqual(Constants.ORGANELLE_REMOVE_COST, cheapOrganelle.MPCost);
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_REMOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_REMOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -187,7 +189,8 @@ public class EditorMPTests
         Assert.False(undo);
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -212,7 +215,8 @@ public class EditorMPTests
         Assert.False(undo);
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var moveData = new OrganelleMoveActionData(template, new Hex(0, 0), new Hex(1, 0), 0, 0);
 
@@ -220,7 +224,8 @@ public class EditorMPTests
             new SingleEditorAction<OrganelleMoveActionData>(_ => redo = true, _ => undo = true, moveData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -238,7 +243,8 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, actionData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var removeData =
             new OrganelleRemoveActionData(organelle, new Hex(0, 0), 0);
@@ -246,7 +252,7 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, removeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -264,7 +270,8 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, actionData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var moveData = new OrganelleMoveActionData(template, new Hex(0, 0), new Hex(1, 0), 0, 0);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
@@ -274,7 +281,7 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, removeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -291,7 +298,8 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, actionData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var moveData = new OrganelleMoveActionData(template, new Hex(0, 0), new Hex(1, 0), 0, 0);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
@@ -303,14 +311,15 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleUpgradeActionData>(_ => { }, _ => { }, upgradeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost + TEST_UPGRADE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost + TEST_UPGRADE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var removeData =
             new OrganelleRemoveActionData(template, new Hex(1, 0), 0);
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, removeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -326,14 +335,16 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var removeData =
             new OrganelleRemoveActionData(template, new Hex(1, 0), 0);
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, removeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_REMOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_REMOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -351,14 +362,14 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<EndosymbiontPlaceActionData>(_ => { }, _ => { }, endosymbiontData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var removeData =
             new OrganelleRemoveActionData(template, new Hex(0, 0), 0);
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, removeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -376,20 +387,20 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<EndosymbiontPlaceActionData>(_ => { }, _ => { }, endosymbiontData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var moveData = new OrganelleMoveActionData(template, new Hex(0, 0), new Hex(1, 0), 0, 0);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var removeData =
             new OrganelleRemoveActionData(template, new Hex(1, 0), 0);
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, removeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -410,7 +421,8 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleUpgradeActionData>(_ => { }, _ => { }, upgradeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(TEST_UPGRADE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(TEST_UPGRADE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var upgrades2 = new OrganelleUpgrades
         {
@@ -420,7 +432,8 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleUpgradeActionData>(_ => { }, _ => { }, upgradeData2));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(TEST_UPGRADE_COST + TEST_UPGRADE_COST_2, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(TEST_UPGRADE_COST + TEST_UPGRADE_COST_2,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -441,7 +454,8 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleUpgradeActionData>(_ => { }, _ => { }, upgradeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(TEST_UPGRADE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(TEST_UPGRADE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var upgrades2 = new OrganelleUpgrades
         {
@@ -451,7 +465,8 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleUpgradeActionData>(_ => { }, _ => { }, upgradeData2));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(TEST_UPGRADE_COST_2, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(TEST_UPGRADE_COST_2,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -474,13 +489,14 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleUpgradeActionData>(_ => { }, _ => { }, upgradeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(TEST_UPGRADE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(TEST_UPGRADE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var upgradeData2 = new OrganelleUpgradeActionData(upgrades1, noUpgrades, template);
         history.AddAction(new SingleEditorAction<OrganelleUpgradeActionData>(_ => { }, _ => { }, upgradeData2));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var upgrades2 = new OrganelleUpgrades
         {
@@ -490,7 +506,8 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleUpgradeActionData>(_ => { }, _ => { }, upgradeData3));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(TEST_UPGRADE_COST_2, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(TEST_UPGRADE_COST_2,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -506,13 +523,14 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, removeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_REMOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_REMOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var actionData = new OrganellePlacementActionData(template, new Hex(0, 0), 0);
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, actionData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -528,19 +546,21 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, removeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_REMOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_REMOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var actionData = new OrganellePlacementActionData(template, new Hex(0, 0), 0);
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, actionData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var moveData = new OrganelleMoveActionData(template, new Hex(0, 0), new Hex(1, 0), 0, 0);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -556,19 +576,21 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, placementData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var removeData = new OrganelleRemoveActionData(template, new Hex(0, 0), 0);
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, removeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var placementData2 = new OrganellePlacementActionData(template, new Hex(0, 0), 0);
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, placementData2));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -589,19 +611,21 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleUpgradeActionData>(_ => { }, _ => { }, upgradeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(TEST_UPGRADE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(TEST_UPGRADE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var removeData = new OrganelleRemoveActionData(template, new Hex(0, 0), 0);
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, removeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_REMOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_REMOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var placementData = new OrganellePlacementActionData(template, new Hex(0, 0), 0);
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, placementData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var upgrades2 = new OrganelleUpgrades
         {
@@ -611,7 +635,8 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleUpgradeActionData>(_ => { }, _ => { }, upgradeData2));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(TEST_UPGRADE_COST_2, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(TEST_UPGRADE_COST_2,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -626,7 +651,8 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, placementData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(dummyCytoplasm.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(dummyCytoplasm.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var template2 = new OrganelleTemplate(cheapOrganelle, new Hex(0, 0), 0);
         var actionData =
@@ -643,7 +669,8 @@ public class EditorMPTests
             new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, actionData)));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -658,13 +685,15 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, placementData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(dummyCytoplasm.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(dummyCytoplasm.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var moveData = new OrganelleMoveActionData(template1, new Hex(0, 0), new Hex(1, 0), 0, 0);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(dummyCytoplasm.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(dummyCytoplasm.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var template2 = new OrganelleTemplate(cheapOrganelle, new Hex(1, 0), 0);
 
@@ -681,7 +710,8 @@ public class EditorMPTests
             new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, actionData)));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -698,7 +728,8 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var template2 = new OrganelleTemplate(cheapOrganelle, new Hex(2, 1), 0);
 
@@ -715,7 +746,8 @@ public class EditorMPTests
             new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, actionData)));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -731,14 +763,16 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var template2 = new OrganelleTemplate(cheapOrganelle, new Hex(0, 0), 0);
         var actionData = new OrganellePlacementActionData(template2, new Hex(0, 0), 0);
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, actionData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -753,13 +787,14 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var moveData2 = new OrganelleMoveActionData(template, new Hex(1, 0), new Hex(0, 0), 0, 0);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData2));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -774,19 +809,21 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var moveData2 = new OrganelleMoveActionData(template, new Hex(1, 0), new Hex(0, 0), 0, 0);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData2));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var moveData3 = new OrganelleMoveActionData(template, new Hex(0, 0), new Hex(2, 0), 0, 0);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData3));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -803,7 +840,8 @@ public class EditorMPTests
         Assert.True(changeCost1 > 0.01f);
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(changeCost1, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(changeCost1,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var rigidityAction2 = new RigidityActionData(0.3f, 0.2f);
         history.AddAction(new SingleEditorAction<RigidityActionData>(_ => { }, _ => { }, rigidityAction2));
@@ -812,13 +850,14 @@ public class EditorMPTests
         Assert.True(totalCost > changeCost1);
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(totalCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(totalCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var rigidityAction3 = new RigidityActionData(0.0f, 0.3f);
         history.AddAction(new SingleEditorAction<RigidityActionData>(_ => { }, _ => { }, rigidityAction3));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -835,7 +874,8 @@ public class EditorMPTests
         Assert.True(changeCost1 > 0.01f);
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(changeCost1, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(changeCost1,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var rigidityAction2 = new RigidityActionData(0.3f, 0.2f);
         history.AddAction(new SingleEditorAction<RigidityActionData>(_ => { }, _ => { }, rigidityAction2));
@@ -844,21 +884,24 @@ public class EditorMPTests
         Assert.True(totalCost > changeCost1);
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(totalCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(totalCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var moveAction = new OrganelleMoveActionData(new OrganelleTemplate(cheapOrganelle, new Hex(0, 0), 0),
             new Hex(0, 0), new Hex(1, 0), 0, 0);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveAction));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(totalCost + Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(totalCost + Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         // Then back to 0 to have full MP remaining
         var rigidityAction3 = new RigidityActionData(0.0f, 0.3f);
         history.AddAction(new SingleEditorAction<RigidityActionData>(_ => { }, _ => { }, rigidityAction3));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         // Undo the move
         var moveAction2 = new OrganelleMoveActionData(new OrganelleTemplate(cheapOrganelle, new Hex(0, 0), 0),
@@ -866,7 +909,7 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveAction2));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         // And once more up to check a more complex combine
         var rigidityAction4 = new RigidityActionData(0.2f, 0.0f);
@@ -874,7 +917,8 @@ public class EditorMPTests
 
         var changeCost4 = MicrobeSpeciesComparer.CalculateRigidityCost(0.2f, 0);
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(changeCost4, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(changeCost4,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     // TODO: implement a test for custom upgrade data changing and having an MP cost once that is supported
@@ -889,24 +933,27 @@ public class EditorMPTests
         var membraneAction1 = new MembraneActionData(originalMembrane, testMembrane1);
         history.AddAction(new SingleEditorAction<MembraneActionData>(_ => { }, _ => { }, membraneAction1));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(TEST_MEMBRANE_COST_1, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(TEST_MEMBRANE_COST_1,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var membraneAction2 = new MembraneActionData(testMembrane1, testMembrane2);
         history.AddAction(new SingleEditorAction<MembraneActionData>(_ => { }, _ => { }, membraneAction2));
         ApplyFacadeEdits(editsFacade, history);
         Assert.True(TEST_MEMBRANE_COST_1 != TEST_MEMBRANE_COST_2);
-        Assert.Equal(TEST_MEMBRANE_COST_2, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(TEST_MEMBRANE_COST_2,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var membraneAction3 = new MembraneActionData(testMembrane2, testMembrane3);
         history.AddAction(new SingleEditorAction<MembraneActionData>(_ => { }, _ => { }, membraneAction3));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(TEST_MEMBRANE_COST_3, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(TEST_MEMBRANE_COST_3,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         // And back to the original
         var membraneAction4 = new MembraneActionData(testMembrane3, originalMembrane);
         history.AddAction(new SingleEditorAction<MembraneActionData>(_ => { }, _ => { }, membraneAction4));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         // Make sure they didn't all combine and cause that way the test to pass
         Assert.True(history.Undo());
@@ -928,13 +975,15 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var removeData = new OrganelleRemoveActionData(template, new Hex(1, 0), 0);
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, removeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_REMOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_REMOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var template2 = new OrganelleTemplate(cheapOrganelle, new Hex(1, 0), 0);
         var actionData = new OrganellePlacementActionData(template2, new Hex(0, 0), 0);
@@ -942,13 +991,14 @@ public class EditorMPTests
 
         // Added back at the same position, so this is free with the new fully working refunds
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         moveData = new OrganelleMoveActionData(template2, new Hex(0, 0), new Hex(1, 0), 0, 0);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -963,7 +1013,8 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, actionData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var moveData = new OrganelleMoveActionData(template, new Hex(0, 0), new Hex(1, 0), 0, 0);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
@@ -972,7 +1023,7 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, removeData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         // Adding it back after a delete operation
         var template2 = new OrganelleTemplate(cheapOrganelle, new Hex(1, 0), 0);
@@ -980,20 +1031,22 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, actionData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         moveData = new OrganelleMoveActionData(template2, new Hex(1, 0), new Hex(2, 0), 0, 0);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         removeData = new OrganelleRemoveActionData(template2, new Hex(2, 0), 0);
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, removeData));
 
         // Fully refunded with the new system
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -1007,7 +1060,7 @@ public class EditorMPTests
 
         Assert.Equal(originalSpecies.Tolerances, initialTolerances);
 
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         // Do some tolerance edits to get down to 0 MP left
         var changedTolerances1 = initialTolerances.Clone();
@@ -1017,35 +1070,44 @@ public class EditorMPTests
         var toleranceData1 = new ToleranceActionData(initialTolerances, changedTolerances1);
         history.AddAction(new SingleEditorAction<ToleranceActionData>(_ => { }, _ => { }, toleranceData1));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances1),
-            speciesComparer.Compare(originalSpecies, editsFacade));
-        Assert.True(SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances1) > 5);
+        Assert.Equal(SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances1,
+                Constants.MAX_SINGLE_EDIT_MP_COST),
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
+        Assert.True(SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances1,
+            Constants.MAX_SINGLE_EDIT_MP_COST) > 5);
 
         var changedTolerances2 = changedTolerances1.Clone();
         changedTolerances2.TemperatureTolerance += 5;
         changedTolerances2.OxygenResistance = 0.1f;
 
-        Assert.Equal(SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances2),
-            SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances1) +
-            SpeciesComparer.CalculateToleranceCost(changedTolerances1, changedTolerances2));
+        Assert.Equal(SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances2,
+                Constants.MAX_SINGLE_EDIT_MP_COST),
+            SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances1,
+                Constants.MAX_SINGLE_EDIT_MP_COST) +
+            SpeciesComparer.CalculateToleranceCost(changedTolerances1, changedTolerances2,
+                Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var toleranceData2 = new ToleranceActionData(changedTolerances1, changedTolerances2);
         history.AddAction(new SingleEditorAction<ToleranceActionData>(_ => { }, _ => { }, toleranceData2));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances1) +
-            SpeciesComparer.CalculateToleranceCost(changedTolerances1, changedTolerances2),
-            speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances1,
+                Constants.MAX_SINGLE_EDIT_MP_COST) +
+            SpeciesComparer.CalculateToleranceCost(changedTolerances1, changedTolerances2,
+                Constants.MAX_SINGLE_EDIT_MP_COST),
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var changedTolerances3 = changedTolerances2.Clone();
         changedTolerances3.TemperatureTolerance += 5;
 
         for (int i = 0; i < 1000; ++i)
         {
-            if (SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances3) >=
+            if (SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances3,
+                    Constants.MAX_SINGLE_EDIT_MP_COST) >=
                 Constants.BASE_MUTATION_POINTS)
             {
                 // If overshot
-                if (SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances3) >
+                if (SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances3,
+                        Constants.MAX_SINGLE_EDIT_MP_COST) >
                     Constants.BASE_MUTATION_POINTS + 0.01)
                 {
                     Assert.Fail("Logic overshoot in MP consuming action creation");
@@ -1061,9 +1123,11 @@ public class EditorMPTests
         var toleranceData3 = new ToleranceActionData(changedTolerances2, changedTolerances3);
         history.AddAction(new SingleEditorAction<ToleranceActionData>(_ => { }, _ => { }, toleranceData3));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances3),
-            speciesComparer.Compare(originalSpecies, editsFacade));
-        Assert.Equal(Constants.BASE_MUTATION_POINTS, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(SpeciesComparer.CalculateToleranceCost(initialTolerances, changedTolerances3,
+                Constants.MAX_SINGLE_EDIT_MP_COST),
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
+        Assert.Equal(Constants.BASE_MUTATION_POINTS,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         // And then it should be possible to go in the opposite direction to restore MP
         var changedTolerances4 = changedTolerances3.Clone();
@@ -1071,7 +1135,8 @@ public class EditorMPTests
         var toleranceData4 = new ToleranceActionData(changedTolerances3, changedTolerances4);
         history.AddAction(new SingleEditorAction<ToleranceActionData>(_ => { }, _ => { }, toleranceData4));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.True(Constants.BASE_MUTATION_POINTS - speciesComparer.Compare(originalSpecies, editsFacade) > 10);
+        Assert.True(Constants.BASE_MUTATION_POINTS -
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST) > 10);
 
         // As we used different stats, they should not all combine into a single action (this verifies the test is
         // actually testing what it is supposed to)
@@ -1093,20 +1158,22 @@ public class EditorMPTests
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, actionData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var deleteData = new OrganelleRemoveActionData(template);
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, deleteData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         // Moving back to the original position then resets all costs
         var moveData = new OrganelleMoveActionData(template, new Hex(1, 0), new Hex(0, 0), 0, 0);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
 
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -1122,25 +1189,28 @@ public class EditorMPTests
         var placementData = new OrganellePlacementActionData(template2, new Hex(1, 0), 0);
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, placementData));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var deleteData = new OrganelleRemoveActionData(template);
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, deleteData));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var template3 = new OrganelleTemplate(cheapOrganelle, new Hex(0, 1), 0);
         var placement2 = new OrganellePlacementActionData(template3, new Hex(0, 1), 0);
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, placement2));
         ApplyFacadeEdits(editsFacade, history);
         Assert.Equal(cheapOrganelle.MPCost + Constants.ORGANELLE_MOVE_COST,
-            speciesComparer.Compare(originalSpecies, editsFacade));
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         // Major infinite MP exploit reported for 0.9.0
         var deleteData2 = new OrganelleRemoveActionData(template3);
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, deleteData2));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -1158,19 +1228,22 @@ public class EditorMPTests
         var placementData = new OrganellePlacementActionData(template2, new Hex(1, 0), 0);
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, placementData));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var deleteData = new OrganelleRemoveActionData(originalToRemove);
         history.AddAction(new SingleEditorAction<OrganelleRemoveActionData>(_ => { }, _ => { }, deleteData));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         var template3 = new OrganelleTemplate(cheapOrganelle, new Hex(0, 0), 0);
         var placement2 = new OrganellePlacementActionData(template3, new Hex(0, 0), 0);
         history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, placement2));
         ApplyFacadeEdits(editsFacade, history);
 
-        Assert.Equal(cheapOrganelle.MPCost, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(cheapOrganelle.MPCost,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     [Fact]
@@ -1186,12 +1259,13 @@ public class EditorMPTests
         var moveData = new OrganelleMoveActionData(originalToMove, new Hex(0, 0), new Hex(1, 0), 0, 2);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(0, speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
 
         moveData = new OrganelleMoveActionData(originalToMove, new Hex(1, 0), new Hex(2, 0), 2, 2);
         history.AddAction(new SingleEditorAction<OrganelleMoveActionData>(_ => { }, _ => { }, moveData));
         ApplyFacadeEdits(editsFacade, history);
-        Assert.Equal(Constants.ORGANELLE_MOVE_COST, speciesComparer.Compare(originalSpecies, editsFacade));
+        Assert.Equal(Constants.ORGANELLE_MOVE_COST,
+            speciesComparer.Compare(originalSpecies, editsFacade, Constants.MAX_SINGLE_EDIT_MP_COST));
     }
 
     private void ApplyFacadeEdits(MicrobeEditsFacade facade, EditorActionHistory<EditorAction> history)


### PR DESCRIPTION
**Brief Description of What This PR Does**

This should correctly translate the MP multiplication system to the base calculation and that allows then clamping all individual edits to at most 100 MP. So this should allow doing a single action with a game configured for max mutation cost in the new game settings.

This was quite a lot of changes so hopefully I didn't introduce any accidental infinite MP change (the tolerances and rigidity needed to be left outside the cap as otherwise you could make infinite tolerance changes by investing just 100 MP)

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://community.revolutionarygamesstudio.com/t/if-you-set-mutation-cost-multiplier-too-high-you-cant-ever-afford-a-nucleus/8922

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
