### PR TITLE
Made storage fill warnings only warn on varying compounds

### DIFF
--- a/src/microbe_stage/IBiomeConditions.cs
+++ b/src/microbe_stage/IBiomeConditions.cs
@@ -58,5 +58,26 @@ public static class BiomeConditionsHelpers
 
             return light;
         }
+
+        public void GetProducedCompoundsThatDependOnVarying(Dictionary<Compound, List<Compound>> compoundsDependOn,
+            HashSet<Compound> result)
+        {
+            result.Clear();
+
+            foreach (var entry in compoundsDependOn)
+            {
+                var compound = entry.Key;
+                var dependencies = entry.Value;
+
+                foreach (var dependency in dependencies)
+                {
+                    if (conditions.IsVaryingCompound(dependency))
+                    {
+                        result.Add(compound);
+                        break;
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/microbe_stage/OrganismStatisticsPanel.cs
+++ b/src/microbe_stage/OrganismStatisticsPanel.cs
@@ -374,17 +374,19 @@ public partial class OrganismStatisticsPanel : PanelContainer
         }
     }
 
-    public void UpdateCompoundBalances(Dictionary<Compound, CompoundBalance> balances, float warningTime)
+    public void UpdateCompoundBalances(Dictionary<Compound, CompoundBalance> balances,
+        HashSet<Compound> dayNightVaryingCompoundProductions, float warningTime)
     {
-        compoundBalance.UpdateBalances(balances, warningTime);
+        compoundBalance.UpdateBalances(balances, dayNightVaryingCompoundProductions, warningTime);
     }
 
     public void UpdateCompoundLastingTimes(Dictionary<Compound, CompoundBalance> normalBalance,
         Dictionary<Compound, CompoundBalance> nightBalance, float nominalStorage,
-        Dictionary<Compound, float> specificStorages, float warningTime, float fillingUpTime)
+        Dictionary<Compound, float> specificStorages, float warningTime, float fillingUpTime,
+        HashSet<Compound> compoundsThatWarnFillTime)
     {
         compoundStorageLastingTimes.UpdateStorage(normalBalance, nightBalance, nominalStorage, specificStorages,
-            warningTime, fillingUpTime, notEnoughStorageWarning);
+            warningTime, fillingUpTime, compoundsThatWarnFillTime, notEnoughStorageWarning);
     }
 
     public void RegisterTooltips()

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -549,7 +549,8 @@ public partial class CellEditorComponent
         tolerancesEditor.UpdateMPCostInToolTips();
     }
 
-    private void UpdateCompoundBalances(Dictionary<Compound, CompoundBalance> balances)
+    private void UpdateCompoundBalances(Dictionary<Compound, CompoundBalance> balances,
+        HashSet<Compound> dayNightVaryingCompoundProductions)
     {
         var warningTime = Editor.CurrentGame.GameWorld.LightCycle.DayLengthRealtimeSeconds *
             Editor.CurrentGame.GameWorld.WorldSettings.DaytimeFraction;
@@ -558,12 +559,12 @@ public partial class CellEditorComponent
         if (!Editor.CurrentGame.GameWorld.WorldSettings.DayNightCycleEnabled)
             warningTime = 10000000;
 
-        organismStatisticsPanel.UpdateCompoundBalances(balances, warningTime);
+        organismStatisticsPanel.UpdateCompoundBalances(balances, dayNightVaryingCompoundProductions, warningTime);
     }
 
     private void UpdateCompoundLastingTimes(Dictionary<Compound, CompoundBalance> normalBalance,
         Dictionary<Compound, CompoundBalance> nightBalance, float nominalStorage,
-        Dictionary<Compound, float> specificStorages)
+        Dictionary<Compound, float> specificStorages, HashSet<Compound> compoundsThatWarnFillTime)
     {
         float lightFraction = Editor.CurrentGame.GameWorld.WorldSettings.DaytimeFraction;
 
@@ -579,7 +580,7 @@ public partial class CellEditorComponent
         }
 
         organismStatisticsPanel.UpdateCompoundLastingTimes(normalBalance, nightBalance, nominalStorage,
-            specificStorages, warningTime, fillingUpTime);
+            specificStorages, warningTime, fillingUpTime, compoundsThatWarnFillTime);
     }
 
     private void UpdateAutoEvoPrediction(EditorAutoEvoRun startedRun, Species playerSpeciesOriginal,

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -45,6 +45,10 @@ public partial class CellEditorComponent :
 
     private readonly List<EditorUserOverride> ignoredEditorWarnings = new();
 
+    private readonly Dictionary<Compound, List<Compound>> tempCompoundSources = new();
+
+    private readonly HashSet<Compound> compoundsThatDependOnDay = new();
+
 #pragma warning disable CA2213
 
     // Selection menu tab selector buttons
@@ -2166,7 +2170,13 @@ public partial class CellEditorComponent :
                 organismStatisticsPanel.CompoundAmountType, organelles, conditionsData, energyBalanceInfo,
                 ref specificStorages, ref nominalStorage, tolerances, specialization);
 
