### PR TITLE
Retry broken scene instantiation on editor entry

### DIFF
--- a/src/auto-evo/AutoEvoExploringTool.cs
+++ b/src/auto-evo/AutoEvoExploringTool.cs
@@ -881,7 +881,7 @@ public partial class AutoEvoExploringTool : NodeWithInput, ISpeciesDataProvider
             MainMenu.OnEnteringGame(false, true);
 
             // Instantiate a new editor scene
-            var editor = (MicrobeEditor)SceneManager.Instance.LoadScene(MainGameState.MicrobeEditor).Instantiate();
+            var editor = SceneManager.Instance.InstantiateScene<MicrobeEditor>(MainGameState.MicrobeEditor);
 
             world.GameProperties.EnterFreeBuild();
             world.GameProperties.TutorialState.Enabled = false;

--- a/src/engine/ISceneInstanceValidator.cs
+++ b/src/engine/ISceneInstanceValidator.cs
@@ -1,0 +1,10 @@
+﻿/// <summary>
+///   Allows a scene root to reject a broken Godot instantiation before the node enters the active scene tree.
+/// </summary>
+public interface ISceneInstanceValidator
+{
+    /// <summary>
+    ///   Returns null when the scene instance is usable, or a short reason when it needs to be retried.
+    /// </summary>
+    public string? ValidateSceneInstance();
+}

--- a/src/engine/SceneInstantiationHelpers.cs
+++ b/src/engine/SceneInstantiationHelpers.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Godot;
+
+/// <summary>
+///   Helpers for instantiating Godot scenes with a retry guard against rare engine scene instancing failures.
+/// </summary>
+public static class SceneInstantiationHelpers
+{
+    public const int DefaultInstantiateAttempts = 3;
+
+    public static T? RetryCreate<T>(Func<T?> createInstance, string description,
+        Func<T, string?>? validate = null, Action<T>? discardInvalid = null, int attempts = DefaultInstantiateAttempts,
+        Action<string>? reportFailure = null)
+        where T : class
+    {
+        if (attempts < 1)
+            throw new ArgumentOutOfRangeException(nameof(attempts), "Attempt count must be at least 1");
+
+        reportFailure ??= GD.PrintErr;
+
+        for (int attempt = 1; attempt <= attempts; ++attempt)
+        {
+            T? instance;
+
+            try
+            {
+                instance = createInstance();
+            }
+            catch (Exception e)
+            {
+                reportFailure($"Failed to create {description} on attempt {attempt}/{attempts}: {e}");
+                continue;
+            }
+
+            if (instance == null)
+            {
+                reportFailure($"Failed to create {description} on attempt {attempt}/{attempts}: returned null");
+                continue;
+            }
+
+            var validationFailure = validate?.Invoke(instance);
+
+            if (validationFailure == null)
+                return instance;
+
+            reportFailure(
+                $"Created invalid {description} on attempt {attempt}/{attempts}: {validationFailure}");
+            discardInvalid?.Invoke(instance);
+        }
+
+        reportFailure($"Giving up on creating {description} after {attempts} failed attempts");
+        return null;
+    }
+
+    public static T? InstantiateSceneWithRetries<T>(string scenePath, Func<T, string?>? validate = null,
+        int attempts = DefaultInstantiateAttempts)
+        where T : Node
+    {
+        return RetryCreate(() =>
+            {
+                var scene = GD.Load<PackedScene>(scenePath);
+                return scene.Instantiate<T>();
+            },
+            scenePath, validate, node => node.Free(), attempts);
+    }
+}

