### PR TITLE
Implemented #6639

### DIFF
--- a/CInterop.cpp
+++ b/CInterop.cpp
@@ -1,0 +1,765 @@
+// ------------------------------------ //
+#include "CInterop.h"
+
+#include <bit>
+#include <cstdarg>
+#include <cstring>
+
+#include "Jolt/Core/Factory.h"
+#include "Jolt/Core/Memory.h"
+#include "Jolt/Jolt.h"
+#include "Jolt/RegisterTypes.h"
+
+#include "core/IntercommunicationManager.hpp"
+#include "core/TaskSystem.hpp"
+#include "physics/DebugDrawForwarder.hpp"
+#include "physics/PhysicalWorld.hpp"
+#include "physics/PhysicsBody.hpp"
+#include "physics/ShapeCreator.hpp"
+#include "physics/ShapeWrapper.hpp"
+#include "physics/SimpleShapes.hpp"
+#include "physics/TrackedConstraint.hpp"
+
+#include "JoltTypeConversions.hpp"
+
+#if (defined(_M_ARM64) || defined(_M_ARM)) && defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
+#ifdef USE_OBJECT_POOLS
+#include "boost/pool/singleton_pool.hpp"
+#endif
+
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "cppcoreguidelines-pro-type-reinterpret-cast"
+
+// ------------------------------------ //
+void PhysicsTrace(const char* fmt, ...);
+
+#ifdef USE_OBJECT_POOLS
+using ShapePool = boost::singleton_pool<Thrive::Physics::ShapeWrapper, sizeof(Thrive::Physics::ShapeWrapper)>;
+#endif
+
+#ifdef JPH_ENABLE_ASSERTS
+bool PhysicsAssert(const char* expression, const char* message, const char* file, unsigned int line);
+#endif
+
+int32_t CheckAPIVersion()
+{
+    return THRIVE_LIBRARY_VERSION;
+}
+
+int32_t InitThriveLibrary()
+{
+    // Register physics things
+    JPH::RegisterDefaultAllocator();
+
+    JPH::Trace = PhysicsTrace;
+    JPH_IF_ENABLE_ASSERTS(JPH::AssertFailed = PhysicsAssert;)
+
+    JPH::Factory::sInstance = new JPH::Factory();
+
+    JPH::RegisterTypes();
+
+    // Start up the task system
+    Thrive::TaskSystem::Get();
+
+#ifdef JPH_DEBUG_RENDERER
+    Thrive::IntercommunicationManager::Get().ReportDebugDrawWorks();
+
+    auto& communication = Thrive::IntercommunicationManager::Get().GetIntercommunicationObjectModifiable();
+
+    Thrive::Physics::DebugDrawForwarder::GetInstance().SetOutputLineReceiver(&communication.DebugLineReceiver);
+    Thrive::Physics::DebugDrawForwarder::GetInstance().SetOutputTriangleReceiver(&communication.DebugTriangleReceiver);
+
+#endif
+
+    LOG_DEBUG("Native library init succeeded");
+    return 0;
+}
+
+void ShutdownThriveLibrary()
+{
+    Thrive::TaskSystem::AssertIsMainThread();
+
+    // Unregister physics
+    JPH::UnregisterTypes();
+
+    delete JPH::Factory::sInstance;
+    JPH::Factory::sInstance = nullptr;
+
+    Thrive::TaskSystem::Get().Shutdown();
+
+#ifdef JPH_DEBUG_RENDERER
+    Thrive::Physics::DebugDrawForwarder::GetInstance().ClearOutputReceivers();
+#endif
+
+    SetLogForwardingCallback(nullptr);
+}
+
+NativeLibIntercommunicationOpaque* GetIntercommunicationBridge()
+{
+    Thrive::TaskSystem::AssertIsMainThread();
+
+    // Const is cast away here as the C interface cannot specify it. The documentation says not to modify the object
+    return const_cast<NativeLibIntercommunicationOpaque*>(reinterpret_cast<const NativeLibIntercommunicationOpaque*>(
+        &Thrive::IntercommunicationManager::Get().GetIntercommunicationObject()));
+}
+
+// ------------------------------------ //
+void SetLogLevel(int8_t level)
+{
+    Thrive::Logger::Get().SetLogLevel(static_cast<Thrive::LogLevel>(level));
+}
+
+void SetLogForwardingCallback(OnLogMessage callback)
+{
+    if (callback == nullptr)
+    {
+        Thrive::Logger::Get().SetLogTargetOverride(nullptr);
+    }
+    else
+    {
+        Thrive::Logger::Get().SetLogTargetOverride([callback](std::string_view message, Thrive::LogLevel level)
+            { callback(message.data(), static_cast<int32_t>(message.length()), static_cast<int8_t>(level)); });
+
+        LOG_DEBUG("Native log message forwarding setup");
+    }
+}
+
+// ------------------------------------ //
+PhysicalWorld* CreatePhysicalWorld()
+{
+    return reinterpret_cast<PhysicalWorld*>(new Thrive::Physics::PhysicalWorld());
+}
+
+void DestroyPhysicalWorld(PhysicalWorld* physicalWorld)
+{
+    if (physicalWorld == nullptr)
+        return;
+
+    delete reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld);
+}
+
+bool ProcessPhysicalWorld(PhysicalWorld* physicalWorld, float delta)
+{
+    return reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)->Process(delta);
+}
+
+void ProcessPhysicalWorldInBackground(PhysicalWorld* physicalWorld, float delta)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)->ProcessInBackground(delta);
+}
+
+bool WaitForPhysicsToCompleteInPhysicalWorld(PhysicalWorld* physicalWorld)
+{
+    return reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)->WaitForPhysicsToComplete();
+}
+
+PhysicsBody* PhysicalWorldCreateMovingBody(
+    PhysicalWorld* physicalWorld, PhysicsShape* shape, JVec3 position, JQuat rotation, bool addToWorld)
+{
+    const auto body = reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+                          ->CreateMovingBody(reinterpret_cast<Thrive::Physics::ShapeWrapper*>(shape)->GetShape(),
+                              Thrive::DVec3FromCAPI(position), Thrive::QuatFromCAPI(rotation), addToWorld);
+
+    if (body)
+        body->AddRef();
+
+    return reinterpret_cast<PhysicsBody*>(body.get());
+}
+
+PhysicsBody* PhysicalWorldCreateMovingBodyWithAxisLock(PhysicalWorld* physicalWorld, PhysicsShape* shape,
+    JVec3 position, JQuat rotation, JVecF3 lockedAxes, bool lockRotation, bool addToWorld)
+{
+    const auto body =
+        reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+            ->CreateMovingBodyWithAxisLock(reinterpret_cast<Thrive::Physics::ShapeWrapper*>(shape)->GetShape(),
+                Thrive::DVec3FromCAPI(position), Thrive::QuatFromCAPI(rotation), Thrive::Vec3FromCAPI(lockedAxes),
+                lockRotation, addToWorld);
+
+    if (body)
+        body->AddRef();
+
+    return reinterpret_cast<PhysicsBody*>(body.get());
+}
+
+PhysicsBody* PhysicalWorldCreateStaticBody(
+    PhysicalWorld* physicalWorld, PhysicsShape* shape, JVec3 position, JQuat rotation, bool addToWorld)
+{
+    const auto body = reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+                          ->CreateStaticBody(reinterpret_cast<Thrive::Physics::ShapeWrapper*>(shape)->GetShape(),
+                              Thrive::DVec3FromCAPI(position), Thrive::QuatFromCAPI(rotation), addToWorld);
+
+    if (body)
+        body->AddRef();
+
+    return reinterpret_cast<PhysicsBody*>(body.get());
+}
+
+PhysicsBody* PhysicalWorldCreateSensor(PhysicalWorld* physicalWorld, PhysicsShape* shape, JVec3 position,
+    JQuat rotation, bool detectSleepingBodies, bool detectStaticBodies)
+{
+    const auto body =
+        reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+            ->CreateSensor(reinterpret_cast<Thrive::Physics::ShapeWrapper*>(shape)->GetShape(),
+                Thrive::DVec3FromCAPI(position), Thrive::QuatFromCAPI(rotation),
+                detectSleepingBodies ? JPH::EMotionType::Kinematic : JPH::EMotionType::Static, detectStaticBodies);
+
+    if (body)
+        body->AddRef();
+
+    return reinterpret_cast<PhysicsBody*>(body.get());
+}
+
+void PhysicalWorldAddBody(PhysicalWorld* physicalWorld, PhysicsBody* body, bool activate)
+{
+    if (body == nullptr)
+        return;
+
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->AddBody(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body), activate);
+}
+
+void PhysicalWorldDetachBody(PhysicalWorld* physicalWorld, PhysicsBody* body)
+{
+    if (body == nullptr)
+        return;
+
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->DetachBody(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body));
+}
+
+void DestroyPhysicalWorldBody(PhysicalWorld* physicalWorld, PhysicsBody* body)
+{
+    if (physicalWorld == nullptr || body == nullptr)
+        return;
+
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->DestroyBody(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body));
+}
+
+void SetPhysicsBodyLinearDamping(PhysicalWorld* physicalWorld, PhysicsBody* body, float damping)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetDamping(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(), damping, nullptr);
+}
+
+void SetPhysicsBodyLinearAndAngularDamping(
+    PhysicalWorld* physicalWorld, PhysicsBody* body, float linearDamping, float angularDamping)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetDamping(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(), linearDamping, &angularDamping);
+}
+
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "cppcoreguidelines-pro-type-member-init"
+
+void ReadPhysicsBodyTransform(
+    PhysicalWorld* physicalWorld, PhysicsBody* body, JVec3* positionReceiver, JQuat* rotationReceiver)
+{
+#ifndef NDEBUG
+    if (physicalWorld == nullptr || body == nullptr || positionReceiver == nullptr || rotationReceiver == nullptr)
+    {
+        LOG_ERROR("Physics body read transform call with invalid parameters");
+        return;
+    }
+#endif
+
+    JPH::DVec3 readPosition;
+    JPH::Quat readQuat;
+
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->ReadBodyTransform(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(), readPosition, readQuat);
+
+    *positionReceiver = Thrive::DVec3ToCAPI(readPosition);
+    *rotationReceiver = Thrive::QuatToCAPI(readQuat);
+}
+
+void ReadPhysicsBodyVelocity(
+    PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3* velocityReceiver, JVecF3* angularVelocityReceiver)
+{
+#ifndef NDEBUG
+    if (physicalWorld == nullptr || body == nullptr || velocityReceiver == nullptr ||
+        angularVelocityReceiver == nullptr)
+    {
+        LOG_ERROR("Physics body read velocity call with invalid parameters");
+        return;
+    }
+#endif
+
+    JPH::Vec3 readVelocity;
+    JPH::Vec3 readAngular;
+
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->ReadBodyVelocity(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(), readVelocity, readAngular);
+
+    *velocityReceiver = Thrive::Vec3ToCAPI(readVelocity);
+    *angularVelocityReceiver = Thrive::Vec3ToCAPI(readAngular);
+}
+
+#pragma clang diagnostic pop
+
+void GiveImpulse(PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 impulse, bool autoActivate)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->GiveImpulse(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(), Thrive::Vec3FromCAPI(impulse),
+            autoActivate);
+}
+
+void GiveAngularImpulse(PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 angularImpulse, bool autoActivate)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->GiveAngularImpulse(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(),
+            Thrive::Vec3FromCAPI(angularImpulse), autoActivate);
+}
+
+void SetBodyControl(
+    PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 movementImpulse, JQuat targetRotation, float rotationRate)
+{
+    if (physicalWorld == nullptr || body == nullptr)
+    {
+        LOG_ERROR("Invalid call to physics body applying control");
+        return;
+    }
+
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetBodyControl(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body), Thrive::Vec3FromCAPI(movementImpulse),
+            Thrive::QuatFromCAPI(targetRotation), rotationRate);
+}
+
+void DisableBodyControl(PhysicalWorld* physicalWorld, PhysicsBody* body)
+{
+    if (physicalWorld == nullptr || body == nullptr)
+    {
+        return;
+    }
+
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->DisableBodyControl(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body));
+}
+
+void SetBodyPosition(PhysicalWorld* physicalWorld, PhysicsBody* body, JVec3 position, bool activate)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetPosition(
+            reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(), Thrive::DVec3FromCAPI(position), activate);
+}
+
+void SetBodyPositionAndRotation(
+    PhysicalWorld* physicalWorld, PhysicsBody* body, JVec3 position, JQuat rotation, bool activate)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetPositionAndRotation(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(),
+            Thrive::DVec3FromCAPI(position), Thrive::QuatFromCAPI(rotation), activate);
+}
+
+void SetBodyVelocity(PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 velocity, bool autoActivate)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetVelocity(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(), Thrive::Vec3FromCAPI(velocity),
+            autoActivate);
+}
+
+void SetBodyAngularVelocity(PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 angularVelocity, bool autoActivate)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetAngularVelocity(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(),
+            Thrive::Vec3FromCAPI(angularVelocity), autoActivate);
+}
+
+void SetBodyVelocityAndAngularVelocity(
+    PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 velocity, JVecF3 angularVelocity, bool autoActivate)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetVelocityAndAngularVelocity(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(),
+            Thrive::Vec3FromCAPI(velocity), Thrive::Vec3FromCAPI(angularVelocity), autoActivate);
+}
+
+void SetBodyAllowSleep(PhysicalWorld* physicalWorld, PhysicsBody* body, bool allowSleep)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetBodyAllowSleep(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId(), allowSleep);
+}
+
+bool FixBodyYCoordinateToZero(PhysicalWorld* physicalWorld, PhysicsBody* body)
+{
+    return reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->FixBodyYCoordinateToZero(reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->GetId());
+}
+
+void ChangeBodyShape(PhysicalWorld* physicalWorld, PhysicsBody* body, PhysicsShape* shape, bool activate)
+{
+    return reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->ChangeBodyShape(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body),
+            reinterpret_cast<Thrive::Physics::ShapeWrapper*>(shape)->GetShape(), activate);
+}
+
+void PhysicsBodyAddAxisLock(PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 axis, bool lockRotation)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->CreateAxisLockConstraint(
+            *reinterpret_cast<Thrive::Physics::PhysicsBody*>(body), Thrive::Vec3FromCAPI(axis), lockRotation);
+}
+
+// ------------------------------------ //
+void PhysicsBodySetCollisionEnabledState(PhysicalWorld* physicalWorld, PhysicsBody* body, bool collisionsEnabled)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetCollisionDisabledState(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body), !collisionsEnabled);
+}
+
+// ------------------------------------ //
+void PhysicsBodyAddCollisionIgnore(PhysicalWorld* physicalWorld, PhysicsBody* body, PhysicsBody* addIgnore)
+{
+    bool handleDuplicates = true;
+
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->AddCollisionIgnore(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body),
+            *reinterpret_cast<Thrive::Physics::PhysicsBody*>(addIgnore), handleDuplicates);
+}
+
+void PhysicsBodyRemoveCollisionIgnore(PhysicalWorld* physicalWorld, PhysicsBody* body, PhysicsBody* removeIgnore)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->RemoveCollisionIgnore(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body),
+            *reinterpret_cast<Thrive::Physics::PhysicsBody*>(removeIgnore));
+}
+
+void PhysicsBodyClearCollisionIgnores(PhysicalWorld* physicalWorld, PhysicsBody* body)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->ClearCollisionIgnores(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body));
+}
+
+void PhysicsBodySetCollisionIgnores(
+    PhysicalWorld* physicalWorld, PhysicsBody* body, PhysicsBody* ignoredBodies[], int32_t count)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetCollisionIgnores(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body),
+            reinterpret_cast<Thrive::Physics::PhysicsBody*&>(ignoredBodies), count);
+}
+
+void PhysicsBodyClearAndSetSingleIgnore(PhysicalWorld* physicalWorld, PhysicsBody* body, PhysicsBody* onlyIgnoredBody)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetSingleCollisionIgnore(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body),
+            *reinterpret_cast<Thrive::Physics::PhysicsBody*>(onlyIgnoredBody));
+}
+
+// ------------------------------------ //
+int32_t* PhysicsBodyEnableCollisionRecording(
+    PhysicalWorld* physicalWorld, PhysicsBody* body, char* collisionRecordingTarget, int32_t maxRecordedCollisions)
+{
+    return const_cast<int32_t*>(reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+            ->EnableCollisionRecording(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body),
+                reinterpret_cast<Thrive::Physics::CollisionRecordListType>(collisionRecordingTarget),
+                maxRecordedCollisions));
+}
+
+void PhysicsBodyDisableCollisionRecording(PhysicalWorld* physicalWorld, PhysicsBody* body)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->DisableCollisionRecording(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body));
+}
+
+void PhysicsBodyAddCollisionFilter(PhysicalWorld* physicalWorld, PhysicsBody* body, OnFilterPhysicsCollision callback)
+{
+    // Needs a two-step cast to be able to cast the function with a pointer argument to a reference argument. This
+    // should be always safe as pointers and references are in-memory handled the same so the methods are equivalent.
+    const auto partiallyConverted = reinterpret_cast<void (*)()>(callback);
+
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->AddCollisionFilter(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body),
+            reinterpret_cast<Thrive::Physics::CollisionFilterCallback>(partiallyConverted));
+}
+
+void PhysicsBodyDisableCollisionFilter(PhysicalWorld* physicalWorld, PhysicsBody* body)
+{
+    reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->DisableCollisionFilter(*reinterpret_cast<Thrive::Physics::PhysicsBody*>(body));
+}
+
+// ------------------------------------ //
+void PhysicalWorldSetGravity(PhysicalWorld* physicalWorld, JVecF3 gravity)
+{
+    return reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)->SetGravity(Thrive::Vec3FromCAPI(gravity));
+}
+
+void PhysicalWorldRemoveGravity(PhysicalWorld* physicalWorld)
+{
+    return reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)->RemoveGravity();
+}
+
+// ------------------------------------ //
+int32_t PhysicalWorldCastRayGetAll(
+    PhysicalWorld* physicalWorld, JVec3 start, JVecF3 endOffset, PhysicsRayWithUserData* dataReceiver, int32_t maxHits)
+{
+    return reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->CastRayGetAllUserData(Thrive::DVec3FromCAPI(start), Thrive::Vec3FromCAPI(endOffset),
+            reinterpret_cast<Thrive::Physics::PhysicsRayWithUserData*>(dataReceiver), maxHits);
+}
+
+// ------------------------------------ //
+float PhysicalWorldGetPhysicsLatestTime(PhysicalWorld* physicalWorld)
+{
+    return reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)->GetLatestPhysicsTime();
+}
+
+float PhysicalWorldGetPhysicsAverageTime(PhysicalWorld* physicalWorld)
+{
+    return reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)->GetAveragePhysicsTime();
+}
+
+bool PhysicalWorldDumpPhysicsState(PhysicalWorld* physicalWorld, const char* path)
+{
+    return reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)->DumpSystemState(path);
+}
+
+void PhysicalWorldSetDebugDrawLevel(PhysicalWorld* physicalWorld, int32_t level)
+{
+    return reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)->SetDebugLevel(level);
+}
+
+void PhysicalWorldSetDebugDrawCameraLocation(PhysicalWorld* physicalWorld, JVecF3 position)
+{
+    return reinterpret_cast<Thrive::Physics::PhysicalWorld*>(physicalWorld)
+        ->SetDebugCameraLocation(Thrive::Vec3FromCAPI(position));
+}
+
+// ------------------------------------ //
+void ReleasePhysicsBodyReference(PhysicsBody* body)
+{
+    if (body == nullptr)
+        return;
+
+    reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->Release();
+}
+
+bool PhysicsBodyIsDetached(PhysicsBody* body)
+{
+    // Due to the C# interop declaration not working correctly for this function, the return value is interpreted as
+    // a byte
+    static_assert(sizeof(bool) == 1);
+
+    const bool detached = reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->IsDetached();
+
+    return detached;
+}
+
+void PhysicsBodySetUserData(PhysicsBody* body, const char* data, int32_t dataLength)
+{
+    if (!reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->SetUserData(data, dataLength))
+    {
+        LOG_ERROR("PhysicsBodySetUserData: called with wrong data length, cannot store the data");
+    }
+}
+
+void PhysicsBodyForceClearRecordingTargets(PhysicsBody* body)
+{
+    reinterpret_cast<Thrive::Physics::PhysicsBody*>(body)->ClearCollisionRecordingTarget();
+}
+
+// ------------------------------------ //
+template<class... ArgsT>
+inline Thrive::Physics::ShapeWrapper* CreateShapeWrapper(ArgsT&&... args)
+{
+    Thrive::Physics::ShapeWrapper* result;
+
+#ifdef USE_OBJECT_POOLS
+    result = Thrive::ConstructFromGlobalPoolRaw<Thrive::Physics::ShapeWrapper>(std::forward<ArgsT>(args)...);
+#else
+    result = new Thrive::Physics::ShapeWrapper(std::forward<ArgsT>(args)...);
+#endif
+
+    if (!result)
+        LOG_ERROR("Failed to allocate ShapeWrapper");
+
+    result->AddRef();
+    return result;
+}
+
+PhysicsShape* CreateBoxShape(float halfSideLength, float density)
+{
+    return reinterpret_cast<PhysicsShape*>(
+        CreateShapeWrapper(Thrive::Physics::SimpleShapes::CreateBox(halfSideLength, density)));
+}
+
+PhysicsShape* CreateBoxShapeWithDimensions(JVecF3 halfDimensions, float density)
+{
+    return reinterpret_cast<PhysicsShape*>(
+        CreateShapeWrapper(Thrive::Physics::SimpleShapes::CreateBox(Thrive::Vec3FromCAPI(halfDimensions), density)));
+}
+
+PhysicsShape* CreateSphereShape(float radius, float density)
+{
+    return reinterpret_cast<PhysicsShape*>(
+        CreateShapeWrapper(Thrive::Physics::SimpleShapes::CreateSphere(radius, density)));
+}
+
+PhysicsShape* CreateCylinderShape(float halfHeight, float radius, float density)
+{
+    return reinterpret_cast<PhysicsShape*>(
+        CreateShapeWrapper(Thrive::Physics::SimpleShapes::CreateCylinder(halfHeight, radius, density)));
+}
+
+PhysicsShape* CreateCapsuleShape(float halfHeight, float radius, float density)
+{
+    return reinterpret_cast<PhysicsShape*>(
+        CreateShapeWrapper(Thrive::Physics::SimpleShapes::CreateCapsule(halfHeight, radius, density)));
+}
+
+PhysicsShape* CreateMicrobeShapeConvex(JVecF3* points, uint32_t pointCount, float density, float scale, float thickness)
+{
+    // We don't want to do any extra data copies here (as the C# marshalling already copies stuff) so this API takes
+    // in the JVecF3 pointer
+
+    return reinterpret_cast<PhysicsShape*>(CreateShapeWrapper(
+        Thrive::Physics::ShapeCreator::CreateMicrobeShapeConvex(points, pointCount, density, scale, thickness)));
+}
+
+PhysicsShape* CreateMicrobeShapeSpheres(JVecF3* points, uint32_t pointCount, float density, float scale)
+{
+    // We don't want to do any extra data copies here (as the C# marshalling already copies stuff) so this API takes
+    // in the JVecF3 pointer
+
+    return reinterpret_cast<PhysicsShape*>(CreateShapeWrapper(
+        Thrive::Physics::ShapeCreator::CreateMicrobeShapeSpheres(points, pointCount, density, scale)));
+}
+
+PhysicsShape* CreateConvexShape(JVecF3* points, uint32_t pointCount, float density, float scale, float convexRadius)
+{
+    return reinterpret_cast<PhysicsShape*>(CreateShapeWrapper(
+        Thrive::Physics::ShapeCreator::CreateConvex(points, pointCount, density, scale, convexRadius)));
+}
+
+PhysicsShape* CreateStaticCompoundShape(SubShapeDefinition* subShapes, uint32_t shapeCount)
+{
+    return reinterpret_cast<PhysicsShape*>(CreateShapeWrapper(Thrive::Physics::ShapeCreator::CreateStaticCompound(
+        reinterpret_cast<Thrive::Physics::SubShapeDefinition*>(subShapes), shapeCount)));
+}
+
+// ------------------------------------ //
+void ReleaseShape(PhysicsShape* shape)
+{
+    if (shape == nullptr)
+        return;
+
+    reinterpret_cast<Thrive::Physics::ShapeWrapper*>(shape)->Release();
+}
+
+// ------------------------------------ //
+float ShapeGetMass(PhysicsShape* shape)
+{
+    return reinterpret_cast<Thrive::Physics::ShapeWrapper*>(shape)->GetShape()->GetMassProperties().mMass;
+}
+
+uint32_t ShapeGetSubShapeIndex(PhysicsShape* shape, uint32_t subShapeData)
+{
+    JPH::SubShapeID unusedRemainder;
+
+    return reinterpret_cast<Thrive::Physics::ShapeWrapper*>(shape)->GetSubShapeFromID(
+        std::bit_cast<JPH::SubShapeID>(subShapeData), unusedRemainder);
+}
+
+uint32_t ShapeGetSubShapeIndexWithRemainder(PhysicsShape* shape, uint32_t subShapeData, uint32_t& remainder)
+{
+    static_assert(sizeof(remainder) == sizeof(JPH::SubShapeID));
+
+    return reinterpret_cast<Thrive::Physics::ShapeWrapper*>(shape)->GetSubShapeFromID(
+        std::bit_cast<JPH::SubShapeID>(subShapeData), reinterpret_cast<JPH::SubShapeID&>(remainder));
+}
+
+// ------------------------------------ //
+JVecF3 ShapeCalculateResultingAngularVelocity(PhysicsShape* shape, JVecF3 appliedTorque, float deltaTime)
+{
+    // This approach is created by combining MotionProperties::ApplyForceTorqueAndDragInternal and
+    // MultiplyWorldSpaceInverseInertiaByVector
+
+    const auto& massProperties =
+        reinterpret_cast<Thrive::Physics::ShapeWrapper*>(shape)->GetShape()->GetMassProperties();
+
+    const auto inverseRotationInertia = massProperties.mInertia.Inversed().GetRotation();
+
+    const auto mInvInertiaDiagonal = inverseRotationInertia.GetDiagonal3();
+    const auto mInertiaRotation = inverseRotationInertia.GetQuaternion().Normalized();
+
+    const auto accumulatedTorque = Thrive::Vec3FromCAPI(appliedTorque);
+    const auto assumedBodyRotation = JPH::Quat::sIdentity();
+
+    JPH::Mat44 rotation = JPH::Mat44::sRotation(assumedBodyRotation * mInertiaRotation);
+    auto result = rotation.Multiply3x3(mInvInertiaDiagonal * rotation.Multiply3x3Transposed(accumulatedTorque));
+
+    return Thrive::Vec3ToCAPI(deltaTime * result);
+}
+
+// ------------------------------------ //
+void ArmWaitForEvent()
+{
+#if defined(__aarch64__) || defined(__arm__) || defined(_M_ARM64) || defined(_M_ARM)
+#if defined(_MSC_VER)
+    __wfe();
+#elif defined(__clang__) || defined(__GNUC__)
+    __asm__ __volatile__("wfe" : : : "memory");
+#endif
+#endif
+}
+
+void ArmSignalEvent()
+{
+#if defined(__aarch64__) || defined(__arm__) || defined(_M_ARM64) || defined(_M_ARM)
+#if defined(_MSC_VER)
+    // DMB ISH: make previous memory writes observable before waking waiters.
+    __dmb(0xB);
+    __sev();
+#elif defined(__clang__) || defined(__GNUC__)
+    __asm__ __volatile__("dmb ish" : : : "memory");
+    __asm__ __volatile__("sev" : : : "memory");
+#endif
+#endif
+}
+
+// ------------------------------------ //
+void SetNativeExecutorThreads(int32_t count)
+{
+    LOG_DEBUG("Set native thread count: " + std::to_string(count));
+    Thrive::TaskSystem::Get().SetThreads(count);
+}
+
+int32_t GetNativeExecutorThreads()
+{
+    return Thrive::TaskSystem::Get().GetThreads();
+}
+
+// ------------------------------------ //
+
+#pragma clang diagnostic pop
+
+void PhysicsTrace(const char* fmt, ...)
+{
+    const char prefix[] = "[Jolt:Trace] ";
+    constexpr size_t prefixLength = sizeof(prefix);
+
+    // Format the message
+    va_list list;
+    va_start(list, fmt);
+    char buffer[1024];
+    vsnprintf(buffer + prefixLength, sizeof(buffer) - prefixLength, fmt, list);
+    va_end(list);
+
+    std::memcpy(buffer, prefix, prefixLength);
+    buffer[1023] = 0;
+
+    LOG_INFO(std::string_view(buffer, std::strlen(buffer)));
+}
+
+#ifdef JPH_ENABLE_ASSERTS
+bool PhysicsAssert(const char* expression, const char* message, const char* file, unsigned int line)
+{
+    LOG_ERROR(std::string("Jolt assert failed in ") + file + ":" + std::to_string(line) + " (" + expression + ") " +
+        (message ? message : ""));
+
+    // True seems to indicate that break is wanted (TODO: maybe set to false in production?)
+    return true;
+}
+#endif

