### PR TITLE
Fixed a few issues with console

### DIFF
--- a/src/engine/console/DebugConsole.cs
+++ b/src/engine/console/DebugConsole.cs
@@ -115,9 +115,6 @@ public partial class DebugConsole : CustomWindow, ICommandInvoker
 
         newPrivateMessages = 0;
         newGlobalMessages = 0;
-
-        for (int i = 0; i < 32; ++i)
-            GD.Print("helo");
     }
 
     public void Print(DebugConsoleManager.RawDebugEntry entry)

--- a/src/engine/console/DebugConsole.cs
+++ b/src/engine/console/DebugConsole.cs
@@ -23,6 +23,10 @@ public partial class DebugConsole : CustomWindow, ICommandInvoker
 
     private bool stickToBottom = true;
 
+    private int newGlobalMessages;
+    private int newPrivateMessages;
+    private string lastAdded = string.Empty;
+
 #pragma warning disable CA2213
     [Export]
     private VBoxContainer debugEntryList = null!;
@@ -90,6 +94,9 @@ public partial class DebugConsole : CustomWindow, ICommandInvoker
 
     public override void _Process(double delta)
     {
+        if (newPrivateMessages > 0 || newGlobalMessages > 0)
+            RefreshLogs();
+
         UpdateLiveEntries();
         UpdateAutoscroll();
 
@@ -105,6 +112,12 @@ public partial class DebugConsole : CustomWindow, ICommandInvoker
             if (node is RichTextLabel label)
                 label.Visible = false;
         }
+
+        newPrivateMessages = 0;
+        newGlobalMessages = 0;
+
+        for (int i = 0; i < 32; ++i)
+            GD.Print("helo");
     }
 
     public void Print(DebugConsoleManager.RawDebugEntry entry)
@@ -198,7 +211,7 @@ public partial class DebugConsole : CustomWindow, ICommandInvoker
 
         commandInput.GrabFocus();
 
-        RefreshLogs(DebugConsoleManager.Instance.MessageCountInHistory, privateHistory.Count);
+        newGlobalMessages = DebugConsoleManager.Instance.MessageCountInHistory;
     }
 
     private void AddPrivateEntry(DebugEntry entry)
@@ -208,20 +221,24 @@ public partial class DebugConsole : CustomWindow, ICommandInvoker
         if (privateHistory.Count > MaxPrivateHistorySize)
             privateHistory.RemoveFromFront();
 
-        RefreshLogs(0, 1);
+        ++newPrivateMessages;
+
+        if (newPrivateMessages > MaxPrivateHistorySize)
+            newPrivateMessages = (int)MaxPrivateHistorySize;
     }
 
-    private void RefreshLogs(int newMessages, int newPrivateMessages)
+    private void RefreshLogs()
     {
         int size = DebugConsoleManager.Instance.MessageCountInHistory;
 
         int globalAdded = 0;
         int localAdded = 0;
-        while (globalAdded < newMessages || localAdded < newPrivateMessages)
+
+        while (globalAdded < newGlobalMessages || localAdded < newPrivateMessages)
         {
             DebugEntry entry;
 
-            int globalIndex = size - newMessages + globalAdded;
+            int globalIndex = size - newGlobalMessages + globalAdded;
             int localIndex = privateHistory.Count - newPrivateMessages + localAdded;
 
             if (globalIndex == size)
@@ -255,7 +272,14 @@ public partial class DebugConsole : CustomWindow, ICommandInvoker
 
             RichTextLabel label;
             EntryView view;
-            if (debugEntryLabels.Count > DebugConsoleManager.MaxHistorySize)
+            if (lastAdded == entry.Text && debugEntryLabels.Count > 0 && debugEntryLabels[^1].Content.Frozen)
+            {
+                view = debugEntryLabels[^1];
+                label = view.Label;
+
+                ++view.LocalAmount;
+            }
+            else if (debugEntryLabels.Count > DebugConsoleManager.MaxHistorySize)
             {
                 view = debugEntryLabels.RemoveFromFront();
                 view.Content = entry;
@@ -278,16 +302,28 @@ public partial class DebugConsole : CustomWindow, ICommandInvoker
                 view = new EntryView(label, entry);
             }
 
-            debugEntryLabels.AddToBack(view);
-            debugEntryList.AddChild(label);
+            lastAdded = entry.Text;
+            if (view.LocalAmount > 1)
+            {
+                // This allocates for string formatting, but it shouldn't be an issue as it should be sporadic enough.
+                label.Text = lastAdded.TrimEnd('\n') + $" [x{view.LocalAmount}]";
+            }
+            else
+            {
+                label.Text = lastAdded;
 
-            label.Text = entry.Text;
+                debugEntryLabels.AddToBack(view);
+                debugEntryList.AddChild(label);
 
-            if (!entry.Frozen)
-                liveEntries.Add(view);
+                if (!entry.Frozen)
+                    liveEntries.Add(view);
+            }
         }
 
         UpdateLiveEntries();
+
+        newPrivateMessages = 0;
+        newGlobalMessages = 0;
     }
 
     private void UpdateLiveEntries()
