### PR TITLE
Make colony engulf distance use closest member

### DIFF
--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -551,8 +551,9 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
                 return false;
             }
 
+            var distanceToPrey = GetClosestColonyMemberDistanceSquared(in entity, position.Position, prey);
             bool engulfPrey = cellProperties.CanEngulfObject(ref ourSpecies, ref engulfer, possiblePrey) ==
-                EngulfCheckResult.Ok && position.Position.DistanceSquaredTo(prey) <
+                EngulfCheckResult.Ok && distanceToPrey <
                 10.0f * engulfer.EngulfingSize;
 
             // If out of ATP and the prey is out of reach to engulf, do nothing
@@ -1269,7 +1270,8 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
     {
         // Turn on engulf mode if close
         // Sometimes "close" is hard to discern since microbes can range from straight lines to circles
-        if ((position.Position - targetPosition).LengthSquared() <= engulfer.EngulfingSize * 2.0f)
+        if (GetClosestColonyMemberDistanceSquared(in entity, position.Position, targetPosition) <=
+            engulfer.EngulfingSize * 2.0f)
         {
             control.SetStateColonyAware(entity, MicrobeState.Engulf);
         }
@@ -1277,6 +1279,30 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
         {
             control.SetStateColonyAware(entity, MicrobeState.Normal);
         }
+    }
+
+    private float GetClosestColonyMemberDistanceSquared(in Entity entity, Vector3 fallbackPosition,
+        Vector3 targetPosition)
+    {
+        var closestDistance = fallbackPosition.DistanceSquaredTo(targetPosition);
+
+        if (!entity.Has<MicrobeColony>())
+            return closestDistance;
+
+        ref var colony = ref entity.Get<MicrobeColony>();
+
+        foreach (var colonyMember in colony.ColonyMembers)
+        {
+            if (!colonyMember.IsAliveAndHas<WorldPosition>())
+                continue;
+
+            var memberDistance = colonyMember.Get<WorldPosition>().Position.DistanceSquaredTo(targetPosition);
+
+            if (memberDistance < closestDistance)
+                closestDistance = memberDistance;
+        }
+
+        return closestDistance;
     }
 
     private void LaunchToxin(ref MicrobeControl control, ref OrganelleContainer organelles,


### PR DESCRIPTION
**Brief Description of What This PR Does**

I changed the microbe AI engulf-mode distance check so colonies use the closest living colony member to the target, instead of only the colony leader / main cell position.

That covers both living prey and normal engulfable chunks, so long colonies can turn on engulf mode when their front cell reaches the target. The non-colony path still uses the original cell position, so single cells should keep the same behaviour.

**Related Issues**

Closes #6702

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).

Tested on my pc:

- `dotnet run --project Scripts -- check files`
- `dotnet build Thrive.sln --no-restore`
- `dotnet test test\code_tests\ThriveTest.csproj --no-build` (100 passed)
- `dotnet run --project Scripts -- check inspectcode`
- Gameplay: launched this branch in Godot, started a new microbe game, entered microbe gameplay, and checked the runtime log. The visible gameplay side is intentionally unchanged here; this is AI distance logic.

Useful runtime log lines from the gameplay check:

```text
Thrive GDExtension initialized successfully
Thrive extension load succeeded, version: 9
------------ Thrive Startup Succeeded ------------
```