### PR TITLE
Consume multicellular slime jet force while idle

### DIFF
--- a/src/microbe_stage/systems/MicrobeMovementSystem.cs
+++ b/src/microbe_stage/systems/MicrobeMovementSystem.cs
@@ -211,6 +211,9 @@ public partial class MicrobeMovementSystem : BaseSystem<World, float>
             // Slime jets work even when not holding down any movement keys
             var jetMovement = CalculateMovementFromSlimeJets(ref organelles);
 
+            if (entity.Has<MicrobeColony>())
+                jetMovement += CalculateColonyMovementFromSlimeJets(entity);
+
             if (jetMovement == Vector3.Zero)
                 return Vector3.Zero;
 
@@ -340,48 +343,7 @@ public partial class MicrobeMovementSystem : BaseSystem<World, float>
 
         // Handle colony jets
         if (hasColony)
-        {
-            // This can trigger similar errors as general colony movement calculation, so we use similar protection
-            // here
-            try
-            {
-                // This is a duplicate fetch of this component, but this method would get pretty ugly / would need to
-                // be split into many methods to allow sharing the variable
-                ref var colony = ref entity.Get<MicrobeColony>();
-
-                foreach (var colonyMember in colony.ColonyMembers)
-                {
-                    // This doesn't really hurt as the slime jets were consumed above, but for consistency with
-                    // basically all other places code like this is needed we skip the leader here
-                    if (colonyMember == entity)
-                        continue;
-
-                    if (!colonyMember.IsAliveAndHas<OrganelleContainer>())
-                    {
-                        throw new Exception("Invalid colony member that doesn't have OrganelleContainer for jets: " +
-                            colonyMember);
-                    }
-
-                    ref var memberOrganelles = ref colonyMember.Get<OrganelleContainer>();
-
-                    movementVector += CalculateMovementFromSlimeJets(ref memberOrganelles);
-                }
-            }
-            catch (Exception e)
-            {
-                // TODO: try to find out the real root cause of this problem rather than detecting and force disbanding
-                // the colony here. Note there's similar block of code for the general movement
-                GD.PrintErr("Error calculating colony jet movement: " + e);
-
-                var entityId = entity;
-
-                Invoke.Instance.Perform(() =>
-                {
-                    GD.PrintErr("Force disbanding the colony that is in invalid state, entity: ", entityId);
-                    MicrobeColonyHelpers.UnbindAllOutsideGameUpdate(entityId, worldSimulation, true);
-                });
-            }
-        }
+            movementVector += CalculateColonyMovementFromSlimeJets(entity);
 
         // MovementDirection is proportional to the current cell rotation, so we need to rotate the movement
         // vector to work correctly
@@ -410,6 +372,51 @@ public partial class MicrobeMovementSystem : BaseSystem<World, float>
                 jet.ConsumeMovementForce(out var jetForce);
                 movementVector += jetForce;
             }
+        }
+
+        return movementVector;
+    }
+
+    private Vector3 CalculateColonyMovementFromSlimeJets(in Entity entity)
+    {
+        var movementVector = Vector3.Zero;
+
+        // This can trigger similar errors as general colony movement calculation, so we use similar protection here
+        try
+        {
+            ref var colony = ref entity.Get<MicrobeColony>();
+
+            foreach (var colonyMember in colony.ColonyMembers)
+            {
+                // This doesn't really hurt as the slime jets were consumed above, but for consistency with basically
+                // all other places code like this is needed we skip the leader here
+                if (colonyMember == entity)
+                    continue;
+
+                if (!colonyMember.IsAliveAndHas<OrganelleContainer>())
+                {
+                    throw new Exception("Invalid colony member that doesn't have OrganelleContainer for jets: " +
+                        colonyMember);
+                }
+
+                ref var memberOrganelles = ref colonyMember.Get<OrganelleContainer>();
+
+                movementVector += CalculateMovementFromSlimeJets(ref memberOrganelles);
+            }
+        }
+        catch (Exception e)
+        {
+            // TODO: try to find out the real root cause of this problem rather than detecting and force disbanding
+            // the colony here. Note there's similar block of code for the general movement
+            GD.PrintErr("Error calculating colony jet movement: " + e);
+
+            var entityId = entity;
+
+            Invoke.Instance.Perform(() =>
+            {
+                GD.PrintErr("Force disbanding the colony that is in invalid state, entity: ", entityId);
+                MicrobeColonyHelpers.UnbindAllOutsideGameUpdate(entityId, worldSimulation, true);
+            });
         }
 
         return movementVector;


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR fixes multicellular colonies being able to stockpile slime jet force while the colony leader is not moving.

The single-cell idle path already consumes slime jet movement when no movement key is held. This PR extends that idle handling to colony member slime jets as well, so queued force is drained and applied immediately instead of accumulating until the next movement input.

The existing colony slime jet loop and invalid-colony protection are moved into a shared helper, so the same logic is used whether the colony is moving normally or only being pushed by slime jets.

**Related Issues**

Closes #6854

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).

**Testing**

- `git diff --check`

Not run locally: full build or in-game multicellular slime jet verification. This checkout is missing the required .NET 10 SDK.