### PR TITLE
Specialisation calculation overhaul A

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -683,7 +683,7 @@ public static class Constants
     ///   Controls how strong the cell specialization effect is (this is a flat multiplier right now but we could use
     ///   something like a power curve or another function for diminishing returns)
     /// </summary>
-    public const float CELL_SPECIALIZATION_STRENGTH_MULTIPLIER = 0.8f;
+    public const float CELL_SPECIALIZATION_STRENGTH_MULTIPLIER = 0.3f;
 
     /// <summary>
     ///   If more chunks exist at once than this, then some are forced to despawn immediately. In reality the effective

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -876,12 +876,8 @@ public static class MicrobeInternalCalculations
         // The raw bonus is just the ratio of the main organelle type
         var bonus = (float)maxHexCount / totalHexCount;
 
-        // Calculate a strength factor that adjusts things
-        var strength = Math.Min((float)totalHexCount / Constants.CELL_SPECIALIZATION_STRENGTH_FULL_AT, 1);
-        strength *= Constants.CELL_SPECIALIZATION_STRENGTH_MULTIPLIER;
-
         // Then return the final result as the bonus being anything above 1
-        return 1 + bonus * strength;
+        return 1 + bonus * Constants.CELL_SPECIALIZATION_STRENGTH_MULTIPLIER;
     }
 
     private static float MovementForce(float movementForce, float directionFactor)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes a big overhaul to the cell specialisation calculation:

* Take into account hex size so that a cell using advanced organelles isn't likely to have a lower bonus automatically.
* Exclude the nucleus from the calculation because its large size would have too large an influence due to above change. And realistically, having a nucleus does not really make any cell "less specialised".
* Remove the minimum size required to trigger the specialisation effect. This prevents the sudden jump going from 5 to 6 organelles and makes design of sub-6 hex cells a bit more interesting. I also don't think this has a dangerously big effect, since the bonus rises gradually from 0 anyway.
* Took a different calculation of simply: most common organelle hexes / total organelle hexes. This makes adding organelles not of the most common type no longer neutral.

Tooltip not adjusted yet.

Of course, this version starts you off with the maximum bonus, reducing whenever you add a different new organelle, which might not feel great.

Other overhauls:
#6805
#6806

Less extreme changes:
#6800

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
* Switching to eukaryotic organelles lowers specialisation bonus
* There's an unexpected sudden jump in process speeds when you reach 6 organelles and trigger the specialisation system.
* Currently, removing non-relevant organelles is not necessary for "specialisation" until very large cells sizes.
* In fact, it could be said that the system provides a strong incentive to just making larger cells.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