--- a/src/engine/SceneManager.cs
+++ b/src/engine/SceneManager.cs
@@ -80,7 +80,7 @@ public partial class SceneManager : Node
     /// <returns>The scene that was switched to</returns>
     public Node SwitchToScene(MainGameState state)
     {
-        var scene = LoadScene(state).Instantiate();
+        var scene = InstantiateScene(state);
         SwitchToScene(scene);
 
         return scene;
@@ -88,7 +88,7 @@ public partial class SceneManager : Node
 
     public Node SwitchToScene(string scenePath)
     {
-        var scene = LoadScene(scenePath).Instantiate();
+        var scene = InstantiateScene(scenePath);
         SwitchToScene(scene);
 
         return scene;
@@ -133,9 +133,7 @@ public partial class SceneManager : Node
     /// </summary>
     public void ReturnToMenu()
     {
-        var scene = LoadScene("res://src/general/MainMenu.tscn");
-
-        var mainMenu = (MainMenu)scene.Instantiate();
+        var mainMenu = InstantiateScene<MainMenu>("res://src/general/MainMenu.tscn");
 
         mainMenu.IsReturningToMenu = true;
 
@@ -181,29 +179,42 @@ public partial class SceneManager : Node
 
     public PackedScene LoadScene(MainGameState state)
     {
-        switch (state)
+        return LoadScene(GetScenePath(state));
+    }
+
+    public Node InstantiateScene(MainGameState state)
+    {
+        return InstantiateScene(GetScenePath(state));
+    }
+
+    public T InstantiateScene<T>(MainGameState state)
+        where T : Node
+    {
+        return InstantiateScene<T>(GetScenePath(state));
+    }
+
+    public Node InstantiateScene(string scenePath)
+    {
+        return InstantiateScene<Node>(scenePath);
+    }
+
+    public T InstantiateScene<T>(string scenePath)
+        where T : Node
+    {
+        return SceneInstantiationHelpers.InstantiateSceneWithRetries<T>(scenePath) ??
+            throw new InvalidOperationException($"Failed to instantiate scene after retries: {scenePath}");
+    }
+
+    public T InstantiateScene<T>(SceneLoadedClassAttribute? sceneLoaded)
+        where T : Node
+    {
+        if (string.IsNullOrEmpty(sceneLoaded?.ScenePath))
         {
-            case MainGameState.MicrobeStage:
-                return LoadScene("res://src/microbe_stage/MicrobeStage.tscn");
-            case MainGameState.MicrobeEditor:
-                return LoadScene("res://src/microbe_stage/editor/MicrobeEditor.tscn");
-            case MainGameState.MulticellularEditor:
-                return LoadScene("res://src/multicellular_stage/editor/MulticellularEditor.tscn");
-            case MainGameState.MacroscopicStage:
-                return LoadScene("res://src/macroscopic_stage/MacroscopicStage.tscn");
-            case MainGameState.MacroscopicEditor:
-                return LoadScene("res://src/macroscopic_stage/editor/MacroscopicEditor.tscn");
-            case MainGameState.SocietyStage:
-                return LoadScene("res://src/society_stage/SocietyStage.tscn");
-            case MainGameState.IndustrialStage:
-                return LoadScene("res://src/industrial_stage/IndustrialStage.tscn");
-            case MainGameState.SpaceStage:
-                return LoadScene("res://src/space_stage/SpaceStage.tscn");
-            case MainGameState.AscensionCeremony:
-                return LoadScene("res://src/ascension_stage/AscensionCeremony.tscn");
-            default:
-                throw new ArgumentException("unknown scene path for given game state");
+            throw new ArgumentException(
+                "The specified class to load a scene for didn't have SceneLoadedClassAttribute");
         }
+
+        return InstantiateScene<T>(sceneLoaded.ScenePath);
     }
 
     public PackedScene LoadScene(string scenePath)
@@ -248,6 +259,33 @@ public partial class SceneManager : Node
     public bool QuittingRequested()
     {
         return alreadyQuit;
+    }
+
+    private static string GetScenePath(MainGameState state)
+    {
+        switch (state)
+        {
+            case MainGameState.MicrobeStage:
+                return "res://src/microbe_stage/MicrobeStage.tscn";
+            case MainGameState.MicrobeEditor:
+                return "res://src/microbe_stage/editor/MicrobeEditor.tscn";
+            case MainGameState.MulticellularEditor:
+                return "res://src/multicellular_stage/editor/MulticellularEditor.tscn";
+            case MainGameState.MacroscopicStage:
+                return "res://src/macroscopic_stage/MacroscopicStage.tscn";
+            case MainGameState.MacroscopicEditor:
+                return "res://src/macroscopic_stage/editor/MacroscopicEditor.tscn";
+            case MainGameState.SocietyStage:
+                return "res://src/society_stage/SocietyStage.tscn";
+            case MainGameState.IndustrialStage:
+                return "res://src/industrial_stage/IndustrialStage.tscn";
+            case MainGameState.SpaceStage:
+                return "res://src/space_stage/SpaceStage.tscn";
+            case MainGameState.AscensionCeremony:
+                return "res://src/ascension_stage/AscensionCeremony.tscn";
+            default:
+                throw new ArgumentException("unknown scene path for given game state");
+        }
     }
 
     [Command("load", true, "Switches to the specified game state.")]

--- a/src/general/MainMenu.cs
+++ b/src/general/MainMenu.cs
@@ -812,7 +812,7 @@ public partial class MainMenu : NodeWithInput
             OnEnteringGame(false, true);
 
             // Instantiate a new editor scene
-            var editor = (MicrobeEditor)SceneManager.Instance.LoadScene(MainGameState.MicrobeEditor).Instantiate();
+            var editor = SceneManager.Instance.InstantiateScene<MicrobeEditor>(MainGameState.MicrobeEditor);
 
             // Start a freebuild game
             editor.CurrentGame = GameProperties.StartNewMicrobeGame(new WorldGenerationSettings(), true);
@@ -835,8 +835,8 @@ public partial class MainMenu : NodeWithInput
             OnEnteringGame(false, true);
 
             // Instantiate a new editor scene
-            var editor = (MulticellularEditor)SceneManager.Instance
-                .LoadScene(MainGameState.MulticellularEditor).Instantiate();
+            var editor = SceneManager.Instance.InstantiateScene<MulticellularEditor>(
+                MainGameState.MulticellularEditor);
 
             // Start a freebuild game
             editor.CurrentGame = GameProperties.StartNewMulticellularGame(new WorldGenerationSettings(), true);

--- a/src/general/NewGameSettings.cs
+++ b/src/general/NewGameSettings.cs
@@ -525,7 +525,7 @@ public partial class NewGameSettings : ControlWithInput
         {
             MainMenu.OnEnteringGame(false, false);
 
-            var microbeStage = (MicrobeStage)SceneManager.Instance.LoadScene(MainGameState.MicrobeStage).Instantiate();
+            var microbeStage = SceneManager.Instance.InstantiateScene<MicrobeStage>(MainGameState.MicrobeStage);
             microbeStage.CurrentGame = GameProperties.StartNewMicrobeGame(settings);
 
             if (descendedGame != null)

--- a/src/general/base_stage/EditorBase.cs
+++ b/src/general/base_stage/EditorBase.cs
@@ -1127,9 +1127,8 @@ public partial class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoad
         {
             GD.Print("Creating new stage of type ", typeof(TStage).Name, " as there isn't one yet");
 
-            var scene = SceneManager.Instance.LoadScene(typeof(TStage).GetCustomAttribute<SceneLoadedClassAttribute>());
-
-            ReturnToStage = (TStage)scene.Instantiate();
+            ReturnToStage = SceneManager.Instance.InstantiateScene<TStage>(
+                typeof(TStage).GetCustomAttribute<SceneLoadedClassAttribute>());
             ReturnToStage.CurrentGame = CurrentGame;
         }
     }

--- a/src/industrial_stage/IndustrialStage.cs
+++ b/src/industrial_stage/IndustrialStage.cs
@@ -399,7 +399,7 @@ public partial class IndustrialStage : StrategyStageBase, ISocietyStructureDataA
     {
         GD.Print("Switching to space scene");
 
-        var spaceStage = SceneManager.Instance.LoadScene(MainGameState.SpaceStage).Instantiate<SpaceStage>();
+        var spaceStage = SceneManager.Instance.InstantiateScene<SpaceStage>(MainGameState.SpaceStage);
         spaceStage.CurrentGame = CurrentGame;
 
         SceneManager.Instance.SwitchToScene(spaceStage);

--- a/src/macroscopic_stage/MacroscopicStage.cs
+++ b/src/macroscopic_stage/MacroscopicStage.cs
@@ -260,10 +260,8 @@ public partial class MacroscopicStage : CreatureStageBase<MacroscopicCreature, D
         if (CurrentGame == null)
             throw new InvalidOperationException("Stage has no current game");
 
-        var scene = SceneManager.Instance.LoadScene(MainGameState.MacroscopicEditor);
-
-        Node sceneInstance = scene.Instantiate();
-        var editor = (MacroscopicEditor)sceneInstance;
+        var editor = SceneManager.Instance.InstantiateScene<MacroscopicEditor>(MainGameState.MacroscopicEditor);
+        Node sceneInstance = editor;
 
         editor.CurrentGame = CurrentGame;
         editor.ReturnToStage = this;
@@ -897,7 +895,7 @@ public partial class MacroscopicStage : CreatureStageBase<MacroscopicCreature, D
 
     private void SwitchToSocietyScene()
     {
-        var societyStage = SceneManager.Instance.LoadScene(MainGameState.SocietyStage).Instantiate<SocietyStage>();
+        var societyStage = SceneManager.Instance.InstantiateScene<SocietyStage>(MainGameState.SocietyStage);
         societyStage.CurrentGame = CurrentGame;
 
         SceneManager.Instance.SwitchToScene(societyStage);

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -704,10 +704,9 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
         {
             // Player is a multicellular species, go to multicellular editor
 
-            var scene = SceneManager.Instance.LoadScene(MainGameState.MulticellularEditor);
-
-            sceneInstance = scene.Instantiate();
-            var editor = (MulticellularEditor)sceneInstance;
+            var editor = SceneManager.Instance.InstantiateScene<MulticellularEditor>(
+                MainGameState.MulticellularEditor);
+            sceneInstance = editor;
 
             editor.CurrentGame = CurrentGame;
             editor.ReturnToStage = this;
@@ -724,10 +723,8 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
                 return;
             }
 
-            var scene = SceneManager.Instance.LoadScene(MainGameState.MicrobeEditor);
-
-            sceneInstance = scene.Instantiate();
-            var editor = (MicrobeEditor)sceneInstance;
+            var editor = SceneManager.Instance.InstantiateScene<MicrobeEditor>(MainGameState.MicrobeEditor);
+            sceneInstance = editor;
 
             editor.CurrentGame = CurrentGame;
             editor.ReturnToStage = this;
@@ -818,9 +815,7 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
         // Make sure no queued player species can spawn with the old species
         WorldSimulation.SpawnSystem.ClearSpawnQueue();
 
-        var scene = SceneManager.Instance.LoadScene(MainGameState.MulticellularEditor);
-
-        var editor = scene.Instantiate<MulticellularEditor>();
+        var editor = SceneManager.Instance.InstantiateScene<MulticellularEditor>(MainGameState.MulticellularEditor);
 
         editor.CurrentGame = CurrentGame ?? throw new InvalidOperationException("Stage has no current game");
         editor.ReturnToStage = this;
@@ -874,9 +869,7 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
 
         GameWorld.NotifySpeciesChangedStages();
 
-        var scene = SceneManager.Instance.LoadScene(MainGameState.MacroscopicEditor);
-
-        var editor = scene.Instantiate<MacroscopicEditor>();
+        var editor = SceneManager.Instance.InstantiateScene<MacroscopicEditor>(MainGameState.MacroscopicEditor);
 
         editor.CurrentGame = CurrentGame ?? throw new InvalidOperationException("Stage has no current game");
 

--- a/src/society_stage/SocietyStage.cs
+++ b/src/society_stage/SocietyStage.cs
@@ -330,7 +330,7 @@ public partial class SocietyStage : StrategyStageBase, ISocietyStructureDataAcce
         GD.Print("Switching to industrial scene");
 
         var industrialStage =
-            SceneManager.Instance.LoadScene(MainGameState.IndustrialStage).Instantiate<IndustrialStage>();
+            SceneManager.Instance.InstantiateScene<IndustrialStage>(MainGameState.IndustrialStage);
         industrialStage.CurrentGame = CurrentGame;
         industrialStage.TakeInitialResourcesFrom(SocietyResources);
 

--- a/src/space_stage/SpaceStage.cs
+++ b/src/space_stage/SpaceStage.cs
@@ -606,7 +606,7 @@ public partial class SpaceStage : StrategyStageBase, ISocietyStructureDataAccess
         GD.Print("Switching to ascension ceremony scene");
 
         var ascensionScene =
-            SceneManager.Instance.LoadScene(MainGameState.AscensionCeremony).Instantiate<AscensionCeremony>();
+            SceneManager.Instance.InstantiateScene<AscensionCeremony>(MainGameState.AscensionCeremony);
         ascensionScene.CurrentGame = CurrentGame;
 
         var us = (SpaceStage?)SceneManager.Instance.SwitchToScene(ascensionScene, true);

--- a/src/stage_starters/AscensionStageStarter.cs
+++ b/src/stage_starters/AscensionStageStarter.cs
@@ -12,7 +12,7 @@ public partial class AscensionStageStarter : ComplexStageStarterBase
     {
         currentGame ??= GameProperties.StartAscensionStageGame(new WorldGenerationSettings());
 
-        var spaceStage = SceneManager.Instance.LoadScene(MainGameState.SpaceStage).Instantiate<SpaceStage>();
+        var spaceStage = SceneManager.Instance.InstantiateScene<SpaceStage>(MainGameState.SpaceStage);
         spaceStage.CurrentGame = currentGame;
 
         return spaceStage;

--- a/src/stage_starters/ComplexStageStarterBase.cs
+++ b/src/stage_starters/ComplexStageStarterBase.cs
@@ -59,7 +59,7 @@ public partial class ComplexStageStarterBase : Node
 
     protected virtual Node LoadScene()
     {
-        return SceneManager.Instance.LoadScene(SimplyLoadableGameState).Instantiate();
+        return SceneManager.Instance.InstantiateScene(SimplyLoadableGameState);
     }
 
     /// <summary>

--- a/src/thriveopedia/Thriveopedia.cs
+++ b/src/thriveopedia/Thriveopedia.cs
@@ -323,14 +323,17 @@ public partial class Thriveopedia : ControlWithInput, ISpeciesDataProvider
 
         if (page == null)
         {
-            var scene = GD.Load<PackedScene>($"res://src/thriveopedia/pages/Thriveopedia{name}Page.tscn");
-            page = scene.Instantiate<IThriveopediaPage>();
+            var path = $"res://src/thriveopedia/pages/Thriveopedia{name}Page.tscn";
+            var pageNode = SceneInstantiationHelpers.InstantiateSceneWithRetries<ThriveopediaPage>(
+                path, ValidateThriveopediaPageInstance);
 
-            if (page == null)
+            if (pageNode is not IThriveopediaPage loadedPage)
             {
                 GD.PrintErr($"Failed to load Thriveopedia page {name} due to scene instantiate failure");
                 return;
             }
+
+            page = loadedPage;
         }
 
         if (page.ParentPageName != null && page.ParentPageName != "CurrentStage" &&
@@ -353,6 +356,17 @@ public partial class Thriveopedia : ControlWithInput, ISpeciesDataProvider
             treeItem.Visible = false;
 
         page.Hide();
+    }
+
+    private string? ValidateThriveopediaPageInstance(ThriveopediaPage page)
+    {
+        if (page is not IThriveopediaPage)
+            return $"root node {page.Name} does not implement {nameof(IThriveopediaPage)}";
+
+        if (page is ISceneInstanceValidator validator)
+            return validator.ValidateSceneInstance();
+
+        return null;
     }
 
     private void AddStageDropdown()

--- a/src/thriveopedia/pages/ThriveopediaMuseumPage.cs
+++ b/src/thriveopedia/pages/ThriveopediaMuseumPage.cs
@@ -251,7 +251,7 @@ public partial class ThriveopediaMuseumPage : ThriveopediaPage, IThriveopediaPag
             MainMenu.OnEnteringGame(false, true);
 
             // Instantiate a new editor scene
-            var editor = SceneManager.Instance.LoadScene(MainGameState.MicrobeEditor).Instantiate<MicrobeEditor>();
+            var editor = SceneManager.Instance.InstantiateScene<MicrobeEditor>(MainGameState.MicrobeEditor);
 
             // Start a freebuild game with the selected species
             editor.CurrentGame = GameProperties.StartNewMicrobeGame(new WorldGenerationSettings(), true,

--- a/src/thriveopedia/pages/ThriveopediaPatchMapPage.cs
+++ b/src/thriveopedia/pages/ThriveopediaPatchMapPage.cs
@@ -9,16 +9,18 @@ using Godot;
 ///     Note a lot of this functionality is duplicated from PatchMapEditorComponent.
 ///   </para>
 /// </remarks>
-public partial class ThriveopediaPatchMapPage : ThriveopediaPage, IThriveopediaPage
+public partial class ThriveopediaPatchMapPage : ThriveopediaPage, IThriveopediaPage, ISceneInstanceValidator
 {
+    private const string MapDrawerPath = "HSplitContainer/MapPanel/MarginContainer/DraggableScrollContainer/" +
+        "PatchMapDrawer";
+    private const string DetailsPanelPath = "HSplitContainer/PatchDetailsPanel";
+    private const string SeedLabelPath = "HSplitContainer/MapPanel/MarginContainer/VBoxContainer/SeedLabel";
+
 #pragma warning disable CA2213
-    [Export]
     private PatchMapDrawer mapDrawer = null!;
 
-    [Export]
     private PatchDetailsPanel detailsPanel = null!;
 
-    [Export]
     private Label seedLabel = null!;
 #pragma warning restore CA2213
 
@@ -34,6 +36,10 @@ public partial class ThriveopediaPatchMapPage : ThriveopediaPage, IThriveopediaP
     public override void _Ready()
     {
         base._Ready();
+
+        var failure = ValidateSceneInstance();
+        if (failure != null)
+            throw new InvalidOperationException(failure);
 
         mapDrawer.OnSelectedPatchChanged = _ =>
         {
@@ -64,6 +70,24 @@ public partial class ThriveopediaPatchMapPage : ThriveopediaPage, IThriveopediaP
 
     public override void OnNavigationPanelSizeChanged(bool collapsed)
     {
+    }
+
+    public string? ValidateSceneInstance()
+    {
+        mapDrawer = GetNodeOrNull<PatchMapDrawer>(MapDrawerPath);
+        detailsPanel = GetNodeOrNull<PatchDetailsPanel>(DetailsPanelPath);
+        seedLabel = GetNodeOrNull<Label>(SeedLabelPath);
+
+        if (mapDrawer == null)
+            return $"missing required PatchMapDrawer node at {MapDrawerPath}";
+
+        if (detailsPanel == null)
+            return $"missing required PatchDetailsPanel node at {DetailsPanelPath}";
+
+        if (seedLabel == null)
+            return $"missing required seed Label node at {SeedLabelPath}";
+
+        return null;
     }
 
     public override void OnTranslationsChanged()

--- a/src/thriveopedia/pages/ThriveopediaPatchMapPage.tscn
+++ b/src/thriveopedia/pages/ThriveopediaPatchMapPage.tscn
@@ -11,11 +11,8 @@
 [sub_resource type="ShaderMaterial" id="1"]
 shader = ExtResource("8")
 
-[node name="ThriveopediaPatchMapPage" unique_id=1940744970 node_paths=PackedStringArray("mapDrawer", "detailsPanel", "seedLabel") instance=ExtResource("2")]
+[node name="ThriveopediaPatchMapPage" unique_id=1940744970 instance=ExtResource("2")]
 script = ExtResource("1")
-mapDrawer = NodePath("HSplitContainer/MapPanel/MarginContainer/DraggableScrollContainer/PatchMapDrawer")
-detailsPanel = NodePath("HSplitContainer/PatchDetailsPanel")
-seedLabel = NodePath("HSplitContainer/MapPanel/MarginContainer/VBoxContainer/SeedLabel")
 DisplayBackground = false
 
 [node name="HSplitContainer" type="HSplitContainer" parent="." index="1" unique_id=1659989176]

--- a/test/code_tests/Engine/SceneInstantiationHelpersTests.cs
+++ b/test/code_tests/Engine/SceneInstantiationHelpersTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Xunit;
+
+public class SceneInstantiationHelpersTests
+{
+    [Fact]
+    public void RetryCreateHandlesFirstNullResult()
+    {
+        int callCount = 0;
+
+        var created = SceneInstantiationHelpers.RetryCreate(() =>
+            {
+                ++callCount;
+
+                if (callCount == 1)
+                    return null;
+
+                return new object();
+            },
+            "test scene", reportFailure: _ => { });
+
+        Assert.NotNull(created);
+        Assert.Equal(2, callCount);
+    }
+
+    [Fact]
+    public void RetryCreateDiscardsInvalidInstancesBeforeRetrying()
+    {
+        var invalidInstance = new TestSceneInstance();
+        int discardCount = 0;
+
+        var created = SceneInstantiationHelpers.RetryCreate(() => discardCount == 0 ? invalidInstance :
+                new TestSceneInstance(),
+            "test scene", instance => ReferenceEquals(instance, invalidInstance) ? "missing node" : null,
+            _ => ++discardCount, reportFailure: _ => { });
+
+        Assert.NotNull(created);
+        Assert.NotSame(invalidInstance, created);
+        Assert.Equal(1, discardCount);
+    }
+
+    [Fact]
+    public void RetryCreateReturnsNullAfterExhaustingAttempts()
+    {
+        int callCount = 0;
+
+        var created = SceneInstantiationHelpers.RetryCreate(() =>
+            {
+                ++callCount;
+                return (object?)null;
+            },
+            "test scene", attempts: 2, reportFailure: _ => { });
+
+        Assert.Null(created);
+        Assert.Equal(2, callCount);
+    }
+
+    private sealed class TestSceneInstance
+    {
+    }
+}


### PR DESCRIPTION
**Brief Description of What This PR Does**

This retries scene instantiation in the editor-entry path and in other scene switches that were still doing direct `PackedScene.Instantiate()` calls.

The issue logs pointed to random broken scene instances during the microbe stage -> editor transition, which then made Thriveopedia page setup fail and left the editor partially initialized or blank. This PR adds a small retry helper, validates Thriveopedia page roots before using them, and makes the patch map page resolve its critical nodes directly instead of trusting exported NodePath state from a broken instance.

Tested on my pc:
- reproduced the reported failure path by forcing a one-shot invalid `ThriveopediaPatchMapPage` instance on the same microbe stage -> editor transition path from the issue logs
- `dotnet build Thrive.sln --no-restore`
- `dotnet test test/code_tests/ThriveTest.csproj --no-build --filter SceneInstantiationHelpersTests`
- `dotnet run --project Scripts -- check files`
- gameplay check in Godot: stage -> editor transition completed, the retry logged once, and the editor finished loading normally

Gameplay screenshots:

![Microbe stage before editor](https://raw.githubusercontent.com/RyuDanuer/Thrive/gameplay-screenshots-issue-5075-20260423/screenshots/gameplay-testing/issue-5075/5075-stage-before-editor.png)

![Editor loaded after retry](https://raw.githubusercontent.com/RyuDanuer/Thrive/gameplay-screenshots-issue-5075-20260423/screenshots/gameplay-testing/issue-5075/5075-editor-after-retry.png)

**Related Issues**

Closes #5075

**Progress Checklist**

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR)
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).
