### PR TITLE
Split auto-evo mutation generation into substeps

### DIFF
--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -22,8 +22,6 @@ public class AutoEvoRun
     /// </summary>
     private readonly RunResults results = new();
 
-    private readonly object totalStepsLock = new();
-
     /// <summary>
     ///   Generated steps are stored here until they are executed
     /// </summary>
@@ -670,12 +668,16 @@ public class AutoEvoRun
     private void UpdateTotalStepsEstimate()
     {
         var estimate = CompleteSteps + runSteps.Sum(s => s.TotalSteps) + 1;
+        int current;
 
-        lock (totalStepsLock)
+        do
         {
-            if (estimate > totalSteps)
-                totalSteps = estimate;
+            current = totalSteps;
+
+            if (estimate <= current)
+                return;
         }
+        while (Interlocked.CompareExchange(ref totalSteps, estimate, current) != current);
     }
 
     private void UpdateMap(bool playerCantGoExtinct)

--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -39,7 +39,7 @@ public class AutoEvoRun
     /// <summary>
     ///   -1 means not yet computed
     /// </summary>
-    private volatile int totalSteps = -1;
+    private int totalSteps = -1;
 
     private int completeSteps;
 
@@ -573,10 +573,8 @@ public class AutoEvoRun
             {
                 GatherInfo(runSteps);
 
-                // +2 is for this step and the result apply step
-                totalSteps = runSteps.Sum(s => s.TotalSteps) + 2;
-
                 Interlocked.Increment(ref completeSteps);
+                UpdateTotalStepsEstimate();
                 state = RunStage.Stepping;
                 return false;
             }
@@ -625,6 +623,8 @@ public class AutoEvoRun
                     }
                 }
 
+                UpdateTotalStepsEstimate();
+
                 return false;
             }
 
@@ -663,6 +663,11 @@ public class AutoEvoRun
 
         // Doing the steps counting this way is slightly faster than an increment after each step
         Interlocked.Add(ref completeSteps, steps);
+    }
+
+    private void UpdateTotalStepsEstimate()
+    {
+        Volatile.Write(ref totalSteps, CompleteSteps + runSteps.Sum(s => s.TotalSteps) + 1);
     }
 
     private void UpdateMap(bool playerCantGoExtinct)

--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -22,6 +22,8 @@ public class AutoEvoRun
     /// </summary>
     private readonly RunResults results = new();
 
+    private readonly object totalStepsLock = new();
+
     /// <summary>
     ///   Generated steps are stored here until they are executed
     /// </summary>
@@ -39,7 +41,7 @@ public class AutoEvoRun
     /// <summary>
     ///   -1 means not yet computed
     /// </summary>
-    private int totalSteps = -1;
+    private volatile int totalSteps = -1;
 
     private int completeSteps;
 
@@ -667,7 +669,13 @@ public class AutoEvoRun
 
     private void UpdateTotalStepsEstimate()
     {
-        Volatile.Write(ref totalSteps, CompleteSteps + runSteps.Sum(s => s.TotalSteps) + 1);
+        var estimate = CompleteSteps + runSteps.Sum(s => s.TotalSteps) + 1;
+
+        lock (totalStepsLock)
+        {
+            if (estimate > totalSteps)
+                totalSteps = estimate;
+        }
     }
 
     private void UpdateMap(bool playerCantGoExtinct)

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -85,7 +85,7 @@ public class ModifyExistingSpecies : IRunStep
                 ++remainingPatchSpeciesToGenerate;
         }
 
-        TotalSteps = remainingPatchSpeciesToGenerate * mutationStepEstimatePerSpecies + FinalMutationPhases;
+        SetTotalStepsEstimate(remainingPatchSpeciesToGenerate * mutationStepEstimatePerSpecies + FinalMutationPhases);
         speciesEnumerator = patch.SpeciesInPatch.GetEnumerator();
     }
 
@@ -151,7 +151,7 @@ public class ModifyExistingSpecies : IRunStep
                 if (currentMutationGeneration == null && !TryStartNextMutationGeneration())
                 {
                     step = Step.MutationFilter;
-                    TotalSteps = FinalMutationPhases;
+                    SetTotalStepsEstimate(FinalMutationPhases);
                     speciesEnumerator = patch.SpeciesInPatch.GetEnumerator();
                 }
                 else
@@ -193,7 +193,7 @@ public class ModifyExistingSpecies : IRunStep
 #endif
                 }
 
-                TotalSteps = 2;
+                SetTotalStepsEstimate(2);
                 step = Step.MutationTest;
                 break;
             }
