### PR TITLE
Support h4 headings in the Thriveopedia

### DIFF
--- a/Scripts/WikiUpdater.cs
+++ b/Scripts/WikiUpdater.cs
@@ -569,7 +569,7 @@ public class WikiUpdater
                 case "UL" or "OL":
                     text = ConvertListToBbcode(child) + "\n\n";
                     break;
-                case "H3":
+                case "H3" or "H4":
                     var headline = child.Children
                         .First(c => c.ClassList.Contains("mw-headline"));
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR makes the Thriveopedia wiki updater handle MediaWiki `h4` headings when extracting page body sections.

`h4` headings are now converted with the same BBCode styling as the existing `h3` handling, so nested headings like the Microbe Stage page's environment subsections can appear in generated in-game Thriveopedia content instead of being skipped.

**Related Issues**

Closes #6868

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).

**Testing**

- `git diff --check`

Not run locally: `dotnet run --project Scripts check` or in-game Thriveopedia verification. This checkout is missing the required .NET 10 SDK.