--- a/CInterop.h
+++ b/CInterop.h
@@ -1,0 +1,228 @@
+#pragma once
+
+#include <cstdint>
+
+#include "Include.h"
+
+#include "interop/CStructures.h"
+
+/// \file Defines all of the API methods that can be called from C#
+
+extern "C"
+{
+    typedef void (*OnLogMessage)(const char* message, int32_t messageLength, int8_t logLevel);
+    typedef void (*OnLineDraw)(JVec3 from, JVec3 to, JColour colour);
+    typedef void (*OnTriangleDraw)(JVec3 vertex1, JVec3 vertex2, JVec3 vertex3, JColour colour);
+
+    typedef bool (*OnFilterPhysicsCollision)(PhysicsCollision* potentialCollision);
+
+    // ------------------------------------ //
+    // General
+
+    /// \returns The API version the native library was compiled with, if different from C# the library should not be
+    /// used
+    [[maybe_unused]] THRIVE_NATIVE_API int32_t CheckAPIVersion();
+
+    /// \brief Prepares the native library for use, must be called first (right after the version check)
+    [[maybe_unused]] THRIVE_NATIVE_API int32_t InitThriveLibrary();
+
+    /// \brief Prepares the native library for shutdown should be called before the process is ended and after all
+    /// other calls to the library have been performed
+    [[maybe_unused]] THRIVE_NATIVE_API void ShutdownThriveLibrary();
+
+    /// \brief Gets the intercommunication bridge for the other native modules to use. Return value should be treated
+    /// as read only.
+    [[maybe_unused]] THRIVE_NATIVE_API NativeLibIntercommunicationOpaque* GetIntercommunicationBridge();
+
+    // ------------------------------------ //
+    // Logging
+
+    [[maybe_unused]] THRIVE_NATIVE_API void SetLogLevel(int8_t level);
+    [[maybe_unused]] THRIVE_NATIVE_API void SetLogForwardingCallback(OnLogMessage callback);
+
+    // ------------------------------------ //
+    // Physics world
+
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicalWorld* CreatePhysicalWorld();
+    [[maybe_unused]] THRIVE_NATIVE_API void DestroyPhysicalWorld(PhysicalWorld* physicalWorld);
+
+    [[maybe_unused]] THRIVE_NATIVE_API bool ProcessPhysicalWorld(PhysicalWorld* physicalWorld, float delta);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void ProcessPhysicalWorldInBackground(PhysicalWorld* physicalWorld, float delta);
+    [[maybe_unused]] THRIVE_NATIVE_API bool WaitForPhysicsToCompleteInPhysicalWorld(PhysicalWorld* physicalWorld);
+
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicsBody* PhysicalWorldCreateMovingBody(PhysicalWorld* physicalWorld,
+        PhysicsShape* shape, JVec3 position, JQuat rotation = QuatIdentity, bool addToWorld = true);
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicsBody* PhysicalWorldCreateMovingBodyWithAxisLock(
+        PhysicalWorld* physicalWorld, PhysicsShape* shape, JVec3 position, JQuat rotation, JVecF3 lockedAxes,
+        bool lockRotation, bool addToWorld = true);
+
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicsBody* PhysicalWorldCreateStaticBody(PhysicalWorld* physicalWorld,
+        PhysicsShape* shape, JVec3 position, JQuat rotation = QuatIdentity, bool addToWorld = true);
+
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicsBody* PhysicalWorldCreateSensor(PhysicalWorld* physicalWorld,
+        PhysicsShape* shape, JVec3 position, JQuat rotation = QuatIdentity, bool detectSleepingBodies = false,
+        bool detectStaticBodies = false);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicalWorldAddBody(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, bool activate);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicalWorldDetachBody(PhysicalWorld* physicalWorld, PhysicsBody* body);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void DestroyPhysicalWorldBody(PhysicalWorld* physicalWorld, PhysicsBody* body);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void SetPhysicsBodyLinearDamping(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, float damping);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void SetPhysicsBodyLinearAndAngularDamping(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, float linearDamping, float angularDamping);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void ReadPhysicsBodyTransform(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, JVec3* positionReceiver, JQuat* rotationReceiver);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void ReadPhysicsBodyVelocity(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3* velocityReceiver, JVecF3* angularVelocityReceiver);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void GiveImpulse(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 impulse, bool autoActivate);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void GiveAngularImpulse(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 angularImpulse, bool autoActivate);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void ApplyBodyControl(PhysicalWorld* physicalWorld, PhysicsBody* body,
+        JVecF3 movementImpulse, JQuat targetRotation, float rotationRate);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void SetBodyControl(PhysicalWorld* physicalWorld, PhysicsBody* body,
+        JVecF3 movementImpulse, JQuat targetRotation, float rotationRate);
+    [[maybe_unused]] THRIVE_NATIVE_API void DisableBodyControl(PhysicalWorld* physicalWorld, PhysicsBody* body);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void SetBodyPosition(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, JVec3 position, bool activate);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void SetBodyPositionAndRotation(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, JVec3 position, JQuat rotation, bool activate = true);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void SetBodyVelocity(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 velocity, bool autoActivate);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void SetBodyAngularVelocity(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 angularVelocity, bool autoActivate);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void SetBodyVelocityAndAngularVelocity(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 velocity, JVecF3 angularVelocity, bool autoActivate);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void SetBodyAllowSleep(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, bool allowSleep);
+
+    [[maybe_unused]] THRIVE_NATIVE_API bool FixBodyYCoordinateToZero(PhysicalWorld* physicalWorld, PhysicsBody* body);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void ChangeBodyShape(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, PhysicsShape* shape, bool activate);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicsBodyAddAxisLock(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, JVecF3 axis, bool lockRotation);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicsBodySetCollisionEnabledState(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, bool collisionsEnabled);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicsBodyAddCollisionIgnore(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, PhysicsBody* addIgnore);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicsBodyRemoveCollisionIgnore(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, PhysicsBody* removeIgnore);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicsBodyClearCollisionIgnores(
+        PhysicalWorld* physicalWorld, PhysicsBody* body);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicsBodySetCollisionIgnores(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, PhysicsBody* ignoredBodies[], int32_t count);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicsBodyClearAndSetSingleIgnore(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, PhysicsBody* onlyIgnoredBody);
+
+    /// Sets up collision recording for a body. The returned value is a pointer to read the currently active collisions
+    /// that have been written to collisionRecordingTarget
+    [[maybe_unused]] THRIVE_NATIVE_API int32_t* PhysicsBodyEnableCollisionRecording(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, char* collisionRecordingTarget, int32_t maxRecordedCollisions);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicsBodyDisableCollisionRecording(
+        PhysicalWorld* physicalWorld, PhysicsBody* body);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicsBodyAddCollisionFilter(
+        PhysicalWorld* physicalWorld, PhysicsBody* body, OnFilterPhysicsCollision callback);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicsBodyDisableCollisionFilter(
+        PhysicalWorld* physicalWorld, PhysicsBody* body);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicalWorldSetGravity(PhysicalWorld* physicalWorld, JVecF3 gravity);
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicalWorldRemoveGravity(PhysicalWorld* physicalWorld);
+
+    [[maybe_unused]] THRIVE_NATIVE_API int32_t PhysicalWorldCastRayGetAll(PhysicalWorld* physicalWorld, JVec3 start,
+        JVecF3 endOffset, PhysicsRayWithUserData* dataReceiver, int32_t maxHits);
+
+    [[maybe_unused]] THRIVE_NATIVE_API float PhysicalWorldGetPhysicsLatestTime(PhysicalWorld* physicalWorld);
+    [[maybe_unused]] THRIVE_NATIVE_API float PhysicalWorldGetPhysicsAverageTime(PhysicalWorld* physicalWorld);
+
+    [[maybe_unused]] THRIVE_NATIVE_API bool PhysicalWorldDumpPhysicsState(
+        PhysicalWorld* physicalWorld, const char* path);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicalWorldSetDebugDrawLevel(
+        PhysicalWorld* physicalWorld, int32_t level = 0);
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicalWorldSetDebugDrawCameraLocation(
+        PhysicalWorld* physicalWorld, JVecF3 position);
+
+    // ------------------------------------ //
+    // Body functions
+    [[maybe_unused]] THRIVE_NATIVE_API void ReleasePhysicsBodyReference(PhysicsBody* body);
+
+    [[maybe_unused]] THRIVE_NATIVE_API bool PhysicsBodyIsDetached(PhysicsBody* body);
+
+    /// Set user data for a physics body, note that currently all data needs to be the same size to fully work,
+    /// which is specified by Thrive::PHYSICS_USER_DATA_SIZE
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicsBodySetUserData(
+        PhysicsBody* body, const char* data, int32_t dataLength);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void PhysicsBodyForceClearRecordingTargets(PhysicsBody* body);
+
+    // ------------------------------------ //
+    // Physics shapes
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicsShape* CreateBoxShape(float halfSideLength, float density = 1000);
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicsShape* CreateBoxShapeWithDimensions(
+        JVecF3 halfDimensions, float density = 1000);
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicsShape* CreateSphereShape(float radius, float density = 1000);
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicsShape* CreateCylinderShape(
+        float halfHeight, float radius, float density = 1000);
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicsShape* CreateCapsuleShape(
+        float halfHeight, float radius, float density = 1000);
+
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicsShape* CreateMicrobeShapeConvex(
+        JVecF3* points, uint32_t pointCount, float density, float scale, float thickness);
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicsShape* CreateMicrobeShapeSpheres(
+        JVecF3* points, uint32_t pointCount, float density, float scale);
+
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicsShape* CreateConvexShape(
+        JVecF3* points, uint32_t pointCount, float density, float scale = 1, float convexRadius = 0.01f);
+
+    [[maybe_unused]] THRIVE_NATIVE_API PhysicsShape* CreateStaticCompoundShape(
+        SubShapeDefinition* subShapes, uint32_t shapeCount);
+
+    [[maybe_unused]] THRIVE_NATIVE_API void ReleaseShape(PhysicsShape* shape);
+
+    [[maybe_unused]] THRIVE_NATIVE_API float ShapeGetMass(PhysicsShape* shape);
+
+    [[maybe_unused]] THRIVE_NATIVE_API JVecF3 ShapeCalculateResultingAngularVelocity(
+        PhysicsShape* shape, JVecF3 appliedTorque, float deltaTime = 1);
+
+    [[maybe_unused]] THRIVE_NATIVE_API uint32_t ShapeGetSubShapeIndex(PhysicsShape* shape, uint32_t subShapeData);
+
+    [[maybe_unused]] THRIVE_NATIVE_API uint32_t ShapeGetSubShapeIndexWithRemainder(
+        PhysicsShape* shape, uint32_t subShapeData, uint32_t& remainder);
+
+    // ------------------------------------ //
+    // Misc
+    [[maybe_unused]] THRIVE_NATIVE_API void ArmWaitForEvent();
+    [[maybe_unused]] THRIVE_NATIVE_API void ArmSignalEvent();
+
+    [[maybe_unused]] THRIVE_NATIVE_API void SetNativeExecutorThreads(int32_t count);
+    [[maybe_unused]] THRIVE_NATIVE_API int32_t GetNativeExecutorThreads();
+}

