### PR TITLE
Made tolerance slider spacers ignore mouse input

### DIFF
--- a/src/microbe_stage/editor/TolerancesEditorSubComponent.tscn
+++ b/src/microbe_stage/editor/TolerancesEditorSubComponent.tscn
@@ -150,6 +150,7 @@ layout_mode = 2
 [node name="Spacer" type="Control" parent="Temperature/RangeDisplayContainer" unique_id=1733797315]
 custom_minimum_size = Vector2(8, 0)
 layout_mode = 2
+mouse_filter = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Temperature/RangeDisplayContainer" unique_id=448157339]
 layout_mode = 2
@@ -177,6 +178,7 @@ value = 50.0
 [node name="Spacer2" type="Control" parent="Temperature/RangeDisplayContainer" unique_id=88187736]
 custom_minimum_size = Vector2(8, 0)
 layout_mode = 2
+mouse_filter = 2
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="Temperature" unique_id=121520012]
 layout_mode = 2
@@ -302,6 +304,7 @@ layout_mode = 2
 [node name="Spacer" type="Control" parent="Pressure/RangeDisplayContainer" unique_id=1702930961]
 custom_minimum_size = Vector2(8, 0)
 layout_mode = 2
+mouse_filter = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Pressure/RangeDisplayContainer" unique_id=797964187]
 layout_mode = 2
@@ -331,6 +334,7 @@ value = 40000000.0
 [node name="Spacer2" type="Control" parent="Pressure/RangeDisplayContainer" unique_id=1570659681]
 custom_minimum_size = Vector2(8, 0)
 layout_mode = 2
+mouse_filter = 2
 
 [node name="HBoxContainer4" type="HBoxContainer" parent="Pressure" unique_id=1472914901]
 layout_mode = 2
@@ -453,6 +457,7 @@ layout_mode = 2
 [node name="Spacer" type="Control" parent="Oxygen/RangeDisplayContainer" unique_id=131682752]
 custom_minimum_size = Vector2(8, 0)
 layout_mode = 2
+mouse_filter = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Oxygen/RangeDisplayContainer" unique_id=242132622]
 layout_mode = 2
@@ -482,6 +487,7 @@ step = 0.05
 [node name="Spacer2" type="Control" parent="Oxygen/RangeDisplayContainer" unique_id=1372406449]
 custom_minimum_size = Vector2(8, 0)
 layout_mode = 2
+mouse_filter = 2
 
 [node name="Spacer" type="Control" parent="Oxygen" unique_id=574127871]
 custom_minimum_size = Vector2(0, 2)
@@ -558,6 +564,7 @@ layout_mode = 2
 [node name="Spacer" type="Control" parent="UV/RangeDisplayContainer" unique_id=1682938016]
 custom_minimum_size = Vector2(8, 0)
 layout_mode = 2
+mouse_filter = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="UV/RangeDisplayContainer" unique_id=1203124143]
 layout_mode = 2
@@ -585,6 +592,7 @@ step = 0.05
 [node name="Spacer2" type="Control" parent="UV/RangeDisplayContainer" unique_id=1944425756]
 custom_minimum_size = Vector2(10, 0)
 layout_mode = 2
+mouse_filter = 2
 
 [connection signal="value_changed" from="Temperature/RangeDisplayContainer/VBoxContainer/TemperatureSlider" to="." method="OnTemperatureSliderChanged"]
 [connection signal="value_changed" from="Temperature/HBoxContainer3/TemperatureRange" to="." method="OnTemperatureToleranceRangeSliderChanged"]


### PR DESCRIPTION
which I think slightly reduces the "glitchiness" around hovering over the grabbers for the sliders (the root cause of the problem is the invisible nature of the actual slider the grabbers are on and how it just ends at the end points)

Hopefully doesn't break anything and has at least some tiny effect.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
