### PR TITLE
Fixed photostudio to use the normal colony spawn

### DIFF
--- a/src/microbe_stage/MicrobeVisualOnlySimulation.cs
+++ b/src/microbe_stage/MicrobeVisualOnlySimulation.cs
@@ -15,6 +15,8 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
 {
     private readonly IMicrobeSpawnEnvironment dummyEnvironment = new DummyMicrobeSpawnEnvironment();
 
+    private readonly ISpawnSystem dummySpawnSystem = new DummySpawnSystem();
+
     private readonly List<Hex> hexWorkData1 = new();
     private readonly List<Hex> hexWorkData2 = new();
 
@@ -26,6 +28,9 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
 
     // This is Disposed indirectly
     private MicrobeVisualsSystem microbeVisualsSystem = null!;
+
+    // Multicellular visual-affecting systems we need to refer back to
+    private DelayedColonyOperationSystem delayedColonyOperationSystem = null!;
 
     private Node visualsParent = null!;
 #pragma warning restore CA2213
@@ -51,8 +56,12 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
         // TODO: but we cannot prevent this entity world from using multithreading
 
         microbeVisualsSystem = new MicrobeVisualsSystem(EntitySystem, null);
+        delayedColonyOperationSystem =
+            new DelayedColonyOperationSystem(this, dummyEnvironment, dummySpawnSystem, EntitySystem);
+
 #pragma warning disable SA1115
         simulationSystems = new Group<float>(simulationSystems.Name,
+            delayedColonyOperationSystem,
             microbeVisualsSystem,
 
             // Base systems
@@ -129,8 +138,10 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
     public Entity CreateVisualisationColony(MulticellularSpecies species)
     {
         // We pass AI-controlled true here to avoid creating player-specific data, but as we don't have the AI system,
-        // it is fine to create the AI properties as it won't actually do anything
-        SpawnHelpers.SpawnMicrobe(this, dummyEnvironment, species, Vector3.Zero, true);
+        // it is fine to create the AI properties as it won't actually do anything.
+        // Need to spawn the full colony here so that spore reproduction mode doesn't cause wrong results.
+        SpawnHelpers.SpawnMicrobe(this, dummyEnvironment, species, Vector3.Zero, true,
+            MulticellularSpawnState.FullColony);
 
         ProcessDelaySpawnedEntitiesImmediately();
 
@@ -139,22 +150,6 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
 
         if (foundEntity == Entity.Null)
             throw new Exception("Could not find microbe entity that should have been created");
-
-        var recorder = StartRecordingEntityCommands();
-
-        var dummySpawnSystem = new DummySpawnSystem();
-
-        int count = species.ModifiableGameplayCells.Count;
-        for (int i = 1; i < count; ++i)
-        {
-            var cell = species.ModifiableGameplayCells[i];
-
-            DelayedColonyOperationSystem.CreateDelayAttachedMicrobe(ref foundEntity.Get<WorldPosition>(),
-                in foundEntity, i, cell, species, this, dummyEnvironment, recorder, dummySpawnSystem, false);
-        }
-
-        recorder.Playback(EntitySystem);
-        FinishRecordingEntityCommands(recorder);
 
         return foundEntity;
     }
@@ -423,7 +418,15 @@ public sealed class MicrobeVisualOnlySimulation : WorldSimulation
 
     public override bool HasSystemsWithPendingOperations()
     {
-        return microbeVisualsSystem.HasPendingOperations();
+        // This is mostly duplicated logic from MicrobeWorldSimulation.HasSystemsWithPendingOperations()
+
+        if (microbeVisualsSystem.HasPendingOperations())
+            return true;
+
+        if (delayedColonyOperationSystem.HasPendingEntities())
+            return true;
+
+        return false;
     }
 
     public override void WriteToArchive(ISArchiveWriter writer)

--- a/src/microbe_stage/MicrobeWorldSimulation.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.cs
@@ -367,7 +367,15 @@ public partial class MicrobeWorldSimulation : WorldSimulationWithPhysics
 
     public override bool HasSystemsWithPendingOperations()
     {
-        return microbeVisualsSystem.HasPendingOperations();
+        // Note any visuals-affecting things added here needs to be added also for MicrobeVisualOnlySimulation
+
+        if (microbeVisualsSystem.HasPendingOperations())
+            return true;
+
+        if (delayedColonyOperationSystem.HasPendingEntities())
+            return true;
+
+        return false;
     }
 
     public override void FreeNodeResources()

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -602,8 +602,7 @@ public static class SpawnHelpers
         MulticellularSpawnState multicellularSpawnState = MulticellularSpawnState.Bud)
     {
         var (recorder, _) = SpawnMicrobeWithoutFinalizing(worldSimulation, spawnEnvironment, species, location,
-            aiControlled,
-            multicellularData, out _, multicellularSpawnState);
+            aiControlled, multicellularData, out _, multicellularSpawnState);
 
         FinalizeEntitySpawn(recorder, worldSimulation);
     }

--- a/src/multicellular_stage/MulticellularSpecies.cs
+++ b/src/multicellular_stage/MulticellularSpecies.cs
@@ -511,6 +511,8 @@ public class MulticellularSpecies : Species, IReadOnlyMulticellularSpecies, ISim
             hash += cell.GetVisualHashCode() ^ (ulong)cell.Position.GetHashCode();
         }
 
+        // Reproduction mode doesn't affect the visual hash code
+
         return hash;
     }
 

--- a/src/multicellular_stage/systems/DelayedColonyOperationSystem.cs
+++ b/src/multicellular_stage/systems/DelayedColonyOperationSystem.cs
@@ -36,6 +36,12 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
     private readonly IMicrobeSpawnEnvironment spawnEnvironment;
     private readonly ISpawnSystem spawnSystem;
 
+    private readonly ForEach entityForEachMarker;
+
+    private readonly QueryDescription delayedOperationQuery = new QueryDescription().WithAll<DelayedMicrobeColony>();
+
+    private bool hasDelayed;
+
     public DelayedColonyOperationSystem(IWorldSimulation worldSimulation, IMicrobeSpawnEnvironment spawnEnvironment,
         ISpawnSystem spawnSystem, World world) :
         base(world)
@@ -45,6 +51,8 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
         this.spawnSystem = spawnSystem;
 
         attachmentOrderComparer = new AttachmentOrderComparer();
+
+        entityForEachMarker = OnHasEntity;
     }
 
     public static void CreateDelayAttachedMicrobe(ref WorldPosition colonyPosition, in Entity colonyEntity,
@@ -110,6 +118,15 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
                 recorder.Add(member, originalEvents.CloneEventCallbacksForColonyMember());
             }
         }
+    }
+
+    public bool HasPendingEntities()
+    {
+        hasDelayed = false;
+
+        // TODO: is there more efficient way to check for pending entities than needing to loop each one?
+        World.Query(delayedOperationQuery, entityForEachMarker);
+        return hasDelayed;
     }
 
     public override void AfterUpdate(in float delta)
@@ -246,6 +263,11 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
     {
         var parentIndex = colony.CalculateSensibleParentIndexForMulticellular(ref entity.Get<AttachedToEntity>());
         colony.FinishQueuedMemberAdd(colonyEntity, parentIndex, entity, targetMemberIndex, recorder);
+    }
+
+    private void OnHasEntity(Entity entity)
+    {
+        hasDelayed = true;
     }
 
     private class AttachmentOrderComparer : IComparer<(Entity Cell, DelayedMicrobeColony Delayed)>


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes things so that no weird state exists in the species preview images for colonies

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/228300288023461893/958598553389903913/1506490701796610199

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
