### PR TITLE
Update banana biome currents and add radioactive chunks

### DIFF
--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -4931,6 +4931,52 @@
           }
         }
       },
+      "radioactiveChunk": {
+        "Name": "RADIOACTIVE_CHUNK",
+        "Meshes": [
+          {
+            "ScenePath": "res://assets/models/RadioactiveChunk1.tscn",
+            "ConvexShapePath": "res://assets/models/RadioactiveChunk1.shape"
+          }
+        ],
+        "Density": 0.000025,
+        "Dissolves": false,
+        "Radius": 10,
+        "ChunkScale": 1,
+        "PhysicsDensity": 2500,
+        "Size": 0,
+        "VentAmount": 0,
+        "Damages": 0,
+        "DeleteOnTouch": false,
+        "Compounds": {
+          "radiation": {
+            "Amount": 10000
+          }
+        }
+      },
+      "googlyEyeCell": {
+        "Name": "GOOGLY_EYE_CELL",
+        "Meshes": [
+          {
+            "ScenePath": "res://assets/models/easter_eggs/GooglyEyeCell.tscn",
+            "SceneModelPath": "Armature/Skeleton/Cube",
+            "SceneAnimationPath": "AnimationPlayer",
+            "PlayAnimation": true,
+            "MissingDefaultShaderSupport": true
+          }
+        ],
+        "Density": 1e-7,
+        "ChunkScale": 1,
+        "Size": 10,
+        "PhysicsDensity": 2000,
+        "Radius": 2,
+        "EasterEgg": true,
+        "Compounds": {
+          "glucose": {
+            "Amount": 1
+          }
+        }
+      },
       "Compounds": {
         "ammonia": {
           "Amount": 180000,

--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -4764,9 +4764,9 @@
       "a": 1
     },
     "WaterCurrents": {
-      "Speed": 1.5,
-      "Chaoticness": 1.5,
-      "InverseScale": 1.0,
+      "Speed": 4.0,
+      "Chaoticness": 6.0,
+      "InverseScale": 0.4,
       "ParticleCount": 1500,
       "UseTrails": true,
       "Colour": {

--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -4954,29 +4954,6 @@
           }
         }
       },
-      "googlyEyeCell": {
-        "Name": "GOOGLY_EYE_CELL",
-        "Meshes": [
-          {
-            "ScenePath": "res://assets/models/easter_eggs/GooglyEyeCell.tscn",
-            "SceneModelPath": "Armature/Skeleton/Cube",
-            "SceneAnimationPath": "AnimationPlayer",
-            "PlayAnimation": true,
-            "MissingDefaultShaderSupport": true
-          }
-        ],
-        "Density": 1e-7,
-        "ChunkScale": 1,
-        "Size": 10,
-        "PhysicsDensity": 2000,
-        "Radius": 2,
-        "EasterEgg": true,
-        "Compounds": {
-          "glucose": {
-            "Amount": 1
-          }
-        }
-      },
       "Compounds": {
         "ammonia": {
           "Amount": 180000,

--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -4929,28 +4929,28 @@
               "Amount": 120
             }
           }
-        }
-      },
-      "radioactiveChunk": {
-        "Name": "RADIOACTIVE_CHUNK",
-        "Meshes": [
-          {
-            "ScenePath": "res://assets/models/RadioactiveChunk1.tscn",
-            "ConvexShapePath": "res://assets/models/RadioactiveChunk1.shape"
-          }
-        ],
-        "Density": 0.000025,
-        "Dissolves": false,
-        "Radius": 10,
-        "ChunkScale": 1,
-        "PhysicsDensity": 2500,
-        "Size": 0,
-        "VentAmount": 0,
-        "Damages": 0,
-        "DeleteOnTouch": false,
-        "Compounds": {
-          "radiation": {
-            "Amount": 10000
+        },
+        "radioactiveChunk": {
+          "Name": "RADIOACTIVE_CHUNK",
+          "Meshes": [
+            {
+              "ScenePath": "res://assets/models/RadioactiveChunk1.tscn",
+              "ConvexShapePath": "res://assets/models/RadioactiveChunk1.shape"
+            }
+          ],
+          "Density": 0.000025,
+          "Dissolves": false,
+          "Radius": 10,
+          "ChunkScale": 1,
+          "PhysicsDensity": 2500,
+          "Size": 0,
+          "VentAmount": 0,
+          "Damages": 0,
+          "DeleteOnTouch": false,
+          "Compounds": {
+            "radiation": {
+              "Amount": 10000
+            }
           }
         }
       },


### PR DESCRIPTION
**Brief Description of What This PR Does**

Updates the Banana biome to use something closer to other recent current settings.

And adds radioactive chunks to the banana biome in reference to "banana's are radioactive" factoids, memes, and the [BED](https://en.wikipedia.org/wiki/Banana_equivalent_dose).

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
