### PR TITLE
Make pressure tolerance sliders logarithmic

### DIFF
--- a/src/microbe_stage/editor/ToleranceRangeDisplay.cs
+++ b/src/microbe_stage/editor/ToleranceRangeDisplay.cs
@@ -19,6 +19,12 @@ public partial class ToleranceRangeDisplay : HSlider
     private bool showMiddleMarker;
 
     [Export]
+    private bool logarithmicScale;
+
+    [Export]
+    private float logarithmicScaleOffset = 1;
+
+    [Export]
     private RangeMarker beginConnectorFromMarker;
 
 #pragma warning disable CA2213
@@ -71,8 +77,7 @@ public partial class ToleranceRangeDisplay : HSlider
 
         var lowerBoundCenter = new Vector2(lowerBoundPos + LINE_WIDTH * 0.5f, Size.Y * 0.5f);
         var upperBoundCenter = new Vector2(upperBoundPos + LINE_WIDTH * 0.5f, Size.Y * 0.5f);
-        var middleBoundCenter =
-            new Vector2((float)(Size.X * (Value - MinValue) / (MaxValue - MinValue)), Size.Y * 0.5f);
+        var middleBoundCenter = new Vector2(Size.X * GetValueFraction((float)Value), Size.Y * 0.5f);
 
         var boundOffset = new Vector2(0, Constants.TOLERANCE_DISPLAY_BOUND_HEIGHT * 0.5f);
 
@@ -134,8 +139,7 @@ public partial class ToleranceRangeDisplay : HSlider
     /// <param name="value"> Has to be between this slider's max and min.</param>
     public void UpdateMarker(float value)
     {
-        optimalValueMarker.OptimalValue = (value - (float)MinValue)
-            / (float)(MaxValue - MinValue);
+        optimalValueMarker.OptimalValue = GetValueFraction(value);
     }
 
     /// <summary>
@@ -186,11 +190,11 @@ public partial class ToleranceRangeDisplay : HSlider
 
     private void SetBoundPositions()
     {
-        var upperBoundFraction = Math.Clamp((upperValue - MinValue) / (MaxValue - MinValue), 0, 1);
-        var lowerBoundFraction = Math.Clamp((lowerValue - MinValue) / (MaxValue - MinValue), 0, 1);
+        var upperBoundFraction = GetValueFraction(upperValue);
+        var lowerBoundFraction = GetValueFraction(lowerValue);
 
-        lowerBoundPos = Size.X * (float)lowerBoundFraction - 1;
-        upperBoundPos = Size.X * (float)upperBoundFraction - 1;
+        lowerBoundPos = Size.X * lowerBoundFraction - 1;
+        upperBoundPos = Size.X * upperBoundFraction - 1;
 
         QueueRedraw();
     }
@@ -209,6 +213,24 @@ public partial class ToleranceRangeDisplay : HSlider
         sliderGrabberXPos = relatedSlider.Size.X * fraction;
 
         QueueRedraw();
+    }
+
+    private float GetValueFraction(float value)
+    {
+        if (MaxValue <= MinValue)
+            return 0;
+
+        value = Math.Clamp(value, (float)MinValue, (float)MaxValue);
+
+        if (!logarithmicScale)
+            return (float)((value - MinValue) / (MaxValue - MinValue));
+
+        var offset = Math.Max(logarithmicScaleOffset, MathUtils.EPSILON);
+        var shiftedValue = value - (float)MinValue;
+        var shiftedMaximum = (float)(MaxValue - MinValue);
+
+        return Math.Clamp((float)(Math.Log((shiftedValue + offset) / offset) /
+            Math.Log((shiftedMaximum + offset) / offset)), 0, 1);
     }
 
     private void SetBoundPositionsInternal()

--- a/src/microbe_stage/editor/TolerancesEditorSubComponent.cs
+++ b/src/microbe_stage/editor/TolerancesEditorSubComponent.cs
@@ -17,9 +17,6 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
     public bool ShowZeroModifiers;
 
     private const float PressureSliderLogOffset = 100000;