--- a/CPUHelpers.cs
+++ b/CPUHelpers.cs
@@ -1,0 +1,39 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+using System.Threading;
+
+/// <summary>
+///   Helpers for CPU operations across x86 and ARM
+/// </summary>
+public class CPUHelpers
+{
+    private static readonly bool IsX86 = X86Base.IsSupported;
+    private static readonly bool IsARM = ArmBase.IsSupported;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void HyperThreadPause()
+    {
+        if (IsX86)
+        {
+            X86Base.Pause();
+        }
+        else if (IsARM)
+        {
+            NativeMethods.ArmWaitForEvent();
+        }
+        else
+        {
+            // Just to be sure.
+            // This actually implements Pause on x86 and yield on ARM.
+            Thread.SpinWait(1);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void HyperThreadWake()
+    {
+        if (IsARM)
+            NativeMethods.ArmSignalEvent();
+    }
+}

--- a/NativeConstants.cs
+++ b/NativeConstants.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.IO;
+using DevCenterCommunication.Models.Enums;
+using SharedBase.Models;
+
+/// <summary>
+///   Shared constants between native helper scripts and Thrive (as well as some helper methods to getting info
+///   related to the libraries)
+/// </summary>
+public class NativeConstants
+{
+    public const int Version = 21;
+    public const int EarlyCheck = 2;
+    public const int ExtensionVersion = 7;
+
+    public const string LibraryFolder = "native_libs";
+    public const string DistributableFolderName = "distributable";
+
+    public const string PackagedLibraryFolder = "lib";
+
+    public enum Library
+    {
+        /// <summary>
+        ///   The main native side library that is pure C++ and doesn't depend on Godot
+        /// </summary>
+        ThriveNative,
+
+        /// <summary>
+        ///   Library for early checking that everything is fine before loading <see cref="ThriveNative"/>
+        /// </summary>
+        EarlyCheck,
+
+        /// <summary>
+        ///   The GDExtension for Thrive
+        /// </summary>
+        ThriveExtension,
+    }
+
+    public static string GetLibraryVersion(Library library)
+    {
+        switch (library)
+        {
+            case Library.ThriveNative:
+                return Version.ToString();
+            case Library.EarlyCheck:
+                return EarlyCheck.ToString();
+            case Library.ThriveExtension:
+                return ExtensionVersion.ToString();
+            default:
+                throw new ArgumentOutOfRangeException(nameof(library), library, null);
+        }
+    }
+
+    public static bool GetLibraryFromName(string name, out Library library)
+    {
+        if (name == "thrive_native")
+        {
+            library = Library.ThriveNative;
+            return true;
+        }
+
+        if (name == "early_checks")
+        {
+            library = Library.EarlyCheck;
+            return true;
+        }
+
+        if (name == "thrive_extension")
+        {
+            library = Library.ThriveExtension;
+            return true;
+        }
+
+        // For handling simplicity, the enum doesn't have an invalid value, so we can't use one here, but instead need
+        // to rely on all of our callers to check the return value
+        library = Library.ThriveNative;
+        return false;
+    }
+
+    public static string GetLibraryDllName(Library library, PackagePlatform platform, PrecompiledTag tags)
+    {
+        switch (library)
+        {
+            case Library.ThriveNative:
+                switch (platform)
+                {
+                    case PackagePlatform.Linux:
+                        if ((tags & PrecompiledTag.WithoutAvx) != 0)
+                            return "libthrive_native_without_avx.so";
+
+                        return "libthrive_native.so";
+                    case PackagePlatform.Windows:
+                        if ((tags & PrecompiledTag.WithoutAvx) != 0)
+                            return "libthrive_native_without_avx.dll";
+
+                        return "libthrive_native.dll";
+                    case PackagePlatform.Windows32:
+                        throw new NotSupportedException("32-bit support is not done currently");
+                    case PackagePlatform.Mac:
+                        if ((tags & PrecompiledTag.WithoutAvx) != 0)
+                            return "libthrive_native_without_avx.dylib";
+
+                        throw new NotImplementedException("Mac cannot support AVX currently");
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(platform), platform, null);
+                }
+
+            case Library.EarlyCheck:
+                switch (platform)
+                {
+                    // TODO: if this is started to be used again, this probably needs AVX handling as well (and should
+                    // always use the non-avx variant)
+                    case PackagePlatform.Linux:
+                        return "libearly_checks.so";
+                    case PackagePlatform.Windows:
+                        return "libearly_checks.dll";
+                    case PackagePlatform.Windows32:
+                        throw new NotSupportedException("32-bit support is not done currently");
+                    case PackagePlatform.Mac:
+                        throw new NotImplementedException("Early check is not used on Mac");
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(platform), platform, null);
+                }
+
+            case Library.ThriveExtension:
+                switch (platform)
+                {
+                    case PackagePlatform.Linux:
+                        if ((tags & PrecompiledTag.WithoutAvx) != 0)
+                            return "libthrive_extension_without_avx.so";
+
+                        return "libthrive_extension.so";
+                    case PackagePlatform.Windows:
+                        if ((tags & PrecompiledTag.WithoutAvx) != 0)
+                            return "libthrive_extension_without_avx.dll";
+
+                        return "libthrive_extension.dll";
+                    case PackagePlatform.Windows32:
+                        throw new NotSupportedException("32-bit support is not done currently");
+                    case PackagePlatform.Mac:
+                        if ((tags & PrecompiledTag.WithoutAvx) != 0)
+                            return "libthrive_extension_without_avx.dylib";
+
+                        throw new NotImplementedException("Mac cannot support AVX currently");
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(platform), platform, null);
+                }
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(library), library, null);
+        }
+    }
+
+    public static string GetPathToLibraryDll(Library library, PackagePlatform platform, string version,
+        bool distributableVersion, PrecompiledTag tags)
+    {
+        var basePath = GetPathToLibrary(library, platform, version, distributableVersion, tags);
+
+        if (platform is PackagePlatform.Windows or PackagePlatform.Windows32)
+        {
+            return Path.Combine(basePath, "bin", GetLibraryDllName(library, platform, tags));
+        }
+
+        // This is for Linux
+        return Path.Combine(basePath, "lib", GetLibraryDllName(library, platform, tags));
+    }
+
+    /// <summary>
+    ///   Path to the library's root where all version-specific folders are added
+    /// </summary>
+    private static string GetPathToLibrary(Library library, PackagePlatform platform, string version,
+        bool distributableVersion, PrecompiledTag tags)
+    {
+        if (distributableVersion)
+        {
+            return Path.Combine(LibraryFolder, DistributableFolderName, platform.ToString().ToLowerInvariant(),
+                library.ToString(), version, (tags & PrecompiledTag.Debug) != 0 ? "debug" : "release");
+        }
+
+        // TODO: should the paths for the libraries include the library name? (cmake is used to compile all at once,
+        // which makes this a bit difficult)
+
+        // The paths are a bit convoluted to easily be able to install with cmake to the target
+        return Path.Combine(LibraryFolder, platform.ToString().ToLowerInvariant(), version,
+            (tags & PrecompiledTag.Debug) != 0 ? "debug" : "release");
+    }
+}