@@ -212,7 +212,7 @@ public class ModifyExistingSpecies : IRunStep
                 newOccupantsWorkMemory.Clear();
                 miche.GetOccupants(newOccupantsWorkMemory);
 
-                TotalSteps = 1;
+                SetTotalStepsEstimate(1);
                 step = Step.FinalApply;
                 break;
             }
@@ -248,7 +248,7 @@ public class ModifyExistingSpecies : IRunStep
                     }
                 }
 
-                TotalSteps = 0;
+                SetTotalStepsEstimate(0);
                 return true;
             }
 
@@ -427,9 +427,15 @@ public class ModifyExistingSpecies : IRunStep
             remainingOutOfSyncSpeciesToGenerate :
             potentialOutOfSyncSpeciesToGenerate;
 
-        TotalSteps = (currentMutationGeneration?.RemainingStepEstimate ?? 0) +
+        SetTotalStepsEstimate((currentMutationGeneration?.RemainingStepEstimate ?? 0) +
             (remainingPatchSpeciesToGenerate + remainingOutOfSyncSpecies) * mutationStepEstimatePerSpecies +
-            FinalMutationPhases;
+            FinalMutationPhases);
+    }
+
+    private void SetTotalStepsEstimate(int estimate)
+    {
+        if (estimate > TotalSteps)
+            TotalSteps = estimate;
     }
 
     private void ProcessMutationRecursionStep(MicrobeSpecies baseSpecies, Mutant baseSpeciesMutant,
@@ -557,6 +563,7 @@ public class ModifyExistingSpecies : IRunStep
         public MutationGenerationFramePhase Phase;
         public IMutationStrategy<MicrobeSpecies>[] Mutations = null!;
         public List<Mutant> OutputSpecies = null!;
+        public Mutant BaseSpeciesMutant = null!;
         public int MutationStrategyIndex;
         public int RecursionIndex;
         public int ChildIndex;
@@ -574,7 +581,6 @@ public class ModifyExistingSpecies : IRunStep
     {
         private readonly ModifyExistingSpecies owner;
         private readonly MicrobeSpecies baseSpecies;
-        private readonly Mutant baseSpeciesMutant;
         private readonly Stack<MutationGenerationFrame> frameStack = new();
 
         public SpeciesMutationGenerationState(ModifyExistingSpecies owner, MicrobeSpecies baseSpecies, Miche miche,
@@ -582,14 +588,13 @@ public class ModifyExistingSpecies : IRunStep
         {
             this.owner = owner;
             this.baseSpecies = baseSpecies;
-            baseSpeciesMutant = new Mutant(baseSpecies,
-                Constants.BASE_MUTATION_POINTS * owner.worldSettings.AIMutationMultiplier);
 
             owner.generateMutationsWorkingMemory.Clear();
             owner.pressureStack.Clear();
 
             var inputSpecies = owner.generateMutationsWorkingMemory.GetMutationsAtDepth(0);
-            inputSpecies.Add(baseSpeciesMutant);
+            inputSpecies.Add(new Mutant(baseSpecies,
+                Constants.BASE_MUTATION_POINTS * owner.worldSettings.AIMutationMultiplier));
 
             frameStack.Push(new MutationGenerationFrame(miche, 1, false));
             RemainingStepEstimate = stepEstimate;
@@ -614,6 +619,8 @@ public class ModifyExistingSpecies : IRunStep
                         owner.generateMutationsWorkingMemory.GetMutationsAtDepth(currentFrame.Depth);
                     currentFrame.OutputSpecies.Clear();
                     currentFrame.OutputSpecies.AddRange(inputSpecies);
+                    currentFrame.BaseSpeciesMutant = new Mutant(baseSpecies,
+                        Constants.BASE_MUTATION_POINTS * owner.worldSettings.AIMutationMultiplier);
 
                     owner.pressureStack.Push(currentFrame.Miche.Pressure);
                     owner.mutationSorter.Setup(baseSpecies, owner.pressureStack);
@@ -634,7 +641,7 @@ public class ModifyExistingSpecies : IRunStep
                         break;
                     }
 
-                    owner.ProcessMutationRecursionStep(baseSpecies, baseSpeciesMutant, currentFrame);
+                    owner.ProcessMutationRecursionStep(baseSpecies, currentFrame.BaseSpeciesMutant, currentFrame);
                     break;
                 }
 

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -15,6 +15,8 @@ public class ModifyExistingSpecies : IRunStep
 {
     // TODO: Possibly make this a performance setting?
     private const int TotalMutationsToTry = 20;
+    private const int FinalMutationPhases = 3;
+    private const int InitialMutationStepEstimatePerSpecies = 256;
 
     private static int autoEvoCacheCounter;
 
@@ -40,6 +42,7 @@ public class ModifyExistingSpecies : IRunStep
     private readonly List<Mutant> temporaryMutations2 = new();
 
     private readonly List<MicrobeSpecies> lastGeneratedMutations = new();
+    private readonly List<MicrobeSpecies> outOfSyncSpecies = new();
 
     private readonly Stack<SelectionPressure> pressureStack = new();
 
@@ -56,8 +59,14 @@ public class ModifyExistingSpecies : IRunStep
     private Dictionary<Species, long>.Enumerator speciesEnumerator;
 
     private Miche? miche;
+    private SpeciesMutationGenerationState? currentMutationGeneration;
 
     private Step step;
+    private int mutationStepEstimatePerSpecies = InitialMutationStepEstimatePerSpecies;
+    private int remainingPatchSpeciesToGenerate;
+    private int remainingOutOfSyncSpeciesToGenerate;
+    private int potentialOutOfSyncSpeciesToGenerate;
+    private bool collectedOutOfSyncSpecies;
 
     public ModifyExistingSpecies(Patch patch, SimulationCache cache, WorldGenerationSettings worldSettings,
         Random randomSeed)
@@ -70,8 +79,13 @@ public class ModifyExistingSpecies : IRunStep
 
         random = new XoShiRo256starstar(randomSeed.NextInt64());
 
-        // Patch species count is used to know how many steps there are to perform
-        TotalSteps = patch.SpeciesInPatch.Count;
+        foreach (var species in patch.SpeciesInPatch.Keys)
+        {
+            if (species is MicrobeSpecies)
+                ++remainingPatchSpeciesToGenerate;
+        }
+
+        TotalSteps = remainingPatchSpeciesToGenerate * mutationStepEstimatePerSpecies + FinalMutationPhases;
         speciesEnumerator = patch.SpeciesInPatch.GetEnumerator();
     }
 
@@ -89,10 +103,19 @@ public class ModifyExistingSpecies : IRunStep
         FinalApply,
     }
 
+    private enum MutationGenerationFramePhase
+    {
+        Initialize,
+        ProcessStrategies,
+        FinalizeLeaf,
+        PrepareChildren,
+        ProcessChildren,
+    }
+
     /// <summary>
     ///   See <see cref="Step"/> for explanation on the step count
     /// </summary>
-    public int TotalSteps => 4 + field;
+    public int TotalSteps { get; private set; }
 
     public bool CanRunConcurrently => true;
 
@@ -113,6 +136,10 @@ public class ModifyExistingSpecies : IRunStep
             miche.GetOccupants(speciesWorkMemory);
 
             miche.GetLeafNodes(nonEmptyLeafNodes, emptyLeafNodes, x => x.Occupant != null);
+
+            mutationStepEstimatePerSpecies = CalculateMutationStepEstimatePerSpecies(miche);
+            potentialOutOfSyncSpeciesToGenerate = Math.Max(0, speciesWorkMemory.Count - patch.SpeciesInPatch.Count);
+            UpdateMutationStepEstimate();
         }
 
         // This auto-evo step is split into sub steps so that each run doesn't take many seconds like it would
