### PR TITLE
Converted ToleranceResult into a struct

### DIFF
--- a/src/macroscopic_stage/editor/MacroscopicEditor.cs
+++ b/src/macroscopic_stage/editor/MacroscopicEditor.cs
@@ -238,8 +238,7 @@ public partial class MacroscopicEditor : EditorBase<EditorAction, MacroscopicSta
     {
         // TODO: macroscopic tolerance effects from metaballs
         return MicrobeEnvironmentalToleranceCalculations.CalculateTolerancesWithoutOrganelleModifiers(
-            calculationTolerances,
-            CurrentPatch.Biome);
+            calculationTolerances, CurrentPatch.Biome);
     }
 
     public void GetCurrentToleranceSummaryByElement(ToleranceModifier toleranceCategory,

--- a/src/microbe_stage/MicrobeEnvironmentalToleranceCalculations.cs
+++ b/src/microbe_stage/MicrobeEnvironmentalToleranceCalculations.cs
@@ -51,8 +51,6 @@ public static class MicrobeEnvironmentalToleranceCalculations
     public static ToleranceResult CalculateTolerances(IReadOnlyEnvironmentalTolerances speciesTolerances,
         IReadOnlyList<OrganelleTemplate> organelles, IBiomeConditions environment, bool excludePositiveBuffs = false)
     {
-        var result = new ToleranceResult();
-
         var resolvedTolerances = new ToleranceValues
         {
             PreferredTemperature = speciesTolerances.PreferredTemperature,
@@ -69,9 +67,7 @@ public static class MicrobeEnvironmentalToleranceCalculations
 
         ApplyResultMinimums(ref resolvedTolerances);
 
-        CalculateTolerancesInternal(resolvedTolerances, noExtraEffects, environment, result, excludePositiveBuffs);
-
-        return result;
+        return CalculateTolerancesInternal(resolvedTolerances, noExtraEffects, environment, excludePositiveBuffs);
     }
 
     /// <summary>
@@ -81,8 +77,6 @@ public static class MicrobeEnvironmentalToleranceCalculations
         IReadOnlyEnvironmentalTolerances speciesTolerances, IBiomeConditions environment,
         bool excludePositiveBuffs = false)
     {
-        var result = new ToleranceResult();
-
         var resolvedTolerances = new ToleranceValues
         {
             PreferredTemperature = speciesTolerances.PreferredTemperature,
@@ -97,9 +91,7 @@ public static class MicrobeEnvironmentalToleranceCalculations
 
         ApplyResultMinimums(ref resolvedTolerances);
 
-        CalculateTolerancesInternal(resolvedTolerances, noExtraEffects, environment, result, excludePositiveBuffs);
-
-        return result;
+        return CalculateTolerancesInternal(resolvedTolerances, noExtraEffects, environment, excludePositiveBuffs);
     }
 
     public static void ApplyOrganelleEffectsOnTolerances(IReadOnlyList<IReadOnlyOrganelleTemplate> organelles,
@@ -226,8 +218,6 @@ public static class MicrobeEnvironmentalToleranceCalculations
     public static ToleranceResult CalculateTolerances(IReadOnlyEnvironmentalTolerances speciesTolerances,
         IndividualHexLayout<CellTemplate> cells, IBiomeConditions environment, bool excludePositiveBuffs = false)
     {
-        var result = new ToleranceResult();
-
         var resolvedTolerances = new ToleranceValues
         {
             PreferredTemperature = speciesTolerances.PreferredTemperature,
@@ -244,9 +234,7 @@ public static class MicrobeEnvironmentalToleranceCalculations
 
         ApplyResultMinimums(ref resolvedTolerances);
 
-        CalculateTolerancesInternal(resolvedTolerances, noExtraEffects, environment, result, excludePositiveBuffs);
-
-        return result;
+        return CalculateTolerancesInternal(resolvedTolerances, noExtraEffects, environment, excludePositiveBuffs);
     }
 
     public static void ApplyCellEffectsOnTolerances(IndividualHexLayout<CellTemplate> cells,
@@ -378,7 +366,7 @@ public static class MicrobeEnvironmentalToleranceCalculations
         }
     }
 
-    public static ResolvedMicrobeTolerances ResolveToleranceValues(ToleranceResult data)
+    public static ResolvedMicrobeTolerances ResolveToleranceValues(in ToleranceResult data)
     {
         var result = default(ResolvedMicrobeTolerances);
 
@@ -478,9 +466,8 @@ public static class MicrobeEnvironmentalToleranceCalculations
             resolvedTolerances.UVResistance = 0;
     }
 
-    private static void CalculateTolerancesInternal(in ToleranceValues speciesTolerances,
-        in ToleranceValues noExtraEffects, IBiomeConditions environment, ToleranceResult result,
-        bool excludePositiveBuffs)
+    private static ToleranceResult CalculateTolerancesInternal(in ToleranceValues speciesTolerances,
+        in ToleranceValues noExtraEffects, IBiomeConditions environment, bool excludePositiveBuffs)
     {
         var patchTemperature = environment.GetCompound(Compound.Temperature, CompoundAmountType.Biome).Ambient;
         var patchPressure = environment.Pressure;
@@ -488,6 +475,8 @@ public static class MicrobeEnvironmentalToleranceCalculations
         var requiredUVResistance = environment.CalculateUVFactor();
 
         bool missingSomething = false;
+
+        var result = default(ToleranceResult);
 
         // Always write the targets for becoming perfectly adapted
         result.PerfectTemperatureAdjustment = patchTemperature - speciesTolerances.PreferredTemperature;
@@ -649,7 +638,7 @@ public static class MicrobeEnvironmentalToleranceCalculations
 
             // If that fixed it, then return immediately without further necessary adjustments
             if (result.OverallScore < 1)
-                return;
+                return result;
 
             // Find the stat that is slightly off due to tiny value rounding and apply a bit of penalty
             if (speciesTolerances.OxygenResistance < requiredOxygenResistance)
@@ -673,6 +662,8 @@ public static class MicrobeEnvironmentalToleranceCalculations
                 result.OverallScore -= MathUtils.EPSILON;
             }
         }
+
+        return result;
     }
 
     /// <summary>
@@ -726,32 +717,4 @@ public static class MicrobeEnvironmentalToleranceCalculations
             UVResistance += other.UVResistance;
         }
     }
