### PR TITLE
Add multicellular adjacency specialization bonus

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -686,6 +686,11 @@ public static class Constants
     public const float CELL_SPECIALIZATION_STRENGTH_MULTIPLIER = 0.8f;
 
     /// <summary>
+    ///   Extra specialization multiplier granted for each adjacent cell of the same type in a multicellular body plan
+    /// </summary>
+    public const float CELL_SPECIALIZATION_ADJACENCY_BONUS = 0.05f;
+
+    /// <summary>
     ///   If more chunks exist at once than this, then some are forced to despawn immediately. In reality the effective
     ///   value is higher as spawned and microbe corpse chunks have now their individual limits (so the real limit is
     ///   double this)

--- a/src/multicellular_stage/MulticellularSpecies.cs
+++ b/src/multicellular_stage/MulticellularSpecies.cs
@@ -354,9 +354,39 @@ public class MulticellularSpecies : Species, IReadOnlyMulticellularSpecies, ISim
     /// <returns>The calculated bonus (or 1, if it can't be calculated)</returns>
     public float GetAdjacencySpecializationBonus(int cellIndexInBodyPlan)
     {
-        // TODO: implement this https://github.com/Revolutionary-Games/Thrive/issues/6764
-        _ = cellIndexInBodyPlan;
-        return 1;
+        int count = ModifiableGameplayCells.Count;
+
+        if (cellIndexInBodyPlan < 0 || cellIndexInBodyPlan >= count)
+        {
+            GD.PrintErr("Invalid multicellular body plan cell index for adjacency bonus: ", cellIndexInBodyPlan);
+            return 1;
+        }
+
+        var targetCell = ModifiableGameplayCells[cellIndexInBodyPlan];
+        var targetCellType = targetCell.ModifiableCellType;
+
+        var targetOccupiedHexes = new List<Hex>();
+        var layoutLookupTemporaryMemory = new List<Hex>();
+        var adjacentCells = new HashSet<CellTemplate>();
+
+        AddCellOccupiedHexes(targetCell, targetOccupiedHexes);
+
+        foreach (var targetHex in targetOccupiedHexes)
+        {
+            foreach (var offset in Hex.HexNeighbourOffset.Values)
+            {
+                var adjacentCell = ModifiableGameplayCells.GetElementAt(targetHex + offset,
+                    layoutLookupTemporaryMemory);
+
+                if (adjacentCell == null || ReferenceEquals(adjacentCell, targetCell))
+                    continue;
+
+                if (ReferenceEquals(adjacentCell.ModifiableCellType, targetCellType))
+                    adjacentCells.Add(adjacentCell);
+            }
+        }
+
+        return 1 + adjacentCells.Count * Constants.CELL_SPECIALIZATION_ADJACENCY_BONUS;
     }
 
     public void SetupWorldEntities(IWorldSimulation worldSimulation)
@@ -448,6 +478,23 @@ public class MulticellularSpecies : Species, IReadOnlyMulticellularSpecies, ISim
         }
 
         return result;
+    }
+
+    private static void AddCellOccupiedHexes(IReadOnlyCellTemplate cell, List<Hex> result)
+    {
+        result.Clear();
+
+        foreach (var organelle in cell.Organelles)
+        {
+            var organelleHexes = organelle.Definition.GetRotatedHexes(organelle.Orientation);
+            int hexCount = organelleHexes.Count;
+
+            for (int i = 0; i < hexCount; ++i)
+            {
+                result.Add(Hex.RotateAxialNTimes(organelleHexes[i], cell.Orientation) +
+                    Hex.RotateAxialNTimes(organelle.Position, cell.Orientation) + cell.Position);
+            }
+        }
     }
 
     private bool RepositionGameplayCells()

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
@@ -51,23 +51,26 @@ public partial class CellBodyPlanEditorComponent
 
         var processes = new List<TweakedProcess>();
 
-        UpdateCellTypesCounts();
         var newProcesses = new List<TweakedProcess>();
