### PR TITLE
Fix some cells not growing to their full size

### DIFF
--- a/src/engine/common_systems/SpatialAnimationSystem.cs
+++ b/src/engine/common_systems/SpatialAnimationSystem.cs
@@ -49,7 +49,6 @@ public partial class SpatialAnimationSystem : BaseSystem<World, float>
             var recorder = worldSimulation.StartRecordingEntityCommands();
             recorder.Remove<SpatialAnimation>(entity);
             worldSimulation.FinishRecordingEntityCommands(recorder);
-            return;
         }
     }
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

It seems like the underlying issue was some cells "overshooting" the 100% mark, which caused an early return and left cells undergrown.  This problem occured when ECS called `Update` with a big delta, leaving the cell only grown to, e.g. 90% of their full size

**Related Issues**

Some cells not growing to their full size

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