@@ -121,41 +148,22 @@ public class ModifyExistingSpecies : IRunStep
         {
             case Step.Mutations:
             {
-                // For each existing species, add adaptations based on the existing pressures
-
-                // Process mutations for one species per step
-                if (speciesEnumerator.MoveNext())
+                if (currentMutationGeneration == null && !TryStartNextMutationGeneration())
                 {
-                    var species = speciesEnumerator.Current.Key;
-
-                    if (species is MicrobeSpecies microbeSpecies)
-                    {
-                        GetMutationsForSpecies(microbeSpecies);
-                    }
+                    step = Step.MutationFilter;
+                    TotalSteps = FinalMutationPhases;
+                    speciesEnumerator = patch.SpeciesInPatch.GetEnumerator();
                 }
                 else
                 {
-                    // All mutations generated, next is the step to try them
-                    step = Step.MutationFilter;
-
-                    // Reset this for another enumeration later
-                    speciesEnumerator = patch.SpeciesInPatch.GetEnumerator();
-
-                    // Just for safety, generate any mutations still missing in case the miche data and species in
-                    // the patch are not in sync
-                    foreach (var species in speciesWorkMemory)
+                    if (currentMutationGeneration != null)
                     {
-                        if (patch.SpeciesInPatch.ContainsKey(species))
-                            continue;
-
-                        // This is really only a problem as this doesn't allow the splitting into steps to work well
-                        GD.PrintErr("Miche tree has a species not in the patch populations, still calculating " +
-                            "mutations for it");
-
-                        if (species is MicrobeSpecies microbeSpecies)
+                        if (currentMutationGeneration.RunStep())
                         {
-                            GetMutationsForSpecies(microbeSpecies);
+                            currentMutationGeneration = null;
                         }
+
+                        UpdateMutationStepEstimate();
                     }
                 }
 
@@ -185,6 +193,7 @@ public class ModifyExistingSpecies : IRunStep
 #endif
                 }
 
+                TotalSteps = 2;
                 step = Step.MutationTest;
                 break;
             }
