### PR TITLE
Make screen filters affect engine UI like dropdowns

### DIFF
--- a/src/engine/ScreenOverlays.tscn
+++ b/src/engine/ScreenOverlays.tscn
@@ -14,7 +14,7 @@ process_mode = 3
 process_priority = 2000
 
 [node name="NormalOverlays" type="CanvasLayer" parent="." unique_id=265471570]
-layer = 124
+layer = 125
 
 [node name="LoadingScreen" parent="NormalOverlays" unique_id=163351852 instance=ExtResource("3")]
 visible = false
@@ -34,17 +34,15 @@ script = ExtResource("8")
 visible = false
 
 [node name="QuickLoad" parent="NormalOverlays" unique_id=835076305 instance=ExtResource("5")]
-grow_horizontal = 2
-grow_vertical = 2
 theme = ExtResource("6")
 
 [node name="OverlaysOnTopOfModals" type="CanvasLayer" parent="." unique_id=941284562]
-layer = 126
+layer = 127
 
 [node name="DebugOverlay" parent="OverlaysOnTopOfModals" unique_id=470426416 instance=ExtResource("7")]
 
 [node name="Effects" type="CanvasLayer" parent="." unique_id=2004192704]
-layer = 128
+layer = 1025
 
 [node name="ScreenFilter" parent="Effects" unique_id=817337921 instance=ExtResource("1")]
 visible = false

--- a/src/engine/UnHandledErrorsGUI.tscn
+++ b/src/engine/UnHandledErrorsGUI.tscn
@@ -23,7 +23,7 @@ popupModsUsedWarning = NodePath("ErrorDialog/VBoxContainer/ExceptionBox/ModsEnab
 counterModsUsedWarning = NodePath("CanvasLayer/MarginContainer/VBoxContainer/ModsEnabledWarning")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="." unique_id=1974040516]
-layer = 126
+layer = 127
 
 [node name="MarginContainer" type="MarginContainer" parent="CanvasLayer" unique_id=1965836583]
 anchors_preset = 1
@@ -60,13 +60,13 @@ ErrorMessage = "UNHANDLED_ERROR_DESCRIPTION"
 ExceptionInfo = ""
 WindowTitle = "UNHANDLED_ERROR_TITLE"
 
-[node name="ModsEnabledWarning2" type="Label" parent="ErrorDialog/VBoxContainer/ExceptionBox" index="1" unique_id=1500109914]
+[node name="ModsEnabledWarning2" type="Label" parent="ErrorDialog/VBoxContainer/ExceptionBox" parent_id_path=PackedInt32Array(1622207355, 146130145) index="1" unique_id=1500109914]
 visible = false
 layout_mode = 2
 text = "MODS_ARE_ENABLED"
 label_settings = ExtResource("4_6ks7o")
 
-[node name="IgnoreFurther" type="CheckBox" parent="ErrorDialog/VBoxContainer" index="2" unique_id=153886069]
+[node name="IgnoreFurther" type="CheckBox" parent="ErrorDialog/VBoxContainer" parent_id_path=PackedInt32Array(1622207355, 68791056) index="2" unique_id=153886069]
 layout_mode = 2
 text = "IGNORE_FURTHER_ERRORS"
 

--- a/src/gui_common/ModalManager.tscn
+++ b/src/gui_common/ModalManager.tscn
@@ -6,7 +6,7 @@
 script = ExtResource("1")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="." unique_id=1173056268]
-layer = 125
+layer = 126
 
 [node name="ActiveModalContainer" type="Control" parent="CanvasLayer" unique_id=587668837]
 layout_mode = 3

--- a/src/gui_common/tooltip/ToolTipManager.tscn
+++ b/src/gui_common/tooltip/ToolTipManager.tscn
@@ -30,7 +30,7 @@ corner_radius_bottom_left = 5
 
 [node name="ToolTipManager" type="CanvasLayer" unique_id=502662551]
 process_mode = 3
