### PR TITLE
Fixed tolerances not being copied when becoming multicellular

### DIFF
--- a/src/general/GameWorld.cs
+++ b/src/general/GameWorld.cs
@@ -879,7 +879,7 @@ public class GameWorld : IArchivable
     /// </summary>
     /// <param name="species">
     ///   The species to convert to a macroscopic one. No checks are done to make sure the species is
-    ///   actually a valid multicellular one.
+    ///   actually valid multicellular.
     /// </param>
     public MacroscopicSpecies ChangeSpeciesToMacroscopic(Species species)
     {
@@ -891,7 +891,7 @@ public class GameWorld : IArchivable
         var lateVersion = new MacroscopicSpecies(species.ID, species.Genus, species.Epithet);
         species.CopyDataToConvertedSpecies(lateVersion);
 
-        // Copy all the cell types, even ones that are unused so the player doesn't lose any when moving stages
+        // Copy all the cell types, even ones that are unused, so the player doesn't lose any when moving stages
         // in case they want to place them later
         lateVersion.ModifiableCellTypes.AddRange(earlySpecies.ModifiableCellTypes);
 

--- a/src/general/Species.cs
+++ b/src/general/Species.cs
@@ -378,6 +378,9 @@ public abstract class Species : ICloneable, IArchivable, IReadOnlySpecies
         // Preserve an endosymbiosis progress object as the same, as this is meant to be used when converting species
         // types
         species.Endosymbiosis = Endosymbiosis;
+
+        // Preserve configured tolerances to not lose them when converting species types
+        species.ModifiableTolerances.CopyFrom(Tolerances);
     }
 
     /// <summary>


### PR DESCRIPTION
which caused a reset of the tolerances to default values when becoming multicellular

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Multiple reports from discord

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
