### PR TITLE
Fix microbe colony members' physics shapes being misplaced

### DIFF
--- a/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
+++ b/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
@@ -27,6 +27,7 @@ using World = Arch.Core.World;
 [WritesToComponent(typeof(CurrentAffected))]
 [ReadsComponent(typeof(OrganelleContainer))]
 [ReadsComponent(typeof(AttachedToEntity))]
+[ReadsComponent(typeof(SpatialAnimation))]
 [RunsAfter(typeof(MicrobeVisualsSystem))]
 [RunsBefore(typeof(PhysicsBodyCreationSystem))]
 [RunsBefore(typeof(MicrobeReproductionSystem))]
@@ -326,13 +327,19 @@ public partial class MicrobePhysicsCreationAndSizeSystem : BaseSystem<World, flo
 
                 ref var attached = ref member.Get<AttachedToEntity>();
 
+                var relativePosition = attached.RelativePosition;
+                if (member.TryGet<SpatialAnimation>(out var animation))
+                {
+                    relativePosition = animation.FinalPosition;
+                }
+
                 memberOrganelles.Add((currentMemberOrganelles.Organelles ??
-                    throw new Exception("Colony member has no organelles but it had a membrane"),
-                    attached.RelativePosition, attached.RelativeRotation));
+                    throw new Exception("Colony member has no organelles but it had a membrane"), relativePosition,
+                    attached.RelativeRotation));
 
                 combinedData.Add((
                     CreateColonyMemberBaseShape(ref extraData, ref currentMemberOrganelles, membrane, isBacteria),
-                    attached.RelativePosition, attached.RelativeRotation));
+                    relativePosition, attached.RelativeRotation));
             }
         }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes colony members' physics shapes being slightly offset because of the animation system

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
