### PR TITLE
FIXING Game crashing on physics debug draw when AVX is disabled. #6728

### DIFF
--- a/DebugDrawForwarder.hpp
+++ b/DebugDrawForwarder.hpp
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <Jolt/Jolt.h>
+
+#ifdef JPH_DEBUG_RENDERER
+
+#include <Jolt/Renderer/DebugRenderer.h>
+
+#include "core/Mutex.hpp"
+#include "core/NativeLibIntercommunication.hpp"
+
+namespace Thrive::Physics
+{
+
+constexpr float MaxDebugDrawRate = 1 / 60.0f;
+constexpr bool AutoAdjustDebugDrawRateWhenSlow = true;
+constexpr float DebugDrawLODBias = 2;
+constexpr float DefaultMaxDistanceToDrawLinesFromCamera = 180;
+
+/// \brief Forwards debug draw from the physics system out of this native library
+class DebugDrawForwarder : public JPH::DebugRenderer
+{
+public:
+    // One extra level of deferring to allow this to not need to be updated whenever the pointers change as that'd be
+    // a bit hard to forward from the other project
+    using LineCallback = OnDebugLines*;
+    using TriangleCallback = OnDebugTriangles*;
+
+    /// \brief Variant of vertex that doesn't require converting back to floats after world space calculation
+    /// and has already converted colour info
+    class DVertex
+    {
+    public:
+        JPH::RVec3 mPosition;
+        JPH::Float3 mNormal;
+        JPH::Float2 mUV;
+        JPH::Float4 mColor;
+    };
+
+private:
+    DebugDrawForwarder();
+
+public:
+    static DebugDrawForwarder& GetInstance()
+    {
+        static DebugDrawForwarder instance;
+        return instance;
+    }
+
+    void FlushOutput();
+    void SetOutputLineReceiver(LineCallback callback);
+    void SetOutputTriangleReceiver(TriangleCallback callback);
+
+    void ClearOutputReceivers();
+
+    bool HasAReceiver() const noexcept;
+
+    // DebugRenderer interface implementation
+    void DrawLine(JPH::RVec3Arg inFrom, JPH::RVec3Arg inTo, JPH::ColorArg inColor) override;
+    void DrawTriangle(JPH::RVec3Arg inV1, JPH::RVec3Arg inV2, JPH::RVec3Arg inV3, JPH::ColorArg inColor,
+        ECastShadow inCastShadow = ECastShadow::Off) override;
+    void DrawGeometry(JPH::RMat44Arg inModelMatrix, const JPH::AABox& inWorldSpaceBounds, float inLODScaleSq,
+        JPH::ColorArg inModelColor, const GeometryRef& inGeometry, ECullMode inCullMode, ECastShadow inCastShadow,
+        EDrawMode inDrawMode) override;
+    void DrawText3D(
+        JPH::RVec3Arg inPosition, const std::string_view& inString, JPH::ColorArg inColor, float inHeight) override;
+
+    // These seem to be about caching and reusing things
+    Batch CreateTriangleBatch(const Triangle* inTriangles, int inTriangleCount) override;
+    Batch CreateTriangleBatch(
+        const Vertex* inVertices, int inVertexCount, const uint32_t* inIndices, int inIndexCount) override;
+
+    /// \brief Returns true once it is time to render debug stuff
+    ///
+    /// This is used to rate limit the expensive debug drawing a bit
+    [[nodiscard]] bool TimeToRenderDebug(float delta)
+    {
+        timeSinceDraw += delta;
+
+        if (timeSinceDraw >= minDrawDelta)
+        {
+            timeSinceDraw = 0;
+            return true;
+        }
+
+        return false;
+    }
+
+    inline void SetCameraPositionForLOD(JPH::Vec3Arg position)
+    {
+        cameraPosition = position;
+    }
+
+    inline void SetCameraLODBias(float newBias)
+    {
+        cameraLODBias = newBias;
+    }
+
+    inline void SetMaxDebugDrawFPS(float framerate)
+    {
+        minDrawDelta = 1 / framerate;
+    }
+
+    inline void SetAutoAdjustMaxDrawFPS(bool autoAdjustOnLag)
+    {
+        adjustRateOnLag = autoAdjustOnLag;
+    }
+
+    inline void SetMaxDrawDistance(float drawDistance)
+    {
+        maxModelDistance = drawDistance;
+    }
+
+private:
+    void DrawTriangleInternal(
+        const DVertex& vertex1, const DVertex& vertex2, const DVertex& vertex3, JPH::Float4 colourTint, bool wireFrame);
+
+private:
+    /// Apparently debug rendering happens from multiple threads so we need a lock
+    Mutex mutex;
+
+    /// Next ID to use for a predefined batch of geometry
+    uint32_t nextBatchID = 1;
+
+    // Might get used if sending each geometry just once is implemented
+    // uint32_t nextGeometryID = 1;
+
+    // /// Predefined geometries and mapping to their IDs
+    // std::unordered_map<GeometryRef, uint32_t> cachedGeometries;
+
+    // ------------------------------------ //
+    // Actual variables of this debug forwarder, everything else needed to be default Jolt stuff
+
+    std::vector<std::tuple<JPH::RVec3, JPH::RVec3, JPH::Float4>> lineBuffer;
+    std::vector<std::tuple<JPH::RVec3, JPH::RVec3, JPH::RVec3, JPH::Float4>> triangleBuffer;
+
+    LineCallback lineCallback = nullptr;
+    TriangleCallback triangleCallback = nullptr;
+
+    JPH::Vec3 cameraPosition = {};
+    float cameraLODBias = DebugDrawLODBias;
+    float minDrawDelta = MaxDebugDrawRate;
+    bool adjustRateOnLag = AutoAdjustDebugDrawRateWhenSlow;
+    float maxModelDistance = DefaultMaxDistanceToDrawLinesFromCamera;
+
+    float timeSinceDraw = 1;
+};
+
+} // namespace Thrive::Physics
+
+#endif // JPH_DEBUG_RENDERER

