### PR TITLE
Fixed the Thriveopedia page get calls that didn't work correctly

### DIFF
--- a/src/thriveopedia/ThriveopediaManager.cs
+++ b/src/thriveopedia/ThriveopediaManager.cs
@@ -23,6 +23,33 @@ public class ThriveopediaManager
     public OnPageOpened? OnPageOpenedHandler { get; set; }
 
     /// <summary>
+    ///   This looks up in the tree to find the owning Thriveopedia instance. This is now preferred rather than looking
+    ///   through the open Thriveopedias because there is the persistent pause menu one, and it has caused various
+    ///   bugs.
+    /// </summary>
+    /// <param name="currentNode">Node that is contained in a Thriveopedia</param>
+    /// <returns>
+    ///   The parent Thriveopedia or null if a node not in a Thriveopedia. If null methods need to cancel (this handles
+    ///   error reporting).
+    /// </returns>
+    public static Thriveopedia? GetParentThriveopedia(Control currentNode)
+    {
+        var parent = currentNode.GetParent();
+
+        while (parent != null)
+        {
+            if (parent is Thriveopedia thriveopedia)
+                return thriveopedia;
+
+            parent = parent.GetParent();
+        }
+
+        GD.PrintErr($"Thriveopedia not found when looking up from node: {currentNode.GetPath()}");
+        LogInterceptor.ForwardCaughtError(new Exception("Cannot find parent Thriveopedia instance"));
+        return null;
+    }
+
+    /// <summary>
     ///   Opens a page in the Thriveopedia via the appropriate menu context. Name must match the PageName property
     ///   of the desired page.
     /// </summary>
@@ -35,17 +62,6 @@ public class ThriveopediaManager
         }
 
         Instance.OnPageOpenedHandler(pageName);
-    }
-
-    public static IThriveopediaPage GetPage(string pageName)
-    {
-        foreach (var thriveopedia in Instance.activeThriveopedias)
-        {
-            // TODO: allow GetPage to return null to be able to support more thriveopedia?
-            return thriveopedia.GetPage(pageName);
-        }
-
-        throw new InvalidOperationException("No active Thriveopedias to get a page from");
     }
 
     public static Species? GetActiveSpeciesData(uint speciesId)

--- a/src/thriveopedia/pages/wiki/TextPageLinkButton.cs
+++ b/src/thriveopedia/pages/wiki/TextPageLinkButton.cs
@@ -14,12 +14,20 @@ public partial class TextPageLinkButton : Button
 #pragma warning disable CA2213
     [Export]
     public ThriveopediaWikiPage ParentPage = null!;
+
+    private Thriveopedia? thriveopedia;
 #pragma warning restore CA2213
 
     public override void _Ready()
     {
         ParentPage.Connect(ThriveopediaWikiPage.SignalName.OnStageChanged,
             new Callable(this, nameof(OnSelectedStageChanged)));
+    }
+
+    public override void _ExitTree()
+    {
+        base._ExitTree();
+        thriveopedia = null;
     }
 
     public override void _Pressed()
@@ -29,10 +37,15 @@ public partial class TextPageLinkButton : Button
 
     public void OnSelectedStageChanged()
     {
+        thriveopedia ??= ThriveopediaManager.GetParentThriveopedia(this);
+
+        if (thriveopedia == null)
+            return;
+
         IThriveopediaPage page;
         try
         {
-            page = ThriveopediaManager.GetPage(PageName);
+            page = thriveopedia.GetPage(PageName);
         }
         catch (Exception e)
         {

--- a/src/thriveopedia/pages/wiki/organelles/ThriveopediaOrganellesRootPage.cs
+++ b/src/thriveopedia/pages/wiki/organelles/ThriveopediaOrganellesRootPage.cs
@@ -11,6 +11,8 @@ public partial class ThriveopediaOrganellesRootPage : ThriveopediaWikiPage
 
     [Export]
     private HFlowContainer organelleListContainer = null!;
+
+    private Thriveopedia? thriveopedia;
 #pragma warning restore CA2213
 
     public override string PageName => "OrganellesRoot";
@@ -26,6 +28,12 @@ public partial class ThriveopediaOrganellesRootPage : ThriveopediaWikiPage
         base._Ready();
 
         linkButtonScene = GD.Load<PackedScene>("res://src/thriveopedia/pages/wiki/IconPageLinkButton.tscn");
+    }
+
+    public override void _ExitTree()
+    {
+        base._ExitTree();
+        thriveopedia = null;
     }
 
     public override void OnThriveopediaOpened()
@@ -51,11 +59,16 @@ public partial class ThriveopediaOrganellesRootPage : ThriveopediaWikiPage
 
     public override void OnSelectedStageChanged()
     {
+        thriveopedia ??= ThriveopediaManager.GetParentThriveopedia(this);
+
+        if (thriveopedia == null)
+            return;
+
         foreach (var node in organelleListContainer.GetChildren())
         {
             if (node is IconPageLinkButton button)
             {
-                var page = (ThriveopediaWikiPage)ThriveopediaManager.GetPage(button.PageName);
+                var page = (ThriveopediaWikiPage)thriveopedia.GetPage(button.PageName);
 
                 // TODO: should this property be in the base page interface to avoid having the cast above?
                 button.Visible = page.VisibleInTree;


### PR DESCRIPTION
as they didn't take into account potentially multiple Thriveopedia instances at once where some may have never been opened. Instead the buttons now find their parent Thriveopedia to function.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/464846402732687391/465937305849298956/1477291790376763464

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
