### PR TITLE
Stop dividing environmental compound effect on process speed by required environmental input.

### DIFF
--- a/simulation_parameters/microbe_stage/bio_processes.json
+++ b/simulation_parameters/microbe_stage/bio_processes.json
@@ -35,11 +35,11 @@
     "Name": "PHOTOSYNTHESIS",
     "Inputs": {
       "sunlight": 1,
-      "carbondioxide": 0.15
+      "carbondioxide": 1
     },
     "Outputs": {
-      "glucose": 0.10,
-      "oxygen": 0.27
+      "glucose": 0.667,
+      "oxygen": 1.8
     }
   },
   "cytotoxinSynthesis": {
@@ -73,11 +73,11 @@
   "bacterial_oxytoxySynthesis": {
     "Name": "OXYTOXY_SYNTHESIS",
     "Inputs": {
-      "oxygen": 0.21,
-      "atp": 3
+      "oxygen": 1,
+      "atp": 14.29
     },
     "Outputs": {
-      "oxytoxy": 0.21
+      "oxytoxy": 1
     }
   },
   "macrolideSynthesis": {
@@ -129,11 +129,11 @@
   "bacterial_oxygenInhibitorSynthesis": {
     "Name": "OXYGEN_INHIBITOR_SYNTHESIS",
     "Inputs": {
-      "oxygen": 0.21,
-      "atp": 3
+      "oxygen": 1,
+      "atp": 14.29
     },
     "Outputs": {
-      "oxytoxy": 0.15
+      "oxytoxy": 0.714
     }
   },
   "mucilage_synthesis": {
@@ -148,22 +148,22 @@
   "chemoSynthesis": {
     "Name": "CHEMO_SYNTHESIS",
     "Inputs": {
-      "hydrogensulfide": 0.08,
-      "carbondioxide": 0.09
+      "hydrogensulfide": 0.889,
+      "carbondioxide": 1
     },
     "Outputs": {
-      "glucose": 0.1
+      "glucose": 1.11
     },
     "IsMetabolismProcess": true
   },
   "bacterial_ChemoSynthesis": {
     "Name": "CHEMO_SYNTHESIS",
     "Inputs": {
-      "hydrogensulfide": 0.04,
-      "carbondioxide": 0.09
+      "hydrogensulfide": 0.444,
+      "carbondioxide": 1
     },
     "Outputs": {
-      "glucose": 0.04
+      "glucose": 0.444
     },
     "IsMetabolismProcess": true
   },
@@ -223,11 +223,11 @@
     "Name": "PHOTOSYNTHESIS",
     "Inputs": {
       "sunlight": 1,
-      "carbondioxide": 0.081
+      "carbondioxide": 1
     },
     "Outputs": {
-      "glucose": 0.015,
-      "oxygen": 0.081
+      "glucose": 0.185,
+      "oxygen": 1
     }
   },
   "iron_chemolithoautotrophy": {
@@ -280,11 +280,11 @@
   "luciferaseSynthesis": {
     "Name": "LUCIFERASE_SYNTHESIS",
     "Inputs": {
-      "oxygen": 0.05,
-      "atp": 0.5
+      "oxygen": 1,
+      "atp": 10
     },
     "Outputs": {
-      "luciferase": 1.5
+      "luciferase": 30
     }
   }
 }

--- a/src/microbe_stage/systems/ProcessSystem.cs
+++ b/src/microbe_stage/systems/ProcessSystem.cs
@@ -697,7 +697,7 @@ public partial class ProcessSystem : BaseSystem<World, float>
 
             var availableRate = inputCompound == Compound.Temperature ?
                 CalculateTemperatureEffect(availableInEnvironment) :
-                availableInEnvironment / (input.Value * speedModifier);
+                availableInEnvironment / speedModifier;
 
             result.AvailableAmounts[inputCompound] = availableInEnvironment;
 
@@ -1174,7 +1174,7 @@ public partial class ProcessSystem : BaseSystem<World, float>
             // do environmental modifier here, and save it for later
             environmentModifier *= inputCompound == Compound.Temperature ?
                 CalculateTemperatureEffect(ambient) :
-                ambient / (entry.Value * overallSpeedModifier);
+                ambient / overallSpeedModifier;
 
             if (environmentModifier <= MathUtils.EPSILON)
                 currentProcessStatistics?.AddLimitingFactor(inputCompound);


### PR DESCRIPTION
**Brief Description of What This PR Does**

As in the title, stops dividing environmental compound effect on process speed by required environmental input.

Also adjusts some processes to still operate _exactly_ the same as in current master.

So this is a purely technical change that should have 0 noticeable impact while playing the game.

In the future, this would allow much easier balancing of processes. And in particular:
* Allow balancing environmental compound usage between processes (currently not possible).
* Allow increasing overall rate of a process without altering the ratio of production to environmental compound usage.

**Related Issues**

It is currently impossible to change the rate of a process without changing the ratio of output to environmental compound input. (and the other way around). This in particular can make advanced organelles have an odd effect on environmental compound balances.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
