### PR TITLE
Tweaked multicellular reproduction speed and needed resources

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -873,6 +873,8 @@ public static class Constants
     /// </summary>
     public const float MULTICELLULAR_REPRODUCTION_COMPOUND_MULTIPLIER = 2;
 
+    public const float MULTICELLULAR_REPRODUCTION_COMPOUND_FROM_EACH_EXTRA_CELL = 0.9f;
+
     /// <summary>
     ///   A multiplier for <see cref="MICROBE_REPRODUCTION_MAX_COMPOUND_USE"/> for multicellular microbes
     /// </summary>
@@ -885,7 +887,17 @@ public static class Constants
 
     public const float MICROBE_REPRODUCTION_COST_BASE_PHOSPHATES = 16;
 
-    public const float MULTICELLULAR_BASE_REPRODUCTION_COST_MULTIPLIER = 1.3f;
+    /// <summary>
+    ///   This is a base cost taken after the full colony has grown. So this can be increased to lengthen the time the
+    ///   player plays as a full colony.
+    /// </summary>
+    public const float MULTICELLULAR_BASE_REPRODUCTION_COST_MULTIPLIER = 1.6f;
+
+    /// <summary>
+    ///   This modifies <see cref="MULTICELLULAR_BASE_REPRODUCTION_COST_MULTIPLIER"/> per cell. So each cost gets extra
+    ///   multiplier on top <c>(cell count * this value) * cost</c>.
+    /// </summary>
+    public const float MULTICELLULAR_BASE_REPRODUCTION_COST_MULTIPLIER_PER_CELL = 0.08f;
 
     /// <summary>
     ///   Determines how big of a fraction of damage (of total health)

--- a/src/microbe_stage/systems/MicrobeReproductionSystem.cs
+++ b/src/microbe_stage/systems/MicrobeReproductionSystem.cs
@@ -71,16 +71,22 @@ public partial class MicrobeReproductionSystem : BaseSystem<World, float>
 
     public static (float RemainingAllowedCompoundUse, float RemainingFreeCompounds)
         CalculateFreeCompoundsAndLimits(WorldGenerationSettings worldSettings, int hexCount, bool isMulticellular,
-            float delta)
+            int cellCount, float delta)
     {
         // TODO: make the current patch affect this?
-        // TODO: make being in a colony affect this
         float remainingFreeCompounds = Constants.MICROBE_REPRODUCTION_FREE_COMPOUNDS *
             (hexCount * Constants.MICROBE_REPRODUCTION_FREE_RATE_FROM_HEX + 1.0f) * delta;
 
-        // TODO: some scaling based on the number of cells in the colony to not have a major slog?
         if (isMulticellular)
+        {
+            var baseAmount = remainingFreeCompounds;
+
             remainingFreeCompounds *= Constants.MULTICELLULAR_REPRODUCTION_COMPOUND_MULTIPLIER;
+
+            // Give more free compounds for multicellular colonies
+            remainingFreeCompounds += baseAmount * (cellCount - 1) *
+                Constants.MULTICELLULAR_REPRODUCTION_COMPOUND_FROM_EACH_EXTRA_CELL;
+        }
 
         float remainingAllowedCompoundUse = float.MaxValue;
 
@@ -321,7 +327,7 @@ public partial class MicrobeReproductionSystem : BaseSystem<World, float>
         if (isInColony)
         {
             var (_, freeCompounds) = CalculateFreeCompoundsAndLimits(gameWorld!.WorldSettings, organelles.HexCount,
-                false, reproductionDelta);
+                false, 1, reproductionDelta);
 
             var species = entity.Get<MicrobeSpeciesMember>().Species;
 
@@ -345,7 +351,7 @@ public partial class MicrobeReproductionSystem : BaseSystem<World, float>
     }
 
     /// <summary>
-    ///   Handles feeding the organelles in a microbe in order for them to split. After all are split the microbe
+    ///   Handles feeding the organelles in a microbe in order for them to split. After all are split, the microbe
     ///   is ready to reproduce. This is allowed to be called only for non-multicellular growth only (and not in
     ///   a cell colony)
     /// </summary>
@@ -363,7 +369,7 @@ public partial class MicrobeReproductionSystem : BaseSystem<World, float>
             return;
 
         var (remainingAllowedCompoundUse, remainingFreeCompounds) =
