### PR TITLE
Process command-triggered console output before final scroll

### DIFF
--- a/src/engine/console/DebugConsole.cs
+++ b/src/engine/console/DebugConsole.cs
@@ -147,6 +147,10 @@ public partial class DebugConsole : CustomWindow, ICommandInvoker
 
         commandRegistry.Execute(context, command);
 
+        // Commands can also cause normal GD.Print output. Process it now so the final scroll position is based on
+        // everything the command synchronously produced.
+        debugConsoleManager.ProcessQueuedMessages();
+
         // This updates the debug entry to reflect the final command output, if any, and releases the executionToken.
         debugConsoleManager.ReleaseCustomDebugEntryId(executionToken);
 

--- a/src/engine/console/DebugConsoleManager.cs
+++ b/src/engine/console/DebugConsoleManager.cs
@@ -57,6 +57,13 @@ public partial class DebugConsoleManager : Node, ICommandInvoker
 
     public override void _Process(double delta)
     {
+        ProcessQueuedMessages();
+
+        base._Process(delta);
+    }
+
+    public int ProcessQueuedMessages()
+    {
         // We choose to stack equivalent consecutive messages, while forcing separation on different entries.
         const DebugEntryFactory.AddMessageMode addMessageMode = DebugEntryFactory.AddMessageMode.Split;
 
@@ -64,12 +71,12 @@ public partial class DebugConsoleManager : Node, ICommandInvoker
         int count = inbox.Count;
 
         if (OnHistoryUpdated == null)
-            return;
+            return 0;
 
         lock (inbox)
         {
             if (count == 0)
-                return;
+                return 0;
 
             TotalMessageCount += count;
 
@@ -109,7 +116,7 @@ public partial class DebugConsoleManager : Node, ICommandInvoker
             OnHistoryUpdated.Invoke(null, new HistoryUpdatedEventArgs(newMessages));
         }
 
-        base._Process(delta);
+        return newMessages;
     }
 
     public void Print(string line, int id, bool isError = false)


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR makes the debug console process any normal console output queued during a command before it does the final command-entry update and scroll-to-bottom handling.

Some commands, like jukebox commands, can print through the command context and also cause normal `GD.Print` output. Before this, the normal output could stay queued until the next process pass, so the visible order / final scroll position could end up confusing. I now flush the queued messages right after the command executes, before releasing the command entry token.

Manual testing:
- I manually smoke-tested game startup in Godot after the console change. Startup completed and shut down normally with `--quit-after`.
- Relevant log snippet:

```text
Jukebox now playing from: Menu
Jukebox: starting track: res://assets/sounds/main-menu-theme-1.ogg position: 0
------------ Thrive Startup Succeeded ------------
Shutdown actions complete
```

I also ran:

```text
dotnet build Thrive.sln -v minimal
0 warnings, 0 errors

dotnet test test\code_tests\ThriveTest.csproj --no-build --no-restore -v minimal
Passed: 100, Failed: 0
```

**Related Issues**

Closes #6938

**Progress Checklist**

- [x] I have added necessary changelog entries (if missing, it is very likely that this PR will be closed)
- [ ] I have added/updated necessary tests
- [ ] I have checked that all added and changed lines are covered by tests
- [ ] I have taken new screenshots if the changes affect the graphics or any UI
- [ ] I have updated the documentation to reflect the changes