### PR TITLE
Update species details text even if the visual hash is the same

### DIFF
--- a/src/gui_common/SpeciesDetailsPanel.cs
+++ b/src/gui_common/SpeciesDetailsPanel.cs
@@ -1,7 +1,7 @@
 ﻿using Godot;
 
 /// <summary>
-///   Shows various details a bout a species for the player
+///   Shows various details about a species for the player
 /// </summary>
 public partial class SpeciesDetailsPanel : MarginContainer
 {
@@ -28,7 +28,25 @@ public partial class SpeciesDetailsPanel : MarginContainer
             var newHash = value?.GetVisualHashCode() ?? 0UL;
 
             if (newHash == speciesVisualHash)
+            {
+                // If the generation changes, we need to still update the text data even if the visuals is the same.
+                // Because otherwise the evolutionary tree text data won't refresh if switching between visually the
+                // same species.
+                // TODO: should we rely on other stats as well as for AI species they don't necessarily increment the
+                // generation? Though it luckily seems that species basically always mutate which means that they will
+                // always have a changed visual hash.
+                // TODO: https://github.com/Revolutionary-Games/Thrive/issues/3045
+                if (value != null && value.Generation != previewSpecies?.Generation)
+                {
+                    if (speciesDetailsLabel != null)
+                    {
+                        previewSpecies = value;
+                        UpdateDetailString();
+                    }
+                }
+
                 return;
+            }
 
             previewSpecies = value;
             speciesVisualHash = newHash;
@@ -66,12 +84,17 @@ public partial class SpeciesDetailsPanel : MarginContainer
 
         hexesPreview.PreviewSpecies = PreviewSpecies;
 
-        speciesDetailsLabel!.ExtendedBbcode = PreviewSpecies?.GetDetailString();
+        UpdateDetailString();
     }
 
     private void OnTranslationsChanged()
     {
         if (previewSpecies != null)
-            UpdateSpeciesPreview();
+            UpdateDetailString();
+    }
+
+    private void UpdateDetailString()
+    {
+        speciesDetailsLabel!.ExtendedBbcode = PreviewSpecies?.GetDetailString();
     }
 }


### PR DESCRIPTION
when the generation has still changed. This properly works for the player species but might not catch all cases of AI species, but luckily they seem to basically always mutate so the original bug wasn't really shown by them

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
fixes #6778 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
