### PR TITLE
Fix Easter Egg chunk shader warnings

### DIFF
--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -4804,11 +4804,13 @@
           "Meshes": [
             {
               "ScenePath": "res://assets/models/easter_eggs/IronRockLittleBanana.tscn",
-              "ConvexShapePath": "res://assets/models/easter_eggs/LittleBanana.shape"
+              "ConvexShapePath": "res://assets/models/easter_eggs/LittleBanana.shape",
+              "MissingDefaultShaderSupport": true
             },
             {
               "ScenePath": "res://assets/models/easter_eggs/IronRockLittleBanana.tscn",
-              "ConvexShapePath": "res://assets/models/easter_eggs/LittleBanana.shape"
+              "ConvexShapePath": "res://assets/models/easter_eggs/LittleBanana.shape",
+              "MissingDefaultShaderSupport": true
             }
           ],
           "Density": 0.00008,


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR marks the small iron banana chunk meshes as missing default shader support. Those scenes use a plain Godot `Material`, not a `ShaderMaterial`, so they should follow the same skip path as the other Easter Egg visuals that can't use the normal microbe dissolve shader parameters.

This keeps the fix small: the existing engulf code can still calculate the AABB from the root `MeshInstance3D`, so there is no extra engulf-specific code needed here.

**Related Issues**

Closes #4702

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).

Tested on my pc:
- `dotnet build Thrive.sln`
- `dotnet test test\code_tests\ThriveTest.csproj --no-build`
- `dotnet run --project Scripts -- check files`
- `dotnet run --project Scripts -- check inspectcode --include simulation_parameters\microbe_stage\biomes.json --no-rebuild`
- Targeted banana Easter Egg data check: confirmed every plain-material Easter Egg chunk scene in the banana biome has `MissingDefaultShaderSupport` set, btw.