### PR TITLE
Fix zero focus species always thinking they can use toxins

### DIFF
--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -1330,9 +1330,10 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
 
     private bool CanShootToxin(CompoundBag compounds, float speciesFocus)
     {
-        // Ensure there is no multiply by 0
+        // Ensure that zero focus species don't constantly think they can fire toxins
         return compounds.GetCompoundAmount(Compound.Oxytoxy) >
-            Constants.MAXIMUM_AGENT_EMISSION_AMOUNT * (speciesFocus + 1) / Constants.MAX_SPECIES_FOCUS;
+            Math.Min(Constants.MAXIMUM_AGENT_EMISSION_AMOUNT * speciesFocus / Constants.MAX_SPECIES_FOCUS,
+                Constants.MINIMUM_AGENT_EMISSION_AMOUNT);
     }
 
     private void CleanMicrobeCache()


### PR DESCRIPTION
Because of this inequality species with focus == 0 tried to attack other species with toxing even though they had none

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