--- a/NativeInterop.cs
+++ b/NativeInterop.cs
@@ -1,0 +1,825 @@
+﻿// #define DEBUG_LIBRARY_LOAD
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
+using System.Text;
+using DevCenterCommunication.Models.Enums;
+using Godot;
+using SharedBase.Models;
+using SharedBase.Utilities;
+
+/// <summary>
+///   Calling interface from C# to the native code side of things for the native module. For the GDExtension stuff see
+///   <see cref="ExtensionInterop"/>
+/// </summary>
+public static class NativeInterop
+{
+    private const string GODOT_INTERNAL_PATH_LIKELY_MARKER = "data_Thrive_";
+
+    // Need these delegate holders to keep delegates alive
+    private static readonly NativeMethods.OnLogMessage LogMessageCallback = ForwardMessage;
+
+    private static readonly Dictionary<string, string> FoundFolderLibraries = new();
+
+    private static bool disableAvx;
+
+    private static bool loadCalled;
+    private static bool nativeLoadSucceeded;
+    private static bool cpuIsInsufficient;
+
+    private static bool printedDistributableNotice;
+    private static bool printedErrorAboutExecutablePath;
+
+    private static int version = -1;
+
+    private static bool printedDistributableWarning;
+
+#if DEBUG
+    private static bool printedSteamLibName;
+#endif
+
+    /// <summary>
+    ///   Performs any initialization needed by the native library (note has to be called after the library is loaded)
+    /// </summary>
+    /// <param name="settings">Current game settings</param>
+    public static void Init(Settings settings)
+    {
+        if (!nativeLoadSucceeded)
+        {
+            GD.PrintErr("Native library init should not be called as the library load failed");
+            throw new InvalidOperationException("Library must be loaded first");
+        }
+
+        // Settings are passed as probably in the future something needs to be setup right in the native side of
+        // things for the initial settings
+        _ = settings;
+
+        NativeMethods.SetLogForwardingCallback(LogMessageCallback);
+
+        var result = NativeMethods.InitThriveLibrary();
+
+        if (result != 0)
+        {
+            throw new InvalidOperationException($"Failed to initialize Thrive native library, code: {result}");
+        }
+
+        // TaskExecutor sets the number of used background threads on the native side
+
+#if DEBUG
+        CheckSizesOfInteropTypes();
+#endif
+    }
+
+    /// <summary>
+    ///   Loads and checks the native library is good to use
+    /// </summary>
+    /// <exception cref="Exception">If the library is not fine (wrong version)</exception>
+    /// <exception cref="DllNotFoundException">If finding the library failed</exception>
+    public static void Load()
+    {
+        if (loadCalled)
+            throw new InvalidOperationException("Load has been called already");
+
+        // Ensure this is not true if load fails partway through
+        nativeLoadSucceeded = false;
+
+        loadCalled = true;
+
+        if (cpuIsInsufficient)
+        {
+            GD.PrintErr("Native library load was called even though current CPU is not capable of running it");
+            throw new InvalidOperationException("Native library is detected as incompatible");
+        }
+
+        version = NativeMethods.CheckAPIVersion();
+
+        if (version != NativeConstants.Version)
+        {
+            GD.PrintErr("Thrive native library is the wrong version! " +
+                "Please verify game files or if you are developing Thrive, recompile the native library.");
+
+            throw new Exception($"Failed to initialize Thrive native library, unexpected version {version} " +
+                $"is not the required: {NativeConstants.Version}");
+        }
+
+        GD.Print("Loaded native Thrive library version ", version);
+        nativeLoadSucceeded = true;
+
+        // Enable debug logging if this is being debugged
+#if DEBUG
+        NativeMethods.SetLogLevel(NativeMethods.LogLevel.Debug);
+#endif
+    }
+
+    /// <summary>
+    ///   Sets the custom import resolver that understands where Thrive libraries are installed to.
+    /// </summary>
+    /// <param name="forAssembly">The assembly to set the resolver for, defaults to the calling assembly</param>
+    public static void SetDllImportResolver(Assembly? forAssembly = null)
+    {
+        forAssembly ??= Assembly.GetCallingAssembly();
+
+        NativeLibrary.SetDllImportResolver(forAssembly, DllImportResolver);
+    }
+
+    /// <summary>
+    ///   Checks that current CPU is sufficiently new (has the required instruction set extensions) for running the
+    ///   Thrive native module
+    /// </summary>
+    /// <returns>True if everything is fine and load can proceed</returns>
+    public static bool CheckCPU()
+    {
+        try
+        {
+            var result = CheckCPUFeaturesFull();
+
+            // Apple doesn't support x86 extensions so we nudge things on the right track here
+            if (OperatingSystem.IsMacOS())
+            {
+                GD.Print("Mac detected so skipping CPU check and not trying to use AVX");
+                disableAvx = true;
+                return true;
+            }
+
+            // If the CPU can support the full speed library all is well
+            if (result == CPUCheckResult.CPUCheckSuccess)
+            {
+                // Ensure AVX is on to look for the right library
+                disableAvx = false;
+                return true;
+            }
+
+            // Try the compatibility library
+            var originalResult = result;
+
+            result = CheckCPUFeaturesCompatibility();
+
+            if (result == CPUCheckResult.CPUCheckSuccess)
+            {
+                GD.Print("Cannot use full-speed Thrive native library due to: " +
+                    GetMissingFeatureList(originalResult));
+
+                GD.Print("Using slower Thrive native library that doesn't rely on as new CPU instructions");
+
+                disableAvx = true;
+                return true;
+            }
+
+            cpuIsInsufficient = true;
+
+            GD.PrintErr("Current CPU detected as not sufficient for Thrive");
+
+            GD.PrintErr(GetMissingFeatureList(result));
+
+            GD.PrintErr("Current CPU: ", OS.GetProcessorName());
+
+            return false;
+        }
+        catch (DllNotFoundException e)
+        {
+            if (Engine.IsEditorHint())
+            {
+                GD.Print("Cannot load early check library within the editor concept due to it missing");
+                return false;
+            }
+
+            GD.PrintErr("Cannot load early check library to check CPU features: ", e);
+            return false;
+        }
+    }
+
+    /// <summary>
+    ///   Releases all native resources and prepares the library for process exit
+    /// </summary>
+    public static void Shutdown()
+    {
+        if (!nativeLoadSucceeded)
+        {
+            GD.Print("Skipping native library shutdown as it was not fully loaded");
+            return;
+        }
+
+        nativeLoadSucceeded = false;
+
+        NativeMethods.ShutdownThriveLibrary();
+    }
+
+    /// <summary>
+    ///   Disable loading avx-enabled libraries even if AVX was detected as being available
+    /// </summary>
+    public static void DisableAvx()
+    {
+        disableAvx = true;
+    }
+
+    /// <summary>
+    ///   Gets the intercommunication interface for the native libraries
+    /// </summary>
+    /// <returns>IntPtr put into the variant on success, 0 on failure</returns>
+    public static Variant GetIntercommunication(out int libraryVersion)
+    {
+        libraryVersion = version;
+
+        if (!nativeLoadSucceeded)
+        {
+            GD.PrintErr("Native load hasn't succeeded, cannot get intercommunication");
+            return Variant.CreateFrom(0);
+        }
+
+        return NativeMethods.GetIntercommunicationBridge().ToInt64();
+    }
+
+    public static void NotifyWantedThreadCountChanged(int threads)
+    {
+        if (!nativeLoadSucceeded)
+            return;
+
+        NativeMethods.SetNativeExecutorThreads(threads);
+    }
+
+    private static CPUCheckResult CheckCPUFeaturesFull()
+    {
+        var result = CPUCheckResult.CPUCheckSuccess;
+
+        // TODO: should this check Avx2.X64.IsSupported instead or also?
+        if (!Avx2.IsSupported)
+            result |= CPUCheckResult.CPUCheckMissingAvx2;
+
+        if (!Avx.IsSupported)
+            result |= CPUCheckResult.CPUCheckMissingAvx;
+
+        if (!Lzcnt.IsSupported)
+            result |= CPUCheckResult.CPUCheckMissingLzcnt;
+
+        // For TZCNT instruction
+        if (!Bmi1.IsSupported)
+            result |= CPUCheckResult.CPUCheckMissingBmi1;
+
+        if (!Fma.IsSupported)
+            result |= CPUCheckResult.CPUCheckMissingFma;
+
+        // F16C cannot be checked easily, so for now assume it is present if the other instruction checks pass
+
+        return result | CheckCPUFeaturesCompatibility();
+    }
+
+    private static CPUCheckResult CheckCPUFeaturesCompatibility()
+    {
+        var result = CPUCheckResult.CPUCheckSuccess;
+
+        if (!Sse42.IsSupported)
+            result |= CPUCheckResult.CPUCheckMissingSse42;
+
+        if (!Sse41.IsSupported)
+            result |= CPUCheckResult.CPUCheckMissingSse41;
+
+        return result;
+    }
+
+    private static string GetMissingFeatureList(CPUCheckResult result)
+    {
+        var builder = new StringBuilder();
+
+        // ReSharper disable StringLiteralTypo
+
+        if ((result & CPUCheckResult.CPUCheckMissingAvx) != 0)
+        {
+            if (builder.Length > 0)
+                builder.Append('\n');
+            builder.Append("CPU is missing AVX 1 extension instruction support");
+        }
+
+        if ((result & CPUCheckResult.CPUCheckMissingAvx2) != 0)
+        {
+            if (builder.Length > 0)
+                builder.Append('\n');
+            builder.Append("CPU is missing AVX 2 extension instruction support");
+        }
+
+        if ((result & CPUCheckResult.CPUCheckMissingSse41) != 0)
+        {
+            if (builder.Length > 0)
+                builder.Append('\n');
+            builder.Append("CPU is missing SSE 4.1 support");
+        }
+
+        if ((result & CPUCheckResult.CPUCheckMissingSse42) != 0)
+        {
+            if (builder.Length > 0)
+                builder.Append('\n');
+            builder.Append("CPU is missing SSE 4.2 support");
+        }
+
+        if ((result & CPUCheckResult.CPUCheckMissingLzcnt) != 0)
+        {
+            if (builder.Length > 0)
+                builder.Append('\n');
+            builder.Append("CPU is missing LZCNT support");
+        }
+
+        if ((result & CPUCheckResult.CPUCheckMissingBmi1) != 0)
+        {
+            if (builder.Length > 0)
+                builder.Append('\n');
+            builder.Append("CPU is missing BMI 1 (TZCNT) support");
+        }
+
+        if ((result & CPUCheckResult.CPUCheckMissingFma) != 0)
+        {
+            if (builder.Length > 0)
+                builder.Append('\n');
+
+            builder.Append("CPU is missing FMA support");
+        }
+
+        if ((result & CPUCheckResult.CPUCheckMissingF16C) != 0)
+        {
+            if (builder.Length > 0)
+                builder.Append('\n');
+            builder.Append("CPU is missing F16C support");
+        }
+
+        // ReSharper restore StringLiteralTypo
+
+        if (builder.Length < 1)
+            builder.Append("Unknown problem with CPU check");
+
+        return builder.ToString();
+    }
+
+    private static void ForwardMessage(IntPtr messageData, int messageLength, NativeMethods.LogLevel level)
+    {
+        var message = Marshal.PtrToStringAnsi(messageData, messageLength);
+
+#if DEBUG
+
+        // Pause the debugger when detecting a native assertion fail to give some idea as to what's going on
+        if (message.Contains("assert failed"))
+        {
+            if (Debugger.IsAttached)
+                Debugger.Break();
+        }
+#endif
+
+        if (level <= NativeMethods.LogLevel.Info)
+        {
+            GD.Print("[NATIVE] ", message);
+        }
+        else if (level <= NativeMethods.LogLevel.Warning)
+        {
+            // TODO: something different for warning level?
+            GD.Print("[NATIVE] WARNING:", message);
+        }
+        else
+        {
+            GD.PrintErr("[NATIVE] ", message);
+        }
+    }
+
+    private static void CheckSizesOfInteropTypes()
+    {
+        CheckSizeOfType<JVec3>(3 * 8);
+        CheckSizeOfType<JVecF3>(3 * 4);
+        CheckSizeOfType<JQuat>(4 * 4);
+        CheckSizeOfType<JColour>(4 * 4);
+
+        // These must match the configuration in the relevant C++ files or otherwise things will break badly
+        CheckSizeOfType<PhysicsCollision>(56);
+        CheckSizeOfType<PhysicsRayWithUserData>(32);
+
+        CheckSizeOfType<SubShapeDefinition>(40);
+
+        // Ensure user data size. If this changes, the macro on the C++ side must be updated.
+        if (NativePhysicsBody.EntityDataSize != 12)
+        {
+            throw new Exception(
+                "Unexpected size for Entity data size to physics, check C# side definition matches C++");
+        }
+    }
+
+    private static void CheckSizeOfType<T>(int expected)
+    {
+        var size = Marshal.SizeOf<T>();
+        if (size != expected)
+        {
+            throw new Exception(
+                $"Unexpected size for type {typeof(T).FullName}, expected size to be: {expected} but it is {size}");
+        }
+    }
+
+    private static PrecompiledTag GetTag(bool debug)
+    {
+        if (disableAvx)
+            return debug ? (PrecompiledTag.Debug | PrecompiledTag.WithoutAvx) : PrecompiledTag.WithoutAvx;
+
+        return debug ? PrecompiledTag.Debug : PrecompiledTag.None;
+    }
+
+    private static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+    {
+        // Would be complicated to inline due to the conditional compilation
+        // ReSharper disable once InlineOutVariableDeclaration
+        IntPtr loaded;
+
+        // TODO: caching once loaded? This method is called again for each native method that is used so this gets
+        // called some extra 50 or so times.
+
+        if (libraryName == "steam_api")
+        {
+            var steamName = "libsteam_api.so";
+
+            if (FeatureInformation.IsWindows())
+            {
+                steamName = "steam_api64.dll";
+            }
+            else if (FeatureInformation.IsMac())
+            {
+                steamName = "libsteam_api.dylib";
+            }
+
+#if DEBUG
+            if (!printedSteamLibName)
+            {
+                GD.Print("Searching for Steam library: ", steamName);
+                printedSteamLibName = true;
+            }
+#endif
+
+            if (LookForLibraryUpInFolders(steamName, out loaded))
+                return loaded;
+
+            if (LoadLibraryIfExists(Path.Join(GetExecutableFolder(), steamName), out loaded))
+                return loaded;
+
+            GD.PrintErr("Steam API library seems to be missing");
+            return NativeLibrary.Load(libraryName, assembly, searchPath);
+        }
+
+        if (!NativeConstants.GetLibraryFromName(libraryName, out var library))
+        {
+#if DEBUG
+            GD.Print("Loading non-thrive library: ", libraryName);
+#endif
+            return NativeLibrary.Load(libraryName, assembly, searchPath);
+        }
+
+        if (library == NativeConstants.Library.ThriveExtension)
+        {
+            if (!OperatingSystem.IsMacOS())
+            {
+                // Special GDExtension handling, we assume Godot has already loaded it
+
+                var modules = Process.GetCurrentProcess().Modules;
+                var count = modules.Count;
+
+                for (var i = 0; i < count; ++i)
+                {
+                    var module = modules[i];
+
+                    if (module.ModuleName.Contains("thrive_extension"))
+                    {
+#if DEBUG_LIBRARY_LOAD
+                        GD.Print($"Trying to use already loaded module path: {module.FileName}");
+#endif
+
+                        return NativeLibrary.Load(module.FileName);
+                    }
+                }
+
+                GD.PrintErr("GDExtension was not loaded by Godot, falling back to default library load but this " +
+                    "will likely fail");
+            }
+            else
+            {
+                // For some reason the modules list stays at one item on a Mac so we need to do some special assuming
+                // here
+                // TODO: this will be problematic in the future if debug specific version of libraries are added as
+                // supported in the .gdextension files
+
+                var file = NativeConstants.GetLibraryDllName(NativeConstants.Library.ThriveExtension,
+                    PackagePlatform.Mac, PrecompiledTag.WithoutAvx);
+
+                if (File.Exists(file))
+                {
+#if DEBUG_LIBRARY_LOAD
+                    GD.Print($"Loading Mac GDExtension from: {file}");
+#endif
+
+                    return NativeLibrary.Load(file);
+                }
+
+                var adjustedFile = Path.Combine("lib", file);
+
+                if (File.Exists(adjustedFile))
+                {
+#if DEBUG_LIBRARY_LOAD
+                    GD.Print($"Loading Mac GDExtension from: {adjustedFile}");
+#endif
+
+                    return NativeLibrary.Load(adjustedFile);
+                }
+
+                // Special case needed for .app packaging
+                var location = GetExecutableFolder();
+
+                adjustedFile = Path.Combine(location, file);
+
+                if (File.Exists(adjustedFile))
+                {
+#if DEBUG_LIBRARY_LOAD
+                    GD.Print($"Loading Mac GDExtension from: {adjustedFile}");
+#endif
+
+                    return NativeLibrary.Load(adjustedFile);
+                }
+
+#if DEBUG_LIBRARY_LOAD
+                GD.Print($"Attempted Mac GDExtension: {adjustedFile}");
+#endif
+
+                adjustedFile = Path.Combine(location, "lib", file);
+
+                if (File.Exists(adjustedFile))
+                {
+#if DEBUG_LIBRARY_LOAD
+                    GD.Print($"Loading Mac GDExtension from: {adjustedFile}");
+#endif
+
+                    return NativeLibrary.Load(adjustedFile);
+                }
+
+#if DEBUG_LIBRARY_LOAD
+                GD.Print($"Last attempted Mac GDExtension: {adjustedFile}");
+#endif
+
+                GD.PrintErr(
+                    "Mac GDExtension special load logic failed, falling back to default library load but this " +
+                    "will likely fail");
+            }
+
+            return NativeLibrary.Load(libraryName, assembly, searchPath);
+        }
+
+        var currentPlatform = PlatformUtilities.GetCurrentPlatform();
+
+        // TODO: add a flag / some kind of option to skip loading the debug library
+
+#if DEBUG
+        if (LoadLibraryIfExists(NativeConstants.GetPathToLibraryDll(library, currentPlatform,
+                NativeConstants.GetLibraryVersion(library), false, GetTag(true)), out loaded))
+        {
+            return loaded;
+        }
+
+        if (LoadLibraryIfExists(NativeConstants.GetPathToLibraryDll(library, currentPlatform,
+                NativeConstants.GetLibraryVersion(library), true, GetTag(true)), out loaded))
+        {
+            if (!printedDistributableWarning)
+            {
+                GD.Print("Loaded a distributable debug library, this is not optimal but likely works");
+                printedDistributableWarning = true;
+            }
+
+            return loaded;
+        }
+#endif
+
+        if (!Engine.IsEditorHint())
+        {
+            // Load from libs directory, needed when the game is packaged
+            if (LoadLibraryIfExists(Path.Join(NativeConstants.PackagedLibraryFolder,
+                    NativeConstants.GetLibraryDllName(library, currentPlatform, GetTag(false))), out loaded))
+            {
+                return loaded;
+            }
+        }
+
+        if (LoadLibraryIfExists(NativeConstants.GetPathToLibraryDll(library, currentPlatform,
+                NativeConstants.GetLibraryVersion(library), false, GetTag(false)), out loaded))
+        {
+            return loaded;
+        }
+
+        if (!printedDistributableNotice)
+        {
+            GD.Print("Library not found yet at expected paths, trying a distributable version");
+            printedDistributableNotice = true;
+        }
+
+        if (LoadLibraryIfExists(NativeConstants.GetPathToLibraryDll(library, currentPlatform,
+                NativeConstants.GetLibraryVersion(library), true, GetTag(false)), out loaded))
+        {
+            return loaded;
+        }
+
+        GD.PrintErr("Couldn't find library at any expected path, falling back to default load behaviour, " +
+            "which is unlikely to find anything");
+
+        return NativeLibrary.Load(libraryName, assembly, searchPath);
+    }
+
+    /// <summary>
+    ///   Tries to get a sensible executable folder. Due to Godot this may not always work but this tries to be right
+    /// </summary>
+    /// <returns>Executable path or empty string</returns>
+    private static string GetExecutableFolder()
+    {
+        try
+        {
+            var location = AppDomain.CurrentDomain.BaseDirectory;
+
+            if (location == null)
+            {
+                throw new Exception("Entry assembly location is empty");
+            }
+
+            location = RemoveFilePrefix(location);
+
+            // Remove one folder level if this is likely an internal Godot path (when packaged)
+            if (location.Contains(GODOT_INTERNAL_PATH_LIKELY_MARKER))
+            {
+                // On Mac handle .app folder usage
+                if (Path.GetFullPath(location).Contains(".app/"))
+                {
+                    return Path.Join(location, "../../MacOS");
+                }
+
+                return Path.Join(location, "..");
+            }
+
+            return location;
+        }
+        catch (Exception e)
+        {
+            // Cannot detect
+            if (!printedErrorAboutExecutablePath)
+            {
+                GD.PrintErr("Cannot determine current location of the running executable: ", e);
+                printedErrorAboutExecutablePath = true;
+            }
+
+            return string.Empty;
+        }
+    }
+
+    private static string RemoveFilePrefix(string location)
+    {
+        if (location.StartsWith("file://"))
+        {
+            location = location.Substring("file://".Length);
+        }
+
+        return location;
+    }
+
+    private static bool LoadLibraryIfExists(string libraryPath, out IntPtr loaded)
+    {
+        var executableFolder = GetExecutableFolder();
+
+        var executableRelative = Path.Join(executableFolder, libraryPath);
+
+        if (File.Exists(libraryPath) || File.Exists(executableRelative))
+        {
+            string full;
+            if (File.Exists(libraryPath))
+            {
+#if DEBUG_LIBRARY_LOAD
+                GD.Print("Loading library: ", libraryPath);
+#endif
+                full = Path.GetFullPath(libraryPath);
+            }
+            else
+            {
+#if DEBUG_LIBRARY_LOAD
+                GD.Print("Loading library relative to executable: ", executableRelative);
+#endif
+                full = Path.GetFullPath(executableRelative);
+            }
+
+            loaded = NativeLibrary.Load(full);
+            return true;
+        }
+
+#if DEBUG_LIBRARY_LOAD
+        GD.Print("Candidate library path doesn't exist: ", libraryPath);
+        GD.Print("Executable relative variant: ", executableRelative);
+#endif
+
+        loaded = IntPtr.Zero;
+        return false;
+    }
+
+    private static bool LookForLibraryUpInFolders(string libraryName, out IntPtr loaded)
+    {
+        // If library was already looked for, return that instead of doing the lookup again assuming that the libraries
+        // won't be moved or deleted during runtime
+        if (FoundFolderLibraries.TryGetValue(libraryName, out var knownPath))
+        {
+            return LoadLibraryIfExists(knownPath, out loaded);
+        }
+
+        var folders = Path.GetFullPath(".").Split(Path.DirectorySeparatorChar);
+
+        loaded = IntPtr.Zero;
+
+        if (folders.Length < 2)
+        {
+            GD.PrintErr("Cannot determine parts of current path to search a library in");
+            return false;
+        }
+
+        for (int take = folders.Length; take > 0; --take)
+        {
+            try
+            {
+                var testPath = Path.Join(string.Join(Path.DirectorySeparatorChar, folders.Take(take)), libraryName);
+
+                if (LoadLibraryIfExists(testPath, out loaded))
+                {
+                    FoundFolderLibraries[libraryName] = testPath;
+
+#if DEBUG_LIBRARY_LOAD
+                    GD.Print($"Remembering that library {libraryName} exists at path: {testPath}");
+#endif
+                    return true;
+                }
+            }
+            catch (Exception e)
+            {
+                GD.Print($"Cannot test for {libraryName} existing at search depth {take}: {e}");
+                break;
+            }
+        }
+
+        FoundFolderLibraries[libraryName] = "NOT_FOUND_LIBRARY";
+        return false;
+    }
+}
+
+/// <summary>
+///   Thrive native library general methods / things needed from multiple places. Specific class methods are split out
+///   as the partial classes to logically split the methods into groups
+/// </summary>
+internal static partial class NativeMethods
+{
+    internal delegate void OnLogMessage(IntPtr messageData, int messageLength, LogLevel level);
+
+    internal delegate void OnLineDraw(JVec3 from, JVec3 to, JColour colour);
+
+    internal delegate void OnTriangleDraw(JVec3 vertex1, JVec3 vertex2, JVec3 vertex3, JColour colour);
+
+    internal enum LogLevel : byte
+    {
+        Debug = 0,
+        Info = 1,
+        Warning = 2,
+        Error = 3,
+    }
+
+    [DllImport("thrive_native")]
+    internal static extern int InitThriveLibrary();
+
+    [DllImport("thrive_native")]
+    internal static extern int CheckAPIVersion();
+
+    [DllImport("early_checks")]
+    internal static extern int CheckEarlyAPIVersion();
+
+    [DllImport("thrive_native")]
+    internal static extern void ShutdownThriveLibrary();
+
+    [DllImport("thrive_native")]
+    internal static extern IntPtr GetIntercommunicationBridge();
+
+    [DllImport("early_checks")]
+    internal static extern CPUCheckResult CheckRequiredCPUFeatures();
+
+    [DllImport("early_checks")]
+    internal static extern CPUCheckResult CheckCompatibilityLibraryCPUFeatures();
+
+    [DllImport("thrive_native")]
+    internal static extern void SetLogLevel(LogLevel level);
+
+    [DllImport("thrive_native")]
+    internal static extern void SetLogForwardingCallback(OnLogMessage callback);
+
+    [DllImport("thrive_native")]
+    internal static extern void ArmWaitForEvent();
+
+    [DllImport("thrive_native")]
+    internal static extern void ArmSignalEvent();
+
+    [DllImport("thrive_native")]
+    internal static extern void SetNativeExecutorThreads(int count);
+
+    [DllImport("thrive_native")]
+    internal static extern int GetNativeExecutorThreads();
+
+    // The wrapper-specific methods are in their respective files like PhysicalWorld.cs etc.
+}

