### PR TITLE
Tried to switch to reusing auto-evo simulation cache

### DIFF
--- a/src/auto-evo/AutoEvoExploringTool.cs
+++ b/src/auto-evo/AutoEvoExploringTool.cs
@@ -761,7 +761,7 @@ public partial class AutoEvoExploringTool : NodeWithInput, ISpeciesDataProvider
         var selectedPatch = world.GameProperties.GameWorld.Map.Patches.Values
             .First(p => p.Name.ToString() == patchName);
 
-        // Get current snapshot
+        // Get the current snapshot
         var patch = new Patch(selectedPatch.Name, 0, selectedPatch.BiomeTemplate, selectedPatch.BiomeType,
             world.PatchHistoryList[generationDisplayed][selectedPatch.ID], selectedPatch.DynamicDataSeed)
         {
@@ -788,10 +788,10 @@ public partial class AutoEvoExploringTool : NodeWithInput, ISpeciesDataProvider
             var cache = new SimulationCache(world.WorldSettings);
             var globalCache = new AutoEvoGlobalCache(world.WorldSettings);
 
-            var generateMiche = new GenerateMiche(patch, cache, globalCache);
+            var generateMiche = new GenerateMiche(patch, globalCache);
             var newMiche = generateMiche.GenerateMicheTree(globalCache);
 
-            generateMiche.PopulateMiche(newMiche);
+            generateMiche.PopulateMiche(newMiche, cache);
 
             micheTree.SetMiche(newMiche);
         }

--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -28,6 +29,8 @@ public class AutoEvoRun
     private readonly Queue<IRunStep> runSteps = new();
 
     private readonly List<Task> concurrentStepTasks = new();
+
+    private readonly ConcurrentStack<SimulationCache> simulationCaches = new();
 
     private volatile RunStage state = RunStage.GatheringInfo;
 
@@ -398,11 +401,9 @@ public class AutoEvoRun
 
         var allSpecies = new HashSet<Species>();
 
