### PR TITLE
Fix weird colony links

### DIFF
--- a/src/multicellular_stage/systems/DelayedColonyOperationSystem.cs
+++ b/src/multicellular_stage/systems/DelayedColonyOperationSystem.cs
@@ -99,7 +99,7 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
         }
     }
 
-    public override void AfterUpdate(in float t)
+    public override void AfterUpdate(in float delta)
     {
         lock (attachLock)
         {
@@ -115,10 +115,13 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
                 if (!pair.Delayed.FinishAttachingToColony.IsAlive())
                 {
                     GD.PrintErr("Delayed attach target entity is dead, ignoring attach request");
+                    continue;
                 }
-                else if (!pair.Delayed.FinishAttachingToColony.Has<MicrobeColony>())
+
+                if (!pair.Delayed.FinishAttachingToColony.Has<MicrobeColony>())
                 {
                     GD.PrintErr("Delayed attach target entity is missing colony, ignoring attach request");
+                    continue;
                 }
 
                 CompleteDelayedColonyAttach(ref pair.Delayed.FinishAttachingToColony.Get<MicrobeColony>(),


### PR DESCRIPTION
**Brief Description of What This PR Does**

It seems like this bug was caused by outer cells being spawned first (with their order being the reverse of that of `GrowColonyMembers`'s) and having very limited options of what cell to attach to (that being the leader cell very often).

This PR reverses this order (as well as switching the script to use a `for` loop), making inner cells spawn first.

**Related Issues**

Fixes #6733

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
