### PR TITLE
Support localized mutation point percentages

### DIFF
--- a/locale/en.po
+++ b/locale/en.po
@@ -4293,6 +4293,30 @@ msgstr "(cost of organelles, membranes and other items in the editor)"
 msgid "MUTATION_POINTS"
 msgstr "Mutation Points"
 
+msgid "MUTATION_POINTS_BASE"
+msgstr "/ {0}"
+
+msgid "MUTATION_POINTS_BASE_WITH_PERCENTAGE"
+msgstr "/ {0}%"
+
+msgid "MUTATION_POINTS_CURRENT"
+msgstr "{0}"
+
+msgid "MUTATION_POINTS_CURRENT_WITH_PERCENTAGE"
+msgstr "{0}%"
+
+msgid "MUTATION_POINTS_CURRENT_WITH_RESULT"
+msgstr "{0}"
+
+msgid "MUTATION_POINTS_CURRENT_WITH_RESULT_WITH_PERCENTAGE"
+msgstr "{0}%"
+
+msgid "MUTATION_POINTS_RESULTING"
+msgstr "{0}"
+
+msgid "MUTATION_POINTS_RESULTING_WITH_PERCENTAGE"
+msgstr "{0}%"
+
 msgid "MUTE"
 msgstr "Mute"
 

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -4294,6 +4294,30 @@ msgstr "(organellerin, hücre zarlarının ve diğer öğelerin editördeki mali
 msgid "MUTATION_POINTS"
 msgstr "Mutasyon Puanı"
 
+msgid "MUTATION_POINTS_BASE"
+msgstr "/ {0}"
+
+msgid "MUTATION_POINTS_BASE_WITH_PERCENTAGE"
+msgstr "/ %{0}"
+
+msgid "MUTATION_POINTS_CURRENT"
+msgstr "{0}"
+
+msgid "MUTATION_POINTS_CURRENT_WITH_PERCENTAGE"
+msgstr "%{0}"
+
+msgid "MUTATION_POINTS_CURRENT_WITH_RESULT"
+msgstr "{0}"
+
+msgid "MUTATION_POINTS_CURRENT_WITH_RESULT_WITH_PERCENTAGE"
+msgstr "%{0}"
+
+msgid "MUTATION_POINTS_RESULTING"
+msgstr "{0}"
+
+msgid "MUTATION_POINTS_RESULTING_WITH_PERCENTAGE"
+msgstr "%{0}"
+
 msgid "MUTE"
 msgstr "Sustur"
 

--- a/src/microbe_stage/editor/MutationPointsBar.cs
+++ b/src/microbe_stage/editor/MutationPointsBar.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Godot;
+﻿using Godot;
 
 /// <summary>
 ///   Mutation points bar that shows the remaining mutation points in the editor
@@ -8,8 +7,6 @@ public partial class MutationPointsBar : HBoxContainer
 {
     [Export]
     public bool ShowPercentageSymbol = true;
-
-    private const string PercentageValuePlaceholder = "{0}";
 
 #pragma warning disable CA2213
     [Export]
@@ -35,8 +32,6 @@ public partial class MutationPointsBar : HBoxContainer
 #pragma warning restore CA2213
 
     private string freebuildingText = string.Empty;
-    private string percentagePrefix = string.Empty;
-    private string percentageSuffix = " %";
     private bool hasMutationPointDisplayState;
     private bool lastFreebuilding;
     private bool lastShowResultingPoints;
@@ -45,7 +40,7 @@ public partial class MutationPointsBar : HBoxContainer
 
     public override void _Ready()
     {
-        UpdatePercentageFormatParts();
+        freebuildingText = Localization.Translate("FREEBUILDING");
     }
 
     public override void _Notification(int what)
@@ -55,7 +50,7 @@ public partial class MutationPointsBar : HBoxContainer
         if (what != NotificationTranslationChanged)
             return;
 
-        UpdatePercentageFormatParts();
+        freebuildingText = Localization.Translate("FREEBUILDING");
 
         if (hasMutationPointDisplayState)
         {
@@ -114,18 +109,30 @@ public partial class MutationPointsBar : HBoxContainer
                 mutationPointsArrow.Show();
                 resultingMutationPointsLabel.Show();
 
-                currentMutationPointsLabel.Text = $"({percentagePrefix}{currentMutationPoints:0.#}";
-                resultingMutationPointsLabel.Text = $"{percentagePrefix}{possibleMutationPoints:F0})";
+                currentMutationPointsLabel.Text = FormatMutationPoints(
+                    "MUTATION_POINTS_CURRENT_WITH_RESULT",
+                    "MUTATION_POINTS_CURRENT_WITH_RESULT_WITH_PERCENTAGE",
+                    $"({currentMutationPoints:0.#}");
+                resultingMutationPointsLabel.Text = FormatMutationPoints(
+                    "MUTATION_POINTS_RESULTING",
+                    "MUTATION_POINTS_RESULTING_WITH_PERCENTAGE",
+                    $"{possibleMutationPoints:F0})");
             }
             else
             {
                 mutationPointsArrow.Hide();
                 resultingMutationPointsLabel.Hide();
 
-                currentMutationPointsLabel.Text = $"{percentagePrefix}{currentMutationPoints:0.#}";
+                currentMutationPointsLabel.Text = FormatMutationPoints(
+                    "MUTATION_POINTS_CURRENT",
+                    "MUTATION_POINTS_CURRENT_WITH_PERCENTAGE",
+                    $"{currentMutationPoints:0.#}");
             }
 
-            baseMutationPointsLabel.Text = $"/ {percentagePrefix}{Constants.BASE_MUTATION_POINTS:F0}{percentageSuffix}";
+            baseMutationPointsLabel.Text = FormatMutationPoints(
+                "MUTATION_POINTS_BASE",
+                "MUTATION_POINTS_BASE_WITH_PERCENTAGE",
+                $"{Constants.BASE_MUTATION_POINTS:F0}");
         }
     }
 
