### PR TITLE
Fixed death not being able to unbind multicellular cells

### DIFF
--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -716,7 +716,9 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
         siderophoreHotkey.Visible = showSiderophore;
 
         bindingModeHotkey.Visible = organelles.CanBind(ref species);
-        unbindAllHotkey.Visible = organelles.CanUnbind(ref species, player);
+
+        // Not a forced unbinding, so we pass false to prevent the player from disbanding their multicellular body
+        unbindAllHotkey.Visible = organelles.CanUnbind(ref species, player, false);
 
         bindingModeHotkey.ButtonPressed = control.State == MicrobeState.Binding;
 

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -745,7 +745,8 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
 
         // Move to multicellular always happens when the player is in a colony, so we force-disband that here before
         // proceeding
-        MicrobeColonyHelpers.UnbindAllOutsideGameUpdate(Player, WorldSimulation);
+        if (!MicrobeColonyHelpers.UnbindAllOutsideGameUpdate(Player, WorldSimulation, true))
+            GD.PrintErr("Failed to disband player colony before moving to multicellular");
 
         if (Player.Has<MicrobeColony>())
             throw new Exception("Unbind failed");

--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -326,8 +326,9 @@ public partial class PlayerMicrobeInput : NodeWithInput
 
         if (stage.Player.Has<MicrobeColony>())
         {
-            if (!MicrobeColonyHelpers.UnbindAllOutsideGameUpdate(stage.Player, stage.WorldSimulation))
+            if (!MicrobeColonyHelpers.UnbindAllOutsideGameUpdate(stage.Player, stage.WorldSimulation, false))
             {
+                // TODO: suppress this message in multicellular?
                 GD.PrintErr("Failed to unbind the player");
             }
         }
