### PR TITLE
Fix initial tooltip positioning

### DIFF
--- a/src/gui_common/tooltip/ToolTipManager.cs
+++ b/src/gui_common/tooltip/ToolTipManager.cs
@@ -99,6 +99,8 @@ public partial class ToolTipManager : CanvasLayer
                 if (MainToolTip == null)
                     throw new InvalidOperationException("Can't set display to true without main tooltip");
 
+                UpdateCurrentTooltip(0);
+
                 // Set timer
                 displayTimer = MainToolTip.DisplayDelay;
             }
@@ -448,9 +450,12 @@ public partial class ToolTipManager : CanvasLayer
                 throw new Exception("Invalid tooltip positioning type");
         }
 
+        var tooltipNode = MainToolTip.ToolTipNode;
+        tooltipNode.ResetSize();
+
         var screenRect = GetViewport().GetVisibleRect();
         var newPos = new Vector2(position.X + offset.X, position.Y + offset.Y);
-        var tooltipSize = MainToolTip.ToolTipNode.Size;
+        var tooltipSize = tooltipNode.GetCombinedMinimumSize();
 
         if (newPos.X + tooltipSize.X > screenRect.Size.X)
         {
@@ -472,11 +477,11 @@ public partial class ToolTipManager : CanvasLayer
 
         // Clamp tooltip position so it doesn't go offscreen
         // TODO: Take into account viewport (window) resizing for the offsetting.
-        MainToolTip.ToolTipNode.Position = new Vector2(
+        tooltipNode.Position = new Vector2(
             Math.Clamp(newPos.X, 0, Math.Max(screenRect.Size.X - tooltipSize.X, 0)),
             Math.Clamp(newPos.Y, 0, Math.Max(screenRect.Size.Y - tooltipSize.Y, 0)) + currentAutoScrollingOffset);
 
-        MainToolTip.ToolTipNode.Size = Vector2.Zero;
+        tooltipNode.Size = Vector2.Zero;
 
         // Handle temporary tooltips/popup
         if (currentIsTemporary && hideTimer >= 0)


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR fixes custom tooltip popups being able to appear for one frame at their default scene position before snapping to the correct location. The tooltip manager now positions the active tooltip immediately when display is requested and calculates its bounds from the combined minimum size instead of a potentially stale hidden `Control.Size`.

**Related Issues**

Fixes #5894

**Testing**

- `dotnet build Thrive.sln --no-restore`
- `dotnet run --project Scripts -- check files rewrite --include src/gui_common/tooltip/ToolTipManager.cs --no-rebuild`
- `dotnet test test\code_tests\ThriveTest.csproj --no-build`

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).