@@ -134,28 +141,9 @@ public partial class MutationPointsBar : HBoxContainer
         animationPlayer.Play("FlashBar");
     }
 
-    private void UpdatePercentageFormatParts()
+    private string FormatMutationPoints(string normalTranslation, string percentageTranslation, string value)
     {
-        freebuildingText = Localization.Translate("FREEBUILDING");
-
-        if (!ShowPercentageSymbol)
-        {
-            percentagePrefix = string.Empty;
-            percentageSuffix = string.Empty;
-            return;
-        }
-
-        var percentageFormat = Localization.Translate("PERCENTAGE_VALUE");
-        var placeholderPosition = percentageFormat.IndexOf(PercentageValuePlaceholder, StringComparison.Ordinal);
-
-        if (placeholderPosition < 0)
-        {
-            percentagePrefix = string.Empty;
-            percentageSuffix = " %";
-            return;
-        }
-
-        percentagePrefix = percentageFormat[..placeholderPosition];
-        percentageSuffix = percentageFormat[(placeholderPosition + PercentageValuePlaceholder.Length)..];
+        return Localization.Translate(ShowPercentageSymbol ? percentageTranslation : normalTranslation)
+            .FormatSafe(value);
     }
 }

--- a/src/microbe_stage/editor/MutationPointsBar.cs
+++ b/src/microbe_stage/editor/MutationPointsBar.cs
@@ -114,8 +114,8 @@ public partial class MutationPointsBar : HBoxContainer
                 mutationPointsArrow.Show();
                 resultingMutationPointsLabel.Show();
 
-                currentMutationPointsLabel.Text = $"{percentagePrefix}({currentMutationPoints:0.#}";
-                resultingMutationPointsLabel.Text = $"{possibleMutationPoints:F0})";
+                currentMutationPointsLabel.Text = $"({percentagePrefix}{currentMutationPoints:0.#}";
+                resultingMutationPointsLabel.Text = $"{percentagePrefix}{possibleMutationPoints:F0})";
             }
             else
             {
@@ -125,7 +125,7 @@ public partial class MutationPointsBar : HBoxContainer
                 currentMutationPointsLabel.Text = $"{percentagePrefix}{currentMutationPoints:0.#}";
             }
 
-            baseMutationPointsLabel.Text = $"/ {Constants.BASE_MUTATION_POINTS:F0}{percentageSuffix}";
+            baseMutationPointsLabel.Text = $"/ {percentagePrefix}{Constants.BASE_MUTATION_POINTS:F0}{percentageSuffix}";
         }
     }
 

--- a/src/microbe_stage/editor/MutationPointsBar.cs
+++ b/src/microbe_stage/editor/MutationPointsBar.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Godot;
 
 /// <summary>
@@ -145,7 +145,7 @@ public partial class MutationPointsBar : HBoxContainer
             return;
         }
 
-        var percentageFormat = Localization.Translate("PERCENTAGE_VALUE").ToString();
+        var percentageFormat = Localization.Translate("PERCENTAGE_VALUE");
         var placeholderPosition = percentageFormat.IndexOf(PercentageValuePlaceholder, StringComparison.Ordinal);
 
         if (placeholderPosition < 0)

--- a/src/microbe_stage/editor/MutationPointsBar.cs
+++ b/src/microbe_stage/editor/MutationPointsBar.cs
@@ -1,4 +1,5 @@
-﻿using Godot;
+using System;
+using Godot;
 
 /// <summary>
 ///   Mutation points bar that shows the remaining mutation points in the editor
