### PR TITLE
Fixed spawned colonies not starting growth at right index

### DIFF
--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -706,6 +706,8 @@ public static class SpawnHelpers
 
         // Needed for later calculations
         float totalSpecializationBonus;
+        MulticellularGrowth multicellularGrowth = default;
+        bool setMulticellularGrowth = false;
 
         if (species is MulticellularSpecies multicellularSpecies)
         {
@@ -749,7 +751,7 @@ public static class SpawnHelpers
                     throw new ArgumentException("First Multicellular cell must have body plan index of 0");
                 }
 
-                var multicellularGrowth = new MulticellularGrowth(multicellularSpecies);
+                multicellularGrowth = new MulticellularGrowth(multicellularSpecies);
 
                 if (multicellularSpawnState == MulticellularSpawnState.Bud)
                 {
@@ -763,15 +765,14 @@ public static class SpawnHelpers
                     resolvedCellType = multicellularSpecies.ColonyRootCellType();
                 }
 
+                // If grown as a full colony, or partial colony, we need to record the growth state here to not get
+                // duplicate cells
+                setMulticellularGrowth = true;
+
                 usedCellDefinition = resolvedCellType;
                 var properties = new CellProperties(usedCellDefinition);
                 membraneType = properties.MembraneType;
                 recorder.Set(entity, properties);
-
-                // This is not in the signature as this is a very specific case
-                // TODO: determine if this has negative effects and the signature should be adjusted (to split on
-                // this one more variable)
-                recorder.Add(entity, multicellularGrowth);
 
                 totalSpecializationBonus = resolvedCellType.CellTypeSpecializationBonus *
                     multicellularSpecies.GetAdjacencySpecializationBonus(multicellularData.CellBodyPlanIndex);
@@ -914,7 +915,7 @@ public static class SpawnHelpers
 
             AbsorptionRate = usedCellDefinition.MembraneType.ResourceAbsorptionFactor,
 
-            // AI requires this, player doesn't (or at least I can't remember right now that it would -hhyyrylainen)
+            // AI requires this, player doesn't (or at least I can't remember right now that it would -hhyyrylainen),
             // but it isn't too big a problem to also specify this for the player
             TotalAbsorbedCompounds = new Dictionary<Compound, float>(),
         });
@@ -977,12 +978,15 @@ public static class SpawnHelpers
 
         if (multicellularSpawnState != MulticellularSpawnState.Bud && multicellular != null)
         {
+            if (!setMulticellularGrowth)
+                throw new Exception("Logic error in spawning a multicellular cell, multicellular growth not set");
+
             switch (multicellularSpawnState)
             {
                 case MulticellularSpawnState.FullColony:
                     spawnLimitWeight +=
                         MicrobeColonyHelpers.SpawnAsFullyGrownMulticellularColony(entity, multicellular,
-                            spawnLimitWeight, recorder);
+                            ref multicellularGrowth, spawnLimitWeight, recorder);
                     break;
 
                 case MulticellularSpawnState.ChanceForFullColony:
@@ -993,7 +997,7 @@ public static class SpawnHelpers
                     if (random.NextDouble() < Constants.CHANCE_MULTICELLULAR_SPAWNS_GROWN)
                     {
                         spawnLimitWeight += MicrobeColonyHelpers.SpawnAsFullyGrownMulticellularColony(entity,
-                            multicellular, spawnLimitWeight, recorder);
+                            multicellular, ref multicellularGrowth, spawnLimitWeight, recorder);
                     }
                     else if (random.NextDouble() < Constants.CHANCE_MULTICELLULAR_SPAWNS_PARTLY_GROWN)
                     {
@@ -1013,7 +1017,7 @@ public static class SpawnHelpers
                         if (cellsToAdd > 0)
                         {
                             spawnLimitWeight += MicrobeColonyHelpers.SpawnAsPartialMulticellularColony(entity,
-                                spawnLimitWeight, cellsToAdd, recorder);
+                                spawnLimitWeight, cellsToAdd, ref multicellularGrowth, recorder);
                         }
                     }
 
@@ -1024,6 +1028,14 @@ public static class SpawnHelpers
                     throw new ArgumentOutOfRangeException(nameof(multicellularSpawnState), multicellularSpawnState,
                         null);
             }
+        }
+
+        if (setMulticellularGrowth)
+        {
+            // This is not in the signature as this is a very specific case
+            // TODO: determine if this has negative effects and the signature should be adjusted (to split on
+            // this one more variable)
+            recorder.Add(entity, multicellularGrowth);
         }
 
         return spawnLimitWeight;

--- a/src/microbe_stage/components/CellProperties.cs
+++ b/src/microbe_stage/components/CellProperties.cs
@@ -241,9 +241,9 @@ public static class CellPropertiesHelpers
             IgnoredCollisionWith = entity,
         });
 
-        // Since the daughter spawns right next to the cell, it should face the same way to avoid colliding
+        // Since the daughter spawns right next to the cell, it should face the same way to avoid colliding.
         // This probably wastes a bit of memory but should be fine to overwrite the WorldPosition component like
-        // this
+        // this.
         recorder.Set(copyEntity, new WorldPosition(spawnPosition, position.Rotation));
 
         // TODO: should this also set an initial look direction that is the same?

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -964,7 +964,7 @@ public static class MicrobeColonyHelpers
     /// </summary>
     /// <returns>How much the added colony members add entity weight</returns>
     public static float SpawnAsFullyGrownMulticellularColony(Entity entity, MulticellularSpecies species,
-        float originalWeight, CommandBuffer commandBuffer)
+        ref MulticellularGrowth multicellularGrowth, float originalWeight, CommandBuffer commandBuffer)
     {
         int members = species.ModifiableGameplayCells.Count - 1;
 
@@ -974,11 +974,15 @@ public static class MicrobeColonyHelpers
 
         SetupColonyWithMembersDelayed(entity, members, commandBuffer);
 
+        // All members are added, so mark as fully grown
+        multicellularGrowth.NextBodyPlanCellToGrowIndex = species.ModifiableGameplayCells.Count;
+        multicellularGrowth.CompoundsNeededForNextCell = null;
+
         return CalculateColonyAdditionalEntityWeight(originalWeight, members);
     }
 
     public static float SpawnAsPartialMulticellularColony(Entity entity, float originalWeight,
-        int membersToAdd, CommandBuffer commandBuffer)
+        int membersToAdd, ref MulticellularGrowth multicellularGrowth, CommandBuffer commandBuffer)
     {
         if (membersToAdd < 1)
         {
@@ -987,6 +991,10 @@ public static class MicrobeColonyHelpers
         }
 
         SetupColonyWithMembersDelayed(entity, membersToAdd, commandBuffer);
+
+        // Adjust growth state to resume correctly after the added members
+        multicellularGrowth.NextBodyPlanCellToGrowIndex += membersToAdd;
+        multicellularGrowth.CompoundsNeededForNextCell = null;
 
         return CalculateColonyAdditionalEntityWeight(originalWeight, membersToAdd);
     }


### PR DESCRIPTION
which lead to duplicate cells growing, now the growth should resume at the right index of the bodyplan to avoid any duplicate cell growth

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/228300288023461893/958598553389903913/1506819557518606418

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
