### PR TITLE
Added locking and organelle duplication to suggestions run

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -3454,7 +3454,7 @@ public partial class CellEditorComponent :
     /// <summary>
     ///   Holds data for the organelle suggestion calculation run
     /// </summary>
-    private class OrganelleSuggestionCalculation
+    private class OrganelleSuggestionCalculation : IDisposable
     {
         private readonly List<OrganelleDefinition> availableOrganelles = new();
         private readonly MicrobeSpecies calculationSpecies;
@@ -3628,6 +3628,11 @@ public partial class CellEditorComponent :
             }
 
             return false;
+        }
+
+        public void Dispose()
+        {
+            dataSetupLock.Dispose();
         }
 
         private void CopyPristineToCalculation()

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Arch.Core;
 using AutoEvo;
 using Godot;
@@ -2995,13 +2996,18 @@ public partial class CellEditorComponent :
         target.Organelles.Clear();
 
         // TODO: if this is too slow to copy each organelle like this, we'll need to find a faster way to get the data
-        // in, perhaps by sharing the entire Organelles object
+        // in, but that will require more locking
         foreach (var entry in editedMicrobeOrganelles.Organelles)
         {
             if (entry.Definition == nucleus)
                 target.IsBacteria = false;
 
-            target.Organelles.AddFast(entry, hexTemporaryMemory, hexTemporaryMemory2);
+            // We have to clone here, as we might have a suggestion run ongoing when we modify the edited organelles
+            // already by, for example, moving something.
+            // This also wastes some memory, but for now this is basically impossible to avoid.
+            var newOrganelle = entry.Clone();
+
+            target.Organelles.AddFast(newOrganelle, hexTemporaryMemory, hexTemporaryMemory2);
         }
 
         // Copy behaviour if it is known
@@ -3463,6 +3469,8 @@ public partial class CellEditorComponent :
         private readonly List<Hex> workMemory2 = new();
         private readonly HashSet<Hex> workMemory3 = new();
 
+        private readonly SemaphoreSlim dataSetupLock = new(1, 1);
+
         private AutoEvoRun? currentRun;
         private BiomeConditions? biome;
         private Patch? patch;
@@ -3499,7 +3507,8 @@ public partial class CellEditorComponent :
         public bool UsePurePopulationScore { get; set; }
 
         /// <summary>
-        ///   Set up this for a new suggestion calculation
+        ///   Set up this for a new suggestion calculation. Note that this can lock for a little bit if we just tried
+        ///   to start another run. So this may cause a lag spike in rare cases on the main thread.
         /// </summary>
         /// <param name="organellesToTry">Valid organelles to try in the suggestion</param>
         /// <param name="selectedPatch">Patch conditions to simulate in</param>
@@ -3515,17 +3524,25 @@ public partial class CellEditorComponent :
                 currentRun = null;
             }
 
-            availableOrganelles.Clear();
-            availableOrganelles.AddRange(organellesToTry);
+            dataSetupLock.Wait();
+            try
+            {
+                availableOrganelles.Clear();
+                availableOrganelles.AddRange(organellesToTry);
 
-            // Refresh the latest edits to our local pristine copy that is then used by a background thread
-            applyLatestEditsToSpecies(pristineSpeciesCopy);
+                // Refresh the latest edits to our local pristine copy that is then used by a background thread
+                applyLatestEditsToSpecies(pristineSpeciesCopy);
 
-            calculatedNoChange = false;
-            bestOrganelle = null;
-            bestResult = -1;
-            resultRead = false;
-            IsCompleted = false;
+                calculatedNoChange = false;
+                bestOrganelle = null;
+                bestResult = -1;
+                resultRead = false;
+                IsCompleted = false;
+            }
+            finally
+            {
+                dataSetupLock.Release();
+            }
 
             StartNextRun();
         }
@@ -3615,27 +3632,35 @@ public partial class CellEditorComponent :
 
         private void CopyPristineToCalculation()
         {
-            // TODO: there is duplication between this and CopyEditedPropertiesToSpecies
-            calculationSpecies.SpeciesColour = pristineSpeciesCopy.SpeciesColour;
-            calculationSpecies.MembraneType = pristineSpeciesCopy.MembraneType;
-            calculationSpecies.MembraneRigidity = pristineSpeciesCopy.MembraneRigidity;
-            calculationSpecies.IsBacteria = pristineSpeciesCopy.IsBacteria;
-
-            // This can't be undone but should be fine as the species to edit cannot change in the editor
-            if (pristineSpeciesCopy.PlayerSpecies)
-                calculationSpecies.BecomePlayerSpecies();
-
-            calculationSpecies.Organelles.Clear();
-
-            foreach (var entry in pristineSpeciesCopy.Organelles)
+            dataSetupLock.Wait();
+            try
             {
-                calculationSpecies.Organelles.AddFast(entry, workMemory1, workMemory2);
+                // TODO: there is duplication between this and CopyEditedPropertiesToSpecies
+                calculationSpecies.SpeciesColour = pristineSpeciesCopy.SpeciesColour;
+                calculationSpecies.MembraneType = pristineSpeciesCopy.MembraneType;
+                calculationSpecies.MembraneRigidity = pristineSpeciesCopy.MembraneRigidity;
+                calculationSpecies.IsBacteria = pristineSpeciesCopy.IsBacteria;
+
+                // This can't be undone but should be fine as the species to edit cannot change in the editor
+                if (pristineSpeciesCopy.PlayerSpecies)
+                    calculationSpecies.BecomePlayerSpecies();
+
+                calculationSpecies.Organelles.Clear();
+
+                foreach (var entry in pristineSpeciesCopy.Organelles)
+                {
+                    calculationSpecies.Organelles.AddFast(entry, workMemory1, workMemory2);
+                }
+
+                // The pristine copy is not modified, so it is safe to not clone here
+                calculationSpecies.ModifiableBehaviour = pristineSpeciesCopy.ModifiableBehaviour;
+
+                calculationSpecies.ModifiableTolerances.CopyFrom(pristineSpeciesCopy.Tolerances);
             }
-
-            // The pristine copy is not modified, so it is safe to not clone here
-            calculationSpecies.ModifiableBehaviour = pristineSpeciesCopy.ModifiableBehaviour;
-
-            calculationSpecies.ModifiableTolerances.CopyFrom(pristineSpeciesCopy.Tolerances);
+            finally
+            {
+                dataSetupLock.Release();
+            }
         }
 
         private bool StartNextRun()


### PR DESCRIPTION
to avoid problems where organelle moves could trigger an error in an ongoing suggestion run as it modified the existing data in unexpected ways. This is slightly more expensive in terms of memory allocations but I couldn't come up with a design with the current species data format that could avoid it.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/464846402732687391/465937305849298956/1506958033706684558

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
