### PR TITLE
Block pause menu during ascension credits

### DIFF
--- a/src/ascension_stage/AscensionCeremony.cs
+++ b/src/ascension_stage/AscensionCeremony.cs
@@ -75,6 +75,9 @@ public partial class AscensionCeremony : Node
 
     public override void _Ready()
     {
+        PauseMenu.Instance.ReportStageTransition();
+        PauseMenu.Instance.Close(false);
+
         foreach (var spawnPointPath in ObserverSpawnPointPaths)
         {
             observerSpawnPoints.Add(GetNode<Node3D>(spawnPointPath));


### PR DESCRIPTION
**Brief Description of What This PR Does**

This stops the pause menu from opening once the ascension credits are running, so that input does not interrupt that sequence.

**Related Issues**

Closes #6634

**Testing**

Checked with the project file checker and a normal C# build on my pc.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).