### PR TITLE
Changed initial multicell bodyplan to be 3 cells

### DIFF
--- a/src/general/GameProperties.cs
+++ b/src/general/GameProperties.cs
@@ -118,7 +118,7 @@ public class GameProperties : IArchivable
         // Modify the player species to actually make sense to be in the multicellular stage
         var playerSpecies = MakePlayerOrganellesMakeSenseForMulticellular(game);
 
-        game.GameWorld.ChangeSpeciesToMulticellular(playerSpecies);
+        game.GameWorld.ChangeSpeciesToMulticellular(playerSpecies, !freebuild);
 
         // TODO: generate multicellular species for freebuild
         if (freebuild)
@@ -145,7 +145,7 @@ public class GameProperties : IArchivable
 
         var playerSpecies = MakePlayerOrganellesMakeSenseForMulticellular(game);
 
-        var earlySpecies = game.GameWorld.ChangeSpeciesToMulticellular(playerSpecies);
+        var earlySpecies = game.GameWorld.ChangeSpeciesToMulticellular(playerSpecies, false);
         MakeCellPlacementMakeSenseForMacroscopic(earlySpecies);
         game.GameWorld.ChangeSpeciesToMacroscopic(earlySpecies);
 

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -721,7 +721,7 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
 
         GD.Print("Disbanding colony and becoming multicellular");
 
-        // Move to multicellular always happens when the player is in a colony, so we force disband that here before
+        // Move to multicellular always happens when the player is in a colony, so we force-disband that here before
         // proceeding
         MicrobeColonyHelpers.UnbindAllOutsideGameUpdate(Player, WorldSimulation);
 
@@ -737,7 +737,7 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
         // This prevents previous members of the player's colony from immediately being hostile
         bool playerHandled = false;
 
-        var multicellularSpecies = GameWorld.ChangeSpeciesToMulticellular(previousSpecies);
+        var multicellularSpecies = GameWorld.ChangeSpeciesToMulticellular(previousSpecies, true);
         foreach (var microbe in playerSpeciesMicrobes)
         {
             // Direct component setting is safe as we verified above we aren't running during a simulation update

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -747,7 +747,7 @@ public partial class CellBodyPlanEditorComponent :
             return;
 
         // For now a single hex represents entire cells
-        RenderHoveredHex(q, r, new[] { new Hex(0, 0) }, isPlacementProbablyValid,
+        RenderHoveredHex(q, r, [new Hex(0, 0)], isPlacementProbablyValid,
             out bool hadDuplicate);
 
         bool showModel = !hadDuplicate;
@@ -812,6 +812,7 @@ public partial class CellBodyPlanEditorComponent :
                 if (placed != null)
                 {
                     placementActions.Add(placed);
+                    GD.Print($"Trying to place cell \"{cellType.CellTypeName}\" at {hex}");
 
                     usedHexes.Add(hex);
                 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

so that the player isn't just a single cell at the start of multicellular

as this has been something people talked about. This is specifically 3 cells so that the player can't reach the "win" condition in a single multicellular generation.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