-        UpdateCompoundBalances(compoundBalanceData);
+        tempCompoundSources.Clear();
+        ProcessSystem.CalculateInputCompoundsNeededForOutputs(organelles, conditionsData, tolerances, specialization,
+            organismStatisticsPanel.CompoundAmountType, true, tempCompoundSources);
+
+        conditionsData.GetProducedCompoundsThatDependOnVarying(tempCompoundSources, compoundsThatDependOnDay);
+
+        UpdateCompoundBalances(compoundBalanceData, compoundsThatDependOnDay);
 
         // TODO: should this skip on being affected by the resource limited?
         var nightBalanceData = CalculateCompoundBalanceWithMethod(organismStatisticsPanel.BalanceDisplayType,
@@ -2174,7 +2184,8 @@ public partial class CellEditorComponent :
             ref nominalStorage, tolerances, specialization);
 
         UpdateCompoundLastingTimes(compoundBalanceData, nightBalanceData, nominalStorage,
-            specificStorages ?? throw new Exception("Special storages should have been calculated"));
+            specificStorages ?? throw new Exception("Special storages should have been calculated"),
+            compoundsThatDependOnDay);
 
         HandleProcessList(energyBalanceInfo, conditionsData);
     }

--- a/src/microbe_stage/editor/CompoundBalanceDisplay.cs
+++ b/src/microbe_stage/editor/CompoundBalanceDisplay.cs
@@ -46,7 +46,8 @@ public partial class CompoundBalanceDisplay : VBoxContainer
         modeSelector.Visible = showDisplayTypeSelector;
     }
 
