### PR TITLE
Fix multicellular editor move

### DIFF
--- a/src/general/IndividualHexLayout.cs
+++ b/src/general/IndividualHexLayout.cs
@@ -81,7 +81,7 @@ public class IndividualHexLayout<TData> : HexLayout<HexWithData<TData>>, IReadOn
 
     public bool CanPlace(Hex position)
     {
-        for (int i = 0; i < Count; i++)
+        for (int i = 0; i < Count; ++i)
         {
             if (this[i].Position == position)
                 return false;

--- a/src/general/IndividualHexLayout.cs
+++ b/src/general/IndividualHexLayout.cs
@@ -74,6 +74,27 @@ public class IndividualHexLayout<TData> : HexLayout<HexWithData<TData>>, IReadOn
         return ((HexLayout<HexWithData<TData>>)this).GetByExactElementRootPosition(location);
     }
 
+    public override bool CanPlace(HexWithData<TData> hex, List<Hex> temporaryStorage, List<Hex> temporaryStorage2)
+    {
+        return CanPlace(hex.Position);
+    }
+
+    public bool CanPlace(Hex position)
+    {
+        for (int i = 0; i < Count; i++)
+        {
+            if (this[i].Position == position)
+                return false;
+        }
+
+        return true;
+    }
+
+    public override bool CanPlaceAllocating(HexWithData<TData> hex)
+    {
+        return CanPlace(hex.Position);
+    }
+
     protected override void GetHexComponentPositions(HexWithData<TData> hex, List<Hex> result)
     {
         result.Clear();

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -791,7 +791,7 @@ public partial class CellBodyPlanEditorComponent :
 
     protected override bool IsMoveTargetValid(Hex position, int rotation, HexWithData<CellTemplate> cell)
     {
-        return editedMicrobeCells.CanPlace(cell, hexTemporaryMemory, hexTemporaryMemory2);
+        return editedMicrobeCells.CanPlace(position);
     }
 
     protected override void OnCurrentActionCanceled()


### PR DESCRIPTION
**Brief Description of What This PR Does**

The hex movement check checked the original position's availability no matter the actual movement target. Because of this, it was possible to move a cell to an occupied hex, which immediately threw an exception.

This PR fixes this by adding a `CanPlace` method that checks if the position itself is available. This eliminates the need to allocate memory for hex layout operation, which means that `IndividualHexLayout` can be refactored further in future to remove allocations that are still done (by allocations here I mean passing these temporary hex lists).

**Related Issues**

It was possible to move a cell to an occupied hex, which immediately threw an exception.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
