### PR TITLE
Fixed bug with colony leader removal not disbanding the colony

### DIFF
--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Arch.Buffer;
 using Arch.Core;
 using Arch.Core.Extensions;
@@ -507,6 +508,17 @@ public static class MicrobeColonyHelpers
         }
 
         newMembers[colony.ColonyMembers.Length] = newMember;
+
+        if (newMembers[0] != colony.Leader)
+        {
+            GD.PrintErr("Logic error in colony member add: leader is not first");
+
+#if DEBUG
+            if (Debugger.IsAttached)
+                Debugger.Break();
+#endif
+        }
+
         colony.ColonyMembers = newMembers;
 
         colony.MarkMembersChanged();
@@ -569,8 +581,18 @@ public static class MicrobeColonyHelpers
 
         for (int i = intendedNewMemberIndex + 1; i < newMembers.Length; ++i)
         {
-            // As we inserted one new item, the items don't anymore map 1-to-1 between the arrays
+            // As we inserted one new item, the items don't any more map 1-to-1 between the arrays
             newMembers[i] = colony.ColonyMembers[i - 1];
+        }
+
+        if (newMembers[0] != colony.Leader)
+        {
+            GD.PrintErr("Logic error in colony member add: leader is not first");
+
+#if DEBUG
+            if (Debugger.IsAttached)
+                Debugger.Break();
+#endif
         }
 
         colony.ColonyMembers = newMembers;
@@ -608,7 +630,7 @@ public static class MicrobeColonyHelpers
 
         var parentMicrobe = colony.ColonyMembers[parentIndex];
 
-        // Calculate the attach position
+        // Calculate the attachment position
         // Note that if the multicellular growth is moved away from precomputed locations, this won't likely be
         // usable to calculate the positions instead
         if (!CalculateColonyMemberAttachPosition(colonyEntity, parentMicrobe, newMemberPosition,
@@ -670,7 +692,8 @@ public static class MicrobeColonyHelpers
         ref var cellProperties = ref colonyEntity.Get<CellProperties>();
         cellProperties.ShapeCreated = false;
 
-        if (colony.ColonyMembers.Length <= 2)
+        // Colony will disband if the root cell is removed, otherwise it will be in a terrible state
+        if (colony.ColonyMembers.Length <= 2 || colonyEntity == removedMember)
         {
             // The whole colony is disbanding
             recorder.Remove<MicrobeColony>(colonyEntity);
@@ -1443,6 +1466,12 @@ public static class MicrobeColonyHelpers
     /// <exception cref="Exception">If this is called with a member not in the list of members</exception>
     private static void RemoveColonyMemberFromMemberList(ref MicrobeColony colony, in Entity removedMember)
     {
+        if (colony.Leader == removedMember)
+        {
+            throw new InvalidOperationException(
+                "Colony must be disbanded rather than the leader removed like a member");
+        }
+
         // TODO: pooling (see the TODO in the add method)
         // TODO: when recursively removing members somehow make sure that we don't need to keep creating more and
         // more of these lists...
@@ -1465,6 +1494,16 @@ public static class MicrobeColonyHelpers
         {
             throw new Exception("Logic error in new member array copy without member " +
                 "(was it ensured removed member was in the list)");
+        }
+
+        if (newMembers.Length > 0 && newMembers[0] != colony.Leader)
+        {
+            GD.PrintErr("Logic error in colony member remove: leader is not first");
+
+#if DEBUG
+            if (Debugger.IsAttached)
+                Debugger.Break();
+#endif
         }
 
         colony.ColonyMembers = newMembers;

--- a/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
+++ b/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -280,7 +281,12 @@ public partial class MicrobePhysicsCreationAndSizeSystem : BaseSystem<World, flo
 
 #if DEBUG
         if (combinedData.Count > 0)
+        {
+            if (Debugger.IsAttached)
+                Debugger.Break();
+
             throw new Exception("Combined shape data list was not properly cleared on last use");
+        }
 #endif
 
         // Base microbe shape is always first
@@ -299,6 +305,11 @@ public partial class MicrobePhysicsCreationAndSizeSystem : BaseSystem<World, flo
             if (memberOrganelles == null)
                 throw new Exception("This should not be null with colonies");
 
+            // Safety check data before trying to run the list processing
+            // Single member colonies can be processed entirely, but in other cases the main membrane isn't in the list
+            if (colonyMembranes.Count != memberCount - 1 && memberCount != 1)
+                throw new Exception("Colony member count mismatch with given membrane count");
+
             // The bodies need to be added colony member list order
             for (int i = 0; i < memberCount; ++i)
             {
@@ -313,9 +324,21 @@ public partial class MicrobePhysicsCreationAndSizeSystem : BaseSystem<World, flo
                     continue;
                 }
 
-                // The -1 is here as the membrane list excludes the lead cell (which is in the first position in
-                // members)
-                var (membrane, isBacteria) = colonyMembranes[i - 1];
+                // Rarely, it seems that colony leader is not first in the list of members
+                Membrane? membrane;
+                bool isBacteria;
+                if (i == 0)
+                {
+                    GD.PrintErr("Colony leader not in first position as is assumed, using potentially wrong " +
+                        "membrane");
+                    (membrane, isBacteria) = colonyMembranes[0];
+                }
+                else
+                {
+                    // The -1 is here as the membrane list excludes the lead cell (which is in the first position in
+                    // members)
+                    (membrane, isBacteria) = colonyMembranes[i - 1];
+                }
 
                 ref var currentMemberOrganelles = ref member.Get<OrganelleContainer>();
 


### PR DESCRIPTION
and that caused a lot of related bugs in code that assumed the colony leader was always at index 0 in the member list. This also adds a bunch of error-checking code to make sure this kind of problem is less likely to appear again in the future.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
This should fix somewhat common errors in multicellular that really wreaked havoc on the normal operation of hte game

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
