### PR TITLE
5600 The no external resources filter now allows for cell generated compounds

### DIFF
--- a/src/microbe_stage/BiomeResourceLimiterAdapter.cs
+++ b/src/microbe_stage/BiomeResourceLimiterAdapter.cs
@@ -23,38 +23,14 @@ public class BiomeResourceLimiterAdapter : IBiomeConditions
     }
 
     public BiomeResourceLimiterAdapter(ResourceLimitingMode limitingMode, IBiomeConditions baseConditions,
-        IReadOnlyList<OrganelleTemplate> organelles) : this(limitingMode, baseConditions)
+        List<TweakedProcess> activeProcesses) : this(limitingMode, baseConditions)
     {
         cellProducedCompounds = new HashSet<Compound>();
-        for (var i = 0; i < organelles.Count; ++i)
+        foreach (var activeProcess in activeProcesses)
         {
-            var organelle = organelles[i];
-            foreach (var process in organelle.Definition.RunnableProcesses)
+            foreach (var output in activeProcess.Process.Outputs)
             {
-                foreach (var output in process.Process.Outputs)
-                {
-                    cellProducedCompounds.Add(output.Key.ID);
-                }
-            }
-        }
-    }
-
-    public BiomeResourceLimiterAdapter(ResourceLimitingMode limitingMode, IBiomeConditions baseConditions,
-        IReadOnlyList<HexWithData<CellTemplate>> cells) : this(limitingMode, baseConditions)
-    {
-        cellProducedCompounds = new HashSet<Compound>();
-        foreach (var cell in cells)
-        {
-            for (int i = 0; i < cell.Data!.ModifiableOrganelles.Count; ++i)
-            {
-                var organelle = cell.Data!.ModifiableOrganelles[i];
-                foreach (var process in organelle.Definition.RunnableProcesses)
-                {
-                    foreach (var output in process.Process.Outputs)
-                    {
-                        cellProducedCompounds.Add(output.Key.ID);
-                    }
-                }
+                cellProducedCompounds.Add(output.Key.ID);
             }
         }
     }

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -185,6 +185,8 @@ public partial class CellEditorComponent :
 
     private EnergyBalanceInfoFull? energyBalanceInfo;
 
+    private List<TweakedProcess> tempAllProcesses = new();
+
     private string? bestPatchName;
 
     // This and worstPatchPopulation used to be displayed but are now kept for potential future use
@@ -2124,8 +2126,10 @@ public partial class CellEditorComponent :
 
         if (organismStatisticsPanel.ResourceLimitingMode != ResourceLimitingMode.AllResources)
         {
+            ProcessSystem.ComputeActiveProcessList(organelles, ref tempAllProcesses);
+
             conditionsData = new BiomeResourceLimiterAdapter(organismStatisticsPanel.ResourceLimitingMode,
-                conditionsData, organelles);
+                conditionsData, tempAllProcesses);
         }
 
         energyBalanceInfo = new EnergyBalanceInfoFull();

--- a/src/microbe_stage/systems/ProcessSystem.cs
+++ b/src/microbe_stage/systems/ProcessSystem.cs
@@ -62,7 +62,7 @@ public partial class ProcessSystem : BaseSystem<World, float>
     ///     list if it is used for unrelated cells before calling this method.
     ///   </para>
     /// </remarks>
-    public static void ComputeActiveProcessList(IReadOnlyList<IPositionedOrganelle> organelles,
+    public static void ComputeActiveProcessList(IReadOnlyList<IReadOnlyPositionedOrganelle> organelles,
         [NotNull] ref List<TweakedProcess>? result)
     {
         result ??= new List<TweakedProcess>();

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -115,6 +115,9 @@ public partial class CellBodyPlanEditorComponent :
 
     private IndividualHexLayout<CellTemplate> editedMicrobeCells = null!;
 
+    private List<IReadOnlyOrganelleTemplate> tempAllOrganelles = new();
+    private List<TweakedProcess> tempAllProcesses = new();
+
     /// <summary>
     ///   True, when visuals of already placed things need to be updated
     /// </summary>
@@ -1259,8 +1262,19 @@ public partial class CellBodyPlanEditorComponent :
 
         if (organismStatisticsPanel.ResourceLimitingMode != ResourceLimitingMode.AllResources)
         {
+            tempAllOrganelles.Clear();
+            foreach (var cell in cells)
+            {
+                foreach (var organelle in cell.Data!.CellType.Organelles)
+                {
+                    tempAllOrganelles.Add(organelle);
+                }
+            }
+
+            ProcessSystem.ComputeActiveProcessList(tempAllOrganelles, ref tempAllProcesses);
+
             conditionsData = new BiomeResourceLimiterAdapter(organismStatisticsPanel.ResourceLimitingMode,
-                conditionsData, cells);
+                conditionsData, tempAllProcesses);
         }
 
         energyBalanceInfo = new EnergyBalanceInfoFull();


### PR DESCRIPTION
**Brief Description of What This PR Does**
This PR changes the ResourceLimitingMode.NoExternalResources filter used in the cell editor. Now, instead of ignoring all resources, it includes both ambient compounds and compounds the cell is capable of producing. 

**Related Issues**

Fixes #5600 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).

**Additional Notes**
In the discussion for the issue, a potential solution was
> assume the cell generates enough of whatever compound it needs so just changing the check for compound being available to see if some process in the cell produces it. Then we could make it so that the compound balance display when negative on a key compound would be much more red.

The suggested code change works, but I wasn't entirely sure what much more red might mean. Currently, the text is red for when a compound balance is negative, should there be something more obvious? Additionally, the BiomeResourceLimiterAdapter is also used for multicellular calculations, I wasn't sure if we wanted to use the same solution or not there. I've left a TODO comment so it's easier to locate. Finally, for resources the cell doesn't produce, the compound balance says +0. Do we want to include that, or would it be better to try and hide the +0?