### PR TITLE
Engulfed toxin damage rework

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -992,10 +992,9 @@ public static class Constants
     public const float TOXIN_DIGESTION_DAMAGE_CHECK_INTERVAL = 0.9f;
 
     /// <summary>
-    ///   Determines how big of a fraction of damage (of total health)
-    ///   is dealt to a microbe at a time when it digests a toxic cell.
+    ///   Determines how damage is dealt to a microbe at a time when it digests a toxic cell.
     /// </summary>
-    public const float TOXIN_DIGESTION_DAMAGE_FRACTION = 0.09f;
+    public const float TOXIN_DIGESTION_DAMAGE = 4.0f;
 
     /// <summary>
     ///   Each enzyme addition grants a fraction, set by this variable, increase in digestion speed.

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -723,7 +723,7 @@ public class SimulationCache
             }
 
             totalPreyToxinContent *= Constants.AUTO_EVO_TOXIN_ENGULFMENT_DEFENSE_MODIFIER;
-            totalPreyToxinContent /= predatorHP;
+            totalPreyToxinContent /= predatorHP * predatorToxinResistance;
 
             // Final engulfment score calculation
             // Engulfing prey by luck is especially easy if you are huge.

--- a/src/microbe_stage/systems/EngulfedDigestionSystem.cs
+++ b/src/microbe_stage/systems/EngulfedDigestionSystem.cs
@@ -261,9 +261,8 @@ public partial class EngulfedDigestionSystem : BaseSystem<World, float>
 
                         ref var health = ref entity.Get<Health>();
 
-                        health.DealMicrobeDamage(ref cellProperties, entity,
-                            health.MaxHealth * Constants.TOXIN_DIGESTION_DAMAGE_FRACTION, "oxytoxy",
-                            HealthHelpers.GetInstantKillProtectionThreshold(entity));
+                        health.DealMicrobeDamage(ref cellProperties, entity, Constants.TOXIN_DIGESTION_DAMAGE,
+                            "oxytoxy", HealthHelpers.GetInstantKillProtectionThreshold(entity));
 
                         entity.SendNoticeIfPossible(() => new SimpleHUDMessage(
                             Localization.Translate("NOTICE_ENGULF_DAMAGE_FROM_TOXIN"),


### PR DESCRIPTION
**Brief Description of What This PR Does**

Changes the damage from toxins in engulfed prey to use a flat HP damage instead of a fraction of max health. (general and toxin damage resistance still apply).

For now, this makes the Double membrane and increased membrane rigidity at least a partial counter.

**Related Issues**

General player annoyance at trying to engulf toxic prey.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
