### PR TITLE
Change migration generation approach (prefer empty patches)

### DIFF
--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -60,7 +60,6 @@ public class MigrateSpecies : IRunStep
 
         // To not randomly pick the same adjacent patch multiple times as a migration target
         var shuffledNeighbours = new List<Patch>();
-        var shuffledEmptyNeighbours = new List<Patch>();
 
         foreach (var patch in sourcePatches)
         {
@@ -75,7 +74,7 @@ public class MigrateSpecies : IRunStep
             if (population < Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION)
                 continue;
 
-            // Try all neighbour patches in random order, but try empty patches first
+            // First try all empty neighbor patches in random order
             shuffledNeighbours.Clear();
             foreach (var adjacent in patch.Adjacent)
             {
@@ -85,80 +84,69 @@ public class MigrateSpecies : IRunStep
 
                 if (adjacent.SpeciesInPatch.Count < 1)
                 {
-                    shuffledEmptyNeighbours.Add(adjacent);
-                    continue;
+                    shuffledNeighbours.Add(adjacent);
                 }
-
-                shuffledNeighbours.Add(adjacent);
             }
-
-            shuffledEmptyNeighbours.Shuffle(random);
-
-            var migrated = false;
-
-            // Prioritize colonizing empty patches
-            foreach (var target in shuffledEmptyNeighbours)
-            {
-                // Skip checking population send to the same patch multiple times
-                if (usedTargets.Contains(target))
-                    continue;
-
-                --attemptsLeft;
-                var targetMiche = results.GetMicheForPatch(target);
-
-                // Calculate random amount of population to send
-                var moveAmount = (long)random.Next(population * Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION_FRACTION,
-                    population * Constants.AUTO_EVO_MAXIMUM_MOVE_POPULATION_FRACTION);
-
-                if (moveAmount > 0 &&
-                    targetMiche.InsertSpecies(species, target, null, cache, true, insertWorkingMemory))
-                {
-                    results.AddMigrationResultForSpecies(species, new SpeciesMigration(patch, target, moveAmount));
-                    usedTargets.Add(target);
-
-                    // Only one migration per patch
-                    migrated = true;
-                    break;
-                }
-
-                if (attemptsLeft <= 0)
-                    break;
-            }
-
-            // Do not continue checking if a migration target was already chosen for this source
-            if (migrated)
-                break;
 
             shuffledNeighbours.Shuffle(random);
 
-            foreach (var target in shuffledNeighbours)
+            // Try to generate a migration. If successful, do not try non-empty target patches.
+            if (GenerateMigrations(results, shuffledNeighbours, usedTargets, patch, population, attemptsLeft))
+                continue;
+
+            // Try all non-empty neighbor patches in random order
+            shuffledNeighbours.Clear();
+            foreach (var adjacent in patch.Adjacent)
             {
-                // Skip checking population send to the same patch multiple times
-                if (usedTargets.Contains(target))
+                // Don't waste calculation time or migration attempts on migrating to patches the species is already in
+                if (adjacent.SpeciesInPatch.ContainsKey(species))
                     continue;
 
-                --attemptsLeft;
-                var targetMiche = results.GetMicheForPatch(target);
-
-                // Calculate random amount of population to send
-                var moveAmount = (long)random.Next(population * Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION_FRACTION,
-                    population * Constants.AUTO_EVO_MAXIMUM_MOVE_POPULATION_FRACTION);
-
-                if (moveAmount > 0 &&
-                    targetMiche.InsertSpecies(species, target, null, cache, true, insertWorkingMemory))
+                if (adjacent.SpeciesInPatch.Count > 0)
                 {
-                    results.AddMigrationResultForSpecies(species, new SpeciesMigration(patch, target, moveAmount));
-                    usedTargets.Add(target);
-
-                    // Only one migration per patch
-                    break;
+                    shuffledNeighbours.Add(adjacent);
                 }
-
-                if (attemptsLeft <= 0)
-                    break;
             }
+
+            shuffledNeighbours.Shuffle(random);
+
+            GenerateMigrations(results, shuffledNeighbours, usedTargets, patch, population, attemptsLeft);
         }
 
         return true;
+    }
+
+    private bool GenerateMigrations(RunResults results, List<Patch> shuffledNeighbours, HashSet<Patch> usedTargets,
+        Patch patch, long population, int attemptsLeft)
+    {
+        var generatedMigration = false;
+        foreach (var target in shuffledNeighbours)
+        {
+            // Skip checking population send to the same patch multiple times
+            if (usedTargets.Contains(target))
+                continue;
+
+            --attemptsLeft;
+            var targetMiche = results.GetMicheForPatch(target);
+
+            // Calculate random amount of population to send
+            var moveAmount = (long)random.Next(population * Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION_FRACTION,
+                population * Constants.AUTO_EVO_MAXIMUM_MOVE_POPULATION_FRACTION);
+
+            if (moveAmount > 0 &&
+                targetMiche.InsertSpecies(species, target, null, cache, true, insertWorkingMemory))
+            {
+                results.AddMigrationResultForSpecies(species, new SpeciesMigration(patch, target, moveAmount));
+                usedTargets.Add(target);
+
+                // Only one migration per patch
+                break;
+            }
+
+            if (attemptsLeft <= 0)
+                break;
+        }
+
+        return generatedMigration;
     }
 }

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -78,11 +78,13 @@ public class MigrateSpecies : IRunStep
             shuffledNeighbours.Clear();
             foreach (var adjacent in patch.Adjacent)
             {
+                // Don't waste calculation time or migration attempts on migrating to patches the species is already in
+                if (adjacent.SpeciesInPatch.ContainsKey(species))
+                    continue;
+
                 shuffledNeighbours.Add(adjacent);
             }
 
