### PR TITLE
Apply screen effects to popups

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -74,6 +74,7 @@ window/size/viewport_height=720
 window/size/initial_position_type=3
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
+window/subwindows/embed_subwindows=true
 mouse_cursor/custom_image="res://assets/textures/gui/cursors/default.png"
 mouse_cursor/tooltip_position_offset=Vector2(15, 15)
 window/size/fullscreen=true

--- a/project.godot
+++ b/project.godot
@@ -74,7 +74,6 @@ window/size/viewport_height=720
 window/size/initial_position_type=3
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
-window/subwindows/embed_subwindows=true
 mouse_cursor/custom_image="res://assets/textures/gui/cursors/default.png"
 mouse_cursor/tooltip_position_offset=Vector2(15, 15)
 window/size/fullscreen=true

--- a/src/engine/ScreenOverlays.tscn
+++ b/src/engine/ScreenOverlays.tscn
@@ -14,7 +14,7 @@ process_mode = 3
 process_priority = 2000
 
 [node name="NormalOverlays" type="CanvasLayer" parent="." unique_id=265471570]
-layer = 125
+layer = 124
 
 [node name="LoadingScreen" parent="NormalOverlays" unique_id=163351852 instance=ExtResource("3")]
 visible = false
@@ -39,7 +39,7 @@ grow_vertical = 2
 theme = ExtResource("6")
 
 [node name="OverlaysOnTopOfModals" type="CanvasLayer" parent="." unique_id=941284562]
-layer = 127
+layer = 126
 
 [node name="DebugOverlay" parent="OverlaysOnTopOfModals" unique_id=470426416 instance=ExtResource("7")]
 

--- a/src/engine/UnHandledErrorsGUI.tscn
+++ b/src/engine/UnHandledErrorsGUI.tscn
@@ -23,7 +23,7 @@ popupModsUsedWarning = NodePath("ErrorDialog/VBoxContainer/ExceptionBox/ModsEnab
 counterModsUsedWarning = NodePath("CanvasLayer/MarginContainer/VBoxContainer/ModsEnabledWarning")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="." unique_id=1974040516]
-layer = 127
+layer = 126
 
 [node name="MarginContainer" type="MarginContainer" parent="CanvasLayer" unique_id=1965836583]
 anchors_preset = 1

--- a/src/gui_common/ModalManager.tscn
+++ b/src/gui_common/ModalManager.tscn
@@ -6,7 +6,7 @@
 script = ExtResource("1")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="." unique_id=1173056268]
-layer = 126
+layer = 125
 
 [node name="ActiveModalContainer" type="Control" parent="CanvasLayer" unique_id=587668837]
 layout_mode = 3

--- a/src/gui_common/tooltip/ToolTipManager.tscn
+++ b/src/gui_common/tooltip/ToolTipManager.tscn
@@ -30,7 +30,7 @@ corner_radius_bottom_left = 5
 
 [node name="ToolTipManager" type="CanvasLayer" unique_id=502662551]
 process_mode = 3
-layer = 128
+layer = 127
 script = ExtResource("23")
 
 [node name="GroupHolder" type="Control" parent="." unique_id=1984538779]


### PR DESCRIPTION
**Brief Description of What This PR Does**

This makes tooltip / popup UI use the same screen effect layer as the rest of the UI, so effects do not leave those popups looking out of place.

**Related Issues**

partially addresses #6612

**Testing**

Checked with the project file checker and a normal C# build on my pc.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).