-}
-
-public class ToleranceResult
-{
-    // The scores are doubles to avoid rounding problems where the score is 1 but something is missing
-    public double OverallScore;
-
-    public double TemperatureScore;
-
-    /// <summary>
-    ///   How to adjust the preferred temperature to get to the exact value in the biome
-    /// </summary>
-    public float PerfectTemperatureAdjustment;
-
-    /// <summary>
-    ///   How to adjust the tolerance range of temperature to qualify as perfectly adapted
-    /// </summary>
-    public float TemperatureRangeSizeAdjustment;
-
-    public double PressureScore;
-    public float PerfectPressureAdjustment;
-    public float PressureRangeSizeAdjustment;
-
-    public double OxygenScore;
-    public float PerfectOxygenAdjustment;
-
-    public double UVScore;
-    public float PerfectUVAdjustment;
 }

--- a/src/microbe_stage/ToleranceResult.cs
+++ b/src/microbe_stage/ToleranceResult.cs
@@ -1,0 +1,30 @@
+﻿/// <summary>
+///   Finalized tolerance calculation results. This is a struct as these need to be created a *ton*
+/// </summary>
+public struct ToleranceResult
+{
+    // The scores are doubles to avoid rounding problems where the score is 1 but something is missing
+    public double OverallScore;
+
+    public double TemperatureScore;
+
+    /// <summary>
+    ///   How to adjust the preferred temperature to get to the exact value in the biome
+    /// </summary>
+    public float PerfectTemperatureAdjustment;
+
+    /// <summary>
+    ///   How to adjust the tolerance range of temperature to qualify as perfectly adapted
+    /// </summary>
+    public float TemperatureRangeSizeAdjustment;
+
+    public double PressureScore;
+    public float PerfectPressureAdjustment;
+    public float PressureRangeSizeAdjustment;
+
+    public double OxygenScore;
+    public float PerfectOxygenAdjustment;
+
+    public double UVScore;
+    public float PerfectUVAdjustment;
+}

--- a/src/microbe_stage/ToleranceResult.cs.uid
+++ b/src/microbe_stage/ToleranceResult.cs.uid
@@ -1,0 +1,1 @@
+uid://b8dt43vnrdq8l


### PR DESCRIPTION
so that it uses less temporary memory allocations in auto-evo

This seems to slightly help with auto-evo run memory usage

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
