### PR TITLE
New logic for determining when AI has enough toxin to shoot

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -647,8 +647,7 @@ public static class Constants
     public const float MAXIMUM_AGENT_EMISSION_AMOUNT = 2.0f;
 
     /// <summary>
-    ///   AI always consider shooting a toxin possible if it has that much toxin stored no matter the current focus
-    ///   value.
+    ///   AI only consider shooting a toxin possible if it has this much toxin stored or more
     /// </summary>
     public const float AI_SHOOT_TOXIN_AFTER = 0.15f;
 

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -647,6 +647,12 @@ public static class Constants
     public const float MAXIMUM_AGENT_EMISSION_AMOUNT = 2.0f;
 
     /// <summary>
+    ///   AI always consider shooting a toxin possible if it has that much toxin stored no matter the current focus
+    ///   value.
+    /// </summary>
+    public const float AI_SHOOT_TOXIN_AFTER = 0.15f;
+
+    /// <summary>
     ///   The time (in seconds) it takes a cloud being absorbed to halve its compounds.
     /// </summary>
     public const float CLOUD_ABSORPTION_HALF_LIFE = 0.02291666666f;

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -1368,17 +1368,22 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
 
     private bool CanShootToxin(CompoundBag compounds, float speciesFocus)
     {
+        var storage = compounds.GetCapacityForCompound(Compound.Oxytoxy) * 0.99f;
+
         // Ensure that zero focus species don't constantly think they can fire toxins
-        return compounds.GetCompoundAmount(Compound.Oxytoxy) >
-            Math.Min(Constants.MAXIMUM_AGENT_EMISSION_AMOUNT * speciesFocus / Constants.MAX_SPECIES_FOCUS,
-                Constants.MINIMUM_AGENT_EMISSION_AMOUNT);
+        // And that otherwise focus nicely scales how many toxins are spewed before max damage
+        var shootThreshold =
+            Math.Clamp(Constants.MAXIMUM_AGENT_EMISSION_AMOUNT * (speciesFocus / Constants.MAX_SPECIES_FOCUS),
+                Constants.AI_SHOOT_TOXIN_AFTER, storage);
+
+        return compounds.GetCompoundAmount(Compound.Oxytoxy) > shootThreshold;
     }
 
     private void CleanMicrobeCache()
     {
-        // Skip when cache hasn't been updated in the meantime, this avoids unnecessarily clearing out a bunch of
+        // Skip when cache hasn't been updated in the meantime; this avoids unnecessarily clearing out a bunch of
         // data from the cache as after we clear the lists, the lists won't be filled again until the cache is
-        // rebuild
+        // rebuilt
         if (!microbeCacheBuilt)
             return;
 

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -1370,6 +1370,10 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
     {
         var storage = compounds.GetCapacityForCompound(Compound.Oxytoxy) * 0.99f;
 
+        // If a cell can't store toxin, cannot shoot it either
+        if (storage <= Constants.AI_SHOOT_TOXIN_AFTER)
+            return false;
+
         // Ensure that zero focus species don't constantly think they can fire toxins
         // And that otherwise focus nicely scales how many toxins are spewed before max damage
         var shootThreshold =


### PR DESCRIPTION
**Brief Description of What This PR Does**
Attempt at some change related to AI shooting toxins

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