--- a/DebugDrawer.cpp
+++ b/DebugDrawer.cpp
@@ -1,0 +1,427 @@
+// ------------------------------------ //
+#include "DebugDrawer.hpp"
+
+BEGIN_GODOT_INCLUDES;
+#include <godot_cpp/classes/camera3d.hpp>
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/immediate_mesh.hpp>
+#include <godot_cpp/classes/mesh_instance3d.hpp>
+#include <godot_cpp/classes/resource_loader.hpp>
+#include <godot_cpp/classes/viewport.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+END_GODOT_INCLUDES;
+
+#include "core/GodotJoltConversions.hpp"
+#include "core/ThriveConfig.hpp"
+
+// ------------------------------------ //
+namespace Thrive
+{
+
+/// \brief Assumption of what the vertex layout memory use is for immediate geometry (3 floats for position,
+/// 3 floats for normal, 2 floats for UVs, 4 floats for colour).
+///
+/// It's really hard to find this in Godot source code so this is a pure assumption that has been tested to work fine.
+constexpr long MemoryUseOfIntermediateVertex = sizeof(float) * (3 + 3 + 2 + 4);
+
+/// 2 vertices + space in index buffer
+constexpr long SingleLineDrawMemoryUse = MemoryUseOfIntermediateVertex * 2 + sizeof(uint32_t);
+
+/// 3 vertices
+constexpr long SingleTriangleDrawMemoryUse = MemoryUseOfIntermediateVertex * 3 + sizeof(uint32_t);
+
+const godot::Vector3 DebugDrawer::pointOffsetLeft = {-PointLineWidth, 0, 0};
+const godot::Vector3 DebugDrawer::pointOffsetUp = {0, PointLineWidth, 0};
+const godot::Vector3 DebugDrawer::pointOffsetRight = {PointLineWidth, 0, 0};
+const godot::Vector3 DebugDrawer::pointOffsetDown = {0, -PointLineWidth, 0};
+const godot::Vector3 DebugDrawer::pointOffsetForward = {0, 0, -PointLineWidth};
+const godot::Vector3 DebugDrawer::pointOffsetBack = {0, 0, PointLineWidth};
+
+DebugDrawer* DebugDrawer::instance = nullptr;
+
+void DebugDrawer::_bind_methods()
+{
+    using namespace godot;
+
+    ClassDB::bind_method(D_METHOD("get_debug_level"), &DebugDrawer::GetDebugLevel);
+    ClassDB::bind_method(D_METHOD("set_debug_level", "newLevel"), &DebugDrawer::SetDebugLevel);
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "debug_level"), "set_debug_level", "get_debug_level");
+
+    ClassDB::bind_method(D_METHOD("get_debug_draw_available"), &DebugDrawer::GetDebugDrawAvailable);
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_draw_available", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR),
+        {}, "get_debug_draw_available");
+
+    ClassDB::bind_method(D_METHOD("init"), &DebugDrawer::Init);
+
+    ClassDB::bind_method(D_METHOD("get_debug_camera_location"), &DebugDrawer::GetDebugCameraLocation);
+    ClassDB::bind_method(D_METHOD("set_debug_camera_location", "location"), &DebugDrawer::SetDebugCameraLocation);
+    ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "debug_camera_location"), "set_debug_camera_location",
+        "get_debug_camera_location");
+
+    ClassDB::bind_method(D_METHOD("increment_physics_debug_level"), &DebugDrawer::IncrementPhysicsDebugLevel);
+    ClassDB::bind_method(D_METHOD("enable_physics_debug"), &DebugDrawer::EnablePhysicsDebug);
+    ClassDB::bind_method(D_METHOD("disable_physics_debug"), &DebugDrawer::DisablePhysicsDebug);
+
+    ClassDB::bind_method(D_METHOD("add_line", "from", "to", "colour"), &DebugDrawer::AddLine);
+    ClassDB::bind_method(D_METHOD("add_point", "point", "colour"), &DebugDrawer::AddPoint);
+
+    ADD_SIGNAL(MethodInfo(SignalNameOnDebugCameraPositionChanged, PropertyInfo(Variant::VECTOR3, "position")));
+    ADD_SIGNAL(MethodInfo(SignalNameOnPhysicsDebugLevelChanged, PropertyInfo(Variant::INT, "debugLevel")));
+
+    ClassDB::bind_method(D_METHOD("get_native_instance"), &DebugDrawer::GetThis);
+    ClassDB::bind_method(D_METHOD("register_debug_draw"), &DebugDrawer::RegisterDebugDraw);
+    ClassDB::bind_method(D_METHOD("remove_debug_draw"), &DebugDrawer::RemoveDebugDraw);
+}
+
+DebugDrawer::DebugDrawer() :
+    SignalOnDebugCameraPositionChanged(SignalNameOnDebugCameraPositionChanged),
+    SignalOnPhysicsDebugLevelChanged(SignalNameOnPhysicsDebugLevelChanged)
+{
+    if (godot::Engine::get_singleton()->is_editor_hint())
+        return;
+
+    if (instance != nullptr)
+        ERR_PRINT("Multiple DebugDrawer native instances created");
+
+    instance = this;
+}
+
+DebugDrawer::~DebugDrawer()
+{
+    auto* config = ThriveConfig::Instance();
+
+    if (config)
+    {
+        config->RegisterDebugDrawReceiver(nullptr);
+    }
+
+    instance = nullptr;
+}
+
+void DebugDrawer::_ready()
+{
+    // We have to do initialization like this as apparently an attached C# script will mess things up and not call the
+    // native ready
+    if (lineDrawer == nullptr)
+        Init();
+}
+
+void DebugDrawer::Init()
+{
+    if (lineDrawer != nullptr)
+        ERR_PRINT("Init called twice");
+
+    Node::_ready();
+
+    if (godot::Engine::get_singleton()->is_editor_hint())
+        return;
+
+    lineMaterial = godot::ResourceLoader::get_singleton()->load("res://src/engine/DebugLineMaterial.tres");
+    triangleMaterial = godot::ResourceLoader::get_singleton()->load("res://src/engine/DebugTriangleMaterial.tres");
+
+    lineDrawer = get_node<godot::MeshInstance3D>("LineDrawer");
+    triangleDrawer = get_node<godot::MeshInstance3D>("TriangleDrawer");
+
+    if (!lineDrawer || !triangleDrawer)
+    {
+        ERR_PRINT("Failed to get DebugDrawer required child node");
+        return;
+    }
+
+    // Make sure the debug stuff is always rendered
+    const auto quiteBigAABB = godot::AABB(godot::Vector3{0, 0, 0},
+        godot::Vector3{DEBUG_DRAW_MAX_DISTANCE_ORIGIN, DEBUG_DRAW_MAX_DISTANCE_ORIGIN, DEBUG_DRAW_MAX_DISTANCE_ORIGIN});
+
+    lineMesh = godot::Ref<godot::ImmediateMesh>(memnew(godot::ImmediateMesh));
+    triangleMesh = godot::Ref<godot::ImmediateMesh>(memnew(godot::ImmediateMesh));
+
+    lineDrawer->set_mesh(lineMesh);
+    lineDrawer->set_visible(false);
+    lineDrawer->set_custom_aabb(quiteBigAABB);
+    lineDrawer->set_ignore_occlusion_culling(true);
+    lineDrawer->set_extra_cull_margin(1000);
+
+    triangleDrawer->set_mesh(triangleMesh);
+    triangleDrawer->set_visible(false);
+    triangleDrawer->set_custom_aabb(quiteBigAABB);
+    triangleDrawer->set_ignore_occlusion_culling(true);
+    triangleDrawer->set_extra_cull_margin(1000);
+
+    // TODO: implement debug text drawing (this is a Control to support that in the future)
+}
+
+// ------------------------------------ //
+void DebugDrawer::_process(double delta)
+{
+    // Don't do anything if not initialized
+    if (lineDrawer == nullptr)
+        return;
+
+    if (!timedLines.empty())
+    {
+        // Only draw the other debug lines if physics lines have been updated to avoid flicker
+        if (!physicsDebugSupported || currentPhysicsDebugLevel == 0 || drawnThisFrame)
+        {
+            HandleTimedLines((float)delta);
+        }
+        else
+        {
+            // To make lines not stick around longer with physics debug
+            OnlyElapseLineTime((float)delta);
+        }
+    }
+
+    if (drawnThisFrame)
+    {
+        timeInactive = 0;
+
+        // Finish the geometry
+        if (startedLineDraw)
+        {
+            lineMesh->surface_end();
+            startedLineDraw = false;
+        }
+
+        if (startedTriangleDraw)
+        {
+            triangleMesh->surface_end();
+            startedTriangleDraw = false;
+        }
+
+        lineDrawer->set_visible(true);
+        triangleDrawer->set_visible(true);
+        drawnThisFrame = false;
+
+        // Send camera position to the debug draw for LOD purposes
+        const auto* camera = get_viewport()->get_camera_3d();
+
+        if (camera != nullptr)
+        {
+            SetDebugCameraLocation(camera->get_global_position());
+        }
+
+        if (!warnedAboutHittingMemoryLimit && usedDrawMemory + SingleTriangleDrawMemoryUse * 100 >= drawMemoryLimit)
+        {
+            warnedAboutHittingMemoryLimit = true;
+
+            // Put some extra buffer in the memory advice
+            extraNeededDrawMemory += SingleTriangleDrawMemoryUse * 100;
+
+            ERR_PRINT("Debug drawer hit immediate geometry memory limit (extra needed memory: " +
+                godot::String::num_int64(static_cast<int64_t>(extraNeededDrawMemory / 1024)) +
+                " KiB), some things were not rendered (this message won't repeat even if the problem occurs again)");
+        }
+
+        // This needs to reset here so that StartDrawingIfNotYetThisFrame gets called again
+        usedDrawMemory = 0;
+        return;
+    }
+
+    timeInactive += delta;
+
+    if (currentPhysicsDebugLevel < 1 || timeInactive > HideAfterInactiveFor)
+    {
+        lineDrawer->set_visible(false);
+        triangleDrawer->set_visible(false);
+    }
+}
+
+// ------------------------------------ //
+void DebugDrawer::IncrementPhysicsDebugLevel() noexcept
+{
+    // C# side prints a warning so we don't do one here
+    if (!physicsDebugSupported)
+        return;
+
+    currentPhysicsDebugLevel = (currentPhysicsDebugLevel + 1) % MAX_DEBUG_DRAW_LEVEL;
+
+    emit_signal(SignalNameOnPhysicsDebugLevelChanged, currentPhysicsDebugLevel);
+
+    godot::UtilityFunctions::print("Setting physics debug level to: ", currentPhysicsDebugLevel);
+}
+
+void DebugDrawer::EnablePhysicsDebug() noexcept
+{
+    if (currentPhysicsDebugLevel == 0)
+        IncrementPhysicsDebugLevel();
+}
+
+void DebugDrawer::DisablePhysicsDebug() noexcept
+{
+    if (currentPhysicsDebugLevel == 0)
+        return;
+
+    currentPhysicsDebugLevel = 0;
+
+    godot::UtilityFunctions::print("Disabling physics debug");
+
+    emit_signal(SignalNameOnPhysicsDebugLevelChanged, currentPhysicsDebugLevel);
+}
+
+// ------------------------------------ //
+void DebugDrawer::OnReceiveLines(
+    const std::vector<std::tuple<JPH::RVec3, JPH::RVec3, JPH::Float4>>& lineBuffer) noexcept
+{
+    for (const auto& entry : lineBuffer)
+    {
+        DrawLine(JoltToGodot(std::get<0>(entry)), JoltToGodot(std::get<1>(entry)), JoltToGodot(std::get<2>(entry)));
+    }
+}
+
+void DebugDrawer::OnReceiveTriangles(
+    const std::vector<std::tuple<JPH::RVec3, JPH::RVec3, JPH::RVec3, JPH::Float4>>& triangleBuffer) noexcept
+{
+    for (const auto& entry : triangleBuffer)
+    {
+        DrawTriangle(JoltToGodot(std::get<0>(entry)), JoltToGodot(std::get<1>(entry)), JoltToGodot(std::get<2>(entry)),
+            JoltToGodot(std::get<3>(entry)));
+    }
+}
+
+bool DebugDrawer::RegisterDebugDraw() noexcept
+{
+    auto* config = ThriveConfig::Instance();
+
+    if (!config)
+    {
+        ERR_PRINT("ThriveConfig is inaccessible");
+        return false;
+    }
+
+    physicsDebugSupported = config->IsDebugDrawSupported();
+
+    if (physicsDebugSupported)
+    {
+        if (lineDrawer == nullptr)
+            ERR_PRINT("DebugDrawer not initialized but told to register debug draw (this will crash soon)");
+
+        config->RegisterDebugDrawReceiver(this);
+    }
+
+    return physicsDebugSupported;
+}
+
+void DebugDrawer::RemoveDebugDraw() noexcept
+{
+    auto* config = ThriveConfig::Instance();
+
+    if (!config)
+        return;
+
+    physicsDebugSupported = config->IsDebugDrawSupported();
+
+    if (physicsDebugSupported)
+    {
+        config->RegisterDebugDrawReceiver(nullptr);
+    }
+}
+
+// ------------------------------------ //
+// Drawing methods
+void DebugDrawer::DrawLine(const godot::Vector3& from, const godot::Vector3& to, const godot::Color& colour)
+{
+    if (usedDrawMemory + SingleLineDrawMemoryUse >= drawMemoryLimit)
+    {
+        extraNeededDrawMemory += SingleLineDrawMemoryUse;
+        return;
+    }
+
+    StartDrawingIfNotYetThisFrame();
+
+    if (!startedLineDraw)
+    {
+        lineMesh->clear_surfaces();
+        lineMesh->surface_begin(godot::Mesh::PRIMITIVE_LINES, lineMaterial);
+        startedLineDraw = true;
+    }
+
+    lineMesh->surface_set_color(colour);
+    lineMesh->surface_add_vertex(from);
+    lineMesh->surface_set_color(colour);
+    lineMesh->surface_add_vertex(to);
+
+    usedDrawMemory += SingleLineDrawMemoryUse;
+}
+
+void DebugDrawer::DrawTriangle(const godot::Vector3& vertex1, const godot::Vector3& vertex2,
+    const godot::Vector3& vertex3, const godot::Color& colour)
+{
+    if (usedDrawMemory + SingleTriangleDrawMemoryUse >= drawMemoryLimit)
+    {
+        extraNeededDrawMemory += SingleLineDrawMemoryUse;
+        return;
+    }
+
+    StartDrawingIfNotYetThisFrame();
+
+    if (!startedTriangleDraw)
+    {
+        triangleMesh->clear_surfaces();
+        triangleMesh->surface_begin(godot::Mesh::PRIMITIVE_TRIANGLES, triangleMaterial);
+        startedTriangleDraw = true;
+    }
+
+    triangleMesh->surface_set_color(colour);
+    triangleMesh->surface_add_vertex(vertex1);
+
+    triangleMesh->surface_set_color(colour);
+    triangleMesh->surface_add_vertex(vertex2);
+
+    triangleMesh->surface_set_color(colour);
+    triangleMesh->surface_add_vertex(vertex3);
+
+    usedDrawMemory += SingleTriangleDrawMemoryUse;
+}
+
+void DebugDrawer::StartDrawingIfNotYetThisFrame()
+{
+    if (drawnThisFrame)
+        return;
+
+    usedDrawMemory = 0;
+    extraNeededDrawMemory = 0;
+
+    drawnThisFrame = true;
+}
+
+// ------------------------------------ //
+// TimedLine handling
+void DebugDrawer::HandleTimedLines(float delta)
+{
+    auto count = timedLines.size();
+    for (size_t i = 0; i < count; ++i)
+    {
+        auto& line = timedLines[i];
+
+        line.TimePassed += delta;
+
+        const auto fraction = line.TimePassed / LineLifeTime;
+
+        if (fraction >= 1)
+        {
+            // Line time ended
+            // Copy last element here to effectively erase the item at current index without keeping order
+            timedLines[i] = timedLines[count - 1];
+            --i;
+            --count;
+            timedLines.pop_back();
+            continue;
+        }
+
+        const auto endColour = godot::Color(line.Colour, 0);
+
+        const auto colour = line.Colour.lerp(endColour, fraction);
+
+        DrawLine(line.From, line.To, colour);
+    }
+}
+
+void DebugDrawer::OnlyElapseLineTime(float delta)
+{
+    for (auto& line : timedLines)
+    {
+        line.TimePassed += delta;
+    }
+}
+
+} // namespace Thrive