-            // TODO: could prefer patches this species is not already in or about to go extinct, or really anything
-            // other than random selection
             shuffledNeighbours.Shuffle(random);
 
             foreach (var target in shuffledNeighbours)

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -78,10 +78,6 @@ public class MigrateSpecies : IRunStep
             shuffledNeighbours.Clear();
             foreach (var adjacent in patch.Adjacent)
             {
-                // Don't waste calculation time or migration attempts on migrating to patches the species is already in
-                if (adjacent.SpeciesInPatch.ContainsKey(species))
-                    continue;
-
                 if (adjacent.SpeciesInPatch.Count < 1)
                 {
                     shuffledNeighbours.Add(adjacent);

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -87,7 +87,7 @@ public class MigrateSpecies : IRunStep
             shuffledNeighbours.Shuffle(random);
 
             // Try to generate a migration. If successful, do not try non-empty target patches.
-            if (GenerateMigrations(results, shuffledNeighbours, usedTargets, patch, population, attemptsLeft))
+            if (GenerateMigrations(results, shuffledNeighbours, usedTargets, patch, population, ref attemptsLeft))
                 continue;
 
             // Try all non-empty neighbor patches in random order
@@ -106,14 +106,14 @@ public class MigrateSpecies : IRunStep
 
             shuffledNeighbours.Shuffle(random);
 
-            GenerateMigrations(results, shuffledNeighbours, usedTargets, patch, population, attemptsLeft);
+            GenerateMigrations(results, shuffledNeighbours, usedTargets, patch, population, ref attemptsLeft);
         }
 
         return true;
     }
 
     private bool GenerateMigrations(RunResults results, List<Patch> shuffledNeighbours, HashSet<Patch> usedTargets,
-        Patch patch, long population, int attemptsLeft)
+        Patch patch, long population, ref int attemptsLeft)
     {
         var generatedMigration = false;
         foreach (var target in shuffledNeighbours)

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -115,7 +115,6 @@ public class MigrateSpecies : IRunStep
     private bool GenerateMigrations(RunResults results, List<Patch> shuffledNeighbours, HashSet<Patch> usedTargets,
         Patch patch, long population, ref int attemptsLeft)
     {
-        var generatedMigration = false;
         foreach (var target in shuffledNeighbours)
         {
             // Skip checking population send to the same patch multiple times
@@ -136,13 +135,13 @@ public class MigrateSpecies : IRunStep
                 usedTargets.Add(target);
 
                 // Only one migration per patch
-                break;
+                return true;
             }
 
             if (attemptsLeft <= 0)
                 break;
         }
 
-        return generatedMigration;
+        return false;
     }
 }

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -60,6 +60,7 @@ public class MigrateSpecies : IRunStep
 
         // To not randomly pick the same adjacent patch multiple times as a migration target
         var shuffledNeighbours = new List<Patch>();
+        var shuffledEmptyNeighbours = new List<Patch>();
 
         foreach (var patch in sourcePatches)
         {
@@ -74,7 +75,7 @@ public class MigrateSpecies : IRunStep
             if (population < Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION)
                 continue;
 
-            // Try all neighbour patches in random order
+            // Try all neighbour patches in random order, but try empty patches first
             shuffledNeighbours.Clear();
             foreach (var adjacent in patch.Adjacent)
             {
@@ -82,8 +83,51 @@ public class MigrateSpecies : IRunStep
                 if (adjacent.SpeciesInPatch.ContainsKey(species))
                     continue;
 
+                if (adjacent.SpeciesInPatch.Count < 1)
+                {
+                    shuffledEmptyNeighbours.Add(adjacent);
+                    continue;
+                }
+
                 shuffledNeighbours.Add(adjacent);
             }
+
+            shuffledEmptyNeighbours.Shuffle(random);
+
+            var migrated = false;
+
+            // Prioritize colonizing empty patches
+            foreach (var target in shuffledEmptyNeighbours)
+            {
+                // Skip checking population send to the same patch multiple times
+                if (usedTargets.Contains(target))
+                    continue;
+
+                --attemptsLeft;
+                var targetMiche = results.GetMicheForPatch(target);
+
+                // Calculate random amount of population to send
+                var moveAmount = (long)random.Next(population * Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION_FRACTION,
+                    population * Constants.AUTO_EVO_MAXIMUM_MOVE_POPULATION_FRACTION);
+
+                if (moveAmount > 0 &&
+                    targetMiche.InsertSpecies(species, target, null, cache, true, insertWorkingMemory))
+                {
+                    results.AddMigrationResultForSpecies(species, new SpeciesMigration(patch, target, moveAmount));
+                    usedTargets.Add(target);
+
+                    // Only one migration per patch
+                    migrated = true;
+                    break;
+                }
+
+                if (attemptsLeft <= 0)
+                    break;
+            }
+
+            // Do not continue checking if a migration target was already chosen for this source
+            if (migrated)
+                break;
 
             shuffledNeighbours.Shuffle(random);
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes to changes to MigrateSpecies to make migrations that do happen more impactful:
* Skip patches that the species is already in (migrations to here are unlikely to have a noticeable effect)
* Prioritize trying to migrate to completely empty patches (logically, there are likely to be more available resources here)

Combined, this speeds up the spread of life in the world, and propagates specific species around the world better.

**Related Issues**

There was a TODO to improve the selection of migration target patches.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
