### PR TITLE
Make FossilisationDialog a CustomWindow

### DIFF
--- a/src/thriveopedia/fossilisation/FossilisationDialog.tscn
+++ b/src/thriveopedia/fossilisation/FossilisationDialog.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://dvtcoa6g3lkyn" path="res://src/thriveopedia/fossilisation/FossilisationDialog.cs" id="1"]
 [ext_resource type="PackedScene" uid="uid://bhpjtbtaeunat" path="res://src/gui_common/CustomRichTextLabel.tscn" id="3"]
 [ext_resource type="FontFile" uid="uid://dblvrxw3ue372" path="res://assets/fonts/Lato-Italic.ttf" id="3_cgult"]
-[ext_resource type="PackedScene" uid="uid://cl64wvnxs6ivs" path="res://src/gui_common/dialogs/CustomWindow.tscn" id="4"]
+[ext_resource type="PackedScene" uid="uid://du8sc8kjirguk" path="res://src/gui_common/dialogs/CustomWindow.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://b1boea8qjx6xx" path="res://src/gui_common/SpeciesDetailsPanel.tscn" id="5"]
 [ext_resource type="Texture2D" uid="uid://baqkntjn5ng0y" path="res://assets/textures/gui/bevel/randomizeButton.png" id="9"]
 [ext_resource type="Texture2D" uid="uid://c8qyts61c8a0y" path="res://assets/textures/gui/bevel/randomizeButtonActive.png" id="10"]
@@ -45,17 +45,7 @@ fossilisationFailedDialog = NodePath("FossilisationFailedDialog")
 WindowTitle = "FOSSILISATION"
 ExclusiveAllowCloseOnEscape = false
 
-[node name="VBoxContainer" parent="." index="0" unique_id=146557504]
-visible = false
-offset_left = 0.0
-offset_top = 0.0
-offset_right = 152.0
-offset_bottom = 69.0
-
-[node name="FocusGrabber" parent="VBoxContainer" index="4" unique_id=158342970]
-NodeToGiveFocusTo = NodePath("../../VBoxContainer2/HBoxContainer/CancelButton")
-
-[node name="VBoxContainer2" type="VBoxContainer" parent="." index="1" unique_id=406948132]
+[node name="VBoxContainer2" type="VBoxContainer" parent="." index="0" unique_id=406948132]
 layout_mode = 0
 offset_left = 11.0
 offset_top = 11.0
@@ -141,7 +131,7 @@ text = "FOSSILISE"
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="OverwriteNameConfirmation" parent="." index="2" unique_id=1179250609 instance=ExtResource("4")]
+[node name="OverwriteNameConfirmation" parent="." index="1" unique_id=1179250609 instance=ExtResource("4")]
 custom_minimum_size = Vector2(440, 0)
 layout_mode = 0
 offset_left = 1.0
@@ -150,15 +140,13 @@ offset_right = 935.0
 offset_bottom = 599.0
 WindowTitle = "CONFIRM_FOSSILISATION_OVERWRITE"
 
-[node name="FossilisationFailedDialog" parent="." index="3" unique_id=2095718850 instance=ExtResource("4")]
+[node name="FossilisationFailedDialog" parent="." index="2" unique_id=2095718850 instance=ExtResource("4")]
 custom_minimum_size = Vector2(440, 0)
 layout_mode = 0
 offset_left = 1.0
 offset_top = 1.0
 offset_right = 935.0
 offset_bottom = 599.0
-HideCancelButton = true
-DialogText = "FOSSILISATION_FAILED_DESCRIPTION"
 WindowTitle = "FOSSILISATION_FAILED"
 
 [connection signal="text_changed" from="VBoxContainer2/HBoxContainer2/SpeciesName" to="." method="OnNameTextChanged"]
@@ -166,4 +154,3 @@ WindowTitle = "FOSSILISATION_FAILED"
 [connection signal="pressed" from="VBoxContainer2/HBoxContainer2/RandomizeButton" to="." method="OnRandomizeNamePressed"]
 [connection signal="pressed" from="VBoxContainer2/HBoxContainer/CancelButton" to="." method="OnCancelPressed"]
 [connection signal="pressed" from="VBoxContainer2/HBoxContainer/FossiliseButton" to="." method="OnFossilisePressed"]
-[connection signal="Confirmed" from="OverwriteNameConfirmation" to="." method="FossiliseSpecies"]