--- a/DebugDrawer.hpp
+++ b/DebugDrawer.hpp
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <vector>
+
+#include "Include.h"
+
+BEGIN_GODOT_INCLUDES;
+#include <godot_cpp/classes/control.hpp>
+#include <godot_cpp/classes/material.hpp>
+#include <Jolt/Jolt.h>
+#include <Jolt/Math/Real.h>
+END_GODOT_INCLUDES;
+
+namespace godot
+{
+class MeshInstance3D;
+class ImmediateMesh;
+} // namespace godot
+
+namespace Thrive
+{
+/// How far away from the world origin debug draw works. When farther away no debug drawing happens. Setting this too
+/// far seems to trigger a problem in Godot where a grey overlay is over all 3D content blocking everything.
+/// TODO: if we need bigger worlds then the DebugDrawer will need to be updated to reposition its meshes to get a
+/// smaller bounding box working
+constexpr float DEBUG_DRAW_MAX_DISTANCE_ORIGIN = 1000000000.0f;
+
+/// \brief Hides the debug drawing after this time of inactivity. Makes sure debug draw is still visible after a while
+/// the game is paused, but will eventually clear up (for example if going to a part of the game that doesn't
+/// use debug drawing
+constexpr float HideAfterInactiveFor = 15.0f;
+
+// These are used from C# so may not be changed
+constexpr auto SignalNameOnDebugCameraPositionChanged = "OnPhysicsDebugCameraPositionChanged";
+constexpr auto SignalNameOnPhysicsDebugLevelChanged = "OnPhysicsDebugLevelChanged";
+
+/// \brief The native code side of the debug drawing in Thrive
+///
+/// This also has a C# side to forward requests here but the core logic is here in C++ for maximum performance
+class DebugDrawer final : public godot::Control
+{
+    GDCLASS(DebugDrawer, godot::Control)
+
+    static constexpr float LineLifeTime = 8;
+
+    // For consistency should match the C# side
+    static constexpr float PointLineWidth = 0.3f;
+
+    static const godot::Vector3 pointOffsetLeft;
+    static const godot::Vector3 pointOffsetUp;
+    static const godot::Vector3 pointOffsetRight;
+    static const godot::Vector3 pointOffsetDown;
+    static const godot::Vector3 pointOffsetForward;
+    static const godot::Vector3 pointOffsetBack;
+
+    struct TimedLine
+    {
+    public:
+        inline TimedLine(const godot::Vector3& from, const godot::Vector3& to, const godot::Color& colour) :
+            From(from), To(to), Colour(colour), TimePassed(0)
+        {
+        }
+
+        // These can't be const to have copy assignment operators
+        godot::Vector3 From;
+        godot::Vector3 To;
+        godot::Color Colour;
+        float TimePassed;
+    };
+
+public:
+    const godot::StringName SignalOnDebugCameraPositionChanged;
+    const godot::StringName SignalOnPhysicsDebugLevelChanged;
+
+    DebugDrawer();
+    ~DebugDrawer();
+
+    void _ready() override;
+    void Init();
+
+    void _process(double delta) override;
+
+    void IncrementPhysicsDebugLevel() noexcept;
+    void EnablePhysicsDebug() noexcept;
+    void DisablePhysicsDebug() noexcept;
+
+    inline void AddLine(const godot::Vector3& from, const godot::Vector3& to, const godot::Color& colour) noexcept
+    {
+        AddTimedLine({from, to, colour});
+    }
+
+    inline void AddPoint(const godot::Vector3& position, const godot::Color& colour) noexcept
+    {
+        AddLine(position + pointOffsetLeft, position + pointOffsetRight, colour);
+        AddLine(position + pointOffsetUp, position + pointOffsetDown, colour);
+        AddLine(position + pointOffsetForward, position + pointOffsetBack, colour);
+    }
+
+    void OnReceiveLines(const std::vector<std::tuple<JPH::RVec3, JPH::RVec3, JPH::Float4>>& lineBuffer) noexcept;
+    void OnReceiveTriangles(const std::vector<std::tuple<JPH::RVec3, JPH::RVec3, JPH::RVec3, JPH::Float4>>&
+            triangleBuffer) noexcept;
+
+    bool RegisterDebugDraw() noexcept;
+    void RemoveDebugDraw() noexcept;
+
+    [[nodiscard]] int GetDebugLevel() const noexcept
+    {
+        return currentPhysicsDebugLevel;
+    }
+
+    void SetDebugLevel(int newLevel) noexcept
+    {
+        currentPhysicsDebugLevel = newLevel;
+
+        if (currentPhysicsDebugLevel > MAX_DEBUG_DRAW_LEVEL)
+            currentPhysicsDebugLevel = MAX_DEBUG_DRAW_LEVEL;
+    }
+
+    [[nodiscard]] bool GetDebugDrawAvailable() const noexcept
+    {
+        return physicsDebugSupported;
+    }
+
+    [[nodiscard]] godot::Vector3 GetDebugCameraLocation() const noexcept
+    {
+        return debugCameraLocation;
+    }
+
+    void SetDebugCameraLocation(godot::Vector3 location) noexcept
+    {
+        if (debugCameraLocation == location)
+            return;
+
+        debugCameraLocation = location;
+
+        emit_signal(SignalNameOnDebugCameraPositionChanged, debugCameraLocation);
+    }
+
+    [[nodiscard]] godot::Variant GetThis() noexcept
+    {
+        return {reinterpret_cast<int64_t>(this)};
+    }
+
+protected:
+    static void _bind_methods();
+
+private:
+    void DrawLine(const godot::Vector3& from, const godot::Vector3& to, const godot::Color& colour);
+    void DrawTriangle(const godot::Vector3& vertex1, const godot::Vector3& vertex2, const godot::Vector3& vertex3,
+        const godot::Color& colour);
+    void StartDrawingIfNotYetThisFrame();
+
+    inline void AddTimedLine(const TimedLine& line)
+    {
+        timedLines.emplace_back(line);
+    }
+
+    void HandleTimedLines(float delta);
+    void OnlyElapseLineTime(float delta);
+
+private:
+    static DebugDrawer* instance;
+
+    godot::Ref<godot::Material> lineMaterial;
+    godot::Ref<godot::Material> triangleMaterial;
+
+    godot::MeshInstance3D* lineDrawer = nullptr;
+    godot::MeshInstance3D* triangleDrawer = nullptr;
+
+    godot::Ref<godot::ImmediateMesh> lineMesh;
+    godot::Ref<godot::ImmediateMesh> triangleMesh;
+
+    godot::Vector3 debugCameraLocation{0, 0, 0};
+
+    std::vector<TimedLine> timedLines;
+
+    /// \brief As the data is not drawn each frame, there's a delay before hiding the draw result
+    double timeInactive = 0;
+
+    int currentPhysicsDebugLevel = 0;
+
+    /// Set a max limit to not draw way too much stuff and slow down things a ton. 8 megabytes
+    const int drawMemoryLimit = 1024 * 1024 * 8;
+    int usedDrawMemory = 0;
+    int extraNeededDrawMemory = 0;
+
+    bool physicsDebugSupported = false;
+    bool warnedAboutHittingMemoryLimit = false;
+    bool drawnThisFrame = false;
+
+    bool startedLineDraw = false;
+    bool startedTriangleDraw = false;
+};
+
+} // namespace Thrive

