### PR TITLE
Show devoured text for engulfed player death

### DIFF
--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -437,10 +437,9 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
             playerWasDigested = true;
             FlashHealthBar(new Color(0.96f, 0.5f, 0.27f), delta);
         }
-
-        // Update to the player's current digested progress, unless the player does not exist
         else if (stage.HasPlayer)
         {
+            // Update to the player's current digested progress, unless the player does not exist
             var percentageValue = Localization.Translate("PERCENTAGE_VALUE");
 
             // Show the digestion progress to the player

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -403,8 +403,20 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
         if (stage == null)
             throw new InvalidOperationException("UpdateHealth called before stage is set");
 
-        // Normal health update if there is a player and the player was not engulfed
-        if (stage.HasPlayer &&
+        var playerAlive = false;
+        var playerEngulfed = false;
+
+        if (stage.HasPlayer)
+        {
+            ref var health = ref stage.Player.Get<Health>();
+            ref var engulfable = ref stage.Player.Get<Engulfable>();
+
+            playerAlive = !health.Dead;
+            playerEngulfed = engulfable.PhagocytosisStep != PhagocytosisPhase.None;
+        }
+
+        // Normal health update if there is a player and the player was not digesting
+        if (stage.HasPlayer && playerAlive &&
             stage.Player.Get<Engulfable>().PhagocytosisStep is PhagocytosisPhase.None or PhagocytosisPhase.Ingestion)
         {
             playerWasDigested = false;
@@ -419,8 +431,15 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
             Localization.Translate("DEVOURED") :
             hp.ToString(CultureInfo.CurrentCulture);
 
+        if (stage.HasPlayer && !playerAlive && playerEngulfed)
+        {
+            hpText = Localization.Translate("DEVOURED");
+            playerWasDigested = true;
+            FlashHealthBar(new Color(0.96f, 0.5f, 0.27f), delta);
+        }
+
         // Update to the player's current digested progress, unless the player does not exist
-        if (stage.HasPlayer)
+        else if (stage.HasPlayer)
         {
             var percentageValue = Localization.Translate("PERCENTAGE_VALUE");
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This keeps the microbe HUD showing the devoured state when the player dies while still engulfed, including the pull-in phase before digestion progress is being shown. Before this, that path could go back through the normal health display and lose the devoured text.

**Related Issues**

Closes #5013

**Testing**

Checked with the file checker and a normal C# build on my pc.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).