-        var generateMicheCache = new SimulationCache(worldSettings);
-
         foreach (var entry in map.Patches)
         {
-            steps.Enqueue(new GenerateMiche(entry.Value, generateMicheCache, globalCache));
+            steps.Enqueue(new GenerateMiche(entry.Value, globalCache));
 
             foreach (var species in entry.Value.SpeciesInPatch)
             {
@@ -412,13 +413,12 @@ public class AutoEvoRun
 
         foreach (var entry in map.Patches)
         {
-            steps.Enqueue(new ModifyExistingSpecies(entry.Value, new SimulationCache(worldSettings), worldSettings,
-                random));
+            steps.Enqueue(new ModifyExistingSpecies(entry.Value, worldSettings, random));
         }
 
         foreach (var species in allSpecies)
         {
-            steps.Enqueue(new MigrateSpecies(species, map, worldSettings, new SimulationCache(worldSettings), random));
+            steps.Enqueue(new MigrateSpecies(species, map, worldSettings, random));
         }
 
         // The new populations don't depend on the mutations but will take into account changes in the miche tree.
@@ -436,7 +436,7 @@ public class AutoEvoRun
     }
 
     /// <summary>
-    ///   Adds a step that adjusts the player species population results
+    ///   Adds a step that adjusts the player species' population results
     /// </summary>
     /// <param name="steps">The list of steps to add the adjustment step to</param>
     /// <param name="map">Used to get a list of patches to act on</param>
@@ -486,9 +486,9 @@ public class AutoEvoRun
     /// <summary>
     ///   Single step run wrapper that handles checking timing if needed
     /// </summary>
-    /// <returns>Returns true when step is complete and can be discarded</returns>
+    /// <returns>Returns true when the step is complete and can be discarded</returns>
     [SuppressMessage("ReSharper", "HeuristicUnreachableCode", Justification = "False positive due to Constant bool")]
-    private static bool RunSingleStep(IRunStep step, RunResults results)
+    private static bool RunSingleStep(IRunStep step, RunResults results, SimulationCache cache)
     {
         DateTime startTime;
 
@@ -496,7 +496,7 @@ public class AutoEvoRun
         if (Constants.AUTO_EVO_TRACK_STEP_TIME)
             startTime = DateTime.Now;
 
-        var result = step.RunStep(results);
+        var result = step.RunStep(results, cache);
 
         if (Constants.AUTO_EVO_TRACK_STEP_TIME)
         {
@@ -595,7 +595,7 @@ public class AutoEvoRun
 
                         if (concurrentStepTasks.Count < 1)
                         {
-                            // No steps that can run concurrently, need to run just a normal run
+                            // No steps that can run concurrently need to run just a normal run
                             NormalRunPartOfNextStep();
                         }
                         else
@@ -627,27 +627,49 @@ public class AutoEvoRun
 
     private void NormalRunPartOfNextStep()
     {
-        if (RunSingleStep(runSteps.Peek(), results))
+        var cache = GetCache();
+        if (RunSingleStep(runSteps.Peek(), results, cache))
             runSteps.Dequeue();
 
         Interlocked.Increment(ref completeSteps);
+
+        ReturnCache(cache);
     }
 
     private void RunSingleStepToCompletion(IRunStep step)
     {
         int steps = 0;
 
+        var cache = GetCache();
+
         // This condition is here to allow abandoning auto-evo runs quickly
         while (!Aborted)
         {
             ++steps;
 
-            if (RunSingleStep(step, results))
+            if (RunSingleStep(step, results, cache))
                 break;
         }
 
         // Doing the steps counting this way is slightly faster than an increment after each step
         Interlocked.Add(ref completeSteps, steps);
+
+        ReturnCache(cache);
+    }
+
+    private SimulationCache GetCache()
+    {
+        if (simulationCaches.TryPop(out var cache))
+            return cache;
+
+        return new SimulationCache(Parameters.World.WorldSettings);
+    }
+
+    private void ReturnCache(SimulationCache cache)
+    {
+        cache.OnAfterUse();
+
+        simulationCaches.Push(cache);
     }
 
     private void UpdateMap(bool playerCantGoExtinct)

--- a/src/auto-evo/EditorAutoEvoRun.cs
+++ b/src/auto-evo/EditorAutoEvoRun.cs
@@ -37,11 +37,9 @@ public class EditorAutoEvoRun : AutoEvoRun
         var map = Parameters.World.Map;
         var worldSettings = Parameters.World.WorldSettings;
 
-        var generateMicheCache = new SimulationCache(worldSettings);
-
         foreach (var entry in map.Patches)
         {
-            steps.Enqueue(new GenerateMiche(entry.Value, generateMicheCache, globalCache));
+            steps.Enqueue(new GenerateMiche(entry.Value, globalCache));
         }
 
         var populationCalculation = new CalculatePopulation(configuration, worldSettings, map,

--- a/src/auto-evo/IRunStep.cs
+++ b/src/auto-evo/IRunStep.cs
@@ -6,22 +6,25 @@
 public interface IRunStep
 {
     /// <summary>
-    ///   Total number of steps. As step is called this is allowed to return lower values
+    ///   Total number of steps. As <see cref="RunStep"/> is called, this is allowed to return lower values
     ///   than initially
     /// </summary>
     /// <value>The total steps.</value>
     public int TotalSteps { get; }
 
     /// <summary>
-    ///   If true this step can be ran concurrently with other steps. If false all previous steps need to finish
-    ///   before this can be ran.
+    ///   If true, this step can be run concurrently with other steps. If false, all previous steps need to finish
+    ///   before this can be run.
     /// </summary>
     public bool CanRunConcurrently { get; }
 
     /// <summary>
     ///   Performs a single step. This needs to be called TotalSteps times
     /// </summary>
-    /// <returns>True once final step is complete</returns>
+    /// <returns>True once the final step is complete</returns>
     /// <param name="results">Results are stored here</param>
-    public bool RunStep(RunResults results);
+    /// <param name="cache">
+    ///   Access to a cache where various auto-evo data can be got from efficiently.
+    /// </param>
+    public bool RunStep(RunResults results, SimulationCache cache);
 }

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -12,16 +12,19 @@ using Xoshiro.PRNG64;
 /// </summary>
 public static class MichePopulation
 {
-    public static void Simulate(SimulationConfiguration parameters, SimulationCache? existingCache,
+    public static void Simulate(SimulationConfiguration parameters, ref SimulationCache? existingCache,
         Random randomSource)
     {
         if (existingCache?.MatchesSettings(parameters.WorldSettings) == false)
             throw new ArgumentException("Given cache doesn't match world settings");
 
-        // This only seems to help a bit, so caching entirely in an auto-evo task by adding the cache parameter
-        // to IRunStep.RunStep might not be worth the effort at all
-        var cache = existingCache ?? new SimulationCache(parameters.WorldSettings);
+        existingCache ??= new SimulationCache(parameters.WorldSettings);
+        Simulate(parameters, existingCache, randomSource);
+    }
 
+    public static void Simulate(SimulationConfiguration parameters, SimulationCache cache,
+        Random randomSource)
+    {
         var insertWorkMemory = new Miche.InsertWorkingMemory();
 
         var random = new XoShiRo256starstar(randomSource.NextInt64());
@@ -30,7 +33,7 @@ public static class MichePopulation
 
         IEnumerable<KeyValuePair<int, Patch>> patchesToSimulate = parameters.OriginalMap.Patches;
 
-        // Skip patches not configured to be simulated in order to run faster
+        // Skip patches that aren't configured to be simulated in order to run faster
         if (parameters.PatchesToRun.Count > 0)
         {
             patchesToSimulate = patchesToSimulate.Where(p => parameters.PatchesToRun.Contains(p.Value));

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -23,12 +23,6 @@ using Systems;
 ///     caching is moved to a higher level in the auto-evo, that needs to be considered.
 ///   </para>
 /// </remarks>
-/// <remarks>
-///   <para>
-///     TODO: would be better to reuse instances of this class after clearing them for next use (there's now a Clear
-///     method for this future usecase)
-///   </para>
-/// </remarks>
 public class SimulationCache
 {
     private readonly CompoundDefinition oxytoxy = SimulationParameters.GetCompound(Compound.Oxytoxy);
@@ -1231,6 +1225,14 @@ public class SimulationCache
         var result = MicrobeEnvironmentalToleranceCalculations.ResolveToleranceValues(tolerances);
 
         return result;
+    }
+
+    /// <summary>
+    ///   Called after being used for an auto-evo step. This performs cleanup and readies this for the next use
+    /// </summary>
+    public void OnAfterUse()
+    {
+        Clear();
     }
 
     /// <summary>

--- a/src/auto-evo/steps/CalculatePopulation.cs
+++ b/src/auto-evo/steps/CalculatePopulation.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using Xoshiro.PRNG64;
 
 /// <summary>
-///   Step that calculate the populations for all species
+///   Step that calculates the populations for all species
 /// </summary>
 public class CalculatePopulation : IRunStep
 {
@@ -34,7 +34,7 @@ public class CalculatePopulation : IRunStep
     /// </summary>
     public Dictionary<Patch, Species>? EnsurePatchesHaveSpecies { get; set; }
 
-    public bool RunStep(RunResults results)
+    public bool RunStep(RunResults results, SimulationCache cache)
     {
         // ReSharper disable RedundantArgumentDefaultValue
         var config = new SimulationConfiguration(configuration, map, worldSettings)
@@ -58,7 +58,7 @@ public class CalculatePopulation : IRunStep
 
         // TODO: allow passing in a random seed
 
-        MichePopulation.Simulate(config, null, new XoShiRo256starstar());
+        MichePopulation.Simulate(config, cache, new XoShiRo256starstar());
 
         return true;
     }

--- a/src/auto-evo/steps/GenerateMiche.cs
+++ b/src/auto-evo/steps/GenerateMiche.cs
@@ -6,13 +6,11 @@
 public class GenerateMiche : IRunStep
 {
     private readonly Patch patch;
-    private readonly SimulationCache cache;
     private readonly AutoEvoGlobalCache globalCache;
 
-    public GenerateMiche(Patch patch, SimulationCache cache, AutoEvoGlobalCache globalCache)
+    public GenerateMiche(Patch patch, AutoEvoGlobalCache globalCache)
     {
         this.patch = patch;
-        this.cache = cache;
         this.globalCache = globalCache;
     }
 
@@ -20,10 +18,10 @@ public class GenerateMiche : IRunStep
 
     public bool CanRunConcurrently => false;
 
-    public bool RunStep(RunResults results)
+    public bool RunStep(RunResults results, SimulationCache cache)
     {
         var generatedMiche = GenerateMicheTree(globalCache);
-        results.AddNewMicheForPatch(patch, PopulateMiche(generatedMiche));
+        results.AddNewMicheForPatch(patch, PopulateMiche(generatedMiche, cache));
 
         return true;
     }
@@ -193,7 +191,7 @@ public class GenerateMiche : IRunStep
         return rootMiche;
     }
 
-    public Miche PopulateMiche(Miche miche)
+    public Miche PopulateMiche(Miche miche, SimulationCache cache)
     {
         // If no species, don't need to do anything
         if (patch.SpeciesInPatch.Count < 1)

--- a/src/auto-evo/steps/LambdaStep.cs
+++ b/src/auto-evo/steps/LambdaStep.cs
@@ -23,7 +23,7 @@ public class LambdaStep : IRunStep
     /// </summary>
     public bool CanRunConcurrently { get; set; }
 
-    public bool RunStep(RunResults results)
+    public bool RunStep(RunResults results, SimulationCache cache)
     {
         operation(results);
         return true;

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -12,15 +12,13 @@ public class MigrateSpecies : IRunStep
     private readonly Species species;
     private readonly PatchMap map;
     private readonly WorldGenerationSettings worldSettings;
-    private readonly SimulationCache cache;
+
     private readonly Random random;
     private readonly Miche.InsertWorkingMemory insertWorkingMemory = new();
 
-    public MigrateSpecies(Species species, PatchMap map, WorldGenerationSettings worldSettings, SimulationCache cache,
-        Random randomSource)
+    public MigrateSpecies(Species species, PatchMap map, WorldGenerationSettings worldSettings, Random randomSource)
     {
         this.species = species;
-        this.cache = cache;
         this.map = map;
         this.worldSettings = worldSettings;
 
@@ -31,7 +29,7 @@ public class MigrateSpecies : IRunStep
 
     public bool CanRunConcurrently => true;
 
-    public bool RunStep(RunResults results)
+    public bool RunStep(RunResults results, SimulationCache cache)
     {
         // Player has a separate GUI to control their migrations purposefully so auto-evo doesn't do it automatically
         if (species.PlayerSpecies)

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Godot;
 using Xoshiro.PRNG64;
 
@@ -16,7 +17,6 @@ public class ModifyExistingSpecies : IRunStep
     private const int TotalMutationsToTry = 20;
 
     private readonly Patch patch;
-    private readonly SimulationCache cache;
 
     private readonly WorldGenerationSettings worldSettings;
 
@@ -48,7 +48,6 @@ public class ModifyExistingSpecies : IRunStep
 
     private readonly List<Tuple<MicrobeSpecies, double>> temporaryResultForTopMutations = new();
 
-    private readonly MutationSorter mutationSorter;
     private readonly Random random;
 
     private readonly List<Mutation> mutationsToTry = new();
@@ -59,20 +58,18 @@ public class ModifyExistingSpecies : IRunStep
     private readonly List<Miche> nonEmptyLeafNodes = new();
     private readonly List<Miche> emptyLeafNodes = new();
 
+    private MutationSorter? mutationSorter;
+
     private Dictionary<Species, long>.Enumerator speciesEnumerator;
 
     private Miche? miche;
 
     private Step step;
 
-    public ModifyExistingSpecies(Patch patch, SimulationCache cache, WorldGenerationSettings worldSettings,
-        Random randomSeed)
+    public ModifyExistingSpecies(Patch patch, WorldGenerationSettings worldSettings, Random randomSeed)
     {
         this.patch = patch;
-        this.cache = cache;
         this.worldSettings = worldSettings;
-
-        mutationSorter = new MutationSorter(patch, cache);
 
         random = new XoShiRo256starstar(randomSeed.NextInt64());
 
@@ -102,8 +99,13 @@ public class ModifyExistingSpecies : IRunStep
 
     public bool CanRunConcurrently => true;
 
-    public bool RunStep(RunResults results)
+    public bool RunStep(RunResults results, SimulationCache cache)
     {
+        if (mutationSorter == null || !mutationSorter.UsesCache(cache))
+        {
+            mutationSorter = new MutationSorter(patch, cache);
+        }
+
         // Setup miche data if missing
         if (miche == null)
         {
@@ -129,7 +131,7 @@ public class ModifyExistingSpecies : IRunStep
 
                     if (species is MicrobeSpecies microbeSpecies)
                     {
-                        GetMutationsForSpecies(microbeSpecies);
+                        GetMutationsForSpecies(microbeSpecies, cache);
                     }
                 }
                 else
@@ -153,7 +155,7 @@ public class ModifyExistingSpecies : IRunStep
 
                         if (species is MicrobeSpecies microbeSpecies)
                         {
-                            GetMutationsForSpecies(microbeSpecies);
+                            GetMutationsForSpecies(microbeSpecies, cache);
                         }
                     }
                 }
@@ -287,7 +289,7 @@ public class ModifyExistingSpecies : IRunStep
         }
     }
 
-    private void GetMutationsForSpecies(MicrobeSpecies microbeSpecies)
+    private void GetMutationsForSpecies(MicrobeSpecies microbeSpecies, SimulationCache cache)
     {
         // The traversal end up being re-calculated quite many times, but this way we avoid quite a lot of memory
         // allocations
@@ -307,7 +309,7 @@ public class ModifyExistingSpecies : IRunStep
             }
 
             var variants = GenerateMutations(microbeSpecies,
-                worldSettings.AutoEvoConfiguration.MutationsPerSpecies, temporaryPressures);
+                worldSettings.AutoEvoConfiguration.MutationsPerSpecies, temporaryPressures, cache);
 
             foreach (var variant in variants)
             {
@@ -331,7 +333,7 @@ public class ModifyExistingSpecies : IRunStep
             }
 
             var variants = GenerateMutations(microbeSpecies,
-                worldSettings.AutoEvoConfiguration.MutationsPerSpecies, temporaryPressures);
+                worldSettings.AutoEvoConfiguration.MutationsPerSpecies, temporaryPressures, cache);
 
             foreach (var variant in variants)
             {
@@ -375,8 +377,15 @@ public class ModifyExistingSpecies : IRunStep
     /// </summary>
     /// <returns>List of viable variants and the provided species</returns>
     private List<MicrobeSpecies> GenerateMutations(MicrobeSpecies baseSpecies, int amount,
-        List<SelectionPressure> selectionPressures)
+        List<SelectionPressure> selectionPressures, SimulationCache cache)
     {
+#if DEBUG
+
+        // Check if methods are called in the wrong order
+        if (mutationSorter == null)
+            throw new InvalidOperationException("Mutation sorter is null");
+#endif
+
         double totalMP = 100 * worldSettings.AIMutationMultiplier;
 
         temporaryMutations1.Clear();
@@ -399,7 +408,7 @@ public class ModifyExistingSpecies : IRunStep
 
         bool lawk = worldSettings.LAWK;
 
-        mutationSorter.Setup(baseSpecies, selectionPressures);
+        mutationSorter!.Setup(baseSpecies, selectionPressures);
 
         tempMutationStrategies.Shuffle(random);
 
@@ -523,6 +532,12 @@ public class ModifyExistingSpecies : IRunStep
                 return 1;
 
             return 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool UsesCache(SimulationCache simulationCache)
+        {
+            return cache == simulationCache;
         }
     }
 }

--- a/src/auto-evo/steps/RegisterNewSpecies.cs
+++ b/src/auto-evo/steps/RegisterNewSpecies.cs
@@ -19,7 +19,7 @@ public class RegisterNewSpecies : IRunStep
     public int TotalSteps => 1;
     public bool CanRunConcurrently => false;
 
-    public bool RunStep(RunResults results)
+    public bool RunStep(RunResults results, SimulationCache cache)
     {
         var currentSpecies = new HashSet<Species>();
         foreach (var patch in world.Map.Patches)

--- a/src/auto-evo/steps/RemoveInvalidMigrations.cs
+++ b/src/auto-evo/steps/RemoveInvalidMigrations.cs
@@ -14,7 +14,7 @@ public class RemoveInvalidMigrations : IRunStep
     public int TotalSteps => 1;
     public bool CanRunConcurrently => false;
 
-    public bool RunStep(RunResults results)
+    public bool RunStep(RunResults results, SimulationCache cache)
     {
         foreach (var species in speciesToCheck)
         {

--- a/src/microbe_stage/editor/PatchMapEditorComponent.cs
+++ b/src/microbe_stage/editor/PatchMapEditorComponent.cs
@@ -421,9 +421,9 @@ public partial class PatchMapEditorComponent<TEditor> : EditorComponentBase<TEdi
 
         // Create a miche tree to only find species that would actually survive in the target patch
         var cache = new SimulationCache(world.WorldSettings);
-        var generation = new GenerateMiche(patch, cache, world.AutoEvoGlobalCache);
+        var generation = new GenerateMiche(patch, world.AutoEvoGlobalCache);
         var miche = generation.GenerateMicheTree(world.AutoEvoGlobalCache);
-        generation.PopulateMiche(miche);
+        generation.PopulateMiche(miche, cache);
 
         Species? foundSpecies = null;
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

and steps get access to a cache as a parameter for more cache sharing

This is a draft as interestingly this uses *more* memory

before:
<img width="834" height="259" alt="Kuvakaappaus - 2026-03-09 16-28-12" src="https://github.com/user-attachments/assets/8efc18ec-88eb-4fe5-a9ca-fddd349abfbe" />

after:
<img width="834" height="259" alt="Kuvakaappaus - 2026-03-09 16-36-02" src="https://github.com/user-attachments/assets/30827344-e90a-4ebd-956a-5057f009098c" />

So I'm opening this as a draft to remember this fact and maybe in the future further investigate this.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #6664 (if this were to be merged, but this would make the game worse as-is right now)

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
