### PR TITLE
Fixed coloured echo command.

### DIFF
--- a/src/engine/console/DebugConsole.cs
+++ b/src/engine/console/DebugConsole.cs
@@ -176,7 +176,7 @@ public partial class DebugConsole : CustomWindow, ICommandInvoker
     [Command("echo", false, "Echoes a colored message in this console.")]
     private static void CommandEcho(CommandContext context, string msg, int r, int g, int b)
     {
-        context.Print(msg, new Color(r, g, b));
+        context.Print(msg, Color.Color8((byte)r, (byte)g, (byte)b));
     }
 
     private void Activate()


### PR DESCRIPTION
**Brief Description of What This PR Does**

This is a fix for the coloured echo command, that was using the `float` constructor when the passed parameters were ints.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