-            CalculateFreeCompoundsAndLimits(gameWorld!.WorldSettings, organelles.HexCount, false,
+            CalculateFreeCompoundsAndLimits(gameWorld!.WorldSettings, organelles.HexCount, false, 1,
                 reproductionDelta);
 
         var compounds = storage.Compounds;

--- a/src/multicellular_stage/MulticellularSpecies.cs
+++ b/src/multicellular_stage/MulticellularSpecies.cs
@@ -440,9 +440,15 @@ public class MulticellularSpecies : Species, IReadOnlyMulticellularSpecies, ISim
         // Apply the multiplier to the costs for being multicellular
         var result = new Dictionary<Compound, float>();
 
+        var fromCellsMultiplier = ModifiableGameplayCells.Count *
+            Constants.MULTICELLULAR_BASE_REPRODUCTION_COST_MULTIPLIER_PER_CELL;
+
         foreach (var entry in baseReproductionCost)
         {
-            result[entry.Key] = entry.Value * Constants.MULTICELLULAR_BASE_REPRODUCTION_COST_MULTIPLIER;
+            var multicellCost = entry.Value * Constants.MULTICELLULAR_BASE_REPRODUCTION_COST_MULTIPLIER;
+
+            var cellExtra = fromCellsMultiplier * multicellCost;
+            result[entry.Key] = multicellCost + cellExtra;
         }
 
         return result;

--- a/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
+++ b/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
@@ -172,8 +172,6 @@ public partial class MulticellularGrowthSystem : BaseSystem<World, float>
 
         bool stillNeedsSomething = false;
 
-        status.ConsumeReproductionCompoundsReverse = !status.ConsumeReproductionCompoundsReverse;
-
         // Consume some compounds for the next cell in the layout
         // Similar logic for "growing" more cells than in PlacedOrganelle growth
         if (multicellularGrowth.CompoundsNeededForNextCell.Count > 0)

--- a/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
+++ b/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
@@ -31,6 +31,7 @@ using World = Arch.Core.World;
 [ReadsComponent(typeof(MicrobeEventCallbacks))]
 [ReadsComponent(typeof(CellProperties))]
 [ReadsComponent(typeof(MicrobeControl))]
+[ReadsComponent(typeof(MicrobeColony))]
 [RunsAfter(typeof(ProcessSystem))]
 [RunsAfter(typeof(ColonyCompoundDistributionSystem))]
 [RuntimeCost(4, false)]
@@ -101,9 +102,17 @@ public partial class MulticellularGrowthSystem : BaseSystem<World, float>
 
         multicellularGrowth.CompoundsUsedForMulticellularGrowth ??= new Dictionary<Compound, float>();
 
+        int cellCount = 1;
+
+        if (entity.Has<MicrobeColony>())
+        {
+            ref var colony = ref entity.Get<MicrobeColony>();
+            cellCount = colony.ColonyMembers.Length;
+        }
+
         var (remainingAllowedCompoundUse, remainingFreeCompounds) =
             MicrobeReproductionSystem.CalculateFreeCompoundsAndLimits(gameWorld!.WorldSettings,
-                organelleContainer.HexCount, true, elapsedSinceLastUpdate);
+                organelleContainer.HexCount, true, cellCount, elapsedSinceLastUpdate);
 
         if (multicellularGrowth.CompoundsNeededForNextCell == null)
         {
@@ -134,7 +143,7 @@ public partial class MulticellularGrowthSystem : BaseSystem<World, float>
                 multicellularGrowth.ResumeBodyPlanAfterReplacingLost = null;
             }
 
-            // Need to setup the next cell to be grown in our body plan
+            // Need to set up the next cell to be grown in our body plan
             if (multicellularGrowth.IsFullyGrownMulticellular)
             {
                 // We have completed our body plan and can (once enough resources) reproduce
@@ -197,7 +206,7 @@ public partial class MulticellularGrowthSystem : BaseSystem<World, float>
                 usedAmount += usedFreeCompounds;
                 allowedUseAmount -= usedFreeCompounds;
 
-                // As we loop just once we don't need to update the free compounds or allowed use compounds
+                // As we loop just once, we don't need to update the free compounds or allowed use compounds
                 // variables
             }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

So that reproduction speed increases with more cells, but to balance that the base cost at the end is also increased so that the end of the life is not super quick while speeding up the cells growing part of life

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #3654

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
