### PR TITLE
Made failure to emit before membrane is ready a non-error print

### DIFF
--- a/src/microbe_stage/components/CellProperties.cs
+++ b/src/microbe_stage/components/CellProperties.cs
@@ -186,8 +186,13 @@ public static class CellPropertiesHelpers
     {
         float amount = compounds.TakeCompound(compound, maxAmount);
 
-        cellProperties.SpawnEjectedCompound(ref cellPosition, compoundCloudSystem, compound, amount, direction,
-            displacement);
+        if (!cellProperties.SpawnEjectedCompound(ref cellPosition, compoundCloudSystem, compound, amount, direction,
+                displacement))
+        {
+            // If membrane was not ready, we didn't eject anything
+            return 0;
+        }
+
         return amount;
     }
 
@@ -352,7 +357,7 @@ public static class CellPropertiesHelpers
 
         if (cellProperties.CreatedMembrane == null)
         {
-            GD.PrintErr($"{nameof(SpawnEjectedCompound)} called before membrane is created, ignoring eject");
+            GD.Print($"{nameof(SpawnEjectedCompound)} called before membrane is created, ignoring eject");
             return false;
         }
 

--- a/src/microbe_stage/systems/EngulfedDigestionSystem.cs
+++ b/src/microbe_stage/systems/EngulfedDigestionSystem.cs
@@ -291,7 +291,7 @@ public partial class EngulfedDigestionSystem : BaseSystem<World, float>
                 var takenAdjusted = taken * efficiency;
                 var added = compounds.AddCompound(compound, takenAdjusted);
 
-                // Eject excess
+                // Eject excess (we just want to get rid of it, we don't care if the eject failed)
                 cellProperties.SpawnEjectedCompound(ref position, compoundCloudSystem, compound,
                     takenAdjusted - added, Vector3.Back);
             }

--- a/src/microbe_stage/systems/MicrobeEmissionSystem.cs
+++ b/src/microbe_stage/systems/MicrobeEmissionSystem.cs
@@ -328,9 +328,6 @@ public partial class MicrobeEmissionSystem : BaseSystem<World, float>
             // Activate all jets, which will constantly secrete slime until we turn them off
             foreach (var jet in organelles.SlimeJets)
             {
-                // Make sure this is animating
-                jet.Active = true;
-
                 // Secrete the slime
                 float slimeToSecrete = Math.Min(Constants.COMPOUNDS_TO_VENT_PER_SECOND * delta,
                     compounds.GetCompoundAmount(Compound.Mucilage));
@@ -340,6 +337,13 @@ public partial class MicrobeEmissionSystem : BaseSystem<World, float>
                 // Eject mucilage at the maximum rate in the opposite direction to this organelle's rotation
                 slimeToSecrete = cellProperties.EjectCompound(ref worldPosition, compounds, clouds, Compound.Mucilage,
                     slimeToSecrete, -direction, 2);
+
+                // If we couldn't emit (due to no membrane yet), then skip for now
+                if (slimeToSecrete <= 0)
+                    continue;
+
+                // Make sure this is animating
+                jet.Active = true;
 
                 // Queue movement force to be used by the movement system based on the amount of slime ejected
                 jet.AddQueuedForce(entity, slimeToSecrete);


### PR DESCRIPTION
**Brief Description of What This PR Does**

and adjusted some code to better take into account ejections failing

Basically this reduces the severity of one non-serious error print

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
