### PR TITLE
Add controller cell orientation input

### DIFF
--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -126,9 +126,15 @@ public partial class PlayerMicrobeInput : NodeWithInput
 
     [RunOnAxis(new[] { "g_look_yaw_negative", "g_look_yaw_positive" }, new[] { -1.0f, 1.0f })]
     [RunOnAxis(new[] { "g_look_pitch_negative", "g_look_pitch_positive" }, new[] { -1.0f, 1.0f })]
-    [RunOnAxisGroup(InvokeAlsoWithNoInput = true, InvokeWithDelta = false)]
-    public void OnControllerLook(float horizontalMovement, float verticalMovement)
+    [RunOnAxisGroup(InvokeAlsoWithNoInput = true, InvokeWithDelta = false, TrackInputMethod = true)]
+    public void OnControllerLook(float horizontalMovement, float verticalMovement, ActiveInputMethod inputMethod)
     {
+        if (inputMethod != ActiveInputMethod.Controller)
+        {
+            hasControllerLookDirection = false;
+            return;
+        }
+
         var direction = new Vector3(horizontalMovement, 0, verticalMovement);
 
         if (direction.LengthSquared() < CONTROLLER_LOOK_EPSILON)

--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -17,9 +17,15 @@ using Godot;
 /// </remarks>
 public partial class PlayerMicrobeInput : NodeWithInput
 {
+    private const float CONTROLLER_LOOK_EPSILON = 0.01f;
+    private const float CONTROLLER_LOOK_POINT_DISTANCE = 10.0f;
+
     private readonly MicrobeMovementEventArgs cachedEventArgs = new(true, Vector3.Zero);
 
+    private Vector3 controllerLookDirection = new(0, 0, -1);
+
     private bool autoMove;
+    private bool hasControllerLookDirection;
 
 #pragma warning disable CA2213 // this is our parent object
 
@@ -83,11 +89,12 @@ public partial class PlayerMicrobeInput : NodeWithInput
 
             if (inputMethod == ActiveInputMethod.Controller)
             {
-                // TODO: look direction for controller input  https://github.com/Revolutionary-Games/Thrive/issues/4034
-                control.LookAtPoint = position.Position + new Vector3(0, 0, -10);
+                var lookDirection = hasControllerLookDirection ? controllerLookDirection : new Vector3(0, 0, -1);
+                control.LookAtPoint = position.Position + lookDirection * CONTROLLER_LOOK_POINT_DISTANCE;
             }
             else
             {
+                hasControllerLookDirection = false;
                 control.LookAtPoint = stage.Camera.CursorWorldPos;
             }
 
@@ -115,6 +122,31 @@ public partial class PlayerMicrobeInput : NodeWithInput
             cachedEventArgs.ReuseEvent(screenRelative, control.MovementDirection);
             stage.TutorialState.SendEvent(TutorialEventType.MicrobePlayerMovement, cachedEventArgs, this);
         }
+    }
+
+    [RunOnAxis(new[] { "g_look_yaw_negative", "g_look_yaw_positive" }, new[] { -1.0f, 1.0f })]
+    [RunOnAxis(new[] { "g_look_pitch_negative", "g_look_pitch_positive" }, new[] { -1.0f, 1.0f })]
+    [RunOnAxisGroup(InvokeAlsoWithNoInput = true, InvokeWithDelta = false)]
+    public void OnControllerLook(float horizontalMovement, float verticalMovement)
+    {
+        var direction = new Vector3(horizontalMovement, 0, verticalMovement);
+
+        if (direction.LengthSquared() < CONTROLLER_LOOK_EPSILON)
+        {
+            hasControllerLookDirection = false;
+            return;
+        }
+
+        controllerLookDirection = direction.Normalized();
+        hasControllerLookDirection = true;
+
+        if (!stage.HasPlayer)
+            return;
+
+        ref var position = ref stage.Player.Get<WorldPosition>();
+        ref var control = ref stage.Player.Get<MicrobeControl>();
+
+        control.LookAtPoint = position.Position + controllerLookDirection * CONTROLLER_LOOK_POINT_DISTANCE;
     }
 
     [RunOnKeyDown("g_fire_siderophore")]

--- a/src/microbe_stage/PlayerMicrobeInput.cs
+++ b/src/microbe_stage/PlayerMicrobeInput.cs
@@ -11,7 +11,7 @@ using Godot;
 /// <remarks>
 ///   <para>
 ///     Note that callbacks from other places directly call some methods in this class, so
-///     an extra care should be taken while modifying the methods as otherwise some stuff
+///     extra care should be taken while modifying the methods as otherwise some stuff
 ///     may no longer work.
 ///   </para>
 /// </remarks>
@@ -89,8 +89,7 @@ public partial class PlayerMicrobeInput : NodeWithInput
 
             if (inputMethod == ActiveInputMethod.Controller)
             {
-                var lookDirection = hasControllerLookDirection ? controllerLookDirection : new Vector3(0, 0, -1);
-                control.LookAtPoint = position.Position + lookDirection * CONTROLLER_LOOK_POINT_DISTANCE;
+                control.LookAtPoint = position.Position + controllerLookDirection * CONTROLLER_LOOK_POINT_DISTANCE;
             }
             else
             {
@@ -124,6 +123,8 @@ public partial class PlayerMicrobeInput : NodeWithInput
         }
     }
 
+    // TODO: for some reason this doesn't feel fully smooth to rotate over? Maybe one axis is deadzoned to 0 when other
+    // is still active thus causing the feel of the cardinal directions "snapping"?
     [RunOnAxis(new[] { "g_look_yaw_negative", "g_look_yaw_positive" }, new[] { -1.0f, 1.0f })]
     [RunOnAxis(new[] { "g_look_pitch_negative", "g_look_pitch_positive" }, new[] { -1.0f, 1.0f })]
     [RunOnAxisGroup(InvokeAlsoWithNoInput = true, InvokeWithDelta = false, TrackInputMethod = true)]
@@ -137,14 +138,12 @@ public partial class PlayerMicrobeInput : NodeWithInput
 
         var direction = new Vector3(horizontalMovement, 0, verticalMovement);
 
+        // Keep previous look direction when no new input
+        // TODO: this seems kind of too sensitive still as angle doesn't stay at the exact same direction
         if (direction.LengthSquared() < CONTROLLER_LOOK_EPSILON)
-        {
-            hasControllerLookDirection = false;
             return;
-        }
 
         controllerLookDirection = direction.Normalized();
-        hasControllerLookDirection = true;
 
         if (!stage.HasPlayer)
             return;


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR lets the player microbe orientation be controlled with the controller right stick. `PlayerMicrobeInput` now reads the existing controller look axes and uses the current stick direction as the microbe `LookAtPoint`, while preserving the old mouse-based orientation for keyboard/mouse input and the previous forward-facing fallback when no controller look input is active.

**Related Issues**

Fixes #4034

**Testing**

- `dotnet build Thrive.sln --no-restore`
- `dotnet run --project Scripts -- check files rewrite --include src/microbe_stage/PlayerMicrobeInput.cs --no-rebuild`
- `dotnet test test\code_tests\ThriveTest.csproj --no-build`

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).