### PR TITLE
Check for signaling agents on player when leaving editor

### DIFF
--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -213,6 +213,36 @@ public partial class MicrobeHUD : CreatureStageHUDBase<MicrobeStage>
         }
     }
 
+    public void ClearSignalingCommandsOnEditorExitIfNecessary(Entity player)
+    {
+        if (!player.Has<CommandSignaler>())
+            return;
+
+        ref var signaler = ref player.Get<CommandSignaler>();
+        ref var organelles = ref player.Get<OrganelleContainer>();
+
+        if (player.Has<MicrobeColony>())
+        {
+            ref var colony = ref player.Get<MicrobeColony>();
+
+            colony.GetColonySpecialOrganelles(out _, out _, out _, out var hasSignalingAgent);
+
+            if (hasSignalingAgent)
+            {
+                return;
+            }
+        }
+        else if (organelles.HasSignalingAgent)
+        {
+            return;
+        }
+
+        packControlRadial.Hide();
+        signalingAgentMenuOpenForMicrobe = null;
+
+        signaler.QueuedSignalingCommand = MicrobeSignalCommand.None;
+    }
+
     public void ShowSignalingCommandsMenu(Entity player)
     {
         if (!player.IsAliveAndHas<CommandSignaler>())

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1082,6 +1082,8 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
             }
         }
 
+        HUD.ClearSignalingCommandsOnEditorExitIfNecessary(Player);
+
         if (!CurrentGame.TutorialState.Enabled)
         {
             tutorialGUI.EventReceiver?.OnTutorialDisabled();


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds call to check in HUD for existing signaling agents, and if there are none, clear signaling agent input.
Only for player as I assume AI handles this seperately.

**Related Issues**

Closes #6783

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
