### PR TITLE
Fixed console history size bug

### DIFF
--- a/src/engine/console/DebugConsoleManager.cs
+++ b/src/engine/console/DebugConsoleManager.cs
@@ -151,7 +151,7 @@ public partial class DebugConsoleManager : Node, ICommandInvoker
 
         lock (inbox)
         {
-            if (inbox.Count > MaxHistorySize)
+            if (inbox.Count >= MaxHistorySize)
                 inbox.RemoveFromFront();
 
             inbox.AddToBack(rawDebugEntry);


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR fixes an issue where the Debug Console threw an exception due to a negative index lookup in the history caused by adding an excess of one message to the history from the inbox.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
