### PR TITLE
Fixed MP error from duplicate hover position symmetry mode

### DIFF
--- a/src/general/base_stage/HexEditorComponentBase.cs
+++ b/src/general/base_stage/HexEditorComponentBase.cs
@@ -175,6 +175,26 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
                 return;
 
             mouseHoverPositions = value;
+
+#if DEBUG
+            if (mouseHoverPositions != null)
+            {
+                // Make sure no duplicates
+                var temp = mouseHoverPositions.ToList();
+                for (int i = 0; i < temp.Count; ++i)
+                {
+                    for (int j = i + 1; j < temp.Count; ++j)
+                    {
+                        if (temp[i].Hex == temp[j].Hex)
+                        {
+                            throw new InvalidOperationException(
+                                $"Duplicate hex {temp[i].Hex} found in mouse hover positions");
+                        }
+                    }
+                }
+            }
+#endif
+
             UpdateMutationPointsBar();
         }
     }

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -799,7 +799,25 @@ public partial class CellEditorComponent :
                     (finalQ, finalR, rotation) =>
                     {
                         RenderHighlightedOrganelle(finalQ, finalR, rotation, shownOrganelle, MovingPlacedHex?.Upgrades);
-                        hoveredHexes.Add((new Hex(finalQ, finalR), rotation));
+
+                        var finalHex = new Hex(finalQ, finalR);
+
+                        // Only add unique positions so that duplicate actions are not attempted which break the MP
+                        // system
+                        bool exists = false;
+                        foreach (var existingHex in hoveredHexes)
+                        {
+                            if (existingHex.Hex == finalHex)
+                            {
+                                exists = true;
+                                break;
+                            }
+                        }
+
+                        if (exists)
+                            return;
+
+                        hoveredHexes.Add((finalHex, rotation));
                     }, effectiveSymmetry);
 
                 MouseHoverPositions = hoveredHexes.ToList();


### PR DESCRIPTION
**Brief Description of What This PR Does**

and added safety code to detect duplicate positions when they are generated

Merging this really soon for the BOTD

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
might fixes https://github.com/Revolutionary-Games/Thrive/issues/6667
but I think we'll only really know after the next release as the problem is reported quite rarely, but after making this fix I could not trigger any more errors with symmetry mode

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