-layer = 127
+layer = 128
 script = ExtResource("23")
 
 [node name="GroupHolder" type="Control" parent="." unique_id=1984538779]
@@ -154,10 +154,10 @@ ShowOsmoregulation = false
 [node name="RequiresNucleus" parent="GroupHolder/editor/rigiditySlider/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(9346694, 1863350977) index="1" unique_id=1907280912]
 visible = false
 
-[node name="ProcessesDescription" parent="GroupHolder/editor/rigiditySlider/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(9346694, 1863350977) index="2" unique_id=1366796537]
+[node name="ProcessesDescription" parent="GroupHolder/editor/rigiditySlider/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(9346694, 1863350977) index="3" unique_id=1366796537]
 visible = false
 
-[node name="ProcessList" parent="GroupHolder/editor/rigiditySlider/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(9346694, 1863350977) index="3" unique_id=1563198072]
+[node name="ProcessList" parent="GroupHolder/editor/rigiditySlider/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(9346694, 1863350977) index="4" unique_id=1563198072]
 visible = false
 
 [node name="baseMobility" parent="GroupHolder/editor/rigiditySlider/MarginContainer/VBoxContainer/ModifierList" parent_id_path=PackedInt32Array(9346694, 1621578455) index="0" unique_id=527654288 instance=ExtResource("2")]
@@ -170,10 +170,10 @@ layout_mode = 2
 DisplayName = "HEALTH"
 ModifierIcon = ExtResource("13")
 
-[node name="HSeparator" parent="GroupHolder/editor/rigiditySlider/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(9346694, 1863350977) index="5" unique_id=1130055289]
+[node name="HSeparator" parent="GroupHolder/editor/rigiditySlider/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(9346694, 1863350977) index="6" unique_id=1130055289]
 visible = false
 
-[node name="OrganelleCostList" parent="GroupHolder/editor/rigiditySlider/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(9346694, 1863350977) index="6" unique_id=1338570209]
+[node name="OrganelleCostList" parent="GroupHolder/editor/rigiditySlider/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(9346694, 1863350977) index="7" unique_id=1338570209]
 visible = false
 
 [node name="aggressionSlider" parent="GroupHolder/editor" unique_id=1459362333 node_paths=PackedStringArray("descriptionLabel") instance=ExtResource("1")]
@@ -256,10 +256,10 @@ Description = "NORMAL_MEMBRANE_DESCRIPTION"
 [node name="RequiresNucleus" parent="GroupHolder/membraneSelection/single/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1864056327, 1863350977) index="1" unique_id=1907280912]
 visible = false
 
-[node name="ProcessesDescription" parent="GroupHolder/membraneSelection/single/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1864056327, 1863350977) index="2" unique_id=1366796537]
+[node name="ProcessesDescription" parent="GroupHolder/membraneSelection/single/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1864056327, 1863350977) index="3" unique_id=1366796537]
 visible = false
 
-[node name="ProcessList" parent="GroupHolder/membraneSelection/single/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1864056327, 1863350977) index="3" unique_id=1563198072]
+[node name="ProcessList" parent="GroupHolder/membraneSelection/single/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1864056327, 1863350977) index="4" unique_id=1563198072]
 visible = false
 
 [node name="baseMobility" parent="GroupHolder/membraneSelection/single/MarginContainer/VBoxContainer/ModifierList" parent_id_path=PackedInt32Array(1864056327, 1621578455) index="0" unique_id=474889058 instance=ExtResource("2")]
@@ -287,10 +287,10 @@ layout_mode = 2
 DisplayName = "TOXIN_RESISTANCE"
 ModifierIcon = ExtResource("16")
 
-[node name="HSeparator" parent="GroupHolder/membraneSelection/single/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1864056327, 1863350977) index="5" unique_id=1130055289]
+[node name="HSeparator" parent="GroupHolder/membraneSelection/single/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1864056327, 1863350977) index="6" unique_id=1130055289]
 visible = false
 
-[node name="OrganelleCostList" parent="GroupHolder/membraneSelection/single/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1864056327, 1863350977) index="6" unique_id=1338570209]
+[node name="OrganelleCostList" parent="GroupHolder/membraneSelection/single/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1864056327, 1863350977) index="7" unique_id=1338570209]
 visible = false
 
 [node name="double" parent="GroupHolder/membraneSelection" unique_id=1238471686 instance=ExtResource("5")]
@@ -302,10 +302,10 @@ Description = "DOUBLE_MEMBRANE_DESCRIPTION"
 [node name="RequiresNucleus" parent="GroupHolder/membraneSelection/double/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1238471686, 1863350977) index="1" unique_id=1907280912]
 visible = false
 
-[node name="ProcessesDescription" parent="GroupHolder/membraneSelection/double/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1238471686, 1863350977) index="2" unique_id=1366796537]
+[node name="ProcessesDescription" parent="GroupHolder/membraneSelection/double/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1238471686, 1863350977) index="3" unique_id=1366796537]
 visible = false
 
-[node name="ProcessList" parent="GroupHolder/membraneSelection/double/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1238471686, 1863350977) index="3" unique_id=1563198072]
+[node name="ProcessList" parent="GroupHolder/membraneSelection/double/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1238471686, 1863350977) index="4" unique_id=1563198072]
 visible = false
 
 [node name="baseMobility" parent="GroupHolder/membraneSelection/double/MarginContainer/VBoxContainer/ModifierList" parent_id_path=PackedInt32Array(1238471686, 1621578455) index="0" unique_id=1706655994 instance=ExtResource("2")]
@@ -333,10 +333,10 @@ layout_mode = 2
 DisplayName = "TOXIN_RESISTANCE"
 ModifierIcon = ExtResource("16")
 
-[node name="HSeparator" parent="GroupHolder/membraneSelection/double/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1238471686, 1863350977) index="5" unique_id=1130055289]
+[node name="HSeparator" parent="GroupHolder/membraneSelection/double/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1238471686, 1863350977) index="6" unique_id=1130055289]
 visible = false
 
-[node name="OrganelleCostList" parent="GroupHolder/membraneSelection/double/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1238471686, 1863350977) index="6" unique_id=1338570209]
+[node name="OrganelleCostList" parent="GroupHolder/membraneSelection/double/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1238471686, 1863350977) index="7" unique_id=1338570209]
 visible = false
 
 [node name="cellulose" parent="GroupHolder/membraneSelection" unique_id=720676102 instance=ExtResource("5")]
@@ -348,10 +348,10 @@ Description = "CELLULOSE_MEMBRANE_DESCRIPTION"
 [node name="RequiresNucleus" parent="GroupHolder/membraneSelection/cellulose/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(720676102, 1863350977) index="1" unique_id=1907280912]
 visible = false
 
-[node name="ProcessesDescription" parent="GroupHolder/membraneSelection/cellulose/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(720676102, 1863350977) index="2" unique_id=1366796537]
+[node name="ProcessesDescription" parent="GroupHolder/membraneSelection/cellulose/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(720676102, 1863350977) index="3" unique_id=1366796537]
 visible = false
 
-[node name="ProcessList" parent="GroupHolder/membraneSelection/cellulose/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(720676102, 1863350977) index="3" unique_id=1563198072]
+[node name="ProcessList" parent="GroupHolder/membraneSelection/cellulose/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(720676102, 1863350977) index="4" unique_id=1563198072]
 visible = false
 
 [node name="baseMobility" parent="GroupHolder/membraneSelection/cellulose/MarginContainer/VBoxContainer/ModifierList" parent_id_path=PackedInt32Array(720676102, 1621578455) index="0" unique_id=1159309638 instance=ExtResource("2")]
@@ -391,10 +391,10 @@ DisplayName = "RESISTANT_TO_BASIC_ENGULFMENT"
 ModifierNameFont = ExtResource("17_ftkue")
 ShowValue = false
 
-[node name="HSeparator" parent="GroupHolder/membraneSelection/cellulose/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(720676102, 1863350977) index="5" unique_id=1130055289]
+[node name="HSeparator" parent="GroupHolder/membraneSelection/cellulose/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(720676102, 1863350977) index="6" unique_id=1130055289]
 visible = false
 
-[node name="OrganelleCostList" parent="GroupHolder/membraneSelection/cellulose/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(720676102, 1863350977) index="6" unique_id=1338570209]
+[node name="OrganelleCostList" parent="GroupHolder/membraneSelection/cellulose/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(720676102, 1863350977) index="7" unique_id=1338570209]
 visible = false
 
 [node name="chitin" parent="GroupHolder/membraneSelection" unique_id=362976481 instance=ExtResource("5")]
@@ -406,10 +406,10 @@ Description = "CHITIN_MEMBRANE_DESCRIPTION"
 [node name="RequiresNucleus" parent="GroupHolder/membraneSelection/chitin/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(362976481, 1863350977) index="1" unique_id=1907280912]
 visible = false
 
-[node name="ProcessesDescription" parent="GroupHolder/membraneSelection/chitin/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(362976481, 1863350977) index="2" unique_id=1366796537]
+[node name="ProcessesDescription" parent="GroupHolder/membraneSelection/chitin/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(362976481, 1863350977) index="3" unique_id=1366796537]
 visible = false
 
-[node name="ProcessList" parent="GroupHolder/membraneSelection/chitin/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(362976481, 1863350977) index="3" unique_id=1563198072]
+[node name="ProcessList" parent="GroupHolder/membraneSelection/chitin/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(362976481, 1863350977) index="4" unique_id=1563198072]
 visible = false
 
 [node name="baseMobility" parent="GroupHolder/membraneSelection/chitin/MarginContainer/VBoxContainer/ModifierList" parent_id_path=PackedInt32Array(362976481, 1621578455) index="0" unique_id=1340329411 instance=ExtResource("2")]
@@ -449,10 +449,10 @@ DisplayName = "RESISTANT_TO_BASIC_ENGULFMENT"
 ModifierNameFont = ExtResource("17_ftkue")
 ShowValue = false
 
-[node name="HSeparator" parent="GroupHolder/membraneSelection/chitin/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(362976481, 1863350977) index="5" unique_id=1130055289]
+[node name="HSeparator" parent="GroupHolder/membraneSelection/chitin/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(362976481, 1863350977) index="6" unique_id=1130055289]
 visible = false
 
-[node name="OrganelleCostList" parent="GroupHolder/membraneSelection/chitin/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(362976481, 1863350977) index="6" unique_id=1338570209]
+[node name="OrganelleCostList" parent="GroupHolder/membraneSelection/chitin/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(362976481, 1863350977) index="7" unique_id=1338570209]
 visible = false
 
 [node name="calciumCarbonate" parent="GroupHolder/membraneSelection" unique_id=127395123 instance=ExtResource("5")]
@@ -464,10 +464,10 @@ Description = "CALCIUM_CARBONATE_MEMBRANE_DESCRIPTION"
 [node name="RequiresNucleus" parent="GroupHolder/membraneSelection/calciumCarbonate/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(127395123, 1863350977) index="1" unique_id=1907280912]
 visible = false
 
-[node name="ProcessesDescription" parent="GroupHolder/membraneSelection/calciumCarbonate/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(127395123, 1863350977) index="2" unique_id=1366796537]
+[node name="ProcessesDescription" parent="GroupHolder/membraneSelection/calciumCarbonate/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(127395123, 1863350977) index="3" unique_id=1366796537]
 visible = false
 
-[node name="ProcessList" parent="GroupHolder/membraneSelection/calciumCarbonate/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(127395123, 1863350977) index="3" unique_id=1563198072]
+[node name="ProcessList" parent="GroupHolder/membraneSelection/calciumCarbonate/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(127395123, 1863350977) index="4" unique_id=1563198072]
 visible = false
 
 [node name="baseMobility" parent="GroupHolder/membraneSelection/calciumCarbonate/MarginContainer/VBoxContainer/ModifierList" parent_id_path=PackedInt32Array(127395123, 1621578455) index="0" unique_id=2000823129 instance=ExtResource("2")]
@@ -501,10 +501,10 @@ DisplayName = "CANNOT_ENGULF"
 ModifierNameFont = ExtResource("16_dd0bc")
 ShowValue = false
 
-[node name="HSeparator" parent="GroupHolder/membraneSelection/calciumCarbonate/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(127395123, 1863350977) index="5" unique_id=1130055289]
+[node name="HSeparator" parent="GroupHolder/membraneSelection/calciumCarbonate/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(127395123, 1863350977) index="6" unique_id=1130055289]
 visible = false
 
-[node name="OrganelleCostList" parent="GroupHolder/membraneSelection/calciumCarbonate/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(127395123, 1863350977) index="6" unique_id=1338570209]
+[node name="OrganelleCostList" parent="GroupHolder/membraneSelection/calciumCarbonate/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(127395123, 1863350977) index="7" unique_id=1338570209]
 visible = false
 
 [node name="silica" parent="GroupHolder/membraneSelection" unique_id=1055494397 instance=ExtResource("5")]
@@ -517,10 +517,10 @@ Description = "SILICA_MEMBRANE_DESCRIPTION"
 [node name="RequiresNucleus" parent="GroupHolder/membraneSelection/silica/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1055494397, 1863350977) index="1" unique_id=1907280912]
 visible = false
 
-[node name="ProcessesDescription" parent="GroupHolder/membraneSelection/silica/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1055494397, 1863350977) index="2" unique_id=1366796537]
+[node name="ProcessesDescription" parent="GroupHolder/membraneSelection/silica/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1055494397, 1863350977) index="3" unique_id=1366796537]
 visible = false
 
-[node name="ProcessList" parent="GroupHolder/membraneSelection/silica/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1055494397, 1863350977) index="3" unique_id=1563198072]
+[node name="ProcessList" parent="GroupHolder/membraneSelection/silica/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1055494397, 1863350977) index="4" unique_id=1563198072]
 visible = false
 
 [node name="baseMobility" parent="GroupHolder/membraneSelection/silica/MarginContainer/VBoxContainer/ModifierList" parent_id_path=PackedInt32Array(1055494397, 1621578455) index="0" unique_id=1185276147 instance=ExtResource("2")]
@@ -554,10 +554,10 @@ DisplayName = "CANNOT_ENGULF"
 ModifierNameFont = ExtResource("16_dd0bc")
 ShowValue = false
 
-[node name="HSeparator" parent="GroupHolder/membraneSelection/silica/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1055494397, 1863350977) index="5" unique_id=1130055289]
+[node name="HSeparator" parent="GroupHolder/membraneSelection/silica/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1055494397, 1863350977) index="6" unique_id=1130055289]
 visible = false
 
-[node name="OrganelleCostList" parent="GroupHolder/membraneSelection/silica/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1055494397, 1863350977) index="6" unique_id=1338570209]
+[node name="OrganelleCostList" parent="GroupHolder/membraneSelection/silica/MarginContainer/VBoxContainer" parent_id_path=PackedInt32Array(1055494397, 1863350977) index="7" unique_id=1338570209]
 visible = false
 
 [node name="processesProduction" type="Control" parent="GroupHolder" unique_id=396680834]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes screen filters also affect dropdowns (and other engine UI, but I'm not entirely sure if there is any) by moving the screen filter canvas layer to a higher layer.

Also reverts some changes to other layers

**Related Issues**

Fixes #6612

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
