### PR TITLE
Display cell body plan adjacency bonuses on hover

### DIFF
--- a/src/general/base_stage/HexEditorComponentBase.cs
+++ b/src/general/base_stage/HexEditorComponentBase.cs
@@ -68,6 +68,12 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
     [Export]
     protected MeshInstance3D editorGrid = null!;
 
+    [Export]
+    protected Control? hexPositionEffectsContainer;
+
+    [Export]
+    protected Font hexEffectFont = null!;
+
     protected Material invalidMaterial = null!;
     protected Material validMaterial = null!;
     protected Material oldMaterial = null!;
@@ -105,7 +111,9 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
 
     private readonly NodePath positionZReference = new("position:z");
 
-    // This is separate from the other Godot resources as this is private and they are protected
+    private readonly List<HexAdjacencyDrawElement> hexDrawList = new();
+
+    // This is different from the other Godot resources as this is private and they are protected
 #pragma warning disable CA2213
     [Export]
     private CustomConfirmationDialog islandPopup = null!;
@@ -218,6 +226,13 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
 
         camera!.Connect(MicrobeCamera.SignalName.OnZoomChanged, new Callable(this, nameof(OnZoomChanged)));
 
+        if (hexPositionEffectsContainer != null)
+        {
+            // This is hidden just in the Godot Editor for clarity, so always show it in the game
+            hexPositionEffectsContainer.Visible = true;
+            hexPositionEffectsContainer.Connect(CanvasItem.SignalName.Draw, Callable.From(DrawHexPositionEffects));
+        }
+
         LoadHexMaterials();
         LoadScenes();
         LoadAudioStreams();
@@ -309,6 +324,8 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
         camera.UpdateCameraPosition(delta, cameraFollow.GlobalPosition);
 
         UpdateFloatingLabelPositions();
+
+        ResetHexAdjacencyDisplay();
     }
 
     public override void WritePropertiesToArchive(ISArchiveWriter writer)
@@ -349,7 +366,7 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
     }
 
     /// <summary>
-    ///   Set tab specific editor world object visibility
+    ///   Set tab-specific editor world object visibility
     /// </summary>
     /// <param name="shown">True if they should be visible</param>
     public virtual void SetEditorWorldTabSpecificObjectVisibility(bool shown)
@@ -616,7 +633,7 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
         var actions = new List<TAction>();
         int alreadyDeleted = 0;
 
