### PR TITLE
fix the position difference between bacteria pili's visual shape and physics shape

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1114,8 +1114,6 @@ public static class Constants
 
     public const float PILUS_PHYSICS_SIZE = 4.6f;
 
-    public const float BACTERIA_PILUS_ATTACH_ADJUSTMENT_MULTIPLIER = 0.575f;
-
     /// <summary>
     ///   Damage a single injectisome stab does
     /// </summary>

--- a/src/microbe_stage/PlacedOrganelle.cs
+++ b/src/microbe_stage/PlacedOrganelle.cs
@@ -399,26 +399,21 @@ public class PlacedOrganelle : IPositionedOrganelle, ICloneable, IArchivable
             cachedExternalPosition + cachedExternalOrientation * Definition.ModelOffset);
     }
 
+    /// <summary>
+    ///   Calculates the local physics transform for an externally positioned organelle. The external position is in
+    ///   unscaled membrane coordinates, and <paramref name="physicsScale"/> converts it to the physics body scale.
+    /// </summary>
     public (Vector3 Position, Quaternion Rotation) CalculatePhysicsExternalTransform(Vector3 externalPosition,
-        Quaternion orientation, bool isBacteria)
+        Quaternion orientation, float physicsScale)
     {
         // The shape needs to be rotated 90 degrees to point forward for (so that the pilus is not a vertical column
         // but is instead a stabby thing)
         var extraRotation = new Quaternion(new Vector3(1, 0, 0), MathF.PI * 0.5f);
 
         // Maybe should have a variable for physics shape offset if different organelles need different things
-        var offset = new Vector3(0, 0, -1.0f);
+        var offset = new Vector3(0, 0, -1.0f) * physicsScale;
 
-        // Need to adjust physics position for bacteria scale
-        if (isBacteria)
-        {
-            // TODO: find the root cause and fix properly why this kind of very specific tweak is needed
-            var length = externalPosition.Length() * Constants.BACTERIA_PILUS_ATTACH_ADJUSTMENT_MULTIPLIER;
-
-            offset.Z += length;
-        }
-
-        return (externalPosition + orientation * offset, orientation * extraRotation);
+        return (externalPosition * physicsScale + orientation * offset, orientation * extraRotation);
     }
 
     /// <summary>