-    private const float PressureToleranceSliderLogOffset = 10000;
-    private const float PressureToleranceSliderMinimum = 200000;
-    private const float PressureToleranceSliderMaximum = 8000000;
     private const float PressureEditorRounding = 10000;
 
     private readonly Dictionary<IPlayerReadableName, float> tempToleranceModifiers = new();
@@ -555,8 +552,7 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
         pressureSlider.Value = ActualPressureToSliderValue(CurrentTolerances.PressureMinimum,
             Constants.TOLERANCE_PRESSURE_MAX, PressureSliderLogOffset);
-        pressureToleranceRangeSlider.Value = ActualPressureToSliderValue(CurrentTolerances.PressureTolerance,
-            PressureToleranceSliderMaximum, PressureToleranceSliderLogOffset, PressureToleranceSliderMinimum);
+        pressureToleranceRangeSlider.Value = CurrentTolerances.PressureTolerance;
 
         oxygenResistanceSlider.Value = CurrentTolerances.OxygenResistance;
         uvResistanceSlider.Value = CurrentTolerances.UVResistance;
@@ -656,16 +652,13 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
         reusableTolerances ??= new EnvironmentalTolerances();
         reusableTolerances.CopyFrom(CurrentTolerances);
-        reusableTolerances.PressureTolerance = RoundPressureForEditing(
-            SliderValueToActualPressure(value, PressureToleranceSliderMaximum, PressureToleranceSliderLogOffset,
-                PressureToleranceSliderMinimum));
+        reusableTolerances.PressureTolerance = value;
 
         automaticallyChanging = true;
 
         if (!TriggerChangeIfPossible())
         {
-            pressureToleranceRangeSlider.Value = ActualPressureToSliderValue(CurrentTolerances.PressureTolerance,
-                PressureToleranceSliderMaximum, PressureToleranceSliderLogOffset, PressureToleranceSliderMinimum);
+            pressureToleranceRangeSlider.Value = CurrentTolerances.PressureTolerance;
         }
 
         automaticallyChanging = false;

--- a/src/microbe_stage/editor/TolerancesEditorSubComponent.cs
+++ b/src/microbe_stage/editor/TolerancesEditorSubComponent.cs
@@ -16,6 +16,12 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
     [ExportCategory("Config")]
     public bool ShowZeroModifiers;
 
+    private const float PressureSliderLogOffset = 100000;
+    private const float PressureToleranceSliderLogOffset = 10000;
+    private const float PressureToleranceSliderMinimum = 200000;
+    private const float PressureToleranceSliderMaximum = 8000000;
+    private const float PressureEditorRounding = 10000;
+
     private readonly Dictionary<IPlayerReadableName, float> tempToleranceModifiers = new();
 
     private CompoundDefinition temperature = null!;
@@ -300,7 +306,9 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
         if (pressureToolTip != null)
         {
-            var pressureCost = pressureSlider.Step * Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE_MINIMUM *
+            var pressureCost = EstimatePressureChangeFromSliderStep(pressureSlider, 0,
+                    Constants.TOLERANCE_PRESSURE_MAX, PressureSliderLogOffset) *
+                Constants.TOLERANCE_CHANGE_MP_PER_PRESSURE_MINIMUM *
                 MPDisplayCostMultiplier;
 
             pressureToolTip.MPCost = (float)pressureCost;
@@ -456,6 +464,37 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
         }
     }
 
