### PR TITLE
Fix auto evo editor prediction mistakenly requiring occupied leaf nodes

### DIFF
--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -260,6 +260,9 @@ public static class MichePopulation
                 if (currentSpecies is not MicrobeSpecies microbeSpecies)
                     continue;
 
+                // TODO: When supporting multicellular species replace the MicrobeSpecies check
+                var occupantMicrobeSpecies = node.Occupant as MicrobeSpecies;
+
                 var traversalScore = 0.0f;
 
                 foreach (var currentMiche in currentBackTraversal)
@@ -274,8 +277,7 @@ public static class MichePopulation
 
                     var occupantScore = 0.0f;
 
-                    // TODO: When supporting multicellular species replace the is MicrobeSpecies with a null check
-                    if (currentMiche.Occupant is MicrobeSpecies occupantMicrobeSpecies)
+                    if (occupantMicrobeSpecies != null)
                     {
                         occupantScore =
                             cache.GetPressureScore(currentMiche.Pressure, patch, occupantMicrobeSpecies);


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR makes it so auto-evo no longer require a current occupant in order to calculate a score for a leaf node, and instead assumes the "occupant's score" is 0 if there isn't one.

This will mainly apparent when looking at the editor auto-evo prediction numbers while moving to a new empty patch, since by definition none of its miches have occupants yet.

**Related Issues**

closes #6699 

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