--- a/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
+++ b/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
@@ -275,7 +275,7 @@ public partial class MicrobePhysicsCreationAndSizeSystem : BaseSystem<World, flo
         ref OrganelleContainer organelles, ref CellProperties cellProperties, in Entity entity,
         List<(PhysicsShape Shape, Vector3 Position, Quaternion Rotation)> combinedData,
         List<(Entity Entity, OrganelleLayout<PlacedOrganelle> Organelles, Vector3 ExtraOffset,
-            Quaternion ExtraRotation)>?
+                Quaternion ExtraRotation)>?
             memberOrganelles, Vector2[] membraneVertices, int vertexCount,
         List<(Membrane Membrane, bool Bacteria)>? colonyMembranes)
     {

--- a/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
+++ b/src/microbe_stage/systems/MicrobePhysicsCreationAndSizeSystem.cs
@@ -44,10 +44,11 @@ public partial class MicrobePhysicsCreationAndSizeSystem : BaseSystem<World, flo
         new(() => new List<(Membrane Membrane, bool Bacteria)>());
 
     private readonly
-        ThreadLocal<List<(OrganelleLayout<PlacedOrganelle> Organelles, Vector3 ExtraOffset, Quaternion ExtraRotation)>>
+        ThreadLocal<List<(Entity Entity, OrganelleLayout<PlacedOrganelle> Organelles, Vector3 ExtraOffset,
+            Quaternion ExtraRotation)>>
         temporaryColonyMemberOrganelles =
             new(() =>
-                new List<(OrganelleLayout<PlacedOrganelle> Organelles,
+                new List<(Entity Entity, OrganelleLayout<PlacedOrganelle> Organelles,
                     Vector3 ExtraOffset, Quaternion ExtraRotation)>());
 
     private readonly Lazy<PhysicsShape> eukaryoticPilus;
@@ -273,7 +274,8 @@ public partial class MicrobePhysicsCreationAndSizeSystem : BaseSystem<World, flo
     private PhysicsShape CreateCompoundMicrobeShape(ref MicrobePhysicsExtraData extraData,
         ref OrganelleContainer organelles, ref CellProperties cellProperties, in Entity entity,
         List<(PhysicsShape Shape, Vector3 Position, Quaternion Rotation)> combinedData,
-        List<(OrganelleLayout<PlacedOrganelle> Organelles, Vector3 ExtraOffset, Quaternion ExtraRotation)>?
+        List<(Entity Entity, OrganelleLayout<PlacedOrganelle> Organelles, Vector3 ExtraOffset,
+            Quaternion ExtraRotation)>?
             memberOrganelles, Vector2[] membraneVertices, int vertexCount,
         List<(Membrane Membrane, bool Bacteria)>? colonyMembranes)
     {
@@ -356,7 +358,7 @@ public partial class MicrobePhysicsCreationAndSizeSystem : BaseSystem<World, flo
                     relativePosition = animation.FinalPosition;
                 }
 
-                memberOrganelles.Add((currentMemberOrganelles.Organelles ??
+                memberOrganelles.Add((member, currentMemberOrganelles.Organelles ??
                     throw new Exception("Colony member has no organelles but it had a membrane"), relativePosition,
                     attached.RelativeRotation));
 
@@ -391,6 +393,9 @@ public partial class MicrobePhysicsCreationAndSizeSystem : BaseSystem<World, flo
         {
             foreach (var entry in memberOrganelles)
             {
+                var memberEntity = entry.Entity;
+                ref var memberCellProperties = ref memberEntity.Get<CellProperties>();
+
                 foreach (var organelle in entry.Organelles)
                 {
                     if (organelle.Definition.HasPilusComponent)
@@ -401,7 +406,7 @@ public partial class MicrobePhysicsCreationAndSizeSystem : BaseSystem<World, flo
                             continue;
                         }
 
-                        combinedData.Add(CreatePilusShape(ref extraData, ref cellProperties, organelle,
+                        combinedData.Add(CreatePilusShape(ref extraData, ref memberCellProperties, organelle,
                             entry.ExtraOffset, entry.ExtraRotation));
                     }
                 }
@@ -425,11 +430,14 @@ public partial class MicrobePhysicsCreationAndSizeSystem : BaseSystem<World, flo
             {
                 foreach (var entry in memberOrganelles)
                 {
+                    var memberEntity = entry.Entity;
+                    ref var memberCellProperties = ref memberEntity.Get<CellProperties>();
+
                     foreach (var organelle in entry.Organelles)
                     {
                         if (organelle.Definition.HasPilusComponent && organelle.Upgrades.HasInjectisomeUpgrade())
                         {
-                            combinedData.Add(CreatePilusShape(ref extraData, ref cellProperties, organelle,
+                            combinedData.Add(CreatePilusShape(ref extraData, ref memberCellProperties, organelle,
                                 entry.ExtraOffset, entry.ExtraRotation));
                             ++extraData.PilusInjectisomeCount;
                         }
@@ -465,9 +473,10 @@ public partial class MicrobePhysicsCreationAndSizeSystem : BaseSystem<World, flo
         var externalPosition = cellProperties.CalculateExternalOrganellePosition(placedOrganelle.Position,
             placedOrganelle.Orientation, out var rotation);
 
+        var physicsScale = cellProperties.IsBacteria ? 0.5f : 1.0f;
+
         var (position, orientation) =
-            placedOrganelle.CalculatePhysicsExternalTransform(externalPosition, rotation,
-                cellProperties.IsBacteria);
+            placedOrganelle.CalculatePhysicsExternalTransform(externalPosition, rotation, physicsScale);
 
         ++extraData.PilusCount;
         ++extraData.TotalShapeCount;


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR fix an issue that when a bacteria cell is large enough, it's pili's visual shape position and physics shape position can be different.

Some Notes:
* This PR implements a new magic number: scale the physics size to `0.5f` when the cell is a bacteria. Use a magic number is definitely a bad style, but before the fix this magic number is already there (only in visual shape calculations). Extract them into a constant will change ~10 more files, so I plan to do this in another PR to make the current one clearer.
* after the fix, the visual shape's and physics shape's position are matched, but when the cell finished growing and is ready to split, the shape change of grown cell will cause an offset between the two shapes. The reason and fixing scope is totally different, so I'll again open a new PR to fix the new issue.
* FOR TESTERS: you can use this [save](https://github.com/user-attachments/files/27594949/4618.zip) and open physics debug shape to verify if the fix actually works.

**Related Issues**

Fixes #4618

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