-        RunWithSymmetry(hex.Q, hex.R, (q, r, _) =>
+        RunWithSymmetry(hex.Q, hex.R, (q, r, _, _) =>
         {
             var removed = TryCreateRemoveHexAtAction(new Hex(q, r), ref alreadyDeleted);
 
@@ -878,13 +895,15 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
     }
 
     /// <summary>
-    ///   Runs given callback for all symmetry positions and rotations
+    ///   Runs the given callback for all symmetry positions and rotations
     /// </summary>
     /// <param name="q">The base q</param>
     /// <param name="r">The base r value of the coordinate</param>
-    /// <param name="callback">The callback that is called based on symmetry, parameters are: q, r, rotation</param>
+    /// <param name="callback">
+    ///   The callback that is called based on symmetry, parameters are: q, r, rotation, isMain
+    /// </param>
     /// <param name="overrideSymmetry">If set, overrides the current symmetry</param>
-    protected void RunWithSymmetry(int q, int r, Action<int, int, int> callback,
+    protected void RunWithSymmetry(int q, int r, Action<int, int, int, bool> callback,
         HexEditorSymmetry? overrideSymmetry = null)
     {
         overrideSymmetry ??= Symmetry;
@@ -893,17 +912,17 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
         {
             case HexEditorSymmetry.None:
             {
-                callback(q, r, placementRotation);
+                callback(q, r, placementRotation, true);
                 break;
             }
 
             case HexEditorSymmetry.XAxisSymmetry:
             {
-                callback(q, r, placementRotation);
+                callback(q, r, placementRotation, true);
 
                 if (q != -1 * q || r != r + q)
                 {
-                    callback(-1 * q, r + q, 6 + (-1 * placementRotation));
+                    callback(-1 * q, r + q, 6 + (-1 * placementRotation), false);
                 }
 
                 break;
@@ -911,17 +930,17 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
 
             case HexEditorSymmetry.FourWaySymmetry:
             {
-                callback(q, r, placementRotation);
+                callback(q, r, placementRotation, true);
 
                 if (q != -1 * q || r != r + q)
                 {
-                    callback(-1 * q, r + q, 6 + (-1 * placementRotation));
-                    callback(-1 * q, -1 * r, (placementRotation + 3) % 6);
-                    callback(q, -1 * (r + q), 9 + (-1 * placementRotation) % 6);
+                    callback(-1 * q, r + q, 6 + (-1 * placementRotation), false);
+                    callback(-1 * q, -1 * r, (placementRotation + 3) % 6, false);
+                    callback(q, -1 * (r + q), 9 + (-1 * placementRotation) % 6, false);
                 }
                 else
                 {
-                    callback(-1 * q, -1 * r, (placementRotation + 3) % 6);
+                    callback(-1 * q, -1 * r, (placementRotation + 3) % 6, false);
                 }
 
                 break;
@@ -929,12 +948,12 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
 
             case HexEditorSymmetry.SixWaySymmetry:
             {
-                callback(q, r, placementRotation);
-                callback(-1 * r, r + q, (placementRotation + 1) % 6);
-                callback(-1 * (r + q), q, (placementRotation + 2) % 6);
-                callback(-1 * q, -1 * r, (placementRotation + 3) % 6);
-                callback(r, -1 * (r + q), (placementRotation + 4) % 6);
-                callback(r + q, -1 * q, (placementRotation + 5) % 6);
+                callback(q, r, placementRotation, true);
+                callback(-1 * r, r + q, (placementRotation + 1) % 6, false);
+                callback(-1 * (r + q), q, (placementRotation + 2) % 6, false);
+                callback(-1 * q, -1 * r, (placementRotation + 3) % 6, false);
+                callback(r, -1 * (r + q), (placementRotation + 4) % 6, false);
+                callback(r + q, -1 * q, (placementRotation + 5) % 6, false);
                 break;
             }
         }
@@ -1194,6 +1213,55 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
         componentBottomLeftButtons.SymmetryEnabled = !CanCancelAction;
     }
 
+    protected void ResetHexAdjacencyDisplay()
+    {
+        if (hexPositionEffectsContainer == null)
+            return;
+
+        bool reset = false;
+
+        foreach (var element in hexDrawList)
+        {
+            if (element.Used)
+            {
+                reset = true;
+                element.Used = false;
+            }
+        }
+
+        if (reset)
+            hexPositionEffectsContainer.QueueRedraw();
+    }
+
+    protected void DisplayHexAdjacencyEffect(Hex targetHex, Hex sourceHex, string text, Color arrowColour)
+    {
+        if (hexPositionEffectsContainer == null)
+        {
+            GD.PrintErr("Hex position effects container is null so draw request is being ignored");
+            return;
+        }
+
+        bool alreadyHandled = false;
+
+        foreach (var existing in hexDrawList)
+        {
+            if (!existing.Used)
+            {
+                alreadyHandled = true;
+
+                existing.Update(targetHex, sourceHex, text, arrowColour);
+                break;
+            }
+        }
+
+        if (!alreadyHandled)
+        {
+            hexDrawList.Add(new HexAdjacencyDrawElement(targetHex, sourceHex, text, arrowColour) { Used = true });
+        }
+
+        hexPositionEffectsContainer.QueueRedraw();
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)
@@ -1228,6 +1296,58 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
         }
     }
 
+    private void DrawHexPositionEffects()
+    {
+        if (hexPositionEffectsContainer == null)
+            return;
+
+        const int arrowWidth = 3;
+        const float arrowHandLength = 11.0f;
+        const float arrowHandAngle = (float)Math.PI / 4;
+        const int textSize = 20;
+
+        foreach (var element in hexDrawList)
+        {
+            if (!element.Used)
+                continue;
+
+            var position1 = camera!.UnprojectPosition(Hex.AxialToCartesian(element.SourceHex));
+
+            // Draw lines where those are set
+            if (element.SourceHex != element.TargetHex)
+            {
+                var position2 = camera!.UnprojectPosition(Hex.AxialToCartesian(element.TargetHex));
+                hexPositionEffectsContainer.DrawLine(position1, position2, element.ArrowColour, arrowWidth, true);
+
+                // Draw the arrow hands
+                var direction = (position2 - position1).Normalized();
+                var backwards = -direction;
+
+                var arrowTip = position2 + backwards * (arrowWidth / 2.2f);
+
+                var arrowHand1 = arrowTip + backwards.Rotated(arrowHandAngle) * arrowHandLength;
+                var arrowHand2 = arrowTip + backwards.Rotated(-arrowHandAngle) * arrowHandLength;
+
+                hexPositionEffectsContainer.DrawLine(arrowTip, arrowHand1, element.ArrowColour, arrowWidth, true);
+                hexPositionEffectsContainer.DrawLine(arrowTip, arrowHand2, element.ArrowColour, arrowWidth, true);
+            }
+
+            // Draw text if set
+            if (!string.IsNullOrEmpty(element.Text))
+            {
+                // Offset the horizontal position so that it matches the centre of the position
+                var textWidth = hexEffectFont.GetStringSize(element.Text, HorizontalAlignment.Left, -1, textSize);
+
+                // The Y-position seems trickier. Might need to get like the font baseline here or something, but this
+                // math works well enough
+                textWidth.Y = -textWidth.Y * 0.5f;
+
+                hexPositionEffectsContainer.DrawString(hexEffectFont, position1 - textWidth * 0.5f,
+                    element.Text, HorizontalAlignment.Left, -1, textSize);
+            }
+        }
+    }
+
     /// <summary>
     ///   Moves the camera in a direction (note that height (y-axis) should not be used)
     /// </summary>
@@ -1256,5 +1376,24 @@ public partial class HexEditorComponentBase<TEditor, TCombinedAction, TAction, T
         public bool Active { get; set; } = true;
 
         public Vector3 TargetPosition { get; set; }
+    }
+
+    private class HexAdjacencyDrawElement(Hex targetHex, Hex sourceHex, string text, Color arrowColour)
+    {
+        public Hex TargetHex { get; set; } = targetHex;
+        public Hex SourceHex { get; set; } = sourceHex;
+        public string Text { get; set; } = text;
+        public Color ArrowColour { get; set; } = arrowColour;
+
+        public bool Used { get; set; }
+
+        public void Update(Hex to, Hex from, string text, Color color)
+        {
+            Used = true;
+            TargetHex = to;
+            SourceHex = from;
+            Text = text;
+            ArrowColour = color;
+        }
     }
 }

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -801,7 +801,7 @@ public partial class CellEditorComponent :
                     effectiveSymmetry = HexEditorSymmetry.None;
 
                 RunWithSymmetry(q, r,
-                    (finalQ, finalR, rotation) =>
+                    (finalQ, finalR, rotation, _) =>
                     {
                         RenderHighlightedOrganelle(finalQ, finalR, rotation, shownOrganelle, MovingPlacedHex?.Upgrades);
 
@@ -1465,7 +1465,7 @@ public partial class CellEditorComponent :
         // This is a list to preserve order, Distinct is used later to ensure no duplicate organelles are added
         var organelles = new List<OrganelleTemplate>();
 
-        RunWithSymmetry(q, r, (symmetryQ, symmetryR, _) =>
+        RunWithSymmetry(q, r, (symmetryQ, symmetryR, _, _) =>
         {
             var organelle = editedMicrobeOrganelles.GetElementAt(new Hex(symmetryQ, symmetryR), hexTemporaryMemory);
 
@@ -2305,7 +2305,7 @@ public partial class CellEditorComponent :
             componentBottomLeftButtons.SymmetryEnabled ? null : HexEditorSymmetry.None;
 
         RunWithSymmetry(q, r,
-            (attemptQ, attemptR, rotation) =>
+            (attemptQ, attemptR, rotation, _) =>
             {
                 var organelle = new OrganelleTemplate(GetOrganelleDefinition(organelleType),
                     new Hex(attemptQ, attemptR), rotation);

--- a/src/microbe_stage/editor/CellEditorComponent.tscn
+++ b/src/microbe_stage/editor/CellEditorComponent.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="PackedScene" uid="uid://bwegwjlcioasf" path="res://src/microbe_stage/editor/EditorComponentBottomLeftButtons.tscn" id="3"]
 [ext_resource type="PackedScene" uid="uid://0hb8nq18ljr8" path="res://src/microbe_stage/editor/LightConfigurationPanel.tscn" id="3_yy73o"]
 [ext_resource type="Script" uid="uid://dfbi66n0pfqh7" path="res://src/microbe_stage/editor/CellEditorComponent.cs" id="4"]
+[ext_resource type="FontFile" uid="uid://b62thy1er4r08" path="res://assets/fonts/Lato-Bold.ttf" id="4_o1pli"]
 [ext_resource type="Theme" uid="uid://b4cx0o110g4b6" path="res://src/gui_common/thrive_theme.tres" id="6"]
 [ext_resource type="PackedScene" uid="uid://seoiqsheiljf" path="res://src/microbe_stage/editor/MutationPointsBar.tscn" id="7"]
 [ext_resource type="FontVariation" uid="uid://cik4lxxj7fi2t" path="res://assets/fonts/variants/Jura-Regular.tres" id="8_07qd0"]
@@ -565,6 +566,7 @@ rightPanelScrollContainer = NodePath("RightPanel/VBoxContainer/OrganismStatistic
 bottomRightPanel = NodePath("BottomRight")
 tutorialAnimationPlayer = NodePath("TutorialAnimations")
 toleranceWarningsFont = ExtResource("28_qclxk")
+hexEffectFont = ExtResource("4_o1pli")
 floatingLabelContainer = NodePath("GrowthOrderNumberContainer")
 islandPopup = NodePath("IslandError")
 componentBottomLeftButtons = NodePath("EditorComponentBottomLeftButtons")

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -367,9 +367,9 @@ public partial class CellBodyPlanEditorComponent :
                     effectiveSymmetry = HexEditorSymmetry.None;*/
 
                 RunWithSymmetry(q, r,
-                    (finalQ, finalR, rotation) =>
+                    (finalQ, finalR, rotation, main) =>
                     {
-                        RenderHighlightedCell(finalQ, finalR, rotation, cellType);
+                        RenderHighlightedCell(finalQ, finalR, rotation, cellType, main);
 
                         var finalHex = new Hex(finalQ, finalR);
 
@@ -664,7 +664,7 @@ public partial class CellBodyPlanEditorComponent :
 
         var cells = new List<HexWithData<CellTemplate>>();
 
-        RunWithSymmetry(q, r, (symmetryQ, symmetryR, _) =>
+        RunWithSymmetry(q, r, (symmetryQ, symmetryR, _, _) =>
         {
             var cell = editedMicrobeCells.AsModifiable()
                 .GetElementAt(new Hex(symmetryQ, symmetryR), hexTemporaryMemory);
@@ -904,7 +904,7 @@ public partial class CellBodyPlanEditorComponent :
         cellPopupMenu.EnableMoveOption = editedMicrobeCells.Count > 1;
     }
 
-    private void RenderHighlightedCell(int q, int r, int rotation, CellType cellToPlace)
+    private void RenderHighlightedCell(int q, int r, int rotation, CellType cellToPlace, bool isMainPosition)
     {
         if (MovingPlacedHex == null && activeActionName == null)
             return;
@@ -915,8 +915,58 @@ public partial class CellBodyPlanEditorComponent :
 
         bool showModel = !hadDuplicate;
 
-        // When force updating this has to run to make sure the cell holder has been forced to refresh so that when
-        // it becomes visible it doesn't have outdated graphics on it
+        if (!hadDuplicate || isMainPosition)
+        {
+            // We are hovering over an existing hex, show its adjacency effects
+            // Or placing a new cell
+            var text = "+" + Localization.Translate("PERCENTAGE_VALUE")
+                .FormatSafe(Math.Round(100 * Constants.CELL_ADJACENCY_SPECIALIZATION_BONUS));
+
+            float totalBonus = 0;
+
+            // If placing on existing cell, check that type to show existing info, otherwise use the cell to place
+            var cellToCheckAgainst = hadDuplicate ?
+                editedMicrobeCells.AsModifiable().GetElementAt(new Hex(q, r), hexTemporaryMemory)?.Data!
+                    .ModifiableCellType :
+                cellToPlace;
+
+            // If we for some reason didn't get the main cell type, use the cell to place as a fallback
+            cellToCheckAgainst ??= cellToPlace;
+
+            foreach (var (_, offset) in Hex.HexNeighbourOffset)
+            {
+                var positionToCheck = new Hex(q + offset.Q, r + offset.R);
+
+                var cellAtPosition =
+                    editedMicrobeCells.AsModifiable().GetElementAt(positionToCheck, hexTemporaryMemory);
+
+                if (cellAtPosition == null)
+                    continue;
+
+                // For now cell adjacency only looks at the type, so we can easily re-calculate that here
+                if (GetEditedCellDataIfEdited(cellAtPosition.Data!.ModifiableCellType) !=
+                    GetEditedCellDataIfEdited(cellToCheckAgainst))
+                {
+                    continue;
+                }
+
+                totalBonus += Constants.CELL_ADJACENCY_SPECIALIZATION_BONUS;
+                DisplayHexAdjacencyEffect(new Hex(q, r), positionToCheck, text, Colors.LightGreen);
+            }
+
+            if (totalBonus > 0)
+            {
+                // TODO: show total bonus number
+                text = "+" + Localization.Translate("PERCENTAGE_VALUE")
+                    .FormatSafe(Math.Round(100 * totalBonus));
+
+                // We just draw the text here and not the line
+                DisplayHexAdjacencyEffect(new Hex(q, r), new Hex(q, r), text, Colors.White);
+            }
+        }
+
+        // When force updating, this has to run to make sure the cell holder has been forced to refresh so that when
+        // it becomes visible, it doesn't have outdated graphics on it
         if (showModel || forceUpdateCellGraphics)
         {
             var cartesianPosition = Hex.AxialToCartesian(new Hex(q, r));
@@ -960,7 +1010,7 @@ public partial class CellBodyPlanEditorComponent :
         var usedHexes = new HashSet<Hex>();
 
         RunWithSymmetry(q, r,
-            (attemptQ, attemptR, rotation) =>
+            (attemptQ, attemptR, rotation, _) =>
             {
                 var hex = new Hex(attemptQ, attemptR);
 

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.tscn
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://ctqyvjb6wvagi" path="res://src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs" id="1"]
 [ext_resource type="PackedScene" uid="uid://ipvxtakaph16" path="res://src/multicellular_stage/editor/CellPopupMenu.tscn" id="3"]
 [ext_resource type="PackedScene" uid="uid://0hb8nq18ljr8" path="res://src/microbe_stage/editor/LightConfigurationPanel.tscn" id="3_nj0t6"]
+[ext_resource type="FontFile" uid="uid://b62thy1er4r08" path="res://assets/fonts/Lato-Bold.ttf" id="4_h03u7"]
 [ext_resource type="Theme" uid="uid://b4cx0o110g4b6" path="res://src/gui_common/thrive_theme.tres" id="5"]
 [ext_resource type="LabelSettings" uid="uid://dvqx73nhtr0y2" path="res://src/gui_common/fonts/Body-Regular-Small.tres" id="6_pwhoj"]
 [ext_resource type="PackedScene" uid="uid://cl64wvnxs6ivs" path="res://src/gui_common/dialogs/CustomConfirmationDialog.tscn" id="7"]
@@ -332,7 +333,7 @@ _data = {
 &"show": SubResource("44")
 }
 
-[node name="CellBodyPlanEditorComponent" type="Control" unique_id=2093309640 node_paths=PackedStringArray("structureTabButton", "reproductionTabButton", "behaviourTabButton", "growthOrderTabButton", "tolerancesTabButton", "structureTab", "reproductionTab", "behaviourEditor", "growthOrderTab", "growthOrderGUI", "showGrowthOrderCoordinates", "tolerancesEditor", "toleranceTab", "toleranceWarningContainer", "cellTypeSelectionList", "modifyTypeButton", "deleteTypeButton", "duplicateTypeButton", "cannotDeleteInUseTypeDialog", "duplicateCellTypeDialog", "duplicateCellTypeName", "cellPopupMenu", "organismStatisticsPanel", "negativeAtpPopup", "wrongGrowthOrderPopup", "floatingLabelContainer", "islandPopup", "componentBottomLeftButtons", "mutationPointsBar", "cancelButton", "finishButtonWarningBadge", "finishOrNextButton")]
+[node name="CellBodyPlanEditorComponent" type="Control" unique_id=2093309640 node_paths=PackedStringArray("structureTabButton", "reproductionTabButton", "behaviourTabButton", "growthOrderTabButton", "tolerancesTabButton", "structureTab", "reproductionTab", "behaviourEditor", "growthOrderTab", "growthOrderGUI", "showGrowthOrderCoordinates", "tolerancesEditor", "toleranceTab", "toleranceWarningContainer", "cellTypeSelectionList", "modifyTypeButton", "deleteTypeButton", "duplicateTypeButton", "cannotDeleteInUseTypeDialog", "duplicateCellTypeDialog", "duplicateCellTypeName", "cellPopupMenu", "organismStatisticsPanel", "negativeAtpPopup", "wrongGrowthOrderPopup", "hexPositionEffectsContainer", "floatingLabelContainer", "islandPopup", "componentBottomLeftButtons", "mutationPointsBar", "cancelButton", "finishButtonWarningBadge", "finishOrNextButton")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -367,6 +368,8 @@ organismStatisticsPanel = NodePath("RightPanel/VBoxContainer/OrganismStatisticsP
 negativeAtpPopup = NodePath("NegativeAtpWarning")
 wrongGrowthOrderPopup = NodePath("WrongGrowthOrderError")
 toleranceWarningsFont = ExtResource("6_pwhoj")
+hexPositionEffectsContainer = NodePath("AdjacencyFactorsContainer")
+hexEffectFont = ExtResource("4_h03u7")
 floatingLabelContainer = NodePath("GrowthOrderNumberContainer")
 islandPopup = NodePath("IslandError")
 componentBottomLeftButtons = NodePath("EditorComponentBottomLeftButtons")
@@ -376,6 +379,16 @@ finishButtonWarningBadge = NodePath("BottomRight/HBoxContainer/ConfirmButton/Mar
 finishOrNextButton = NodePath("BottomRight/HBoxContainer/ConfirmButton")
 
 [node name="GrowthOrderNumberContainer" type="Control" parent="." unique_id=390900625]
+visible = false
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
+[node name="AdjacencyFactorsContainer" type="Control" parent="." unique_id=337223688]
 visible = false
 layout_mode = 1
 anchors_preset = 15


### PR DESCRIPTION
to make it clearer to the player where those bonuses come from

I didn't get the arrow heads looking exactly like I wanted but I already spent over half the time making this feature on tweaking those and this is the best I was able to get.

Will merge this pretty much immediately for the BOTD.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