@@ -203,6 +212,7 @@ public class ModifyExistingSpecies : IRunStep
                 newOccupantsWorkMemory.Clear();
                 miche.GetOccupants(newOccupantsWorkMemory);
 
+                TotalSteps = 1;
                 step = Step.FinalApply;
                 break;
             }
@@ -238,6 +248,7 @@ public class ModifyExistingSpecies : IRunStep
                     }
                 }
 
+                TotalSteps = 0;
                 return true;
             }
 
@@ -317,17 +328,21 @@ public class ModifyExistingSpecies : IRunStep
         }
     }
 
-    private void GetMutationsForSpecies(MicrobeSpecies microbeSpecies)
+    private int CalculateMutationStepEstimatePerSpecies(Miche currentMiche)
     {
-        double totalMP = Constants.BASE_MUTATION_POINTS * worldSettings.AIMutationMultiplier;
+        var steps = 2 + currentMiche.Pressure.Mutations.Count * Constants.AUTO_EVO_MAX_MUTATION_RECURSIONS;
 
-        generateMutationsWorkingMemory.Clear();
-        pressureStack.Clear();
+        if (currentMiche.IsLeafNode())
+            return steps;
 
-        var inputSpecies = generateMutationsWorkingMemory.GetMutationsAtDepth(0);
-        inputSpecies.Add(new Mutant(microbeSpecies, totalMP));
+        steps += currentMiche.Children.Count + 1;
 
-        GenerateMutations(microbeSpecies, miche!, 1, false);
+        foreach (var child in currentMiche.Children)
+        {
+            steps += CalculateMutationStepEstimatePerSpecies(child);
+        }
+
+        return steps;
     }
 
     /// <summary>
@@ -359,169 +374,318 @@ public class ModifyExistingSpecies : IRunStep
         }
     }
 