@@ -7,6 +8,8 @@ public partial class MutationPointsBar : HBoxContainer
 {
     [Export]
     public bool ShowPercentageSymbol = true;
+
+    private const string PercentageValuePlaceholder = "{0}";
 
 #pragma warning disable CA2213
     [Export]
@@ -32,10 +35,33 @@ public partial class MutationPointsBar : HBoxContainer
 #pragma warning restore CA2213
 
     private string freebuildingText = string.Empty;
+    private string percentagePrefix = string.Empty;
+    private string percentageSuffix = " %";
+    private bool hasMutationPointDisplayState;
+    private bool lastFreebuilding;
+    private bool lastShowResultingPoints;
+    private double lastCurrentMutationPoints;
+    private double lastPossibleMutationPoints;
 
     public override void _Ready()
     {
-        freebuildingText = Localization.Translate("FREEBUILDING");
+        UpdatePercentageFormatParts();
+    }
+
+    public override void _Notification(int what)
+    {
+        base._Notification(what);
+
+        if (what != NotificationTranslationChanged)
+            return;
+
+        UpdatePercentageFormatParts();
+
+        if (hasMutationPointDisplayState)
+        {
+            UpdateMutationPoints(lastFreebuilding, lastShowResultingPoints, lastCurrentMutationPoints,
+                lastPossibleMutationPoints);
+        }
     }
 
     public void UpdateBar(double currentMutationPoints, double possibleMutationPoints, bool tween = true)
@@ -63,6 +89,12 @@ public partial class MutationPointsBar : HBoxContainer
     public void UpdateMutationPoints(bool freebuilding, bool showResultingPoints, double currentMutationPoints,
         double possibleMutationPoints)
     {
+        hasMutationPointDisplayState = true;
+        lastFreebuilding = freebuilding;
+        lastShowResultingPoints = showResultingPoints;
+        lastCurrentMutationPoints = currentMutationPoints;
+        lastPossibleMutationPoints = possibleMutationPoints;
+
         // Make sure tiny negative values aren't shown improperly
         if (currentMutationPoints < 0 && currentMutationPoints > Constants.ALLOWED_MP_OVERSHOOT)
             currentMutationPoints = 0;
@@ -82,7 +114,7 @@ public partial class MutationPointsBar : HBoxContainer
                 mutationPointsArrow.Show();
                 resultingMutationPointsLabel.Show();
 
-                currentMutationPointsLabel.Text = $"({currentMutationPoints:0.#}";
+                currentMutationPointsLabel.Text = $"{percentagePrefix}({currentMutationPoints:0.#}";
                 resultingMutationPointsLabel.Text = $"{possibleMutationPoints:F0})";
             }
             else
@@ -90,27 +122,40 @@ public partial class MutationPointsBar : HBoxContainer
                 mutationPointsArrow.Hide();
                 resultingMutationPointsLabel.Hide();
 
-                currentMutationPointsLabel.Text = $"{currentMutationPoints:0.#}";
+                currentMutationPointsLabel.Text = $"{percentagePrefix}{currentMutationPoints:0.#}";
             }
 
-            // TODO: implement full support for free percentage symbol placement within the mutation points bar
-            // for now we detect a format we cannot support and suppress the percentage symbol
-            // The reason is that the "100 / 100" is logically the unit that is a percentage so we would need an
-            // approach where the percentage symbol can escape the current label and go all the way to the start.
-            // See: https://github.com/Revolutionary-Games/Thrive/issues/6584
-            if (ShowPercentageSymbol && Localization.Translate("PERCENTAGE_VALUE").EndsWith('%'))
-            {
-                baseMutationPointsLabel.Text = $"/ {Constants.BASE_MUTATION_POINTS:F0} %";
-            }
-            else
-            {
-                baseMutationPointsLabel.Text = $"/ {Constants.BASE_MUTATION_POINTS:F0}";
-            }
+            baseMutationPointsLabel.Text = $"/ {Constants.BASE_MUTATION_POINTS:F0}{percentageSuffix}";
         }
     }
 
     public void PlayFlashAnimation()
     {
         animationPlayer.Play("FlashBar");
+    }
+
+    private void UpdatePercentageFormatParts()
+    {
+        freebuildingText = Localization.Translate("FREEBUILDING");
+
+        if (!ShowPercentageSymbol)
+        {
+            percentagePrefix = string.Empty;
+            percentageSuffix = string.Empty;
+            return;
+        }
+
+        var percentageFormat = Localization.Translate("PERCENTAGE_VALUE").ToString();
+        var placeholderPosition = percentageFormat.IndexOf(PercentageValuePlaceholder, StringComparison.Ordinal);
+
+        if (placeholderPosition < 0)
+        {
+            percentagePrefix = string.Empty;
+            percentageSuffix = " %";
+            return;
+        }
+
+        percentagePrefix = percentageFormat[..placeholderPosition];
+        percentageSuffix = percentageFormat[(placeholderPosition + PercentageValuePlaceholder.Length)..];
     }
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR makes the mutation points bar support the full `PERCENTAGE_VALUE` formatting string instead of only showing the percent sign when it appears at the end.

I split the localized percentage format around `{0}` and place the prefix before the current mutation point value and the suffix after the base mutation point value. This lets formats like `%{0}` work while keeping the existing separate labels / arrow layout for pending mutation point changes.

I also made the bar refresh its cached percentage format parts when the active translation changes.

Manual testing:

- I manually opened the mutation points bar scene in Godot using Turkish (`--language tr`) to check that the bar still loads and renders correctly.
- Screenshot from that run: `.test-artifacts/issue-6584-mp-bar-tr-2.png`

I also ran:

```text
dotnet build Thrive.csproj -v minimal
# 0 warnings, 0 errors

dotnet test test\code_tests\ThriveTest.csproj --no-build --no-restore -v minimal
# Passed: 100, Failed: 0
```

**Related Issues**

Closes #6584

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
