### PR TITLE
Rename AbsorptionRatio to AbsorptionRate in CompoundAbsorber

### DIFF
--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -880,7 +880,7 @@ public static class SpawnHelpers
             // Microbes only want to grab stuff they want
             OnlyAbsorbUseful = true,
 
-            AbsorptionRatio = usedCellDefinition.MembraneType.ResourceAbsorptionFactor,
+            AbsorptionRate = usedCellDefinition.MembraneType.ResourceAbsorptionFactor,
 
             // AI requires this, player doesn't (or at least I can't remember right now that it would -hhyyrylainen)
             // but it isn't too big a problem to also specify this for the player

--- a/src/microbe_stage/components/CompoundAbsorber.cs
+++ b/src/microbe_stage/components/CompoundAbsorber.cs
@@ -22,12 +22,12 @@ public struct CompoundAbsorber : IArchivableComponent
     public float AbsorbRadius;
 
     /// <summary>
-    ///   How fast this can absorb things. If 0 then the absorption speed is not limited.
+    ///   How fast this can absorb things. If 0 then the absorption speed is not limited. (this is unimplemented)
     /// </summary>
     public float AbsorbSpeed;
 
     /// <summary>
-    ///   The effectiveness (ratio of gained vs compounds taken from the clouds) of absorption
+    ///   A multiplier on the rate at which this entity can consume clouds and absorb compounds from them
     /// </summary>
     public float AbsorptionRate;
 

--- a/src/microbe_stage/components/CompoundAbsorber.cs
+++ b/src/microbe_stage/components/CompoundAbsorber.cs
@@ -29,7 +29,7 @@ public struct CompoundAbsorber : IArchivableComponent
     /// <summary>
     ///   The effectiveness (ratio of gained vs compounds taken from the clouds) of absorption
     /// </summary>
-    public float AbsorptionRatio;
+    public float AbsorptionRate;
 
     /// <summary>
     ///   When true, then the <see cref="CompoundBag"/> that we put things in must have useful compounds set and
@@ -53,7 +53,7 @@ public struct CompoundAbsorber : IArchivableComponent
 
         writer.Write(AbsorbRadius);
         writer.Write(AbsorbSpeed);
-        writer.Write(AbsorptionRatio);
+        writer.Write(AbsorptionRate);
         writer.Write(OnlyAbsorbUseful);
     }
 }
@@ -70,7 +70,7 @@ public static class CompoundAbsorberHelpers
             TotalAbsorbedCompounds = reader.ReadObject<Dictionary<Compound, float>>(),
             AbsorbRadius = reader.ReadFloat(),
             AbsorbSpeed = reader.ReadFloat(),
-            AbsorptionRatio = reader.ReadFloat(),
+            AbsorptionRate = reader.ReadFloat(),
             OnlyAbsorbUseful = reader.ReadBool(),
         };
     }

--- a/src/microbe_stage/systems/CompoundAbsorptionSystem.cs
+++ b/src/microbe_stage/systems/CompoundAbsorptionSystem.cs
@@ -58,7 +58,7 @@ public partial class CompoundAbsorptionSystem : BaseSystem<World, float>
         }
 
         compoundCloudSystem.AbsorbCompounds(position.Position, absorber.AbsorbRadius, storage.Compounds,
-            absorber.TotalAbsorbedCompounds, delta, absorber.AbsorptionRatio);
+            absorber.TotalAbsorbedCompounds, delta, absorber.AbsorptionRate);
 
         // Player infinite compounds cheat, doesn't *really* belong here, but this is probably the best place to put
         // this instead of creating a dedicated cheat handling system


### PR DESCRIPTION
**Brief Description of What This PR Does**

Renames "AbsorptionRatio" to "AbsorptionRate" in the CompoundAbsorber component and re-writes its documentation.

Both of these to better match how it actually functions.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