-    public void UpdateBalances(Dictionary<Compound, CompoundBalance> balances, float dayLengthWarningThreshold)
+    public void UpdateBalances(Dictionary<Compound, CompoundBalance> balances,
+        HashSet<Compound> dayNightVaryingCompoundProductions, float dayLengthWarningThreshold)
     {
         childCache.UnMarkAll();
 
@@ -54,7 +55,7 @@ public partial class CompoundBalanceDisplay : VBoxContainer
 
         foreach (var entry in balances)
         {
-            // Skip any gas compounds as they aren't stored by cells so no point in showing in the balance
+            // Skip any gas compounds as they aren't stored by cells, so no point in showing in the balance
             if (simulationParameters.GetCompoundDefinition(entry.Key).IsGas)
                 continue;
 
@@ -68,7 +69,8 @@ public partial class CompoundBalanceDisplay : VBoxContainer
 
             if (entry.Value.FillTime > 0)
             {
-                UpdateExtraValueDescription(compoundControl, entry.Value, dayLengthWarningThreshold);
+                UpdateExtraValueDescription(compoundControl, entry.Value,
+                    dayNightVaryingCompoundProductions.Contains(entry.Key), dayLengthWarningThreshold);
             }
             else
             {
@@ -81,23 +83,26 @@ public partial class CompoundBalanceDisplay : VBoxContainer
     }
 
     private static void UpdateExtraValueDescription(CompoundAmount compoundControl, CompoundBalance balance,
-        float dayLengthWarningThreshold)
+        bool actuallyVariesDuringDay, float dayLengthWarningThreshold)
     {
+        // Only warn for things that actually vary during the day/night cycle
+        var isTooLong = balance.FillTime > dayLengthWarningThreshold && actuallyVariesDuringDay;
+
         if (compoundControl.ExtraValueDescription == null)
         {
-            SetNewExtraDescription(compoundControl, balance, dayLengthWarningThreshold);
+            SetNewExtraDescription(compoundControl, balance, dayLengthWarningThreshold, isTooLong);
         }
         else
         {
             // For object allocation efficiency reuse the existing string but just update the value
             var updateTarget = compoundControl.ExtraValueDescription;
 
-            if (balance.FillTime > dayLengthWarningThreshold)
+            if (isTooLong)
             {
                 if (updateTarget.TranslationKey != "COMPOUND_BALANCE_FILL_TIME_TOO_LONG")
                 {
-                    // Need to swap base key
-                    SetNewExtraDescription(compoundControl, balance, dayLengthWarningThreshold);
+                    // Need to swap the base key
+                    SetNewExtraDescription(compoundControl, balance, dayLengthWarningThreshold, true);
                     return;
                 }
 
@@ -111,8 +116,8 @@ public partial class CompoundBalanceDisplay : VBoxContainer
             {
                 if (updateTarget.TranslationKey != "COMPOUND_BALANCE_FILL_TIME")
                 {
-                    // Need to swap base key
-                    SetNewExtraDescription(compoundControl, balance, dayLengthWarningThreshold);
+                    // Need to swap the base key
+                    SetNewExtraDescription(compoundControl, balance, dayLengthWarningThreshold, false);
                     return;
                 }
 
@@ -124,9 +129,9 @@ public partial class CompoundBalanceDisplay : VBoxContainer
     }
 
     private static void SetNewExtraDescription(CompoundAmount compoundControl, CompoundBalance balance,
-        float dayLengthWarningThreshold)
+        float dayLengthWarningThreshold, bool tooLong)
     {
-        if (balance.FillTime > dayLengthWarningThreshold)
+        if (tooLong)
         {
             compoundControl.ExtraValueDescription = new LocalizedString("COMPOUND_BALANCE_FILL_TIME_TOO_LONG",
                 Math.Round(balance.FillTime), Math.Round(dayLengthWarningThreshold));

--- a/src/microbe_stage/editor/CompoundStorageStatistics.cs
+++ b/src/microbe_stage/editor/CompoundStorageStatistics.cs
@@ -42,7 +42,7 @@ public partial class CompoundStorageStatistics : VBoxContainer
     public void UpdateStorage(Dictionary<Compound, CompoundBalance> daytimeBalances,
         Dictionary<Compound, CompoundBalance> nightBalance, float nominalStorage,
         Dictionary<Compound, float> specialCapacities, float nightDuration, float fillTimeWarning,
-        CustomRichTextLabel notEnoughStorageWarning)
+        HashSet<Compound> compoundsThatWarnFillTime, CustomRichTextLabel notEnoughStorageWarning)
     {
         childCache.UnMarkAll();
 
@@ -94,9 +94,10 @@ public partial class CompoundStorageStatistics : VBoxContainer
                         compoundControl.ValueColour = CompoundAmount.Colour.White;
                     }
 
-                    // Check and give warnings if not enough compound can be generated during the day to survive
-                    // the night
-                    if (!MicrobeInternalCalculations.CanGenerateEnoughCompoundToSurviveNight(nightEntry.Balance,
+                    // Check and give warnings if not enough compounds can be generated during the day to survive
+                    // the night, but only for compound that depend on day to generate
+                    if (compoundsThatWarnFillTime.Contains(entry.Key) &&
+                        !MicrobeInternalCalculations.CanGenerateEnoughCompoundToSurviveNight(nightEntry.Balance,
                             entry.Value.Balance, nightDuration, fillTimeWarning, out var generated, out var required))
                     {
                         storageWarningBuilder.Append(new LocalizedString(

--- a/src/microbe_stage/systems/ProcessSystem.cs
+++ b/src/microbe_stage/systems/ProcessSystem.cs
@@ -382,6 +382,60 @@ public partial class ProcessSystem : BaseSystem<World, float>
         }
     }
 
+    /// <summary>
+    ///   Calculates what input compounds are needed for each output compound. The key in the result is the output
+    ///   compound. This does not clear the result before running to allow chaining!
+    /// </summary>
+    public static void CalculateInputCompoundsNeededForOutputs(IReadOnlyList<OrganelleTemplate> organelles,
+        IBiomeConditions biome, ResolvedMicrobeTolerances environmentTolerances, float specializationFactor,
+        CompoundAmountType amountType, bool requireInputCompoundsInBiome, Dictionary<Compound, List<Compound>> result)
+    {
+        if (specializationFactor <= 0)
+            throw new ArgumentException("Specialization factor must be positive", nameof(specializationFactor));
+
+        float speedModifier = environmentTolerances.ProcessSpeedModifier * specializationFactor;
+
+        var count = organelles.Count;
+        for (int i = 0; i < count; ++i)
+        {
+            foreach (var process in organelles[i].Definition.RunnableProcesses)
+            {
+                var speedAdjusted =
+                    CalculateProcessMaximumSpeed(process, speedModifier, biome, amountType,
+                        requireInputCompoundsInBiome);
+
+                if (speedAdjusted.CurrentSpeed <= MathUtils.EPSILON)
+                    continue;
+
+                foreach (var output in speedAdjusted.Outputs)
+                {
+                    if (!result.TryGetValue(output.Key, out var list))
+                    {
+                        list = new List<Compound>();
+                        result[output.Key] = list;
+                    }
+
+                    foreach (var input in speedAdjusted.Inputs)
+                    {
+                        if (!list.Contains(input.Key))
+                        {
+                            list.Add(input.Key);
+                        }
+                    }
+
+                    // And we also need to add environmental inputs to properly detect varying
+                    foreach (var input in speedAdjusted.EnvironmentalInputs)
+                    {
+                        if (!list.Contains(input.Key))
+                        {
+                            list.Add(input.Key);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     public static void ComputeCompoundBalance(IEnumerable<OrganelleTemplate> organelles, IBiomeConditions biome,
         ResolvedMicrobeTolerances environmentTolerances, float specializationFactor, CompoundAmountType amountType,
         bool requireInputCompoundsInBiome, Dictionary<Compound, CompoundBalance> result)

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
@@ -103,7 +103,8 @@ public partial class CellBodyPlanEditorComponent
         organismStatisticsPanel.UpdateProcessList(processStatistics);
     }
 
-    private void UpdateCompoundBalances(Dictionary<Compound, CompoundBalance> balances)
+    private void UpdateCompoundBalances(Dictionary<Compound, CompoundBalance> balances,
+        HashSet<Compound> dayNightVaryingCompoundProductions)
     {
         var warningTime = Editor.CurrentGame.GameWorld.LightCycle.DayLengthRealtimeSeconds *
             Editor.CurrentGame.GameWorld.WorldSettings.DaytimeFraction;
@@ -112,12 +113,12 @@ public partial class CellBodyPlanEditorComponent
         if (!Editor.CurrentGame.GameWorld.WorldSettings.DayNightCycleEnabled)
             warningTime = 10000000;
 
-        organismStatisticsPanel.UpdateCompoundBalances(balances, warningTime);
+        organismStatisticsPanel.UpdateCompoundBalances(balances, dayNightVaryingCompoundProductions, warningTime);
     }
 
     private void UpdateCompoundLastingTimes(Dictionary<Compound, CompoundBalance> normalBalance,
         Dictionary<Compound, CompoundBalance> nightBalance, float nominalStorage,
-        Dictionary<Compound, float> specificStorages)
+        Dictionary<Compound, float> specificStorages, HashSet<Compound> compoundsThatWarnFillTime)
     {
         // TODO: Check if it's possible to move those calculations elsewhere to avoid duplication with
         // CellEditorComponent.UpdateCompoundLastingTimes
@@ -135,7 +136,7 @@ public partial class CellBodyPlanEditorComponent
         }
 
         organismStatisticsPanel.UpdateCompoundLastingTimes(normalBalance, nightBalance, nominalStorage,
-            specificStorages, warningTime, fillingUpTime);
+            specificStorages, warningTime, fillingUpTime, compoundsThatWarnFillTime);
     }
 
     private void UpdateGUIAfterLoadingSpecies(Species species)

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -41,6 +41,10 @@ public partial class CellBodyPlanEditorComponent :
     /// </summary>
     private readonly HashSet<Hex> wrongGrowthOrderCells = new();
 
+    private readonly Dictionary<Compound, List<Compound>> tempCompoundSources = new();
+
+    private readonly HashSet<Compound> compoundsThatDependOnDay = new();
+
 #pragma warning disable CA2213
 
     // Selection menu tab selector buttons
@@ -1279,7 +1283,17 @@ public partial class CellBodyPlanEditorComponent :
         tooltip.DisplayName = cellType.CellTypeName;
         tooltip.MutationPointCost = Math.Min(cellType.MPCost * Editor.CurrentGame.GameWorld.WorldSettings.MPMultiplier,
             Constants.MAX_SINGLE_EDIT_MP_COST);
-        tooltip.DisplayCellTypeBalances(balances);
+
+        tempCompoundSources.Clear();
+        ProcessSystem.CalculateInputCompoundsNeededForOutputs(cellType.ModifiableOrganelles, Editor.CurrentPatch.Biome,
+            environmentalTolerances, specialization,
+            organismStatisticsPanel.CompoundAmountType, true, tempCompoundSources);
+
+        Editor.CurrentPatch.Biome.GetProducedCompoundsThatDependOnVarying(tempCompoundSources,
+            compoundsThatDependOnDay);
+
+        tooltip.DisplayCellTypeBalances(balances, compoundsThatDependOnDay);
+
         tooltip.UpdateATPBalance(energyBalanceInfo.TotalProduction, energyBalanceInfo.TotalConsumption);
 
         tooltip.UpdateHealthIndicator(MicrobeInternalCalculations.CalculateHealth(environmentalTolerances,
@@ -1450,6 +1464,8 @@ public partial class CellBodyPlanEditorComponent :
         var environmentalTolerances =
             MicrobeEnvironmentalToleranceCalculations.ResolveToleranceValues(Editor.CalculateRawTolerances());
 
+        tempCompoundSources.Clear();
+
         // TODO: improve performance by calculating the balance per cell type
         foreach (var hex in cells)
         {
@@ -1462,6 +1478,10 @@ public partial class CellBodyPlanEditorComponent :
                 environmentalTolerances, specialization, hex.Data.MembraneType,
                 maximumMovementDirection, moving, true, Editor.CurrentGame.GameWorld.WorldSettings,
                 organismStatisticsPanel.CompoundAmountType, null, energyBalanceInfo);
+
+            ProcessSystem.CalculateInputCompoundsNeededForOutputs(hex.Data.ModifiableOrganelles, conditionsData,
+                environmentalTolerances, specialization,
+                organismStatisticsPanel.CompoundAmountType, true, tempCompoundSources);
         }
 
         // Passing those variables by refs to the following functions to reuse them
@@ -1475,7 +1495,9 @@ public partial class CellBodyPlanEditorComponent :
                 cells, conditionsData, energyBalanceInfo,
                 ref specificStorages, ref nominalStorage, environmentalTolerances);
 
-        UpdateCompoundBalances(compoundBalanceData);
+        conditionsData.GetProducedCompoundsThatDependOnVarying(tempCompoundSources, compoundsThatDependOnDay);
+
+        UpdateCompoundBalances(compoundBalanceData, compoundsThatDependOnDay);
 
         // TODO: should this skip on being affected by the resource limited?
         var nightBalanceData = CalculateCompoundBalanceWithMethod(organismStatisticsPanel.BalanceDisplayType,
@@ -1483,7 +1505,8 @@ public partial class CellBodyPlanEditorComponent :
             ref nominalStorage, environmentalTolerances);
 
         UpdateCompoundLastingTimes(compoundBalanceData, nightBalanceData, nominalStorage,
-            specificStorages ?? throw new Exception("Special storages should have been calculated"));
+            specificStorages ?? throw new Exception("Special storages should have been calculated"),
+            compoundsThatDependOnDay);
 
         // TODO: find out why this method used to take the cells parameter but now causes a warning so it is removed
         // HandleProcessList( cells, energyBalance, conditionsData);

--- a/src/multicellular_stage/editor/CellTypeTooltip.cs
+++ b/src/multicellular_stage/editor/CellTypeTooltip.cs
@@ -94,9 +94,10 @@ public partial class CellTypeTooltip : Control, ICustomToolTip
         mpLabel.Text = StringUtils.FormatMutationPointCost(mpCost);
     }
 
-    public void DisplayCellTypeBalances(Dictionary<Compound, CompoundBalance> balance)
+    public void DisplayCellTypeBalances(Dictionary<Compound, CompoundBalance> balance,
+        HashSet<Compound> dayNightVaryingCompoundProductions)
     {
-        compoundBalanceDisplay.UpdateBalances(balance, float.MaxValue);
+        compoundBalanceDisplay.UpdateBalances(balance, dayNightVaryingCompoundProductions, float.MaxValue);
     }
 
     public void UpdateHealthIndicator(float value)


### PR DESCRIPTION
**Brief Description of What This PR Does**
this prevents nonsensical displays like ammonia filling up taking longer than a day, but there is no organelle that would depend on the time of day for producing the compound. So this suppresses those warning dispalys for compound production that doesn't stop during the night.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