--- a/SimpleBarrier.cs
+++ b/SimpleBarrier.cs
@@ -1,0 +1,51 @@
+﻿using System.Runtime.InteropServices;
+using System.Threading;
+
+/// <summary>
+///   A simple thread synchronization barrier
+/// </summary>
+[StructLayout(LayoutKind.Explicit, Size = 128)]
+public class SimpleBarrier
+{
+    [FieldOffset(0)]
+    private readonly int threadCount;
+
+    // remaining participants on the local phase
+    [FieldOffset(4)]
+    private volatile int remainingParticipants;
+
+    // local phase
+    [FieldOffset(64)]
+    private volatile int currentPhase;
+
+    public SimpleBarrier(int count)
+    {
+        threadCount = count;
+        remainingParticipants = count;
+    }
+
+    public void SignalAndWait()
+    {
+        int phase = currentPhase;
+
+        int remaining = Interlocked.Decrement(ref remainingParticipants);
+
+        if (remaining == 0)
+        {
+            // we're the manager thread
+            remainingParticipants = threadCount;
+
+            // phase change
+            Interlocked.Increment(ref currentPhase);
+
+            CPUHelpers.HyperThreadWake();
+        }
+        else
+        {
+            while (currentPhase == phase)
+            {
+                CPUHelpers.HyperThreadPause();
+            }
+        }
+    }
+}

