### PR TITLE
Hide zeroed ingested matter sooner

### DIFF
--- a/src/microbe_stage/systems/EngulfedDigestionSystem.cs
+++ b/src/microbe_stage/systems/EngulfedDigestionSystem.cs
@@ -33,6 +33,12 @@ using World = Arch.Core.World;
 [RuntimeCost(2)]
 public partial class EngulfedDigestionSystem : BaseSystem<World, float>
 {
+    /// <summary>
+    ///   The ingested matter HUD displays one decimal place, so lower non-zero values are indistinguishable from
+    ///   empty storage to the player.
+    /// </summary>
+    private const float DIGESTED_ENGULF_SIZE_THRESHOLD = 0.05f;
+
     private readonly CompoundCloudSystem compoundCloudSystem;
     private readonly IReadOnlyList<Compound> digestibleCompounds;
 
@@ -309,11 +315,12 @@ public partial class EngulfedDigestionSystem : BaseSystem<World, float>
                 GD.PrintErr("Engulfing system hasn't initialized InitialTotalEngulfableCompounds");
             }
 
-            // If out of stuff to digest, or as a safety check, the engulf size has gone to zero, consider digested
-            // Note that the digestion threshold has to be slightly above zero
-            // to avoid https://github.com/Revolutionary-Games/Thrive/issues/4794
+            // If out of stuff to digest, or as a safety check, the engulf size has gone to zero, consider digested.
+            // The thresholds have to be slightly above zero to avoid
+            // https://github.com/Revolutionary-Games/Thrive/issues/4794 and to prevent a rounded 0.0 ingested
+            // matter value from lingering on the HUD.
             if (totalAmountLeft <= 0.001f || engulfable.DigestedAmount >= Constants.FULLY_DIGESTED_LIMIT ||
-                engulfable.AdjustedEngulfSize <= 0)
+                engulfable.AdjustedEngulfSize <= DIGESTED_ENGULF_SIZE_THRESHOLD)
             {
                 engulfable.PhagocytosisStep = PhagocytosisPhase.Digested;
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This makes engulfed objects count as digested once their adjusted engulf size falls below the HUD's displayed precision. The previous compound-only safety threshold could leave the Ingested Matter bar visible while the displayed value had already rounded to `0.0`.

This keeps the existing tiny compound threshold that prevents the permanent stuck digestion issue, while also triggering the digested state earlier when the remaining ingested matter is visually empty.

**Related Issues**

Fixes #6594

**Testing**

- `dotnet run --project Scripts -- check files rewrite --include src/microbe_stage/systems/EngulfedDigestionSystem.cs`
- `dotnet build Thrive.sln`
- `dotnet run --project Scripts -- check compile`
- `dotnet run --project Scripts -- test`