-    /// <summary>
-    ///   Adds a new list of all possible species that might emerge in response to the provided pressures,
-    ///   as well as a copy of the original species to <see cref="mutationsToTry"/>.
-    /// </summary>
-    private void GenerateMutations(MicrobeSpecies baseSpecies, Miche currentMiche, int depth, bool lastChild)
+    private bool TryStartNextMutationGeneration()
     {
-        var baseSpeciesMutant = new Mutant(baseSpecies,
-            Constants.BASE_MUTATION_POINTS * worldSettings.AIMutationMultiplier);
+        while (speciesEnumerator.MoveNext())
+        {
+            if (speciesEnumerator.Current.Key is not MicrobeSpecies microbeSpecies)
+                continue;
 
-        var inputSpecies = generateMutationsWorkingMemory.GetMutationsAtDepth(depth - 1);
+            --remainingPatchSpeciesToGenerate;
+            currentMutationGeneration = new SpeciesMutationGenerationState(this, microbeSpecies, miche!,
+                mutationStepEstimatePerSpecies);
+            return true;
+        }
 
-        var outputSpecies = generateMutationsWorkingMemory.GetMutationsAtDepth(depth);
-        outputSpecies.Clear();
-        outputSpecies.AddRange(inputSpecies);
+        if (!collectedOutOfSyncSpecies)
+        {
+            collectedOutOfSyncSpecies = true;
+            outOfSyncSpecies.Clear();
 
-        pressureStack.Push(currentMiche.Pressure);
-        mutationSorter.Setup(baseSpecies, pressureStack);
+            foreach (var species in speciesWorkMemory)
+            {
+                if (patch.SpeciesInPatch.ContainsKey(species))
+                    continue;
 
-        // TODO: avoid this temporary memory allocation somehow (this is slightly tricky as this method is called
-        // recursively)
-        var mutations = currentMiche.Pressure.Mutations.ToArray();
-        mutations.Shuffle(random);
+                GD.PrintErr("Miche tree has a species not in the patch populations, still calculating mutations " +
+                    "for it");
 
-        bool lawk = worldSettings.LAWK;
+                if (species is MicrobeSpecies microbeSpecies)
+                {
+                    outOfSyncSpecies.Add(microbeSpecies);
+                }
+            }
+
+            remainingOutOfSyncSpeciesToGenerate = outOfSyncSpecies.Count;
+            potentialOutOfSyncSpeciesToGenerate = remainingOutOfSyncSpeciesToGenerate;
+        }
+
+        if (remainingOutOfSyncSpeciesToGenerate < 1)
+            return false;
+
+        var outOfSyncIndex = outOfSyncSpecies.Count - remainingOutOfSyncSpeciesToGenerate;
+        --remainingOutOfSyncSpeciesToGenerate;
+
+        currentMutationGeneration = new SpeciesMutationGenerationState(this, outOfSyncSpecies[outOfSyncIndex], miche!,
+            mutationStepEstimatePerSpecies);
+        return true;
+    }
+
+    private void UpdateMutationStepEstimate()
+    {
+        var remainingOutOfSyncSpecies = collectedOutOfSyncSpecies ?
+            remainingOutOfSyncSpeciesToGenerate :
+            potentialOutOfSyncSpeciesToGenerate;
+
+        TotalSteps = (currentMutationGeneration?.RemainingStepEstimate ?? 0) +
+            (remainingPatchSpeciesToGenerate + remainingOutOfSyncSpecies) * mutationStepEstimatePerSpecies +
+            FinalMutationPhases;
+    }
+
+    private void ProcessMutationRecursionStep(MicrobeSpecies baseSpecies, Mutant baseSpeciesMutant,
+        MutationGenerationFrame frame)
+    {
+        var mutationStrategy = frame.Mutations[frame.MutationStrategyIndex];
+
+        if (!frame.HasActiveStrategy)
+        {
+            temporaryMutations1.Clear();
+            temporaryMutations1.AddRange(frame.OutputSpecies);
+            temporaryMutations1.Add(baseSpeciesMutant);
+            frame.HasActiveStrategy = true;
+            frame.RecursionIndex = 0;
+        }
+
+        temporaryMutations2.Clear();
+
+        foreach (var speciesTuple in temporaryMutations1)
+        {
+            var mutated = mutationStrategy.MutationsOf(speciesTuple.Species, speciesTuple.MP, worldSettings.LAWK,
+                random, patch.Biome);
+
+            if (mutated == null)
+                continue;
+
+            foreach (var tuple in mutated)
+            {
+#if DEBUG
+                if (tuple.Species.AutoEvoAttemptCache != 0)
+                    throw new Exception("Mutation shouldn't have a cache number yet");
+#endif
+
+                tuple.Species.OnAttemptedInAutoEvo(true);
+            }
+
+            PruneMutations(temporaryMutations2, speciesTuple.Species, mutated, patch, cache, pressureStack);
+        }
+
+        temporaryMutations1.Clear();
+        PruneMutations(temporaryMutations1, baseSpecies, temporaryMutations2, patch, cache, pressureStack);
+
         var maxVariants = Constants.MAX_VARIANTS_IN_MUTATIONS;
         var halfMaxVariants = maxVariants / 2;
 
-        foreach (var mutationStrategy in mutations)
+        if (temporaryMutations1.Count + frame.OutputSpecies.Count > maxVariants)
         {
-            temporaryMutations1.Clear();
-            temporaryMutations1.AddRange(outputSpecies);
-            temporaryMutations1.Add(baseSpeciesMutant);
+            PruneMutations(temporaryMutations1, baseSpecies, frame.OutputSpecies, patch, cache, pressureStack);
+            GetTopMutations(temporaryMutations2, temporaryMutations1, halfMaxVariants, mutationSorter);
 
-            for (int i = 0; i < Constants.AUTO_EVO_MAX_MUTATION_RECURSIONS; ++i)
+            var remainingVariants = halfMaxVariants - temporaryMutations1.Count;
+            if (remainingVariants > 0)
             {
-                temporaryMutations2.Clear();
-
-                foreach (var speciesTuple in temporaryMutations1)
-                {
-                    // TODO: this seems like the longest part, so splitting this into multiple steps (maybe bundling
-                    // up mutation strategies) would be good to have the auto-evo steps flow more smoothly
-                    var mutated = mutationStrategy.MutationsOf(speciesTuple.Species, speciesTuple.MP, lawk, random,
-                        patch.Biome);
-
-                    if (mutated != null)
-                    {
-                        // Make sure the species stats are up to date as pruning will calculate scores etc.
-                        foreach (var tuple in mutated)
-                        {
-#if DEBUG
-                            if (tuple.Species.AutoEvoAttemptCache != 0)
-                                throw new Exception("Mutation shouldn't have a cache number yet");
-#endif
-
-                            tuple.Species.OnAttemptedInAutoEvo(true);
-
-                            // If the visual hash of a species needs to be consistent while in the cache, then this
-                            // would need to be called
-                            // tuple.Species.OnEdited();
-                        }
-
-                        PruneMutations(temporaryMutations2, speciesTuple.Species, mutated, patch, cache,
-                            pressureStack);
-                    }
-                }
-
                 temporaryMutations1.Clear();
-                PruneMutations(temporaryMutations1, baseSpecies, temporaryMutations2, patch, cache, pressureStack);
-
-                // This section is complicated to look at, but essentially:
-                // If the number of temporary species going into the next round would be too many,
-                // prune also the pre-mutation species, and then select the top + a random selection of all species
-                // But, if the number of species falls too low after pruning,
-                // fall back to selecting pre-pruning, pre-mutation species
-                if (temporaryMutations1.Count + outputSpecies.Count > maxVariants)
-                {
-                    PruneMutations(temporaryMutations1, baseSpecies, outputSpecies, patch, cache, pressureStack);
-                    GetTopMutations(temporaryMutations2, temporaryMutations1, halfMaxVariants, mutationSorter);
-
-                    var remainingVariants = halfMaxVariants - temporaryMutations1.Count;
-                    if (remainingVariants > 0)
-                    {
-                        temporaryMutations1.Clear();
-                        GetTopMutations(temporaryMutations1, outputSpecies, remainingVariants, mutationSorter);
-                        temporaryMutations2.AddRange(temporaryMutations1);
-                        AddRandomMutations(temporaryMutations2, outputSpecies, halfMaxVariants);
-                    }
-                    else
-                    {
-                        AddRandomMutations(temporaryMutations2, temporaryMutations1, halfMaxVariants / 2);
-                        temporaryMutations1.Clear();
-                        GetTopMutations(temporaryMutations1, outputSpecies, halfMaxVariants / 2, mutationSorter);
-                        temporaryMutations2.AddRange(temporaryMutations1);
-                    }
-
-                    outputSpecies.Clear();
-                    outputSpecies.AddRange(temporaryMutations2);
-                }
-                else
-                {
-                    outputSpecies.AddRange(temporaryMutations1);
-                }
-
-                if (temporaryMutations1.Count == 0)
-                    break;
-
-                if (!mutationStrategy.Repeatable)
-                    break;
+                GetTopMutations(temporaryMutations1, frame.OutputSpecies, remainingVariants, mutationSorter);
+                temporaryMutations2.AddRange(temporaryMutations1);
+                AddRandomMutations(temporaryMutations2, frame.OutputSpecies, halfMaxVariants);
             }
-        }
-
-        if (lastChild)
-            generateMutationsWorkingMemory.ClearDepth(depth - 1);
-
-        if (currentMiche.IsLeafNode())
-        {
-            lastGeneratedMutations.Clear();
-
-            GetTopMutations(temporaryMutations1, outputSpecies, worldSettings.AutoEvoConfiguration.MutationsPerSpecies,
-                mutationSorter);
-            foreach (var topMutation in temporaryMutations1)
+            else
             {
-                lastGeneratedMutations.Add(topMutation.Species);
+                AddRandomMutations(temporaryMutations2, temporaryMutations1, halfMaxVariants / 2);
+                temporaryMutations1.Clear();
+                GetTopMutations(temporaryMutations1, frame.OutputSpecies, halfMaxVariants / 2, mutationSorter);
+                temporaryMutations2.AddRange(temporaryMutations1);
             }
 
-            var resultType = (currentMiche.Occupant == baseSpecies) ?
-                RunResults.NewSpeciesType.SplitDueToMutation :
-                RunResults.NewSpeciesType.FillNiche;
-
-            foreach (var species in lastGeneratedMutations)
-            {
-                mutationsToTry.Add(new Mutation(baseSpecies, species, resultType));
-            }
-
-            pressureStack.Pop();
+            frame.OutputSpecies.Clear();
+            frame.OutputSpecies.AddRange(temporaryMutations2);
         }
         else
         {
-            // Prune out any results that don't improve this branch
-            temporaryMutations1.Clear();
-            PruneMutations(temporaryMutations1, baseSpecies, outputSpecies, patch, cache, pressureStack);
-            outputSpecies.Clear();
-            outputSpecies.AddRange(temporaryMutations1);
-
-            if (outputSpecies.Count != 0)
-            {
-                int childCount = currentMiche.Children.Count;
-                int index = 0;
-
-                foreach (var child in currentMiche.Children)
-                {
-                    bool isLast = index == childCount - 1;
-                    GenerateMutations(baseSpecies, child, depth + 1, isLast);
-                    ++index;
-                }
-            }
-
-            pressureStack.Pop();
+            frame.OutputSpecies.AddRange(temporaryMutations1);
         }
+
+        ++frame.RecursionIndex;
+
+        if (temporaryMutations1.Count != 0 && mutationStrategy.Repeatable &&
+            frame.RecursionIndex < Constants.AUTO_EVO_MAX_MUTATION_RECURSIONS)
+        {
+            return;
+        }
+
+        frame.HasActiveStrategy = false;
+        ++frame.MutationStrategyIndex;
+    }
+
+    private void FinalizeLeafMutations(MicrobeSpecies baseSpecies, Miche currentMiche, List<Mutant> outputSpecies)
+    {
+        lastGeneratedMutations.Clear();
+
+        GetTopMutations(temporaryMutations1, outputSpecies, worldSettings.AutoEvoConfiguration.MutationsPerSpecies,
+            mutationSorter);
+        foreach (var topMutation in temporaryMutations1)
+        {
+            lastGeneratedMutations.Add(topMutation.Species);
+        }
+
+        var resultType = currentMiche.Occupant == baseSpecies ?
+            RunResults.NewSpeciesType.SplitDueToMutation :
+            RunResults.NewSpeciesType.FillNiche;
+
+        foreach (var species in lastGeneratedMutations)
+        {
+            mutationsToTry.Add(new Mutation(baseSpecies, species, resultType));
+        }
+    }
+
+    private void PrepareChildren(MicrobeSpecies baseSpecies, List<Mutant> outputSpecies)
+    {
+        temporaryMutations1.Clear();
+        PruneMutations(temporaryMutations1, baseSpecies, outputSpecies, patch, cache, pressureStack);
+        outputSpecies.Clear();
+        outputSpecies.AddRange(temporaryMutations1);
     }
 
     private record struct Mutation(MicrobeSpecies ParentSpecies, MicrobeSpecies MutatedSpecies,
         RunResults.NewSpeciesType AddType);
