### PR TITLE
Fix #3773: refactor `OptionsMenu` to prevent unnecessary settings updates during programmatic control changes

### DIFF
--- a/src/gui_common/menus/OptionsMenu.cs
+++ b/src/gui_common/menus/OptionsMenu.cs
@@ -1890,9 +1890,7 @@ public partial class OptionsMenu : ControlWithInput
 
         if (graphicsPreset.Selected != wanted)
         {
-            isProgrammaticControlUpdateInProgress = true;
             graphicsPreset.Selected = wanted;
-            isProgrammaticControlUpdateInProgress = false;
         }
     }
 
@@ -2548,9 +2546,7 @@ public partial class OptionsMenu : ControlWithInput
         // Apply the current value to the slider to make sure it is showing the actual setting value
         if (pressed)
         {
-            isProgrammaticControlUpdateInProgress = true;
             threadCountSlider.Value = Settings.Instance.ThreadCount.Value;
-            isProgrammaticControlUpdateInProgress = false;
         }
     }
 
@@ -2587,9 +2583,7 @@ public partial class OptionsMenu : ControlWithInput
 
         if (pressed)
         {
-            isProgrammaticControlUpdateInProgress = true;
             nativeThreadCountSlider.Value = Settings.Instance.NativeThreadCount.Value;
-            isProgrammaticControlUpdateInProgress = false;
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR refactors OptionsMenu so programmatic UI updates no longer trigger the same callbacks as real user input. It
  adds a guarded update scope around bulk control synchronization paths, such as opening the menu, restoring saved or
  default values, discarding changes, and applying graphics presets, and makes affected handlers ignore those internal
  updates. This prevents unnecessary settings comparisons and repeated `Apply*Settings()` calls during menu
  synchronization, while keeping normal player-driven option changes working as before.

**Related Issues**

Fixes #3773 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
