### PR TITLE
Reset multicellular growth status when lead cell is engulfed

### DIFF
--- a/src/microbe_stage/MicrobeWorldSimulation.generated.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.generated.cs
@@ -22,143 +22,155 @@ public partial class MicrobeWorldSimulation
                 try
                 {
                     // Timeslot 1 on thread 2
-                    irradiationSystem.BeforeUpdate(delta);
-                    irradiationSystem.Update(delta);
-                    irradiationSystem.AfterUpdate(delta);
-                    strainSystem.BeforeUpdate(delta);
-                    strainSystem.Update(delta);
-                    strainSystem.AfterUpdate(delta);
+                    countLimitedDespawnSystem.BeforeUpdate(delta);
+                    countLimitedDespawnSystem.Update(delta);
+                    countLimitedDespawnSystem.AfterUpdate(delta);
+                    entitySignalingSystem.BeforeUpdate(delta);
+                    entitySignalingSystem.Update(delta);
+                    entitySignalingSystem.AfterUpdate(delta);
+                    damageCooldownSystem.BeforeUpdate(delta);
+                    damageCooldownSystem.Update(delta);
+                    damageCooldownSystem.AfterUpdate(delta);
                     MicrobeTerrainSystem.BeforeUpdate(delta);
                     MicrobeTerrainSystem.Update(delta);
                     MicrobeTerrainSystem.AfterUpdate(delta);
-                    endosymbiontOrganelleSystem.BeforeUpdate(delta);
-                    endosymbiontOrganelleSystem.Update(delta);
-                    endosymbiontOrganelleSystem.AfterUpdate(delta);
-                    microbeDivisionClippingSystem.BeforeUpdate(delta);
-                    microbeDivisionClippingSystem.Update(delta);
-                    microbeDivisionClippingSystem.AfterUpdate(delta);
-                    colonyCompoundDistributionSystem.BeforeUpdate(delta);
-                    colonyCompoundDistributionSystem.Update(delta);
-                    colonyCompoundDistributionSystem.AfterUpdate(delta);
-                    barrier1.SignalAndWait();
                     barrier1.SignalAndWait();
 
-                    // Timeslot 3 on thread 2
-                    spatialAnimationSystem.BeforeUpdate(delta);
-                    spatialAnimationSystem.Update(delta);
-                    spatialAnimationSystem.AfterUpdate(delta);
-                    barrier1.SignalAndWait();
-
-                    // Timeslot 4 on thread 2
+                    // Timeslot 2 on thread 2
                     microbePhysicsCreationAndSizeSystem.BeforeUpdate(delta);
                     microbePhysicsCreationAndSizeSystem.Update(delta);
                     microbePhysicsCreationAndSizeSystem.AfterUpdate(delta);
+                    microbeDivisionClippingSystem.BeforeUpdate(delta);
+                    microbeDivisionClippingSystem.Update(delta);
+                    microbeDivisionClippingSystem.AfterUpdate(delta);
+                    irradiationSystem.BeforeUpdate(delta);
+                    irradiationSystem.Update(delta);
+                    irradiationSystem.AfterUpdate(delta);
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 3 on thread 2
+                    simpleShapeCreatorSystem.BeforeUpdate(delta);
+                    simpleShapeCreatorSystem.Update(delta);
+                    simpleShapeCreatorSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
                     barrier1.SignalAndWait();
 
-                    // Timeslot 6 on thread 2
+                    // Timeslot 5 on thread 2
+                    physicsUpdateAndPositionSystem.BeforeUpdate(delta);
+                    physicsUpdateAndPositionSystem.Update(delta);
+                    physicsUpdateAndPositionSystem.AfterUpdate(delta);
+                    barrier1.SignalAndWait();
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 7 on thread 2
+                    disallowPlayerBodySleepSystem.BeforeUpdate(delta);
+                    disallowPlayerBodySleepSystem.Update(delta);
+                    disallowPlayerBodySleepSystem.AfterUpdate(delta);
                     physicsCollisionManagementSystem.BeforeUpdate(delta);
                     physicsCollisionManagementSystem.Update(delta);
                     physicsCollisionManagementSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
 
-                    // Timeslot 7 on thread 2
+                    // Timeslot 8 on thread 2
                     toxinCollisionSystem.BeforeUpdate(delta);
                     toxinCollisionSystem.Update(delta);
                     toxinCollisionSystem.AfterUpdate(delta);
+                    pilusDamageSystem.BeforeUpdate(delta);
+                    pilusDamageSystem.Update(delta);
+                    pilusDamageSystem.AfterUpdate(delta);
                     microbeCollisionSoundSystem.BeforeUpdate(delta);
                     microbeCollisionSoundSystem.Update(delta);
                     microbeCollisionSoundSystem.AfterUpdate(delta);
                     damageOnTouchSystem.BeforeUpdate(delta);
                     damageOnTouchSystem.Update(delta);
                     damageOnTouchSystem.AfterUpdate(delta);
-                    pilusDamageSystem.BeforeUpdate(delta);
-                    pilusDamageSystem.Update(delta);
-                    pilusDamageSystem.AfterUpdate(delta);
-                    physicsUpdateAndPositionSystem.BeforeUpdate(delta);
-                    physicsUpdateAndPositionSystem.Update(delta);
-                    physicsUpdateAndPositionSystem.AfterUpdate(delta);
-                    attachedEntityPositionSystem.BeforeUpdate(delta);
-                    attachedEntityPositionSystem.Update(delta);
-                    attachedEntityPositionSystem.AfterUpdate(delta);
-                    barrier1.SignalAndWait();
-
-                    // Timeslot 8 on thread 2
                     microbeTemporaryEffectsSystem.BeforeUpdate(delta);
                     microbeTemporaryEffectsSystem.Update(delta);
                     microbeTemporaryEffectsSystem.AfterUpdate(delta);
-                    multicellularGrowthSystem.BeforeUpdate(delta);
-                    multicellularGrowthSystem.Update(delta);
-                    multicellularGrowthSystem.AfterUpdate(delta);
-                    osmoregulationAndHealingSystem.BeforeUpdate(delta);
-                    osmoregulationAndHealingSystem.Update(delta);
-                    osmoregulationAndHealingSystem.AfterUpdate(delta);
-                    radiationDamageSystem.BeforeUpdate(delta);
-                    radiationDamageSystem.Update(delta);
-                    radiationDamageSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
                     barrier1.SignalAndWait();
 
                     // Timeslot 10 on thread 2
+                    engulfedDigestionSystem.BeforeUpdate(delta);
+                    engulfedDigestionSystem.Update(delta);
+                    engulfedDigestionSystem.AfterUpdate(delta);
+                    allCompoundsVentingSystem.BeforeUpdate(delta);
+                    allCompoundsVentingSystem.Update(delta);
+                    allCompoundsVentingSystem.AfterUpdate(delta);
+                    siderophoreSystem.BeforeUpdate(delta);
+                    siderophoreSystem.Update(delta);
+                    siderophoreSystem.AfterUpdate(delta);
+                    attachedEntityPositionSystem.BeforeUpdate(delta);
+                    attachedEntityPositionSystem.Update(delta);
+                    attachedEntityPositionSystem.AfterUpdate(delta);
+                    osmoregulationAndHealingSystem.BeforeUpdate(delta);
+                    osmoregulationAndHealingSystem.Update(delta);
+                    osmoregulationAndHealingSystem.AfterUpdate(delta);
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 11 on thread 2
+                    SpawnSystem.BeforeUpdate(delta);
+                    SpawnSystem.Update(delta);
+                    SpawnSystem.AfterUpdate(delta);
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 12 on thread 2
+                    engulfedHandlingSystem.BeforeUpdate(delta);
+                    engulfedHandlingSystem.Update(delta);
+                    engulfedHandlingSystem.AfterUpdate(delta);
+                    radiationDamageSystem.BeforeUpdate(delta);
+                    radiationDamageSystem.Update(delta);
+                    radiationDamageSystem.AfterUpdate(delta);
+                    multicellularGrowthSystem.BeforeUpdate(delta);
+                    multicellularGrowthSystem.Update(delta);
+                    multicellularGrowthSystem.AfterUpdate(delta);
                     organelleComponentFetchSystem.BeforeUpdate(delta);
                     organelleComponentFetchSystem.Update(delta);
                     organelleComponentFetchSystem.AfterUpdate(delta);
+                    colonyStatsUpdateSystem.BeforeUpdate(delta);
+                    colonyStatsUpdateSystem.Update(delta);
+                    colonyStatsUpdateSystem.AfterUpdate(delta);
                     slimeSlowdownSystem.BeforeUpdate(delta);
                     slimeSlowdownSystem.Update(delta);
                     slimeSlowdownSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
                     barrier1.SignalAndWait();
 
-                    // Timeslot 12 on thread 2
+                    // Timeslot 14 on thread 2
                     microbeEmissionSystem.BeforeUpdate(delta);
                     microbeEmissionSystem.Update(delta);
                     microbeEmissionSystem.AfterUpdate(delta);
-                    engulfedDigestionSystem.BeforeUpdate(delta);
-                    engulfedDigestionSystem.Update(delta);
-                    engulfedDigestionSystem.AfterUpdate(delta);
-                    siderophoreSystem.BeforeUpdate(delta);
-                    siderophoreSystem.Update(delta);
-                    siderophoreSystem.AfterUpdate(delta);
-                    allCompoundsVentingSystem.BeforeUpdate(delta);
-                    allCompoundsVentingSystem.Update(delta);
-                    allCompoundsVentingSystem.AfterUpdate(delta);
-                    barrier1.SignalAndWait();
-                    barrier1.SignalAndWait();
-
-                    // Timeslot 14 on thread 2
-                    colonyStatsUpdateSystem.BeforeUpdate(delta);
-                    colonyStatsUpdateSystem.Update(delta);
-                    colonyStatsUpdateSystem.AfterUpdate(delta);
-                    microbeMovementSoundSystem.BeforeUpdate(delta);
-                    microbeMovementSoundSystem.Update(delta);
-                    microbeMovementSoundSystem.AfterUpdate(delta);
-                    barrier1.SignalAndWait();
-
-                    // Timeslot 15 on thread 2
                     microbeDeathSystem.BeforeUpdate(delta);
                     microbeDeathSystem.Update(delta);
                     microbeDeathSystem.AfterUpdate(delta);
-                    physicsBodyControlSystem.BeforeUpdate(delta);
-                    physicsBodyControlSystem.Update(delta);
-                    physicsBodyControlSystem.AfterUpdate(delta);
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 15 on thread 2
                     colonyBindingSystem.BeforeUpdate(delta);
                     colonyBindingSystem.Update(delta);
                     colonyBindingSystem.AfterUpdate(delta);
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 16 on thread 2
+                    microbeMovementSoundSystem.BeforeUpdate(delta);
+                    microbeMovementSoundSystem.Update(delta);
+                    microbeMovementSoundSystem.AfterUpdate(delta);
                     microbeFlashingSystem.BeforeUpdate(delta);
                     microbeFlashingSystem.Update(delta);
                     microbeFlashingSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
 
-                    // Timeslot 16 on thread 2
+                    // Timeslot 17 on thread 2
                     microbeEventCallbackSystem.BeforeUpdate(delta);
                     microbeEventCallbackSystem.Update(delta);
                     microbeEventCallbackSystem.AfterUpdate(delta);
-                    damageSoundSystem.BeforeUpdate(delta);
-                    damageSoundSystem.Update(delta);
-                    damageSoundSystem.AfterUpdate(delta);
+                    physicsBodyControlSystem.BeforeUpdate(delta);
+                    physicsBodyControlSystem.Update(delta);
+                    physicsBodyControlSystem.AfterUpdate(delta);
+                    barrier1.SignalAndWait();
                     barrier1.SignalAndWait();
 
-                    // Timeslot 17 on thread 2
+                    // Timeslot 19 on thread 2
                     delayedColonyOperationSystem.BeforeUpdate(delta);
                     delayedColonyOperationSystem.Update(delta);
                     delayedColonyOperationSystem.AfterUpdate(delta);
@@ -187,33 +199,30 @@ public partial class MicrobeWorldSimulation
             collisionShapeLoaderSystem.BeforeUpdate(delta);
             collisionShapeLoaderSystem.Update(delta);
             collisionShapeLoaderSystem.AfterUpdate(delta);
+            spatialAnimationSystem.BeforeUpdate(delta);
+            spatialAnimationSystem.Update(delta);
+            spatialAnimationSystem.AfterUpdate(delta);
+            colonyCompoundDistributionSystem.BeforeUpdate(delta);
+            colonyCompoundDistributionSystem.Update(delta);
+            colonyCompoundDistributionSystem.AfterUpdate(delta);
+            endosymbiontOrganelleSystem.BeforeUpdate(delta);
+            endosymbiontOrganelleSystem.Update(delta);
+            endosymbiontOrganelleSystem.AfterUpdate(delta);
+            microbeVisualsSystem.BeforeUpdate(delta);
+            microbeVisualsSystem.Update(delta);
+            microbeVisualsSystem.AfterUpdate(delta);
+            barrier1.SignalAndWait();
+
+            // Timeslot 2 on thread 1
             pathBasedSceneLoader.BeforeUpdate(delta);
             pathBasedSceneLoader.Update(delta);
             pathBasedSceneLoader.AfterUpdate(delta);
             predefinedVisualLoaderSystem.BeforeUpdate(delta);
             predefinedVisualLoaderSystem.Update(delta);
             predefinedVisualLoaderSystem.AfterUpdate(delta);
-            animationControlSystem.BeforeUpdate(delta);
-            animationControlSystem.Update(delta);
-            animationControlSystem.AfterUpdate(delta);
-            countLimitedDespawnSystem.BeforeUpdate(delta);
-            countLimitedDespawnSystem.Update(delta);
-            countLimitedDespawnSystem.AfterUpdate(delta);
-            simpleShapeCreatorSystem.BeforeUpdate(delta);
-            simpleShapeCreatorSystem.Update(delta);
-            simpleShapeCreatorSystem.AfterUpdate(delta);
-            damageCooldownSystem.BeforeUpdate(delta);
-            damageCooldownSystem.Update(delta);
-            damageCooldownSystem.AfterUpdate(delta);
-            entitySignalingSystem.BeforeUpdate(delta);
-            entitySignalingSystem.Update(delta);
-            entitySignalingSystem.AfterUpdate(delta);
-            barrier1.SignalAndWait();
-
-            // Timeslot 2 on thread 1
-            microbeVisualsSystem.BeforeUpdate(delta);
-            microbeVisualsSystem.Update(delta);
-            microbeVisualsSystem.AfterUpdate(delta);
+            strainSystem.BeforeUpdate(delta);
+            strainSystem.Update(delta);
+            strainSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 3 on thread 1
@@ -223,75 +232,87 @@ public partial class MicrobeWorldSimulation
             barrier1.SignalAndWait();
 
             // Timeslot 4 on thread 1
-            entityMaterialFetchSystem.BeforeUpdate(delta);
-            entityMaterialFetchSystem.Update(delta);
-            entityMaterialFetchSystem.AfterUpdate(delta);
-            barrier1.SignalAndWait();
-
-            // Timeslot 5 on thread 1
             physicsBodyCreationSystem.BeforeUpdate(delta);
             physicsBodyCreationSystem.Update(delta);
             physicsBodyCreationSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
-            // Timeslot 6 on thread 1
-            microbeHeatAccumulationSystem.BeforeUpdate(delta);
-            microbeHeatAccumulationSystem.Update(delta);
-            microbeHeatAccumulationSystem.AfterUpdate(delta);
+            // Timeslot 5 on thread 1
             mucocystSystem.BeforeUpdate(delta);
             mucocystSystem.Update(delta);
             mucocystSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
+            // Timeslot 6 on thread 1
+            physicsBodyDisablingSystem.BeforeUpdate(delta);
+            physicsBodyDisablingSystem.Update(delta);
+            physicsBodyDisablingSystem.AfterUpdate(delta);
+            barrier1.SignalAndWait();
+
             // Timeslot 7 on thread 1
+            microbeHeatAccumulationSystem.BeforeUpdate(delta);
+            microbeHeatAccumulationSystem.Update(delta);
+            microbeHeatAccumulationSystem.AfterUpdate(delta);
             ProcessSystem.BeforeUpdate(delta);
             ProcessSystem.Update(delta);
             ProcessSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 8 on thread 1
-            physicsBodyDisablingSystem.BeforeUpdate(delta);
-            physicsBodyDisablingSystem.Update(delta);
-            physicsBodyDisablingSystem.AfterUpdate(delta);
-            soundListenerSystem.BeforeUpdate(delta);
-            soundListenerSystem.Update(delta);
-            soundListenerSystem.AfterUpdate(delta);
-            cellBurstEffectSystem.BeforeUpdate(delta);
-            cellBurstEffectSystem.Update(delta);
-            cellBurstEffectSystem.AfterUpdate(delta);
-            intercellularMatrixSystem.BeforeUpdate(delta);
-            intercellularMatrixSystem.Update(delta);
-            intercellularMatrixSystem.AfterUpdate(delta);
-            disallowPlayerBodySleepSystem.BeforeUpdate(delta);
-            disallowPlayerBodySleepSystem.Update(delta);
-            disallowPlayerBodySleepSystem.AfterUpdate(delta);
-            CameraFollowSystem.BeforeUpdate(delta);
-            CameraFollowSystem.Update(delta);
-            CameraFollowSystem.AfterUpdate(delta);
-            TimedLifeSystem.BeforeUpdate(delta);
-            TimedLifeSystem.Update(delta);
-            TimedLifeSystem.AfterUpdate(delta);
-            FluidCurrentsSystem.BeforeUpdate(delta);
-            FluidCurrentsSystem.Update(delta);
-            FluidCurrentsSystem.AfterUpdate(delta);
+            unneededCompoundVentingSystem.BeforeUpdate(delta);
+            unneededCompoundVentingSystem.Update(delta);
+            unneededCompoundVentingSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 9 on thread 1
             engulfingSystem.BeforeUpdate(delta);
             engulfingSystem.Update(delta);
             engulfingSystem.AfterUpdate(delta);
+            barrier1.SignalAndWait();
+
+            // Timeslot 10 on thread 1
+            animationControlSystem.BeforeUpdate(delta);
+            animationControlSystem.Update(delta);
+            animationControlSystem.AfterUpdate(delta);
+            entityMaterialFetchSystem.BeforeUpdate(delta);
+            entityMaterialFetchSystem.Update(delta);
+            entityMaterialFetchSystem.AfterUpdate(delta);
+            spatialAttachSystem.BeforeUpdate(delta);
+            spatialAttachSystem.Update(delta);
+            spatialAttachSystem.AfterUpdate(delta);
+            cellBurstEffectSystem.BeforeUpdate(delta);
+            cellBurstEffectSystem.Update(delta);
+            cellBurstEffectSystem.AfterUpdate(delta);
+            microbeRenderPrioritySystem.BeforeUpdate(delta);
+            microbeRenderPrioritySystem.Update(delta);
+            microbeRenderPrioritySystem.AfterUpdate(delta);
+            intercellularMatrixSystem.BeforeUpdate(delta);
+            intercellularMatrixSystem.Update(delta);
+            intercellularMatrixSystem.AfterUpdate(delta);
+            TimedLifeSystem.BeforeUpdate(delta);
+            TimedLifeSystem.Update(delta);
+            TimedLifeSystem.AfterUpdate(delta);
+            barrier1.SignalAndWait();
+
+            // Timeslot 11 on thread 1
             microbeReproductionSystem.BeforeUpdate(delta);
             microbeReproductionSystem.Update(delta);
             microbeReproductionSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
-            // Timeslot 10 on thread 1
-            unneededCompoundVentingSystem.BeforeUpdate(delta);
-            unneededCompoundVentingSystem.Update(delta);
-            unneededCompoundVentingSystem.AfterUpdate(delta);
+            // Timeslot 12 on thread 1
+            soundListenerSystem.BeforeUpdate(delta);
+            soundListenerSystem.Update(delta);
+            soundListenerSystem.AfterUpdate(delta);
+            CameraFollowSystem.BeforeUpdate(delta);
+            CameraFollowSystem.Update(delta);
+            CameraFollowSystem.AfterUpdate(delta);
+            FluidCurrentsSystem.BeforeUpdate(delta);
+            FluidCurrentsSystem.Update(delta);
+            FluidCurrentsSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
-            // Timeslot 11 on thread 1
+            // Timeslot 13 on thread 1
             if (RunAI)
             {
                 microbeAI.BeforeUpdate(delta);
@@ -302,52 +323,43 @@ public partial class MicrobeWorldSimulation
 
             barrier1.SignalAndWait();
 
-            // Timeslot 12 on thread 1
-            spatialAttachSystem.BeforeUpdate(delta);
-            spatialAttachSystem.Update(delta);
-            spatialAttachSystem.AfterUpdate(delta);
-            barrier1.SignalAndWait();
-
-            // Timeslot 13 on thread 1
-            engulfedHandlingSystem.BeforeUpdate(delta);
-            engulfedHandlingSystem.Update(delta);
-            engulfedHandlingSystem.AfterUpdate(delta);
-            microbeMovementSystem.BeforeUpdate(delta);
-            microbeMovementSystem.Update(delta);
-            microbeMovementSystem.AfterUpdate(delta);
-            SpawnSystem.BeforeUpdate(delta);
-            SpawnSystem.Update(delta);
-            SpawnSystem.AfterUpdate(delta);
-            barrier1.SignalAndWait();
-
             // Timeslot 14 on thread 1
-            organelleTickSystem.BeforeUpdate(delta);
-            organelleTickSystem.Update(delta);
-            organelleTickSystem.AfterUpdate(delta);
-            barrier1.SignalAndWait();
-
-            // Timeslot 15 on thread 1
-            entityLightSystem.BeforeUpdate(delta);
-            entityLightSystem.Update(delta);
-            entityLightSystem.AfterUpdate(delta);
             spatialPositionSystem.BeforeUpdate(delta);
             spatialPositionSystem.Update(delta);
             spatialPositionSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
+            // Timeslot 15 on thread 1
+            microbeMovementSystem.BeforeUpdate(delta);
+            microbeMovementSystem.Update(delta);
+            microbeMovementSystem.AfterUpdate(delta);
+            barrier1.SignalAndWait();
+
             // Timeslot 16 on thread 1
+            organelleTickSystem.BeforeUpdate(delta);
+            organelleTickSystem.Update(delta);
+            organelleTickSystem.AfterUpdate(delta);
+            barrier1.SignalAndWait();
+
+            // Timeslot 17 on thread 1
+            entityLightSystem.BeforeUpdate(delta);
+            entityLightSystem.Update(delta);
+            entityLightSystem.AfterUpdate(delta);
+            barrier1.SignalAndWait();
+
+            // Timeslot 18 on thread 1
             fadeOutActionSystem.BeforeUpdate(delta);
             fadeOutActionSystem.Update(delta);
             fadeOutActionSystem.AfterUpdate(delta);
             physicsSensorSystem.BeforeUpdate(delta);
             physicsSensorSystem.Update(delta);
             physicsSensorSystem.AfterUpdate(delta);
-            microbeRenderPrioritySystem.BeforeUpdate(delta);
-            microbeRenderPrioritySystem.Update(delta);
-            microbeRenderPrioritySystem.AfterUpdate(delta);
+            damageSoundSystem.BeforeUpdate(delta);
+            damageSoundSystem.Update(delta);
+            damageSoundSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
-            // Timeslot 17 on thread 1
+            // Timeslot 19 on thread 1
             soundEffectSystem.BeforeUpdate(delta);
             soundEffectSystem.Update(delta);
             soundEffectSystem.AfterUpdate(delta);
@@ -423,12 +435,12 @@ public partial class MicrobeWorldSimulation
             physicsBodyDisablingSystem.BeforeUpdate(delta);
             physicsBodyDisablingSystem.Update(delta);
             physicsBodyDisablingSystem.AfterUpdate(delta);
-            microbeHeatAccumulationSystem.BeforeUpdate(delta);
-            microbeHeatAccumulationSystem.Update(delta);
-            microbeHeatAccumulationSystem.AfterUpdate(delta);
             colonyCompoundDistributionSystem.BeforeUpdate(delta);
             colonyCompoundDistributionSystem.Update(delta);
             colonyCompoundDistributionSystem.AfterUpdate(delta);
+            microbeHeatAccumulationSystem.BeforeUpdate(delta);
+            microbeHeatAccumulationSystem.Update(delta);
+            microbeHeatAccumulationSystem.AfterUpdate(delta);
             mucocystSystem.BeforeUpdate(delta);
             mucocystSystem.Update(delta);
             mucocystSystem.AfterUpdate(delta);

--- a/src/microbe_stage/components/Engulfable.cs
+++ b/src/microbe_stage/components/Engulfable.cs
@@ -350,7 +350,7 @@ public static class EngulfableHelpers
     }
 
     /// <summary>
-    ///   Called when an entity is thrown out from the engulfer, for example due to being indigestible or if the
+    ///   Called when an entity is thrown out from the engulfer, for example, due to being indigestible or if the
     ///   attacker dies
     /// </summary>
     /// <remarks>
@@ -505,6 +505,14 @@ public static class EngulfableHelpers
         {
             ref var callbacks = ref entity.Get<MicrobeEventCallbacks>();
             callbacks.OnEjectedFromHostileEngulfer?.Invoke(entity);
+        }
+
+        // If a multicellular lead cell was engulfed and then ejected, it has lost all colony members and thus all
+        // growth progress
+        if (entity.Has<MulticellularGrowth>())
+        {
+            ref var growth = ref entity.Get<MulticellularGrowth>();
+            growth.OnLeadCellEjectedFromEngulfment();
         }
     }
 

