### PR TITLE
Fixed regression in symmetry mode in macroscopic

### DIFF
--- a/src/macroscopic_stage/IMetaballDisplayer.cs
+++ b/src/macroscopic_stage/IMetaballDisplayer.cs
@@ -8,6 +8,17 @@ public interface IMetaballDisplayer<TMetaball>
     /// </summary>
     public float? OverrideColourAlpha { get; set; }
 
+    /// <summary>
+    ///   If set to false, this will not draw / update hierarchy lines (but any already drawn lines might still be
+    ///   visible, so this should be set to false before drawing anything for the first time)
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     Not supported by all display types, in which case they do nothing if this is set to true.
+    ///   </para>
+    /// </remarks>
+    public bool DisplayHierarchyLines { get; set; }
+
     public bool Visible { get; set; }
 
     public void DisplayFromLayout(IReadOnlyCollection<TMetaball> layout);

--- a/src/macroscopic_stage/MacroscopicConvolutionDisplayer.cs
+++ b/src/macroscopic_stage/MacroscopicConvolutionDisplayer.cs
@@ -30,6 +30,11 @@ public partial class MacroscopicConvolutionDisplayer : MeshInstance3D, IMetaball
         }
     }
 
+    /// <summary>
+    ///   Note: not supported (doesn't do anything)
+    /// </summary>
+    public bool DisplayHierarchyLines { get; set; }
+
     public override void _Ready()
     {
         base._Ready();

--- a/src/macroscopic_stage/MacroscopicMetaballDisplayer.cs
+++ b/src/macroscopic_stage/MacroscopicMetaballDisplayer.cs
@@ -34,6 +34,8 @@ public partial class MacroscopicMetaballDisplayer : MultiMeshInstance3D, IMetaba
         }
     }
 
+    public bool DisplayHierarchyLines { get; set; } = true;
+
     public override void _Ready()
     {
         base._Ready();
@@ -131,7 +133,8 @@ public partial class MacroscopicMetaballDisplayer : MultiMeshInstance3D, IMetaba
             ++i;
         }
 
-        hierarchyLineScene.UpdateLines(layout);
+        if (DisplayHierarchyLines)
+            hierarchyLineScene.UpdateLines(layout);
 
         CustomAabb = new Aabb(-extends, extends * 2);
     }

--- a/src/macroscopic_stage/editor/MetaballEditorComponentBase.cs
+++ b/src/macroscopic_stage/editor/MetaballEditorComponentBase.cs
@@ -606,6 +606,9 @@ public partial class MetaballEditorComponentBase<TEditor, TCombinedAction, TActi
         structuralMetaballDisplayer = CreateStructuralMetaballDisplayer();
         hoverMetaballDisplayer = CreateStructuralMetaballDisplayer();
         hoverMetaballDisplayer.OverrideColourAlpha = DefaultHoverAlpha;
+
+        // The hierarchy data doesn't exist, so doesn't make sense to try to update the lines really for them
+        hoverMetaballDisplayer.DisplayHierarchyLines = false;
     }
 
     protected virtual void LoadScenes()


### PR DESCRIPTION
which triggered an error in the structure line display for the hover metaballs

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/464846402732687391/465937305849298956/1498031196175597729

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
