### PR TITLE
Fix colony previews displaying a spore as a colony root

### DIFF
--- a/src/microbe_stage/MicrobeVisualOnlySimulation.cs
+++ b/src/microbe_stage/MicrobeVisualOnlySimulation.cs
@@ -130,7 +130,8 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
     {
         // We pass AI-controlled true here to avoid creating player-specific data, but as we don't have the AI system,
         // it is fine to create the AI properties as it won't actually do anything
-        SpawnHelpers.SpawnMicrobe(this, dummyEnvironment, species, Vector3.Zero, true);
+        SpawnHelpers.SpawnMicrobe(this, dummyEnvironment, species, Vector3.Zero, true,
+            MulticellularSpawnState.ColonyRoot);
 
         ProcessDelaySpawnedEntitiesImmediately();
 

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -590,7 +590,7 @@ public static class SpawnHelpers
 
     public static void SpawnMicrobe(IWorldSimulation worldSimulation, IMicrobeSpawnEnvironment spawnEnvironment,
         Species species, Vector3 location, bool aiControlled,
-        MulticellularSpawnState multicellularSpawnState = MulticellularSpawnState.Bud)
+        MulticellularSpawnState multicellularSpawnState = MulticellularSpawnState.InitialState)
     {
         SpawnMicrobe(worldSimulation, spawnEnvironment, species, location, aiControlled, (null, 0),
             multicellularSpawnState);
@@ -599,7 +599,7 @@ public static class SpawnHelpers
     public static void SpawnMicrobe(IWorldSimulation worldSimulation, IMicrobeSpawnEnvironment spawnEnvironment,
         Species species, Vector3 location, bool aiControlled,
         (CellType? MulticellularCellType, int CellBodyPlanIndex) multicellularData,
-        MulticellularSpawnState multicellularSpawnState = MulticellularSpawnState.Bud)
+        MulticellularSpawnState multicellularSpawnState = MulticellularSpawnState.InitialState)
     {
         var (recorder, _) = SpawnMicrobeWithoutFinalizing(worldSimulation, spawnEnvironment, species, location,
             aiControlled,
@@ -611,7 +611,7 @@ public static class SpawnHelpers
     public static (CommandBuffer Recorder, float Weight) SpawnMicrobeWithoutFinalizing(IWorldSimulation worldSimulation,
         IMicrobeSpawnEnvironment spawnEnvironment, Species species,
         Vector3 location, bool aiControlled, (CellType? MulticellularCellType, int CellBodyPlanIndex) multicellularData,
-        out Entity entity, MulticellularSpawnState multicellularSpawnState = MulticellularSpawnState.Bud,
+        out Entity entity, MulticellularSpawnState multicellularSpawnState = MulticellularSpawnState.InitialState,
         Random? random = null)
     {
         var recorder = worldSimulation.StartRecordingEntityCommands();
@@ -623,7 +623,7 @@ public static class SpawnHelpers
         IMicrobeSpawnEnvironment spawnEnvironment, Species species,
         Vector3 location, bool aiControlled, (CellType? MulticellularCellType, int CellBodyPlanIndex) multicellularData,
         CommandBuffer recorder, out Entity entity,
-        MulticellularSpawnState multicellularSpawnState = MulticellularSpawnState.Bud,
+        MulticellularSpawnState multicellularSpawnState = MulticellularSpawnState.InitialState,
         bool giveInitialCompounds = true, Random? random = null)
     {
         // If this method is modified, it must be ensured that CellPropertiesHelpers.ReApplyCellTypeProperties and
@@ -752,7 +752,7 @@ public static class SpawnHelpers
 
                 var multicellularGrowth = new MulticellularGrowth(multicellularSpecies);
 
-                if (multicellularSpawnState == MulticellularSpawnState.Bud)
+                if (multicellularSpawnState == MulticellularSpawnState.InitialState)
                 {
                     resolvedCellType = multicellularSpecies.FirstCellTypeToSpawn();
 
@@ -976,7 +976,8 @@ public static class SpawnHelpers
 
         float spawnLimitWeight = OrganelleContainerHelpers.CalculateCellEntityWeight(organelleCount);
 
-        if (multicellularSpawnState != MulticellularSpawnState.Bud && multicellular != null)
+        if (multicellularSpawnState is not MulticellularSpawnState.InitialState
+            and not MulticellularSpawnState.ColonyRoot && multicellular != null)
         {
             switch (multicellularSpawnState)
             {
@@ -1074,7 +1075,7 @@ public static class SpawnHelpers
         Vector3 location, out Entity entity)
     {
         return SpawnMicrobeWithoutFinalizing(worldSimulation, spawnEnvironment, species, location, true, (null, 0),
-            out entity, MulticellularSpawnState.Bud);
+            out entity, MulticellularSpawnState.InitialState);
     }
 
     public static void SpawnCloud(CompoundCloudSystem clouds, Vector3 location, Compound compound, float amount,

--- a/src/microbe_stage/components/CellProperties.cs
+++ b/src/microbe_stage/components/CellProperties.cs
@@ -207,7 +207,7 @@ public static class CellPropertiesHelpers
     public static void Divide(this ref CellProperties cellProperties, ref OrganelleContainer organelles,
         in Entity entity, Species species, IWorldSimulation worldSimulation, IMicrobeSpawnEnvironment spawnEnvironment,
         ISpawnSystem spawnerToRegisterWith, ModifyDividedCellCallback? customizeCallback,
-        MulticellularSpawnState multicellularSpawnState = MulticellularSpawnState.Bud)
+        MulticellularSpawnState multicellularSpawnState = MulticellularSpawnState.InitialState)
     {
         if (organelles.Organelles == null)
             throw new InvalidOperationException("Organelles not initialized");

--- a/src/multicellular_stage/MulticellularSpawnState.cs
+++ b/src/multicellular_stage/MulticellularSpawnState.cs
@@ -4,9 +4,13 @@
 public enum MulticellularSpawnState
 {
     /// <summary>
-    ///   Spawn as just a single cell
+    ///   Might be a single cell, a spore, or a bunch of cells. Depends on the reproduction method.
     /// </summary>
-    Bud = 0,
+    InitialState = 0,
+    /// <summary>
+    ///   Just the colony root (a single cell).
+    /// </summary>
+    ColonyRoot,
     FullColony,
     ChanceForFullColony,
 }

--- a/src/multicellular_stage/systems/DelayedColonyOperationSystem.cs
+++ b/src/multicellular_stage/systems/DelayedColonyOperationSystem.cs
@@ -75,8 +75,8 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
 
         var weight = SpawnHelpers.SpawnMicrobeWithoutFinalizing(worldSimulation, spawnEnvironment, species,
             colonyPosition.Position + colonyPosition.Rotation * attachPosition.RelativePosition, true,
-            (cellTemplate.ModifiableCellType, bodyPlanIndex), recorder, out var member, MulticellularSpawnState.Bud,
-            giveStartingCompounds);
+            (cellTemplate.ModifiableCellType, bodyPlanIndex), recorder, out var member,
+            MulticellularSpawnState.InitialState, giveStartingCompounds);
 
         // Register with the spawn system to allow this entity to despawn if it gets cut off from the colony later
         // or attaching fails


### PR DESCRIPTION
**Brief Description of What This PR Does**

Slightly rearranges multicellular spawn states. Instead of `Bud`, there are two new types: `InitialState` that spawns whatever the reproduction method needs to be spawned and `ColonyRoot` that spawns just the colony root cell.

**Related Issues**

https://discord.com/channels/228300288023461893/958598553389903913/1506490701796610199

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
