### PR TITLE
fix Flagella position calculation bug when at (0, 0)

### DIFF
--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Components;
 using Godot;
 using Systems;
 
@@ -43,7 +44,13 @@ public static class MicrobeInternalCalculations
 
     public static Vector3 GetOrganelleDirection(OrganelleTemplate organelle)
     {
-        return (Hex.AxialToCartesian(new Hex(0, 0)) - Hex.AxialToCartesian(organelle.Position)).Normalized();
+        Vector3 middle = Hex.AxialToCartesian(new Hex(0, 0));
+        var delta = middle - Hex.AxialToCartesian(organelle.Position);
+
+        if (delta == Vector3.Zero)
+            delta = CellPropertiesHelpers.DefaultVisualPos;
+
+        return delta.Normalized();
     }
 
     public static float GetTotalNominalCapacity(IEnumerable<OrganelleTemplate> organelles)


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes an inconsistency where movement organelles placed at the cell center could produce a zero direction in internal movement calculations. This caused centered flagella to be ignored by movement ATP cost calculations, making the editor’s ATP balance change between sessions after organelle repositioning.

The direction calculation now falls back to the same default forward position already used by the runtime movement component when an organelle is at `(0, 0)`, keeping ATP cost and speed estimates consistent with actual movement behavior.

**Related Issues**

fixes #3432

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
