### PR TITLE
Prevent console stacking across command output

### DIFF
--- a/src/engine/console/DebugConsole.cs
+++ b/src/engine/console/DebugConsole.cs
@@ -111,6 +111,7 @@ public partial class DebugConsole : CustomWindow, ICommandInvoker
     {
         var debugEntryFactory = DebugConsoleManager.Instance.DebugEntryFactory;
 
+        debugEntryFactory.FlushAllExcept(entry.Id);
         debugEntryFactory.TryAddMessage(entry.Id, entry, DebugEntryFactory.AddMessageMode.NoStacking);
         debugEntryFactory.UpdateDebugEntry(entry.Id);
     }

--- a/src/engine/console/DebugEntryFactory.cs
+++ b/src/engine/console/DebugEntryFactory.cs
@@ -57,6 +57,17 @@ public class DebugEntryFactory
         return true;
     }
 
+    public void FlushAllExcept(int idToKeep)
+    {
+        foreach (var id in pipelines.Keys)
+        {
+            if (id == idToKeep)
+                continue;
+
+            Flush(id);
+        }
+    }
+
     /// <summary>
     ///   This should be called right after flushing a pipeline to initialize the timestamp.
     /// </summary>

--- a/test/code_tests/Engine/Console.Tests/DebugEntryFactoryTests.cs
+++ b/test/code_tests/Engine/Console.Tests/DebugEntryFactoryTests.cs
@@ -1,0 +1,29 @@
+namespace ThriveTest.Engine.Console.Tests;
+
+using Godot;
+using Xunit;
+
+public class DebugEntryFactoryTests
+{
+    [Fact]
+    public static void DebugEntryFactory_FlushAllExceptPreventsStackingAcrossCommandOutput()
+    {
+        var factory = new DebugEntryFactory();
+        var normalMessage = new DebugConsoleManager.RawDebugEntry("Jukebox: starting track", Colors.White, 1, 1);
+        var commandMessage = new DebugConsoleManager.RawDebugEntry("Skipped to next track", Colors.White, 2, 1 << 16);
+
+        Assert.True(factory.TryAddMessage(normalMessage.Id, normalMessage));
+        var firstNormalEntry = factory.GetDebugEntry(normalMessage.Id);
+
+        factory.FlushAllExcept(commandMessage.Id);
+
+        Assert.True(firstNormalEntry.Frozen);
+
+        Assert.True(factory.TryAddMessage(commandMessage.Id, commandMessage));
+        Assert.True(factory.TryAddMessage(normalMessage.Id, normalMessage));
+        var secondNormalEntry = factory.GetDebugEntry(normalMessage.Id);
+
+        Assert.NotSame(firstNormalEntry, secondNormalEntry);
+        Assert.Equal(1, secondNormalEntry.Amount);
+    }
+}


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR prevents normal console output from stacking into an older entry after command-context output has been printed in between.

The specific problem was that the local command output uses a custom console entry id, while normal `GD.Print` output uses the thread id. If a normal output entry was still open and a command printed through its context, a later matching normal output could still stack into that older normal entry. I now flush all other debug-entry pipelines before adding a command-context print to the local console, so later normal output starts a new entry instead of merging across the command output.

I also added a regression test for this exact boundary.

Manual testing:

- I manually smoke-tested the game startup in Godot after the console change. Startup completed and shut down normally with `--quit-after`.
- I checked the Godot log for startup errors related to this change and didn't see any.

I also ran:

```text
dotnet build Thrive.sln -v minimal
# 0 warnings, 0 errors

dotnet test test\code_tests\ThriveTest.csproj -v minimal
# Passed: 101, Failed: 0
```

**Related Issues**

Closes #6944

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