--- a/src/microbe_stage/systems/EngulfedHandlingSystem.cs
+++ b/src/microbe_stage/systems/EngulfedHandlingSystem.cs
@@ -18,6 +18,7 @@ using World = Arch.Core.World;
 [WritesToComponent(typeof(SpatialInstance))]
 [WritesToComponent(typeof(CompoundStorage))]
 [WritesToComponent(typeof(CellProperties))]
+[WritesToComponent(typeof(MulticellularGrowth))]
 [ReadsComponent(typeof(OrganelleContainer))]
 [ReadsComponent(typeof(WorldPosition))]
 [RunsAfter(typeof(EngulfingSystem))]

--- a/src/microbe_stage/systems/EngulfingSystem.cs
+++ b/src/microbe_stage/systems/EngulfingSystem.cs
@@ -38,6 +38,7 @@ using World = Arch.Core.World;
 [WritesToComponent(typeof(DamageCooldown))]
 [WritesToComponent(typeof(TimedLife))]
 [WritesToComponent(typeof(StrainAffected))]
+[WritesToComponent(typeof(MulticellularGrowth))]
 [ReadsComponent(typeof(CollisionManagement))]
 [ReadsComponent(typeof(MicrobePhysicsExtraData))]
 [ReadsComponent(typeof(OrganelleContainer))]
