### PR TITLE
Fix ATP production bar tooltip showing wrong numbers

### DIFF
--- a/src/microbe_stage/EnergyBalanceInfoFull.cs
+++ b/src/microbe_stage/EnergyBalanceInfoFull.cs
@@ -54,7 +54,7 @@ public class EnergyBalanceInfoFull : EnergyBalanceInfoSimple
             foreach (var inputCompound in requiredInputCompounds)
             {
                 compoundData.TryGetValue(inputCompound.Key, out var existingAmount);
-                compoundData[inputCompound.Key] = existingAmount + amount;
+                compoundData[inputCompound.Key] = existingAmount + inputCompound.Value;
             }
         }
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

The ATP production bar was showing wrong amounts of compounds being required. Essentially, the amounts shown were actually the amount of ATP produced because of a wrong variable being added.

**Related Issues**

--

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