@@ -308,7 +344,7 @@ public partial class DebugConsole : CustomWindow, ICommandInvoker
 
     private void RefreshLogs(object? o, DebugConsoleManager.HistoryUpdatedEventArgs e)
     {
-        RefreshLogs(e.NewMessages, 0);
+        newGlobalMessages = e.NewMessages;
     }
 
     private void CommandSubmitted(string command)
@@ -344,5 +380,6 @@ public partial class DebugConsole : CustomWindow, ICommandInvoker
     {
         public readonly RichTextLabel Label = label;
         public DebugEntry Content = content;
+        public int LocalAmount = 1;
     }
 }

--- a/src/engine/console/DebugConsoleManager.cs
+++ b/src/engine/console/DebugConsoleManager.cs
@@ -57,8 +57,10 @@ public partial class DebugConsoleManager : Node, ICommandInvoker
 
     public override void _Process(double delta)
     {
-        // We choose to stack equivalent consecutive messages, while forcing separation on different entries.
-        const DebugEntryFactory.AddMessageMode addMessageMode = DebugEntryFactory.AddMessageMode.Split;
+        // We choose to always split messages, whether they are equal or different.
+        // See issue: https://github.com/Revolutionary-Games/Thrive/issues/6944
+        const DebugEntryFactory.AddMessageMode addMessageMode = DebugEntryFactory.AddMessageMode.Split |
+            DebugEntryFactory.AddMessageMode.NoStacking;
 
         int newMessages = 0;
         int count = inbox.Count;
@@ -87,7 +89,7 @@ public partial class DebugConsoleManager : Node, ICommandInvoker
                     DebugEntryFactory.ResetTimestamp(id, rawDebugEntry.Timestamp);
                     if (DebugEntryFactory.TryAddMessage(id, rawDebugEntry, addMessageMode))
                     {
-                        var newEntry = DebugEntryFactory.GetDebugEntry(id);
+                        var newEntry = DebugEntryFactory.GetDebugEntry(id, true);
                         history.AddToBack(newEntry);
 
                         ++newMessages;


### PR DESCRIPTION
- issue #6944
- messages sometimes not showing
- message order sometimes inconsistent with private entries.

**Brief Description of What This PR Does**

This PR closes a few known issues.

First, it closes issue #6944, which caused messages to coalesce in an inconsistent way due to the global message handling: since the local messages by the command context were invisible to the global console manager, I moved the message combination logic from the global context to the local console. This way, the message combination feature is unique and personalised to every console instance.

Secondly, it has been reported that the messages' order was sometimes inconsistent and/or they were not showing at all. This was caused by the fact that command execution directly logged the private entry to the console. Now, the private entry rendering is deferred just like the global messages so the whole logic is now chronologically consistent.

**Related Issues**

Closes #6944 
Closes #6938 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
