### PR TITLE
Refresh preview cell visualization on move action

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.Callbacks.cs
@@ -137,6 +137,11 @@ public partial class CellEditorComponent
 
         // TODO: dynamic MP PR had this line:
         // OnMembraneChanged();
+
+        // Make sure the preview visuals are up to date if we are on that tab so that undoing / redoing a move doesn't
+        // just not do anything. That may have been the reason for the dynamic MP PR TODO.
+        microbeVisualizationOrganellePositionsAreDirty = true;
+        UpdateCellVisualization();
     }
 
     [ArchiveAllowedMethod]
@@ -164,6 +169,11 @@ public partial class CellEditorComponent
 
         // TODO: dynamic MP PR had this line:
         // OnMembraneChanged();
+
+        // Make sure the preview visuals are up to date if we are on that tab so that undoing / redoing a move doesn't
+        // just not do anything. That may have been the reason for the dynamic MP PR TODO.
+        microbeVisualizationOrganellePositionsAreDirty = true;
+        UpdateCellVisualization();
     }
 
     [ArchiveAllowedMethod]

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -2497,6 +2497,9 @@ public partial class CellEditorComponent :
 
         autoEvoPredictionDirty = true;
         suggestionDirty = true;
+
+        microbeVisualizationOrganellePositionsAreDirty = true;
+        organelleDataDirty = true;
     }
 
     private void OnRigidityChanged()


### PR DESCRIPTION
**Brief Description of What This PR Does**

so that it just doesn't stay outdated and non-updated, also added a few extra lines to new microbe change to make sure it also has to refresh everything

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
A really old bug that wasn't reported until now that the undo/redo of the move action doesn't cause preview cell graphics to be rebuilt

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
