### PR TITLE
Fixed colour change animation being overridden and not resetting to default

### DIFF
--- a/src/engine/common_components/ColourAnimation.cs
+++ b/src/engine/common_components/ColourAnimation.cs
@@ -151,13 +151,14 @@ public static class ColourAnimationHelpers
     }
 
     /// <summary>
-    ///   Stops animations and resets to default colour (and forces a colour update to happen)
+    ///   Stops animations and resets to the default colour (and forces a colour update to happen)
     /// </summary>
     public static void ResetColour(this ref ColourAnimation animation)
     {
         animation.AnimationTargetColour = animation.DefaultColour;
 
         animation.Animating = false;
+        animation.AnimationUserInfo = 0;
         animation.ColourApplied = false;
     }
 
@@ -186,6 +187,5 @@ public static class ColourAnimationHelpers
 
         animation.AnimationStartColour = animation.CurrentColour;
         animation.AnimationElapsed = 0;
-        animation.AnimationUserInfo = 0;
     }
 }

--- a/src/engine/common_systems/ColourAnimationSystem.cs
+++ b/src/engine/common_systems/ColourAnimationSystem.cs
@@ -7,7 +7,8 @@ using Godot;
 using World = Arch.Core.World;
 
 /// <summary>
-///   Handles updating the state of <see cref="ColourAnimation"/> based on animations triggered elsewhere
+///   Handles updating the state of <see cref="ColourAnimation"/> based on animations triggered elsewhere.
+///   After animation finishes, resets the colour to the default colour.
 /// </summary>
 [RuntimeCost(2)]
 [RunsOnFrame]
@@ -54,6 +55,13 @@ public partial class ColourAnimationSystem : BaseSystem<World, float>
             {
                 // No new animation to run, stop processing this entity
                 colourAnimation.Animating = false;
+                colourAnimation.AnimationUserInfo = 0;
+
+                // Reset to the default colour so that no colour accidentally sticks
+                // TODO: maybe add a new property to allow the animation to keep colour on completion?
+                // TODO: also if we are far off from the default colour, should be quickly animate to it rather than
+                // abruptly jumping to it?
+                colourAnimation.AnimationTargetColour = colourAnimation.DefaultColour;
             }
         }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This fixes two problems:
- The default colour change animation did not use max priority to never be overridden so it didn't work well
- After animating the colour could have been left in a non-default state which currently is not an intended thing

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #6842

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