--- a/TaskExecutor.cs
+++ b/TaskExecutor.cs
@@ -1,0 +1,561 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Arch.Core;
+using Godot;
+using Schedulers;
+using Environment = System.Environment;
+using Thread = System.Threading.Thread;
+
+/// <summary>
+///   Manages the running of a reasonable number of parallel tasks at once
+/// </summary>
+#pragma warning disable CA1001 // singleton anyway
+public class TaskExecutor
+#pragma warning restore CA1001
+{
+    private const int ThreadSleepAfterNoWorkFor = 160;
+
+    private static readonly TaskExecutor SingletonInstance = new();
+
+    private readonly object threadNotifySync = new();
+
+    private readonly ConcurrentQueue<ThreadCommand> queuedTasks = new();
+
+    private readonly List<Task> mainThreadTaskStorage = new();
+
+    private bool running = true;
+    private int currentThreadCount;
+    private int usedNativeTaskCount;
+
+    private volatile int queuedParallelRunnableCount;
+
+    /// <summary>
+    ///   For naming the created threads.
+    /// </summary>
+    private int threadCounter;
+
+    static TaskExecutor()
+    {
+    }
+
+    private TaskExecutor(int overrideParallelCount = -1)
+    {
+        if (overrideParallelCount >= 0)
+        {
+            ParallelTasks = overrideParallelCount;
+            SetNativeThreadCount(overrideParallelCount);
+        }
+        else
+        {
+            ReApplyThreadCount();
+        }
+
+        Thread.CurrentThread.Name = "TMain";
+
+        // Start Arch multithreading
+        var jobScheduler = new JobScheduler(new JobScheduler.Config
+        {
+            ThreadPrefixName = "Arch",
+
+            // These thread counts about make sense now.
+            // Because the calling thread is blocked whenever there are parallel operations running.
+            // TODO: Though it would be nice again to find a way to share threads or some other mechanism to ensure
+            // these don't run at once (though as these are for purely gameplay systems, they don't usually run at the
+            // same time as something else that is taking up all of the normal threads)
+            ThreadCount = Math.Clamp(ParallelTasks - 2, 2, 4),
+            MaxExpectedConcurrentJobs = 64,
+#if DEBUG
+            StrictAllocationMode = true,
+#else
+            StrictAllocationMode = false,
+#endif
+        });
+        World.SharedJobScheduler = jobScheduler;
+
+        GD.Print("TaskExecutor started with parallel job count: ", ParallelTasks);
+    }
+
+    // Max is used here to ensure that clamp calls that use this value cannot fail
+    public static int CPUCount => Math.Max(Environment.ProcessorCount, 1);
+    public static int MinimumThreadCount => Settings.Instance.RunAutoEvoDuringGamePlay.Value ? 2 : 1;
+    public static int MaximumThreadCount => CPUCount;
+
+    public static TaskExecutor Instance => SingletonInstance;
+
+    public int ParallelTasks
+    {
+        get => currentThreadCount;
+        set
+        {
+            if (currentThreadCount == value)
+                return;
+
+            while (currentThreadCount > value)
+            {
+                QuitThread();
+            }
+
+            while (currentThreadCount < value)
+            {
+                SpawnThread();
+            }
+        }
+    }
+
+    public int NativeTasks
+    {
+        get => usedNativeTaskCount;
+        set
+        {
+            if (usedNativeTaskCount == value)
+                return;
+
+            usedNativeTaskCount = Math.Clamp(value, 1, MaximumThreadCount);
+
+            NativeInterop.NotifyWantedThreadCountChanged(usedNativeTaskCount);
+        }
+    }
+
+    /// <summary>
+    ///   Computes how many threads there should be by default
+    /// </summary>
+    /// <param name="hyperthreading">
+    ///   True, if hyperthreading is on.
+    ///   There is no platform-independent way to get this in C#.
+    /// </param>
+    /// <param name="autoEvoDuringGameplay">If true, reserves extra (minimum thread) for auto-evo</param>
+    /// <returns>The number of threads to use</returns>
+    public static int GetWantedThreadCount(bool hyperthreading, bool autoEvoDuringGameplay)
+    {
+        int targetTaskCount = CPUCount;
+
+        // The divisible by 2 check here makes sure there are 2n number of threads (where n is the number of real cores
+        // this holds for desktop hyperthreading where there are always 2 threads per core)
+        if (hyperthreading && targetTaskCount % 2 == 0)
+            targetTaskCount /= 2;
+
+        int max = MaximumThreadCount;
+        if (targetTaskCount > max)
+            targetTaskCount = max;
+
+        // There needs to be 2 threads as when auto-evo is running, it hogs one thread
+        if (autoEvoDuringGameplay && targetTaskCount < 2)
+        {
+            targetTaskCount = 2;
+        }
+
+        return targetTaskCount;
+    }
+
+    public static int CalculateNativeThreadCountFromManagedThreads(int managedCount)
+    {
+        // Reduce thread count when low number of threads are used
+        // TODO: tweak these low task number threads if necessary
+        if (managedCount <= 3)
+            return 1;
+
+        if (managedCount <= 4)
+            return 2;
+
+        if (managedCount <= 6)
+            return 3;
+
+        int targetTaskCount = Math.Clamp((int)Math.Round(managedCount * 0.5f), 2, CPUCount);
+
+        // Cap the maximum threads as there isn't that much benefit from too many threads
+        // And in fact in the benchmark these hurt the first part score
+        if (targetTaskCount > 8)
+            return 8;
+
+        return targetTaskCount;
+    }
+
+    // TODO: add a variant that allows adding multiple tasks at once
+    /// <summary>
+    ///   Sends a new task to be executed
+    /// </summary>
+    public void AddTask(Task task, bool wakeWorkerThread = true)
+    {
+        queuedTasks.Enqueue(new ThreadCommand(task));
+
+        if (wakeWorkerThread)
+            NotifyNewTasksAdded(1);
+    }
+
+    /// <summary>
+    ///   Runs a list of tasks and waits for them to complete. The
+    ///   first task is run on the calling thread before waiting.
+    /// </summary>
+    /// <param name="tasks">
+    ///   List of tasks to execute and wait to finish. Not modified but must be List to avoid a memory allocation in
+    ///   the foreach.
+    /// </param>
+    /// <param name="runExtraTasksOnCallingThread">
+    ///   If true, the main thread processes tasks while there are queued tasks. Set this to false if you want to wait
+    ///   only for the task list to complete. If this is true, then this call blocks until all tasks (for example,
+    ///   ones queued from another thread while this method is executing) are complete, which may be unwanted in
+    ///   some cases.
+    /// </param>
+    public void RunTasks(List<Task> tasks, bool runExtraTasksOnCallingThread = false)
+    {
+        // Queue all but the first task
+        Task? firstTask = null;
+
+        foreach (var task in tasks)
+        {
+            if (firstTask != null)
+            {
+                AddTask(task, false);
+            }
+            else
+            {
+                firstTask = task;
+            }
+
+            mainThreadTaskStorage.Add(task);
+        }
+
+        if (firstTask == null)
+        {
+            // No tasks given to execute. Should we throw here?
+            return;
+        }
+
+        // Should be fine to wake up all the threads as the main thread is going to also be busy,
+        // so this is purely to be able to run things at full speed
+        NotifyAllNewTasksAdded();
+
+        // Run the first task on this thread
+        firstTask.RunSynchronously();
+
+        // TODO: it should be plausible to make it so that only tasks in "tasks" are ran on the calling thread
+        // but due to implementation difficulty that is not currently done, instead this parameter is used
+        // to give control to the caller if they want to accept the tradeoffs regarding the current implementation
+        if (runExtraTasksOnCallingThread)
+        {
+            // Process tasks also on the main thread
+
+            // This should be the non-blocking variant, so the current thread won't wait for more tasks,
+            // just immediately exits the loop if there are no tasks to run
+            while (queuedTasks.TryDequeue(out ThreadCommand command))
+            {
+                // If we take out a quit command here, we need to put it back for the actual threads to get and break
+                if (command.CommandType == ThreadCommand.Type.Quit)
+                {
+                    queuedTasks.Enqueue(new ThreadCommand(ThreadCommand.Type.Quit));
+                    break;
+                }
+
+                if (ProcessNormalCommand(command))
+                    break;
+            }
+        }
+
+        // TODO: if Quit is called from another thread here, this thread will become permanently stuck waiting for the
+        // tasks
+
+        // Wait for all given tasks to complete
+        foreach (var task in mainThreadTaskStorage)
+        {
+            // TODO: so apparently this Wait call can allocate memory, in SpinThenBlockingWait which eventually calls
+            // EnsureLockObjectCreated
+            task.Wait();
+        }
+
+        mainThreadTaskStorage.Clear();
+    }
+
+    public void ReApplyThreadCount()
+    {
+        var settings = Settings.Instance;
+
+        if (settings.UseManualThreadCount.Value)
+        {
+            ParallelTasks = Math.Clamp(settings.ThreadCount.Value, MinimumThreadCount, MaximumThreadCount);
+        }
+        else
+        {
+            ParallelTasks = GetWantedThreadCount(settings.AssumeCPUHasHyperthreading.Value,
+                settings.RunAutoEvoDuringGamePlay.Value);
+        }
+
+        SetNativeThreadCount(ParallelTasks);
+    }
+
+    public void OnProgramExit()
+    {
+        // Stop Arch scheduling as it might keep the process otherwise alive incorrectly
+        StopArch();
+
+        running = false;
+        NotifyAllNewTasksAdded();
+        CPUHelpers.HyperThreadWake();
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Stop Arch scheduling (though as a singleton this class is never really disposed)
+            StopArch();
+        }
+    }
+
+    private void StopArch()
+    {
+        // Stop Arch scheduling (though as a singleton this class is never really disposed)
+        var scheduler = World.SharedJobScheduler;
+        World.SharedJobScheduler = null;
+        scheduler?.Dispose();
+    }
+
+    private void SpawnThread()
+    {
+        var thread = new Thread(RunExecutorThread)
+        {
+            IsBackground = true,
+            Name = $"TaskThread_{++threadCounter}",
+        };
+        thread.Start();
+        ++currentThreadCount;
+    }
+
+    private void QuitThread()
+    {
+        if (currentThreadCount <= 0)
+            return;
+
+        queuedTasks.Enqueue(new ThreadCommand(ThreadCommand.Type.Quit));
+        NotifyNewTasksAdded(1);
+
+        --currentThreadCount;
+    }
+
+    private void SetNativeThreadCount(int parallelTasks)
+    {
+        var settings = Settings.Instance;
+
+        int result;
+
+        if (settings.UseManualNativeThreadCount.Value)
+        {
+            result = settings.NativeThreadCount.Value;
+        }
+        else
+        {
+            result = CalculateNativeThreadCountFromManagedThreads(parallelTasks);
+        }
+
+        NativeTasks = result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void NotifyAllNewTasksAdded()
+    {
+        lock (threadNotifySync)
+        {
+            Monitor.PulseAll(threadNotifySync);
+        }
+
+        CPUHelpers.HyperThreadWake();
+    }
+
+    private void NotifyNewTasksAdded(int count)
+    {
+        if (count < 0)
+        {
+            GD.PrintErr($"Too low count passed to {nameof(NotifyNewTasksAdded)}");
+            return;
+        }
+
+        if (count == 1)
+        {
+            lock (threadNotifySync)
+            {
+                Monitor.Pulse(threadNotifySync);
+            }
+
+            CPUHelpers.HyperThreadWake();
+
+            return;
+        }
+
+        // If count is more than threads, don't bother sending that many
+        if (count > currentThreadCount)
+            count = currentThreadCount;
+
+        lock (threadNotifySync)
+        {
+            for (int i = 0; i < count; ++i)
+            {
+                Monitor.Pulse(threadNotifySync);
+            }
+        }
+
+        CPUHelpers.HyperThreadWake();
+    }
+
+    private void RunExecutorThread()
+    {
+        // This is used to sleep only when no new work is arriving to allow this thread to sleep only sometimes
+        int noWorkCounter = 0;
+
+        // This whole thing is in a try-catch now to try to solve issue of background threads disappearing without a
+        // trace
+        try
+        {
+            while (running)
+            {
+                // Wait a bit before going to sleep
+                if (noWorkCounter > ThreadSleepAfterNoWorkFor)
+                {
+                    lock (threadNotifySync)
+                    {
+                        // This timeout here is just for safety to avoid locking up, reducing this doesn't seem to have
+                        // any performance impact. This is set now for a balance of threads not being able to be stuck
+                        // too long in case the wake-up thread notifying is not working
+                        Monitor.Wait(threadNotifySync, 10);
+                    }
+                }
+
+                if (queuedTasks.TryDequeue(out ThreadCommand command))
+                {
+                    if (command.CommandType == ThreadCommand.Type.Quit)
+                    {
+                        return;
+                    }
+
+                    if (ProcessNormalCommand(command))
+                        return;
+
+                    noWorkCounter = 0;
+                }
+                else
+                {
+                    ++noWorkCounter;
+
+                    // Reduce hyperthreading resource use while just busy looping
+                    CPUHelpers.HyperThreadPause();
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            GD.PrintErr("Background thread failed to run, this is a serious problem and may deadlock the game: ", e);
+        }
+    }
+
+    private bool ProcessNormalCommand(ThreadCommand command)
+    {
+        if (command.CommandType == ThreadCommand.Type.Task)
+        {
+            try
+            {
+                // Task may not be null when the command type was a task
+                command.Task!.RunSynchronously();
+            }
+            catch (TaskSchedulerException exception)
+            {
+                GD.Print("Background task failed due to thread exiting: ", exception.Message);
+                return true;
+            }
+            catch (Exception e)
+            {
+                // This shouldn't hit in normal circumstances, but people have been submitting crash reports where
+                // an exception likely directly is caused by the run synchronous call
+
+                LogInterceptor.ForwardCaughtError(e);
+
+                GD.PrintErr("Trying to run background task failed with exception: ", e);
+                return true;
+            }
+
+            // Make sure task exceptions aren't ignored.
+            // TODO: if some places want to catch the exception themselves we should make sure that this still allows
+            // those places to do that
+            if (command.Task.Exception != null)
+            {
+                // Forward to the GUI so that the player sees it
+                LogInterceptor.ForwardCaughtError(command.Task.Exception);
+
+                GD.PrintErr("Background task caused an exception: ", command.Task.Exception);
+            }
+        }
+        else if (command.CommandType == ThreadCommand.Type.ParallelRunnable)
+        {
+            try
+            {
+                throw new Exception("TODO: reimplement parallel runnable");
+
+                // command.ParallelRunnable!.Run(command.ParallelIndex, command.MaxIndex);
+            }
+            catch (Exception e)
+            {
+                LogInterceptor.ForwardCaughtError(e);
+
+                GD.PrintErr("Background ParallelRunnable failed due to: ", e);
+                return true;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref queuedParallelRunnableCount);
+            }
+        }
+        else if (command.CommandType == ThreadCommand.Type.Invalid)
+        {
+            GD.PrintErr("Something has queued a task of invalid type. " +
+                "Ignoring it, but the underlying bug needs to be fixed.");
+        }
+        else
+        {
+            throw new Exception("Task command type value out of range");
+        }
+
+        return false;
+    }
+
+    private struct ThreadCommand
+    {
+        public readonly Task? Task;
+
+        public readonly Type CommandType;
+
+        public ThreadCommand(Task task)
+        {
+            CommandType = Type.Task;
+            Task = task;
+
+            if (Task == null)
+                throw new ArgumentNullException(nameof(task), "Task must be provided to this constructor");
+        }
+
+        public ThreadCommand(Type commandType)
+        {
+            CommandType = commandType;
+
+            if (CommandType != Type.Quit)
+                throw new ArgumentException("This constructor is only allowed to create quit type commands");
+
+            Task = null;
+        }
+
+        public enum Type
+        {
+            // Default-initialise type to invalid to catch errors caused by default initialisation of this class
+            Invalid = 0,
+            Task,
+            ParallelRunnable,
+            Quit,
+        }
+    }
+}


### PR DESCRIPTION
**Brief Description of What This PR Does**

The fix compiles cleanly in a non-AVX native build. -Added native ARM wait/signal exports
-Wired C# P/Invoke for those native calls in nativeinerops.cs -Used wake signaling where waiters are released
-Bumped native API version
-The ARM wait/wake path is now implemented with WFE/SEV (+ memory barrier before SEV) and used in the hot wait sites.

Moreover:
I also added missing <bit> include in CInterop.cpp (line 4) (needed for existing std::bit_cast usage in this file).
