### PR TITLE
Fixed tooltip visual position jump by being transparent initially

### DIFF
--- a/src/gui_common/tooltip/ToolTipManager.cs
+++ b/src/gui_common/tooltip/ToolTipManager.cs
@@ -18,6 +18,13 @@ public partial class ToolTipManager : CanvasLayer
     private const double AUTO_SCROLLING_DELAY = 2.0f;
     private const float AUTO_SCROLLING_SPEED = 40.0f;
 
+    /// <summary>
+    ///   How many frames (game updates) a tooltip stays transparent before it is made visible to avoid re-layout
+    ///   causing visible jumps to a tooltip that just appeared. This has to be at least 3 to remove the flicker, 2
+    ///   is too little.
+    /// </summary>
+    private const int TOOLTIP_INVISIBLE_FRAMES = 3;
+
     private static ToolTipManager? instance;
 
     /// <summary>
@@ -33,6 +40,7 @@ public partial class ToolTipManager : CanvasLayer
 #pragma warning restore CA2213
 
     private bool display;
+    private int tooltipNonTransparentDelay;
     private double displayTimer;
     private double hideTimer;
 
@@ -44,8 +52,13 @@ public partial class ToolTipManager : CanvasLayer
 
     private Vector2 lastMousePosition;
 
-    private ICustomToolTip? mainToolTip;
     private ICustomToolTip? previousToolTip;
+
+    /// <summary>
+    ///   Used to know what the last hidden tooltip is (even if it was a while ago) to know when the same tooltip is
+    ///   shown again, used to reduce flicker.
+    /// </summary>
+    private WeakReference<ICustomToolTip>? lastHiddenToolTip;
 
     private bool nodeReferencesResolved;
 
@@ -69,14 +82,14 @@ public partial class ToolTipManager : CanvasLayer
     /// </summary>
     public ICustomToolTip? MainToolTip
     {
-        get => mainToolTip;
+        get;
         set
         {
-            if (mainToolTip != value)
+            if (field != value)
                 ResetAutoScrolling();
 
-            previousToolTip = mainToolTip;
-            mainToolTip = value;
+            previousToolTip = field;
+            field = value;
         }
     }
 
@@ -478,6 +491,20 @@ public partial class ToolTipManager : CanvasLayer
 
         MainToolTip.ToolTipNode.Size = Vector2.Zero;
 
+        // Handle initial transparency to avoid visual jumps in position after the initial display.
+        // Being transparent but `Visible` allows the layout and position to settle before we make the tooltip
+        // user-visible.
+        if (tooltipNonTransparentDelay > 0 && delta > 0)
+        {
+            if (--tooltipNonTransparentDelay <= 0)
+            {
+                // The initial show made things transparent, so we are only responsible for making things visible again
+                MainToolTip.ToolTipNode.Modulate = Colors.White;
+            }
+
+            return;
+        }
+
         // Handle temporary tooltips/popup
         if (currentIsTemporary && hideTimer >= 0)
         {
@@ -529,6 +556,32 @@ public partial class ToolTipManager : CanvasLayer
         {
             case ToolTipTransitioning.Immediate:
             {
+                // When becoming visible, tooltips will flicker for one frame, so we force them transparent.
+                // This only applies on the initial display when the tooltip needs to lay out its content.
+                // The tooltip processing later will make it then visible.
+                if (visible)
+                {
+                    bool doTransparencyFix = true;
+
+                    // If we just hid this tooltip, we don't need to re-layout it, so we don't need to use the
+                    // invisible time
+                    if (lastHiddenToolTip != null && lastHiddenToolTip.TryGetTarget(out var lastHidden))
+                    {
+                        if (lastHidden == tooltip)
+                            doTransparencyFix = false;
+                    }
+
+                    if (doTransparencyFix)
+                    {
+                        tooltip.ToolTipNode.Modulate = Colors.Transparent;
+                        tooltipNonTransparentDelay = TOOLTIP_INVISIBLE_FRAMES;
+                    }
+                }
+                else
+                {
+                    lastHiddenToolTip = new WeakReference<ICustomToolTip>(tooltip);
+                }
+
                 tooltip.ToolTipNode.Visible = visible;
                 break;
             }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Make initial tooltips transparent and only after a few frames become non-transparent. This fixes tooltips being visually in the wrong place for one frame when becoming visible. Also added flicker-fix for when the same tooltip is rapidly hidden and shown which would otherwise get worse due to the invisible frames.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
fixes #5894
closes #6901

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