@@ -473,7 +474,7 @@ public partial class PlayerMicrobeInput : NodeWithInput
 
     private void RemoveCellFromColony(Entity target)
     {
-        if (!MicrobeColonyHelpers.UnbindAllOutsideGameUpdate(target, stage.WorldSimulation))
+        if (!MicrobeColonyHelpers.UnbindAllOutsideGameUpdate(target, stage.WorldSimulation, false))
         {
             GD.PrintErr("Target microbe failed to unbind");
         }

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -627,8 +627,8 @@ public static class MicrobeColonyHelpers
     ///   <see cref="AttachedToEntityHelpers.EntityAttachRelationshipModifyLock"/>
     /// </summary>
     /// <returns>True when the colony still exists. False if the entire colony was disbanded</returns>
-    public static bool RemoveFromColony(this ref MicrobeColony colony, in Entity colonyEntity, Entity removedMember,
-        CommandBuffer recorder)
+    public static bool RemoveFromColonyAndDisbandIfEmpty(this ref MicrobeColony colony, in Entity colonyEntity,
+        Entity removedMember, CommandBuffer recorder)
     {
         if (colonyEntity.Has<MulticellularGrowth>())
         {
@@ -735,7 +735,7 @@ public static class MicrobeColonyHelpers
             // This might stackoverflow if we have absolute, hugely nested cell colonies, but there would probably
             // need to be colonies with thousands of cells, which would already choke the game so that isn't much
             // of a concern
-            if (!colony.RemoveFromColony(colonyEntity, next, recorder))
+            if (!colony.RemoveFromColonyAndDisbandIfEmpty(colonyEntity, next, recorder))
             {
                 // Colony is entirely disbanded, doesn't make sense to continue removing things
                 DependentMembersToRemove.Clear();
@@ -743,8 +743,8 @@ public static class MicrobeColonyHelpers
             }
         }
 
-        // Check against a logic error. All colony members ultimately depend on the leader so the above early
-        // exit must trigger uf the colony leader is removed
+        // Check against a logic error. All colony members ultimately depend on the leader, so the above early
+        // exit must trigger if the colony leader is removed
         if (removedMember == colony.Leader)
             throw new Exception("Colony should have been fully disbanded when leader was removed");
 
@@ -753,11 +753,13 @@ public static class MicrobeColonyHelpers
 
         colony.MarkMembersChanged();
 
+        // Colony still exists
         return true;
     }
 
     /// <summary>
-    ///   Removes this cell and child cells from the colony.
+    ///   Removes this cell and child cells from the colony. When multicellular bodies are forcefully split apart
+    ///   this should use forceUnbind set to true as otherwise it will not work.
     /// </summary>
     /// <remarks>
     ///   <para>
@@ -765,7 +767,8 @@ public static class MicrobeColonyHelpers
     ///   </para>
     /// </remarks>
     /// <returns>True if unbind happened</returns>
-    public static bool UnbindAll(in Entity entity, CommandBuffer entityCommandRecorder)
+    public static bool UnbindAll(in Entity entity, CommandBuffer entityCommandRecorder, bool forcedUnbind,
+        bool verboseErrors = false)
     {
         ref var control = ref entity.Get<MicrobeControl>();
 
@@ -776,20 +779,25 @@ public static class MicrobeColonyHelpers
 
         ref var organelles = ref entity.Get<OrganelleContainer>();
 
-        if (!organelles.CanUnbind(ref entity.Get<SpeciesMember>(), entity))
+        if (!organelles.CanUnbind(ref entity.Get<SpeciesMember>(), entity, forcedUnbind, verboseErrors))
             return false;
 
         // TODO: once the colony leader can leave without the entire colony disbanding this perhaps should
         // keep the disband entire colony functionality
         // Colony!.RemoveFromColony(this); (when entity is a colony leader)
-        return RemoveFromColony(entity, entityCommandRecorder);
+        var removed = RemoveFromColony(entity, entityCommandRecorder, verboseErrors);
+
+        if (!removed && verboseErrors)
+            GD.PrintErr("RemoveFromColony returned false");
+
+        return removed;
     }
 
     /// <summary>
     ///   Removes the given entity from the microbe colony it is in (if any)
     /// </summary>
     /// <returns>True on success</returns>
-    public static bool RemoveFromColony(in Entity entity, CommandBuffer entityCommandRecorder)
+    public static bool RemoveFromColony(in Entity entity, CommandBuffer entityCommandRecorder, bool verboseErrors)
     {
         lock (AttachedToEntityHelpers.EntityAttachRelationshipModifyLock)
         {
@@ -799,7 +807,7 @@ public static class MicrobeColonyHelpers
 
                 try
                 {
-                    colony.RemoveFromColony(entity, entity, entityCommandRecorder);
+                    colony.RemoveFromColonyAndDisbandIfEmpty(entity, entity, entityCommandRecorder);
                 }
                 catch (Exception e)
                 {
@@ -821,7 +829,7 @@ public static class MicrobeColonyHelpers
 
                 try
                 {
-                    colony.RemoveFromColony(member.ColonyLeader, entity, entityCommandRecorder);
+                    colony.RemoveFromColonyAndDisbandIfEmpty(member.ColonyLeader, entity, entityCommandRecorder);
                 }
                 catch (Exception e)
                 {
@@ -837,7 +845,9 @@ public static class MicrobeColonyHelpers
     /// <summary>
     ///   Variant of unbinding allowed to be called *only* outside the game update loop
     /// </summary>
-    public static bool UnbindAllOutsideGameUpdate(in Entity entity, IWorldSimulation entityWorld)
+    /// <returns>True when the unbinding happened</returns>
+    public static bool UnbindAllOutsideGameUpdate(in Entity entity, IWorldSimulation entityWorld,
+        bool forcedUnbind, bool verboseOutput = true)
     {
         if (entityWorld.Processing)
         {
@@ -857,7 +867,7 @@ public static class MicrobeColonyHelpers
 #endif
 
         var recorder = entityWorld.StartRecordingEntityCommands();
-        var result = UnbindAll(entity, recorder);
+        var result = UnbindAll(entity, recorder, forcedUnbind, verboseOutput);
 
         // TODO: should this skip applying the recorder if the operation failed
 

--- a/src/microbe_stage/components/OrganelleContainer.cs
+++ b/src/microbe_stage/components/OrganelleContainer.cs
@@ -309,10 +309,23 @@ public static class OrganelleContainerHelpers
     }
 
     public static bool CanUnbind(this ref OrganelleContainer organelleContainer, ref SpeciesMember species,
-        in Entity entity)
+        in Entity entity, bool forcedUnbind, bool verboseErrors = false)
     {
-        return species.Species is MicrobeSpecies &&
-            (entity.Has<MicrobeColony>() || entity.Has<MicrobeColonyMember>());
+        bool partOfColony = entity.Has<MicrobeColony>() || entity.Has<MicrobeColonyMember>();
+
+        // Multicellular species can be forced to disband
+        if (forcedUnbind && partOfColony)
+            return true;
+
+        var result = species.Species is MicrobeSpecies && partOfColony;
+
+        if (verboseErrors && !result)
+        {
+            GD.Print($"OrganelleContainer: cannot unbind, species type is: {species.Species.GetType().Name}, " +
+                $"part of colony: {partOfColony}");
+        }
+
+        return result;
     }
 
     public static void CreateOrganelleLayout(this ref OrganelleContainer container, ICellDefinition cellDefinition,
@@ -387,7 +400,10 @@ public static class OrganelleContainerHelpers
         if (!container.HasBindingAgent && entity.Has<MicrobeColony>())
         {
             var recorder = worldSimulation.StartRecordingEntityCommands();
-            MicrobeColonyHelpers.UnbindAll(entity, recorder);
+            if (!MicrobeColonyHelpers.UnbindAll(entity, recorder, true, true))
+            {
+                GD.PrintErr("Failed to unbind all cells when lead cell removed binding agent on organelles edit");
+            }
 
             worldSimulation.FinishRecordingEntityCommands(recorder);
         }

--- a/src/microbe_stage/systems/ColonyStatsUpdateSystem.cs
+++ b/src/microbe_stage/systems/ColonyStatsUpdateSystem.cs
@@ -62,7 +62,7 @@ public partial class ColonyStatsUpdateSystem : BaseSystem<World, float>
 
         lock (AttachedToEntityHelpers.EntityAttachRelationshipModifyLock)
         {
-            parentColony.RemoveFromColony(memberInfo.ColonyLeader, entity, recorder);
+            parentColony.RemoveFromColonyAndDisbandIfEmpty(memberInfo.ColonyLeader, entity, recorder);
         }
 
         // As this is called by the destruction callback, the world can't be doing anything else so we can safely

--- a/src/microbe_stage/systems/EngulfingSystem.cs
+++ b/src/microbe_stage/systems/EngulfingSystem.cs
@@ -1235,7 +1235,7 @@ public partial class EngulfingSystem : BaseSystem<World, float>
         CommandBuffer? recorder = null;
 
         // Steal this cell from a colony if it is in a colony currently
-        // Right now this causes extra operations for deleting the attach component but avoiding that would
+        // Right now this causes extra operations for deleting the attached component but avoiding that would
         // complicate the code a lot here
         if (targetEntity.Has<MicrobeColonyMember>() || targetEntity.Has<MicrobeColony>())
         {
@@ -1246,7 +1246,7 @@ public partial class EngulfingSystem : BaseSystem<World, float>
             // started but that may have been caused by my testing method of overriding the required size ratio (
             // in just one place so maybe some other later check then immediately canceled the engulf)
             // - hhyyrylainen
-            if (!MicrobeColonyHelpers.RemoveFromColony(targetEntity, recorder))
+            if (!MicrobeColonyHelpers.RemoveFromColony(targetEntity, recorder, true))
             {
                 GD.PrintErr("Failed to engulf a member of a cell colony (can't remove it)");
                 return false;

--- a/src/microbe_stage/systems/MicrobeDeathSystem.cs
+++ b/src/microbe_stage/systems/MicrobeDeathSystem.cs
@@ -285,9 +285,9 @@ public partial class MicrobeDeathSystem : BaseSystem<World, float>
             {
                 commandRecorder = worldSimulation.StartRecordingEntityCommands();
 
-                if (!MicrobeColonyHelpers.UnbindAll(entity, commandRecorder))
+                if (!MicrobeColonyHelpers.UnbindAll(entity, commandRecorder, true, true))
                 {
-                    GD.PrintErr("Failed to unbind microbe from colony on death");
+                    GD.PrintErr("Failed to unbind microbe from colony on death (see above for error)");
                 }
             }
             else
@@ -303,9 +303,9 @@ public partial class MicrobeDeathSystem : BaseSystem<World, float>
             // Handle colony lead cell dying (disband the colony)
             commandRecorder ??= worldSimulation.StartRecordingEntityCommands();
 
-            if (!MicrobeColonyHelpers.UnbindAll(entity, commandRecorder))
+            if (!MicrobeColonyHelpers.UnbindAll(entity, commandRecorder, true, true))
             {
-                GD.PrintErr("Failed to unbind colony of a dying lead cell");
+                GD.PrintErr("Failed to unbind colony of a dying lead cell (see above for error)");
             }
         }
 

--- a/src/microbe_stage/systems/MicrobeMovementSystem.cs
+++ b/src/microbe_stage/systems/MicrobeMovementSystem.cs
@@ -290,7 +290,7 @@ public partial class MicrobeMovementSystem : BaseSystem<World, float>
                 Invoke.Instance.Perform(() =>
                 {
                     GD.PrintErr("Force disbanding the colony that is in invalid state, entity: ", entityId);
-                    MicrobeColonyHelpers.UnbindAllOutsideGameUpdate(entityId, worldSimulation);
+                    MicrobeColonyHelpers.UnbindAllOutsideGameUpdate(entityId, worldSimulation, true);
                 });
             }
         }


### PR DESCRIPTION
**Brief Description of What This PR Does**

and overall added more error printing to the unbind processes. User-triggered unbinding is still prevented as non-forced actions.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
I think this might fix errors related to colony members staying attached and multiple stacking at the same location: https://community.revolutionarygamesstudio.com/t/cell-stacking-bug-multicellular/8960 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
