### PR TITLE
Using correct marshalling hint in NativePhysicsBody.cs

### DIFF
--- a/Scripts/NativeLibs.cs
+++ b/Scripts/NativeLibs.cs
@@ -2206,6 +2206,9 @@ public class NativeLibs
 
     private static class NativeMethods
     {
+        // Warning: do NOT use MarshalAs here, as kernel32.dll calls return the BOOL macro, which is by default a 4 byte
+        // integer. This is the only place where the marshalling of the bool value is actually correct.
+        // This is in general true for Windows native methods.
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         public static extern bool CreateHardLink(string lpFileName, string lpExistingFileName,
             IntPtr lpSecurityAttributes);

--- a/src/engine/physics/NativePhysicsBody.cs
+++ b/src/engine/physics/NativePhysicsBody.cs
@@ -69,7 +69,7 @@ public class NativePhysicsBody : IDisposable, IEquatable<NativePhysicsBody>
     public bool MicrobeControlEnabled { get; set; }
 
     public bool IsDisposed => disposed;
-    public bool IsDetached => NativeMethods.PhysicsBodyIsDetached(AccessBodyInternal()) != 0;
+    public bool IsDetached => NativeMethods.PhysicsBodyIsDetached(AccessBodyInternal());
 
     public static bool operator ==(NativePhysicsBody? left, NativePhysicsBody? right)
     {
@@ -212,7 +212,8 @@ internal static partial class NativeMethods
     // TODO: find out why this had to be converted to have return type "byte" instead of bool
     // BUG: https://github.com/Revolutionary-Games/Thrive/issues/5676
     [DllImport("thrive_native")]
-    internal static extern byte PhysicsBodyIsDetached(IntPtr body);
+    [return: MarshalAs(UnmanagedType.U1)]
+    internal static extern bool PhysicsBodyIsDetached(IntPtr body);
 
     [DllImport("thrive_native")]
     internal static extern void PhysicsBodySetUserData(IntPtr body, in Entity userData, int userDataSize);

--- a/src/engine/physics/NativePhysicsBody.cs
+++ b/src/engine/physics/NativePhysicsBody.cs
@@ -209,8 +209,6 @@ internal static partial class NativeMethods
     [DllImport("thrive_native")]
     internal static extern void ReleasePhysicsBodyReference(IntPtr body);
 
-    // TODO: find out why this had to be converted to have return type "byte" instead of bool
-    // BUG: https://github.com/Revolutionary-Games/Thrive/issues/5676
     [DllImport("thrive_native")]
     [return: MarshalAs(UnmanagedType.U1)]
     internal static extern bool PhysicsBodyIsDetached(IntPtr body);

--- a/src/engine/physics/PhysicalWorld.cs
+++ b/src/engine/physics/PhysicalWorld.cs
@@ -684,6 +684,7 @@ internal static partial class NativeMethods
     internal static extern void SetBodyAllowSleep(IntPtr world, IntPtr body, bool allowSleep);
 
     [DllImport("thrive_native")]
+    [return: MarshalAs(UnmanagedType.U1)]
     internal static extern bool FixBodyYCoordinateToZero(IntPtr world, IntPtr body);
 
     [DllImport("thrive_native")]
@@ -747,6 +748,7 @@ internal static partial class NativeMethods
     internal static extern float PhysicalWorldGetPhysicsAverageTime(IntPtr physicalWorld);
 
     [DllImport("thrive_native", CharSet = CharSet.Ansi, BestFitMapping = false)]
+    [return: MarshalAs(UnmanagedType.U1)]
     internal static extern bool PhysicalWorldDumpPhysicsState(IntPtr physicalWorld, string path);
 
     [DllImport("thrive_native")]

--- a/src/engine/physics/PhysicalWorld.cs
+++ b/src/engine/physics/PhysicalWorld.cs
@@ -598,12 +598,14 @@ internal static partial class NativeMethods
     internal static extern void DestroyPhysicalWorld(IntPtr physicalWorld);
 
     [DllImport("thrive_native")]
+    [return: MarshalAs(UnmanagedType.U1)]
     internal static extern bool ProcessPhysicalWorld(IntPtr physicalWorld, float delta);
 
     [DllImport("thrive_native")]
     internal static extern void ProcessPhysicalWorldInBackground(IntPtr physicalWorld, float delta);
 
     [DllImport("thrive_native")]
+    [return: MarshalAs(UnmanagedType.U1)]
     internal static extern bool WaitForPhysicsToCompleteInPhysicalWorld(IntPtr physicalWorld);
 
     [DllImport("thrive_native")]

--- a/src/extension/interop/ExtensionInterop.cs
+++ b/src/extension/interop/ExtensionInterop.cs
@@ -124,5 +124,6 @@ internal static partial class NativeMethods
     internal static extern int ExtensionGetVersion(IntPtr thriveConfig);
 
     [DllImport("thrive_extension")]
+    [return: MarshalAs(UnmanagedType.U1)]
     internal static extern bool ArrayMeshUnwrap(in godot_variant mesh, float texelSize);
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Issue #5676 was caused by incorrect marshalling of the bool type as a 4-byte integer. This PR forces the usage of a single byte for the bool return type.

As a general future reference, the `MarshalAs` attribute *should* be used anywhere the return value is bool in native calls.

**Related Issues**

Closes #5676 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
