### PR TITLE
Doubled the engulf size requirement for attached entities

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -921,6 +921,12 @@ public static class Constants
     /// </summary>
     public const float ENGULF_SIZE_RATIO_REQ = 1.5f;
 
+    /// <summary>
+    ///   How much increased "size" things that are attached (microbe colony members, for example) get in engulfability
+    ///   calculations. This is purely for being the target and doesn't help eating other things.
+    /// </summary>
+    public const float ENGULF_SIZE_ATTACHED_MULTIPLIER = 2;
+
     public const float EUKARYOTIC_ENGULF_SIZE_MULTIPLIER = 2.0f;
 
     /// <summary>

--- a/src/microbe_stage/components/Engulfer.cs
+++ b/src/microbe_stage/components/Engulfer.cs
@@ -147,7 +147,13 @@ public static class EngulferHelpers
 
             // Needs to be big enough to engulf
             var targetSize = engulfable.AdjustedEngulfSize;
-            if (engulfer.EngulfingSize < targetSize * Constants.ENGULF_SIZE_RATIO_REQ)
+
+            // Objects attached to something are harder to swallow
+            var adjustedTargetSize = targetSize;
+            if (target.Has<AttachedToEntity>())
+                adjustedTargetSize *= Constants.ENGULF_SIZE_ATTACHED_MULTIPLIER;
+
+            if (engulfer.EngulfingSize < adjustedTargetSize * Constants.ENGULF_SIZE_RATIO_REQ)
                 return EngulfCheckResult.TargetTooBig;
 
             // Limit the number of things that can be engulfed at once


### PR DESCRIPTION
This should make it harder for things to eat members out of a colony

I made this because things will be possible to eat out of colonies with this bugfix: https://github.com/Revolutionary-Games/Thrive/pull/6819 

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