--- a/NativeLibIntercommunication.hpp
+++ b/NativeLibIntercommunication.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <Jolt/Jolt.h>
+#include <Jolt/Math/Real.h>
+
+namespace Thrive
+{
+
+constexpr uint64_t INTEROP_MAGIC_VALUE = 42 * 42;
+
+using OnDebugLines = void (*)(const std::vector<std::tuple<JPH::RVec3, JPH::RVec3, JPH::Float4>>& lineBuffer);
+using OnDebugTriangles = void (*)(const std::vector<std::tuple<JPH::RVec3, JPH::RVec3, JPH::RVec3, JPH::Float4>>&
+        triangleBuffer);
+
+/// \brief Contains pointers and other info passed through from ThriveNative to ThriveExtension during runtime setup phase
+class NativeLibIntercommunication
+{
+public:
+    NativeLibIntercommunication()
+    {
+        SanityCheckValue = INTEROP_MAGIC_VALUE;
+    }
+
+    // Callback receivers
+
+    // Sanity check value to make sure reader and writer are probably synchronized
+    uint64_t SanityCheckValue;
+
+    OnDebugLines DebugLineReceiver = nullptr;
+    OnDebugTriangles DebugTriangleReceiver = nullptr;
+
+    // Flags
+    bool PhysicsDebugSupported = false;
+};
+
+} // namespace Thrive