-        foreach (var cellType in cellTypesCount)
+        var cells = editedMicrobeCells;
+        int cellCount = cells.Count;
+
+        for (int cellIndex = 0; cellIndex < cellCount; ++cellIndex)
         {
+            var cellType = GetEditedCellDataIfEdited(cells[cellIndex].Data!.ModifiableCellType);
             newProcesses.Clear();
 
-            ProcessSystem.ComputeActiveProcessList(cellType.Key.ModifiableOrganelles, ref newProcesses);
+            ProcessSystem.ComputeActiveProcessList(cellType.ModifiableOrganelles, ref newProcesses);
 
             var specialization =
-                MicrobeInternalCalculations.CalculateSpecializationBonus(cellType.Key.ModifiableOrganelles,
-                    tempMemory3);
+                MicrobeInternalCalculations.CalculateSpecializationBonus(cellType.ModifiableOrganelles,
+                    tempMemory3) * CalculateEditedCellAdjacencySpecializationBonus(cellIndex);
 
             for (int i = 0; i < newProcesses.Count; ++i)
             {
                 // Apply specialization here to approximate it in this editor
                 newProcesses[i] = new TweakedProcess(newProcesses[i].Process,
-                    newProcesses[i].Rate * cellType.Value * specialization)
+                    newProcesses[i].Rate * specialization)
                 {
                     SpeedMultiplier = newProcesses[i].SpeedMultiplier,
                 };
@@ -252,11 +255,8 @@ public partial class CellBodyPlanEditorComponent
             var type = GetEditedCellDataIfEdited(cells[i].Data!.ModifiableCellType);
 
             var specialization =
-                MicrobeInternalCalculations.CalculateSpecializationBonus(type.ModifiableOrganelles, tempMemory3);
-
-            // TODO: calculate adjacency specialization values
-            // https://github.com/Revolutionary-Games/Thrive/issues/6764
-            // totalSpecialization += specialization * adjacencySpecialization;
+                MicrobeInternalCalculations.CalculateSpecializationBonus(type.ModifiableOrganelles, tempMemory3) *
+                CalculateEditedCellAdjacencySpecializationBonus(i);
 
             totalSpecialization += specialization;
 

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -1268,7 +1268,8 @@ public partial class CellBodyPlanEditorComponent :
             MicrobeInternalCalculations.MaximumSpeedDirection(cellType.ModifiableOrganelles);
 
         var specialization =
-            MicrobeInternalCalculations.CalculateSpecializationBonus(cellType.ModifiableOrganelles, tempMemory3);
+            MicrobeInternalCalculations.CalculateSpecializationBonus(cellType.ModifiableOrganelles, tempMemory3) *
+            CalculateAverageEditedCellAdjacencySpecializationBonus(cellType);
 
         ProcessSystem.ComputeEnergyBalanceFull(cellType.ModifiableOrganelles, Editor.CurrentPatch.Biome,
             environmentalTolerances, specialization,
@@ -1467,12 +1468,13 @@ public partial class CellBodyPlanEditorComponent :
         tempCompoundSources.Clear();
 
         // TODO: improve performance by calculating the balance per cell type
-        foreach (var hex in cells)
+        int cellCount = cells.Count;
+        for (int i = 0; i < cellCount; ++i)
         {
+            var hex = cells[i];
             var specialization =
-                MicrobeInternalCalculations.CalculateSpecializationBonus(hex.Data!.ModifiableOrganelles, tempMemory3);
-
-            // TODO: adjacency bonuses from body plan (GetAdjacencySpecializationBonus)
+                MicrobeInternalCalculations.CalculateSpecializationBonus(hex.Data!.ModifiableOrganelles, tempMemory3) *
+                CalculateEditedCellAdjacencySpecializationBonus(i);
 
             ProcessSystem.ComputeEnergyBalanceFull(hex.Data.ModifiableOrganelles, conditionsData,
                 environmentalTolerances, specialization, hex.Data.MembraneType,
@@ -1520,13 +1522,14 @@ public partial class CellBodyPlanEditorComponent :
         in ResolvedMicrobeTolerances tolerances)
     {
         Dictionary<Compound, CompoundBalance> compoundBalanceData = new();
-        foreach (var cell in cells)
+        int cellCount = cells.Count;
+        for (int i = 0; i < cellCount; ++i)
         {
+            var cell = cells[i];
             var organelles = GetEditedCellDataIfEdited(cell.Data!.ModifiableCellType).ModifiableOrganelles;
             var specialization =
-                MicrobeInternalCalculations.CalculateSpecializationBonus(organelles, tempMemory3);
-
-            // TODO: efficiency from cell layout positions (GetAdjacencySpecializationBonus)
+                MicrobeInternalCalculations.CalculateSpecializationBonus(organelles, tempMemory3) *
+                CalculateEditedCellAdjacencySpecializationBonus(i);
 
             AddCellTypeCompoundBalance(compoundBalanceData, organelles, calculationType,
                 amountType, biome, energyBalance, tolerances, specialization);
@@ -1570,6 +1573,66 @@ public partial class CellBodyPlanEditorComponent :
             cellTypesCount.TryGetValue(type, out var count);
             cellTypesCount[type] = count + 1;
         }
+    }
+
+    private float CalculateEditedCellAdjacencySpecializationBonus(int cellIndex)
+    {
+        int cellCount = editedMicrobeCells.Count;
+
+        if (cellIndex < 0 || cellIndex >= cellCount)
+            return 1;
+
+        var targetCell = editedMicrobeCells[cellIndex];
+        var targetType = GetEditedCellDataIfEdited(targetCell.Data!.ModifiableCellType);
+        int adjacentSameTypeCells = 0;
+
+        for (int i = 0; i < cellCount; ++i)
+        {
+            if (i == cellIndex)
+                continue;
+
+            var otherCell = editedMicrobeCells[i];
+
+            if (!ReferenceEquals(GetEditedCellDataIfEdited(otherCell.Data!.ModifiableCellType), targetType))
+                continue;
+
+            if (AreHexesAdjacent(targetCell.Position, otherCell.Position))
+                ++adjacentSameTypeCells;
+        }
+
+        return 1 + adjacentSameTypeCells * Constants.CELL_SPECIALIZATION_ADJACENCY_BONUS;
+    }
+
+    private float CalculateAverageEditedCellAdjacencySpecializationBonus(CellType cellType)
+    {
+        double totalSpecialization = 0;
+        int matchingCells = 0;
+        int cellCount = editedMicrobeCells.Count;
+
+        for (int i = 0; i < cellCount; ++i)
+        {
+            if (!ReferenceEquals(GetEditedCellDataIfEdited(editedMicrobeCells[i].Data!.ModifiableCellType), cellType))
+                continue;
+
+            totalSpecialization += CalculateEditedCellAdjacencySpecializationBonus(i);
+            ++matchingCells;
+        }
+
+        if (matchingCells < 1)
+            return 1;
+
+        return (float)(totalSpecialization / matchingCells);
+    }
+
+    private bool AreHexesAdjacent(Hex first, Hex second)
+    {
+        foreach (var offset in Hex.HexNeighbourOffset.Values)
+        {
+            if (first + offset == second)
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/test/code_tests/MulticellularStage.Tests/MulticellularSpeciesTests.cs
+++ b/test/code_tests/MulticellularStage.Tests/MulticellularSpeciesTests.cs
@@ -1,0 +1,59 @@
+namespace ThriveTest.MulticellularStage.Tests;
+
+using System.Collections.Generic;
+using Xunit;
+
+public class MulticellularSpeciesTests
+{
+    private readonly MembraneType dummyMembrane = new()
+    {
+        Name = "Dummy",
+    };
+
+    private readonly OrganelleDefinition singleHexOrganelle = new()
+    {
+        Name = "DummyCytoplasm",
+        Hexes = [new Hex(0, 0)],
+    };
+
+    [Fact]
+    public void MulticellularSpecies_SameCellTypeAdjacencyIncreasesSpecialization()
+    {
+        var species = new MulticellularSpecies(1, "Test", "species");
+        var type1 = CreateCellType(2);
+        var type2 = CreateCellType(1.5f);
+
+        species.ModifiableCellTypes.Add(type1);
+        species.ModifiableCellTypes.Add(type2);
+
+        var temporaryMemory1 = new List<Hex>();
+        var temporaryMemory2 = new List<Hex>();
+
+        species.ModifiableGameplayCells.AddFast(new CellTemplate(type1, new Hex(0, 0), 0), temporaryMemory1,
+            temporaryMemory2);
+        species.ModifiableGameplayCells.AddFast(new CellTemplate(type1, new Hex(1, 0), 0), temporaryMemory1,
+            temporaryMemory2);
+        species.ModifiableGameplayCells.AddFast(new CellTemplate(type2, new Hex(0, 1), 0), temporaryMemory1,
+            temporaryMemory2);
+
+        Assert.Equal(1.05f, species.GetAdjacencySpecializationBonus(0), 0.0001f);
+        Assert.Equal(1.05f, species.GetAdjacencySpecializationBonus(1), 0.0001f);
+        Assert.Equal(1, species.GetAdjacencySpecializationBonus(2));
+        Assert.Equal(1.9f, species.CalculateAverageSpecialization(), 0.0001f);
+    }
+
+    private CellType CreateCellType(float specializationBonus)
+    {
+        var organelles = new OrganelleLayout<OrganelleTemplate>();
+        var temporaryMemory1 = new List<Hex>();
+        var temporaryMemory2 = new List<Hex>();
+
+        organelles.AddFast(new OrganelleTemplate(singleHexOrganelle, new Hex(0, 0), 0), temporaryMemory1,
+            temporaryMemory2);
+
+        return new CellType(organelles, dummyMembrane)
+        {
+            SpecializationBonus = specializationBonus,
+        };
+    }
+}

--- a/test/code_tests/MulticellularStage.Tests/MulticellularSpeciesTests.cs
+++ b/test/code_tests/MulticellularStage.Tests/MulticellularSpeciesTests.cs
@@ -1,4 +1,4 @@
-namespace ThriveTest.MulticellularStage.Tests;
+﻿namespace ThriveTest.MulticellularStage.Tests;
 
 using System.Collections.Generic;
 using Xunit;


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR adds the multicellular cell position adjacency specialization bonus from #6764. Each adjacent same-type cell gives the cell a 5% specialization multiplier, and the multicellular editor stat/balance displays now include the same bonus the stage already applies.

I also added a code test for same-type adjacency and average specialization.

**Related Issues**

Closes #6764

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).

Tested on my machine:
- `dotnet build Thrive.sln`
- `dotnet test test\code_tests\ThriveTest.csproj --no-build`
- `dotnet run --project Scripts -- check files`
- `dotnet run --project Scripts -- check inspectcode --include simulation_parameters\Constants.cs --include src\multicellular_stage\MulticellularSpecies.cs --include src\multicellular_stage\editor\CellBodyPlanEditorComponent.cs --include src\multicellular_stage\editor\CellBodyPlanEditorComponent.GUI.cs --include test\code_tests\MulticellularStage.Tests\MulticellularSpeciesTests.cs --no-rebuild`