+    private static float ActualPressureToSliderValue(float pressure, float maximum, float offset, float minimum = 0)
+    {
+        pressure = Math.Clamp(pressure, minimum, maximum);
+
+        return Math.Clamp((float)(Math.Log((pressure - minimum + offset) / offset) /
+            Math.Log((maximum - minimum + offset) / offset)), 0, 1);
+    }
+
+    private static float SliderValueToActualPressure(float sliderValue, float maximum, float offset, float minimum = 0)
+    {
+        sliderValue = Math.Clamp(sliderValue, 0, 1);
+
+        return (float)(minimum + offset * (Math.Pow((maximum - minimum + offset) / offset, sliderValue) - 1));
+    }
+
+    private static float RoundPressureForEditing(float pressure)
+    {
+        return MathF.Round(pressure / PressureEditorRounding) * PressureEditorRounding;
+    }
+
+    private static double EstimatePressureChangeFromSliderStep(Slider slider, float minimum, float maximum,
+        float offset)
+    {
+        var previous = SliderValueToActualPressure((float)Math.Max(slider.Value - slider.Step, slider.MinValue),
+            maximum, offset, minimum);
+        var next = SliderValueToActualPressure((float)Math.Min(slider.Value + slider.Step, slider.MaxValue),
+            maximum, offset, minimum);
+
+        return Math.Max(Math.Abs(next - previous) * 0.5f, PressureEditorRounding);
+    }
+
     private void CalculateStatsAndShow(EnvironmentalTolerances calculationTolerances,
         EnvironmentalToleranceToolTip toolTip)
     {
@@ -514,8 +553,10 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
         temperatureSlider.Value = CurrentTolerances.PreferredTemperature;
         temperatureToleranceRangeSlider.Value = CurrentTolerances.TemperatureTolerance;
 
-        pressureSlider.Value = CurrentTolerances.PressureMinimum;
-        pressureToleranceRangeSlider.Value = CurrentTolerances.PressureTolerance;
+        pressureSlider.Value = ActualPressureToSliderValue(CurrentTolerances.PressureMinimum,
+            Constants.TOLERANCE_PRESSURE_MAX, PressureSliderLogOffset);
+        pressureToleranceRangeSlider.Value = ActualPressureToSliderValue(CurrentTolerances.PressureTolerance,
+            PressureToleranceSliderMaximum, PressureToleranceSliderLogOffset, PressureToleranceSliderMinimum);
 
         oxygenResistanceSlider.Value = CurrentTolerances.OxygenResistance;
         uvResistanceSlider.Value = CurrentTolerances.UVResistance;
@@ -594,13 +635,15 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
         reusableTolerances ??= new EnvironmentalTolerances();
         reusableTolerances.CopyFrom(CurrentTolerances);
-        reusableTolerances.PressureMinimum = value;
+        reusableTolerances.PressureMinimum = RoundPressureForEditing(
+            SliderValueToActualPressure(value, Constants.TOLERANCE_PRESSURE_MAX, PressureSliderLogOffset));
 
         automaticallyChanging = true;
 
         if (!TriggerChangeIfPossible())
         {
-            pressureSlider.Value = CurrentTolerances.PressureMinimum;
+            pressureSlider.Value = ActualPressureToSliderValue(CurrentTolerances.PressureMinimum,
+                Constants.TOLERANCE_PRESSURE_MAX, PressureSliderLogOffset);
         }
 
         automaticallyChanging = false;
@@ -613,13 +656,16 @@ public partial class TolerancesEditorSubComponent : EditorComponentBase<ICellEdi
 
         reusableTolerances ??= new EnvironmentalTolerances();
         reusableTolerances.CopyFrom(CurrentTolerances);
-        reusableTolerances.PressureTolerance = value;
+        reusableTolerances.PressureTolerance = RoundPressureForEditing(
+            SliderValueToActualPressure(value, PressureToleranceSliderMaximum, PressureToleranceSliderLogOffset,
+                PressureToleranceSliderMinimum));
 
         automaticallyChanging = true;
 
         if (!TriggerChangeIfPossible())
         {
-            pressureToleranceRangeSlider.Value = CurrentTolerances.PressureTolerance;
+            pressureToleranceRangeSlider.Value = ActualPressureToSliderValue(CurrentTolerances.PressureTolerance,
+                PressureToleranceSliderMaximum, PressureToleranceSliderLogOffset, PressureToleranceSliderMinimum);
         }
 
         automaticallyChanging = false;

--- a/src/microbe_stage/editor/TolerancesEditorSubComponent.tscn
+++ b/src/microbe_stage/editor/TolerancesEditorSubComponent.tscn
@@ -316,6 +316,8 @@ size_flags_horizontal = 3
 max_value = 80000000.0
 value = 0.0
 hasTwoBounds = true
+logarithmicScale = true
+logarithmicScaleOffset = 100000.0
 relatedSlider = NodePath("../PressureSlider")
 
 [node name="PressureSlider" type="HSlider" parent="Pressure/RangeDisplayContainer/VBoxContainer" unique_id=691339473]
@@ -327,9 +329,9 @@ focus_next = NodePath("../../../HBoxContainer4/PressureRange")
 focus_previous = NodePath("../../../../Temperature/HBoxContainer3/TemperatureRange")
 theme_override_constants/center_grabber = 1
 theme_override_styles/slider = SubResource("StyleBoxEmpty_n6u17")
-max_value = 80000000.0
-step = 200000.0
-value = 40000000.0
+max_value = 1.0
+step = 0.001
+value = 0.5
 
 [node name="Spacer2" type="Control" parent="Pressure/RangeDisplayContainer" unique_id=1570659681]
 custom_minimum_size = Vector2(8, 0)
@@ -357,11 +359,9 @@ focus_neighbor_bottom = NodePath("../../../Oxygen/RangeDisplayContainer/VBoxCont
 focus_next = NodePath("../../../Oxygen/RangeDisplayContainer/VBoxContainer/OxygenResistanceSlider")
 focus_previous = NodePath("../../RangeDisplayContainer/VBoxContainer/PressureSlider")
 mouse_filter = 1
-min_value = 200000.0
-max_value = 8000000.0
-step = 200000.0
-value = 200000.0
-rounded = true
+max_value = 1.0
+step = 0.001
+value = 0.5
 scrollable = false
 
 [node name="Spacer2" type="Control" parent="Pressure/HBoxContainer4" unique_id=1359946918]

--- a/src/microbe_stage/editor/TolerancesEditorSubComponent.tscn
+++ b/src/microbe_stage/editor/TolerancesEditorSubComponent.tscn
@@ -330,7 +330,7 @@ focus_previous = NodePath("../../../../Temperature/HBoxContainer3/TemperatureRan
 theme_override_constants/center_grabber = 1
 theme_override_styles/slider = SubResource("StyleBoxEmpty_n6u17")
 max_value = 1.0
-step = 0.001
+step = 0.005
 value = 0.5
 
 [node name="Spacer2" type="Control" parent="Pressure/RangeDisplayContainer" unique_id=1570659681]
@@ -359,9 +359,11 @@ focus_neighbor_bottom = NodePath("../../../Oxygen/RangeDisplayContainer/VBoxCont
 focus_next = NodePath("../../../Oxygen/RangeDisplayContainer/VBoxContainer/OxygenResistanceSlider")
 focus_previous = NodePath("../../RangeDisplayContainer/VBoxContainer/PressureSlider")
 mouse_filter = 1
-max_value = 1.0
-step = 0.001
-value = 0.5
+min_value = 200000.0
+max_value = 8000000.0
+step = 200000.0
+value = 200000.0
+rounded = true
 scrollable = false
 
 [node name="Spacer2" type="Control" parent="Pressure/HBoxContainer4" unique_id=1359946918]


### PR DESCRIPTION
**Brief Description of What This PR Does**

This makes the pressure minimum and pressure range controls use logarithmic slider positions while still storing the real pressure values in pascals. The surface pressure range was squeezed into a tiny part of the old linear slider, so this should make those values way less annoying to adjust tbh.

I also made the pressure range display use the same log scale, so the slider grabber and the displayed range stay visually lined up.

I tested this on my machine with:

- `dotnet run --project Scripts -- check files rewrite --include src/microbe_stage/editor/TolerancesEditorSubComponent.cs --include src/microbe_stage/editor/ToleranceRangeDisplay.cs --include src/microbe_stage/editor/TolerancesEditorSubComponent.tscn --no-rebuild`
- `dotnet run --project Scripts -- check inspectcode --include src/microbe_stage/editor/TolerancesEditorSubComponent.cs --include src/microbe_stage/editor/ToleranceRangeDisplay.cs --no-rebuild`
- `dotnet build Thrive.sln --no-restore`
- `dotnet test test\code_tests\ThriveTest.csproj --no-build`

**Related Issues**

Closes #5963

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).