--- a/ThriveConfig.cpp
+++ b/ThriveConfig.cpp
@@ -1,0 +1,189 @@
+// ------------------------------------ //
+#include "ThriveConfig.hpp"
+
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include "nodes/DebugDrawer.hpp"
+#include "physics/DebugDrawForwarder.hpp"
+
+// ------------------------------------ //
+namespace Thrive
+{
+
+constexpr int INIT_MAGIC = 765442;
+
+ThriveConfig* ThriveConfig::instance = nullptr;
+
+DebugDrawer* activeDrawerInstance = nullptr;
+
+void ForwardLines(const std::vector<std::tuple<JPH::RVec3, JPH::RVec3, JPH::Float4>>& lineBuffer) noexcept
+{
+    if (activeDrawerInstance == nullptr)
+        return;
+
+    activeDrawerInstance->OnReceiveLines(lineBuffer);
+}
+
+void ForwardTriangles(
+    const std::vector<std::tuple<JPH::RVec3, JPH::RVec3, JPH::RVec3, JPH::Float4>>& triangleBuffer) noexcept
+{
+    if (activeDrawerInstance == nullptr)
+        return;
+
+    activeDrawerInstance->OnReceiveTriangles(triangleBuffer);
+}
+
+int InitValueLocation = -1;
+
+ThriveConfig::~ThriveConfig()
+{
+    if (initialized)
+    {
+        ERR_PRINT("ThriveConfig is still initialized during destruction, Shutdown should be called first");
+    }
+}
+
+void ThriveConfig::_bind_methods()
+{
+    using namespace godot;
+    ClassDB::bind_method(
+        D_METHOD("ReportOtherVersions", "csharpVersion", "nativeLibraryVersion"), &ThriveConfig::ReportOtherVersions);
+    ClassDB::bind_method(D_METHOD("Initialize", "intercommunication"), &ThriveConfig::Initialize);
+    ClassDB::bind_method(D_METHOD("Shutdown"), &ThriveConfig::Shutdown);
+}
+
+// ------------------------------------ //
+bool ThriveConfig::ReportOtherVersions(int csharpVersion, int nativeLibraryVersion) noexcept
+{
+    if (csharpVersion != THRIVE_EXTENSION_VERSION)
+    {
+        ERR_PRINT("Thrive GDExtension version (" + godot::String::num_int64(THRIVE_EXTENSION_VERSION) +
+            ") doesn't match what the C# side version is: " + godot::String::num_int64(csharpVersion));
+        return false;
+    }
+
+    if (nativeLibraryVersion != THRIVE_LIBRARY_VERSION)
+    {
+        // We'll try to be forward compatible, so just check if the native library is too old
+        if (nativeLibraryVersion < THRIVE_LIBRARY_VERSION)
+        {
+            ERR_PRINT("This Thrive GDExtension version was compiled against Thrive native version " +
+                godot::String::num_int64(THRIVE_LIBRARY_VERSION) +
+                " but it is now tried to be used with version: " + godot::String::num_int64(nativeLibraryVersion));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+ThriveConfig* ThriveConfig::InitializeImplementation(NativeLibIntercommunication& intercommunication) noexcept
+{
+    if (intercommunication.SanityCheckValue != INTEROP_MAGIC_VALUE)
+    {
+        ERR_PRINT("Interop data passed to Thrive Extension is corrupt (unexpected magic value)");
+        return nullptr;
+    }
+
+    // This is kept for when there's more complex initialization
+    /*if (false)
+    {
+        ERR_PRINT("ThriveConfig object initialization failed");
+        return nullptr;
+    }*/
+
+    // Init succeeded
+    initialized = true;
+    InitValueLocation = INIT_MAGIC;
+    instance = this;
+
+    // Store for later accessing
+    storedIntercommunication = &intercommunication;
+
+    godot::UtilityFunctions::print("Thrive GDExtension initialized successfully");
+    return this;
+}
+
+godot::Variant ThriveConfig::Initialize(const godot::Variant& intercommunication) noexcept
+{
+    if (intercommunication.get_type() != godot::Variant::INT)
+    {
+        ERR_PRINT("Extension initialize expected to get an int as parameter");
+        return {false};
+    }
+
+    const auto convertedIntercommunication =
+        reinterpret_cast<NativeLibIntercommunication*>(static_cast<int64_t>(intercommunication));
+
+    if (convertedIntercommunication == nullptr)
+    {
+        ERR_PRINT("Extension initialize was given a null value as the intercommunication object");
+        return {false};
+    }
+
+    return {reinterpret_cast<int64_t>(InitializeImplementation(*convertedIntercommunication))};
+}
+
+bool ThriveConfig::Shutdown() noexcept
+{
+    if (!initialized)
+    {
+        ERR_PRINT("This config object is not initialized (shutdown called)");
+        return false;
+    }
+
+    instance = nullptr;
+    initialized = false;
+    return true;
+}
+
+// ------------------------------------ //
+
+bool ThriveConfig::IsDebugDrawSupported() const noexcept
+{
+    if (!storedIntercommunication)
+    {
+        ERR_PRINT("ThriveConfig not initialized (missing intercommunication)");
+        return false;
+    }
+
+    return storedIntercommunication->PhysicsDebugSupported;
+}
+
+void ThriveConfig::RegisterDebugDrawReceiver(DebugDrawer* drawer) noexcept
+{
+    if (!storedIntercommunication)
+    {
+        ERR_PRINT("ThriveConfig not initialized (missing intercommunication)");
+        return;
+    }
+
+    if (drawer == nullptr)
+    {
+        storedIntercommunication->DebugLineReceiver = nullptr;
+        storedIntercommunication->DebugTriangleReceiver = nullptr;
+        activeDrawerInstance = nullptr;
+        return;
+    }
+
+    activeDrawerInstance = drawer;
+    storedIntercommunication->DebugLineReceiver = ForwardLines;
+    storedIntercommunication->DebugTriangleReceiver = ForwardTriangles;
+}
+
+// ------------------------------------ //
+int ThriveConfig::GetVersion() const noexcept
+{
+    // Detect library load conflicts between what Godot loaded and what is used through C# interop
+    if (InitValueLocation != INIT_MAGIC)
+    {
+        ERR_PRINT(
+            "Unexpected value in init data location. Has this library been loaded twice from conflicting places?");
+        return -1;
+    }
+
+    return THRIVE_EXTENSION_VERSION;
+}
+
+} // namespace Thrive


### PR DESCRIPTION
**Brief Description of What This PR Does**

Implemented a targeted fix for https://github.com/Revolutionary-Games/Thrive/issues/6728 by removing persisted RVec3Arg usage from the physics debug draw data path.
The debug-draw pipeline no longer stores/passes RVec3Arg references across frames/callbacks; it now uses owned JPH::RVec3 values.
Non-AVX compile validation succeeded for the extension path (THRIVE_AVX=OFF), producing libthrive_extension_without_avx.dll, so the cross-module signature changes are consistent.