@@ -49,6 +50,7 @@ using World = Arch.Core.World;
 [RunsAfter(typeof(PilusDamageSystem))]
 [RunsAfter(typeof(MicrobeVisualsSystem))]
 [RunsBefore(typeof(SpatialAttachSystem))]
+[RunsBefore(typeof(MulticellularGrowthSystem))]
 [RuntimeCost(10)]
 [RunsOnMainThread]
 public partial class EngulfingSystem : BaseSystem<World, float>

--- a/src/multicellular_stage/components/MulticellularGrowth.cs
+++ b/src/multicellular_stage/components/MulticellularGrowth.cs
@@ -170,16 +170,7 @@ public static class MulticellularGrowthHelpers
         in Entity entity, IWorldSimulation worldSimulation)
     {
         // Clear variables
-
-        // The first cell is the last to duplicate (budding reproduction) so the body plan starts filling at index 1
-        // Note that this is also set in the struct constructor
-        multicellularGrowth.NextBodyPlanCellToGrowIndex = 1;
-        multicellularGrowth.EnoughResourcesForBudding = false;
-
-        multicellularGrowth.CompoundsNeededForNextCell = null;
-        multicellularGrowth.CompoundsUsedForMulticellularGrowth = null;
-
-        multicellularGrowth.TotalNeededForMulticellularGrowth = null;
+        multicellularGrowth.OnLeadCellEjectedFromEngulfment();
 
         // Delete the cells in our colony currently
         if (entity.Has<MicrobeColony>())
@@ -199,6 +190,23 @@ public static class MulticellularGrowthHelpers
             recorder.Remove<MicrobeColony>(entity);
             worldSimulation.FinishRecordingEntityCommands(recorder);
         }
+    }
+
+    /// <summary>
+    ///   Resets all growth progress tracking after exiting engulfment (which disbanded the entire colony) to grow the
+    ///   usual body plan as needed.
+    /// </summary>
+    public static void OnLeadCellEjectedFromEngulfment(this ref MulticellularGrowth multicellularGrowth)
+    {
+        // The first cell is the last to duplicate (budding reproduction), so the body plan starts filling at index 1
+        // Note that this is also set in the struct constructor
+        multicellularGrowth.NextBodyPlanCellToGrowIndex = 1;
+        multicellularGrowth.EnoughResourcesForBudding = false;
+
+        multicellularGrowth.CompoundsNeededForNextCell = null;
+        multicellularGrowth.CompoundsUsedForMulticellularGrowth = null;
+
+        multicellularGrowth.TotalNeededForMulticellularGrowth = null;
     }
 
     public static void OnMulticellularColonyCellLost(this ref MulticellularGrowth multicellularGrowth,


### PR DESCRIPTION
**Brief Description of What This PR Does**

so that on expel the growth resumes from the beginning as the cell has totally lost the entire microbe colony

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/464846402732687391/465937305849298956/1497596626020204788

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