+
+    private sealed class MutationGenerationFrame
+    {
+        public readonly Miche Miche;
+        public readonly int Depth;
+        public readonly bool LastChild;
+
+        public MutationGenerationFramePhase Phase;
+        public IMutationStrategy<MicrobeSpecies>[] Mutations = null!;
+        public List<Mutant> OutputSpecies = null!;
+        public int MutationStrategyIndex;
+        public int RecursionIndex;
+        public int ChildIndex;
+        public bool HasActiveStrategy;
+
+        public MutationGenerationFrame(Miche miche, int depth, bool lastChild)
+        {
+            Miche = miche;
+            Depth = depth;
+            LastChild = lastChild;
+        }
+    }
+
+    private class SpeciesMutationGenerationState
+    {
+        private readonly ModifyExistingSpecies owner;
+        private readonly MicrobeSpecies baseSpecies;
+        private readonly Mutant baseSpeciesMutant;
+        private readonly Stack<MutationGenerationFrame> frameStack = new();
+
+        public SpeciesMutationGenerationState(ModifyExistingSpecies owner, MicrobeSpecies baseSpecies, Miche miche,
+            int stepEstimate)
+        {
+            this.owner = owner;
+            this.baseSpecies = baseSpecies;
+            baseSpeciesMutant = new Mutant(baseSpecies,
+                Constants.BASE_MUTATION_POINTS * owner.worldSettings.AIMutationMultiplier);
+
+            owner.generateMutationsWorkingMemory.Clear();
+            owner.pressureStack.Clear();
+
+            var inputSpecies = owner.generateMutationsWorkingMemory.GetMutationsAtDepth(0);
+            inputSpecies.Add(baseSpeciesMutant);
+
+            frameStack.Push(new MutationGenerationFrame(miche, 1, false));
+            RemainingStepEstimate = stepEstimate;
+        }
+
+        public int RemainingStepEstimate { get; private set; }
+
+        public bool RunStep()
+        {
+            if (RemainingStepEstimate > 0)
+                --RemainingStepEstimate;
+
+            var currentFrame = frameStack.Peek();
+
+            switch (currentFrame.Phase)
+            {
+                case MutationGenerationFramePhase.Initialize:
+                {
+                    var inputSpecies = owner.generateMutationsWorkingMemory.GetMutationsAtDepth(currentFrame.Depth - 1);
+
+                    currentFrame.OutputSpecies =
+                        owner.generateMutationsWorkingMemory.GetMutationsAtDepth(currentFrame.Depth);
+                    currentFrame.OutputSpecies.Clear();
+                    currentFrame.OutputSpecies.AddRange(inputSpecies);
+
+                    owner.pressureStack.Push(currentFrame.Miche.Pressure);
+                    owner.mutationSorter.Setup(baseSpecies, owner.pressureStack);
+
+                    currentFrame.Mutations = currentFrame.Miche.Pressure.Mutations.ToArray();
+                    currentFrame.Mutations.Shuffle(owner.random);
+                    currentFrame.Phase = MutationGenerationFramePhase.ProcessStrategies;
+                    break;
+                }
+
+                case MutationGenerationFramePhase.ProcessStrategies:
+                {
+                    if (currentFrame.MutationStrategyIndex >= currentFrame.Mutations.Length)
+                    {
+                        currentFrame.Phase = currentFrame.Miche.IsLeafNode() ?
+                            MutationGenerationFramePhase.FinalizeLeaf :
+                            MutationGenerationFramePhase.PrepareChildren;
+                        break;
+                    }
+
+                    owner.ProcessMutationRecursionStep(baseSpecies, baseSpeciesMutant, currentFrame);
+                    break;
+                }
+
+                case MutationGenerationFramePhase.FinalizeLeaf:
+                {
+                    owner.FinalizeLeafMutations(baseSpecies, currentFrame.Miche, currentFrame.OutputSpecies);
+                    FinishCurrentFrame();
+                    break;
+                }
+
+                case MutationGenerationFramePhase.PrepareChildren:
+                {
+                    owner.PrepareChildren(baseSpecies, currentFrame.OutputSpecies);
+                    currentFrame.Phase = MutationGenerationFramePhase.ProcessChildren;
+                    break;
+                }
+
+                case MutationGenerationFramePhase.ProcessChildren:
+                {
+                    if (currentFrame.OutputSpecies.Count == 0 ||
+                        currentFrame.ChildIndex >= currentFrame.Miche.Children.Count)
+                    {
+                        FinishCurrentFrame();
+                        break;
+                    }
+
+                    var child = currentFrame.Miche.Children[currentFrame.ChildIndex];
+                    var isLastChild = currentFrame.ChildIndex == currentFrame.Miche.Children.Count - 1;
+                    ++currentFrame.ChildIndex;
+                    frameStack.Push(new MutationGenerationFrame(child, currentFrame.Depth + 1, isLastChild));
+                    break;
+                }
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            return frameStack.Count == 0;
+        }
+
+        private void FinishCurrentFrame()
+        {
+            var finishedFrame = frameStack.Pop();
+            owner.pressureStack.Pop();
+
+            if (finishedFrame.LastChild)
+            {
+                owner.generateMutationsWorkingMemory.ClearDepth(finishedFrame.Depth - 1);
+            }
+        }
+    }
 
     /// <summary>
     ///   Working memory used to reduce memory allocations in <see cref="GenerateMutations"/>.


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR splits `ModifyExistingSpecies` mutation generation into resumable substeps, so the expensive mutation recursion no longer happens as one long auto-evo step. The mutation traversal now keeps explicit frame state and continues over many `RunStep` calls instead of recursively finishing a whole species in one call.

I also updated `AutoEvoRun` to refresh the total step estimate while steps are running, as `ModifyExistingSpecies.TotalSteps` now changes while its internal mutation work is consumed.

I manually tested this with the Auto-Evo Exploring Tool by running 5 worlds for 15 generations. The run completed, and the log had 0 matches for `Single auto-evo step ModifyExistingSpecies`. The measured worst `ModifyExistingSpecies` substep was 163.764 ms, under the 0.4s warning threshold.

```text
AUTOMATED_AUTO_EVO_TOOL_TEST completed worlds=5 currentWorldGeneration=15 totalSpecies=209
ISSUE_5416_STEP_PROFILE step=ModifyExistingSpecies count=1828475 totalMs=889089.560 maxMs=163.764
```

I also ran:

```text
dotnet build Thrive.sln -v minimal
# 0 warnings, 0 errors

dotnet test test\code_tests\ThriveTest.csproj --no-build --no-restore -v minimal
# Passed: 100, Failed: 0
```

**Related Issues**

Closes #5416

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