--- a/src/thriveopedia/fossilisation/FossilisationDialog.tscn
+++ b/src/thriveopedia/fossilisation/FossilisationDialog.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://dvtcoa6g3lkyn" path="res://src/thriveopedia/fossilisation/FossilisationDialog.cs" id="1"]
 [ext_resource type="PackedScene" uid="uid://bhpjtbtaeunat" path="res://src/gui_common/CustomRichTextLabel.tscn" id="3"]
 [ext_resource type="FontFile" uid="uid://dblvrxw3ue372" path="res://assets/fonts/Lato-Italic.ttf" id="3_cgult"]
-[ext_resource type="PackedScene" uid="uid://cl64wvnxs6ivs" path="res://src/gui_common/dialogs/CustomConfirmationDialog.tscn" id="4"]
+[ext_resource type="PackedScene" uid="uid://cl64wvnxs6ivs" path="res://src/gui_common/dialogs/CustomWindow.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://b1boea8qjx6xx" path="res://src/gui_common/SpeciesDetailsPanel.tscn" id="5"]
 [ext_resource type="Texture2D" uid="uid://baqkntjn5ng0y" path="res://assets/textures/gui/bevel/randomizeButton.png" id="9"]
 [ext_resource type="Texture2D" uid="uid://c8qyts61c8a0y" path="res://assets/textures/gui/bevel/randomizeButtonActive.png" id="10"]

--- a/src/thriveopedia/fossilisation/FossilisationDialog.tscn
+++ b/src/thriveopedia/fossilisation/FossilisationDialog.tscn
@@ -45,7 +45,17 @@ fossilisationFailedDialog = NodePath("FossilisationFailedDialog")
 WindowTitle = "FOSSILISATION"
 ExclusiveAllowCloseOnEscape = false
 
-[node name="VBoxContainer2" type="VBoxContainer" parent="." index="0" unique_id=406948132]
+[node name="VBoxContainer" parent="." index="0" unique_id=146557504]
+visible = false
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 152.0
+offset_bottom = 69.0
+
+[node name="FocusGrabber" parent="VBoxContainer" index="4" unique_id=158342970]
+NodeToGiveFocusTo = NodePath("../../VBoxContainer2/HBoxContainer/CancelButton")
+
+[node name="VBoxContainer2" type="VBoxContainer" parent="." index="1" unique_id=406948132]
 layout_mode = 0
 offset_left = 11.0
 offset_top = 11.0
@@ -131,7 +141,7 @@ text = "FOSSILISE"
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="OverwriteNameConfirmation" parent="." index="1" unique_id=1179250609 instance=ExtResource("4")]
+[node name="OverwriteNameConfirmation" parent="." index="2" unique_id=1179250609 instance=ExtResource("4")]
 custom_minimum_size = Vector2(440, 0)
 layout_mode = 0
 offset_left = 1.0
@@ -140,13 +150,15 @@ offset_right = 935.0
 offset_bottom = 599.0
 WindowTitle = "CONFIRM_FOSSILISATION_OVERWRITE"
 
-[node name="FossilisationFailedDialog" parent="." index="2" unique_id=2095718850 instance=ExtResource("4")]
+[node name="FossilisationFailedDialog" parent="." index="3" unique_id=2095718850 instance=ExtResource("4")]
 custom_minimum_size = Vector2(440, 0)
 layout_mode = 0
 offset_left = 1.0
 offset_top = 1.0
 offset_right = 935.0
 offset_bottom = 599.0
+HideCancelButton = true
+DialogText = "FOSSILISATION_FAILED_DESCRIPTION"
 WindowTitle = "FOSSILISATION_FAILED"
 
 [connection signal="text_changed" from="VBoxContainer2/HBoxContainer2/SpeciesName" to="." method="OnNameTextChanged"]
@@ -154,3 +166,4 @@ WindowTitle = "FOSSILISATION_FAILED"
 [connection signal="pressed" from="VBoxContainer2/HBoxContainer2/RandomizeButton" to="." method="OnRandomizeNamePressed"]
 [connection signal="pressed" from="VBoxContainer2/HBoxContainer/CancelButton" to="." method="OnCancelPressed"]
 [connection signal="pressed" from="VBoxContainer2/HBoxContainer/FossiliseButton" to="." method="OnFossilisePressed"]
+[connection signal="Confirmed" from="OverwriteNameConfirmation" to="." method="FossiliseSpecies"]


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR changes FossilisationDialog so that it's derived from CustomWindow rather than CustomConfirmationDialog. Nothing seems to have broken even though I changed literally only one line.

**Related Issues**

Closes #4157

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [X] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
