### PR TITLE
Switch FossilisationDialog scene to inherit from CustomWindow

### DIFF
--- a/src/thriveopedia/fossilisation/FossilisationDialog.tscn
+++ b/src/thriveopedia/fossilisation/FossilisationDialog.tscn
@@ -3,7 +3,8 @@
 [ext_resource type="Script" uid="uid://dvtcoa6g3lkyn" path="res://src/thriveopedia/fossilisation/FossilisationDialog.cs" id="1"]
 [ext_resource type="PackedScene" uid="uid://bhpjtbtaeunat" path="res://src/gui_common/CustomRichTextLabel.tscn" id="3"]
 [ext_resource type="FontFile" uid="uid://dblvrxw3ue372" path="res://assets/fonts/Lato-Italic.ttf" id="3_cgult"]
-[ext_resource type="PackedScene" uid="uid://cl64wvnxs6ivs" path="res://src/gui_common/dialogs/CustomConfirmationDialog.tscn" id="4"]
+[ext_resource type="PackedScene" uid="uid://du8sc8kjirguk" path="res://src/gui_common/dialogs/CustomWindow.tscn" id="4"]
+[ext_resource type="PackedScene" uid="uid://cl64wvnxs6ivs" path="res://src/gui_common/dialogs/CustomConfirmationDialog.tscn" id="4_confirm"]
 [ext_resource type="PackedScene" uid="uid://b1boea8qjx6xx" path="res://src/gui_common/SpeciesDetailsPanel.tscn" id="5"]
 [ext_resource type="Texture2D" uid="uid://baqkntjn5ng0y" path="res://assets/textures/gui/bevel/randomizeButton.png" id="9"]
 [ext_resource type="Texture2D" uid="uid://c8qyts61c8a0y" path="res://assets/textures/gui/bevel/randomizeButtonActive.png" id="10"]
@@ -45,17 +46,7 @@ fossilisationFailedDialog = NodePath("FossilisationFailedDialog")
 WindowTitle = "FOSSILISATION"
 ExclusiveAllowCloseOnEscape = false
 
-[node name="VBoxContainer" parent="." index="0" unique_id=146557504]
-visible = false
-offset_left = 0.0
-offset_top = 0.0
-offset_right = 152.0
-offset_bottom = 69.0
-
-[node name="FocusGrabber" parent="VBoxContainer" index="4" unique_id=158342970]
-NodeToGiveFocusTo = NodePath("../../VBoxContainer2/HBoxContainer/CancelButton")
-
-[node name="VBoxContainer2" type="VBoxContainer" parent="." index="1" unique_id=406948132]
+[node name="VBoxContainer2" type="VBoxContainer" parent="." index="0" unique_id=406948132]
 layout_mode = 0
 offset_left = 11.0
 offset_top = 11.0
@@ -141,7 +132,7 @@ text = "FOSSILISE"
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="OverwriteNameConfirmation" parent="." index="2" unique_id=1179250609 instance=ExtResource("4")]
+[node name="OverwriteNameConfirmation" parent="." index="1" unique_id=1179250609 instance=ExtResource("4_confirm")]
 custom_minimum_size = Vector2(440, 0)
 layout_mode = 0
 offset_left = 1.0
@@ -150,7 +141,7 @@ offset_right = 935.0
 offset_bottom = 599.0
 WindowTitle = "CONFIRM_FOSSILISATION_OVERWRITE"
 
-[node name="FossilisationFailedDialog" parent="." index="3" unique_id=2095718850 instance=ExtResource("4")]
+[node name="FossilisationFailedDialog" parent="." index="2" unique_id=2095718850 instance=ExtResource("4_confirm")]
 custom_minimum_size = Vector2(440, 0)
 layout_mode = 0
 offset_left = 1.0

--- a/src/thriveopedia/fossilisation/FossilisationDialog.tscn
+++ b/src/thriveopedia/fossilisation/FossilisationDialog.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" uid="uid://dvtcoa6g3lkyn" path="res://src/thriveopedia/fossilisation/FossilisationDialog.cs" id="1"]
 [ext_resource type="PackedScene" uid="uid://bhpjtbtaeunat" path="res://src/gui_common/CustomRichTextLabel.tscn" id="3"]
+[ext_resource type="PackedScene" uid="uid://bgeijgq7runaw" path="res://src/gui_common/FocusGrabber.tscn" id="3_5l8nu"]
 [ext_resource type="FontFile" uid="uid://dblvrxw3ue372" path="res://assets/fonts/Lato-Italic.ttf" id="3_cgult"]
 [ext_resource type="PackedScene" uid="uid://du8sc8kjirguk" path="res://src/gui_common/dialogs/CustomWindow.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://cl64wvnxs6ivs" path="res://src/gui_common/dialogs/CustomConfirmationDialog.tscn" id="4_confirm"]
@@ -55,12 +56,19 @@ offset_bottom = 409.0
 mouse_filter = 0
 mouse_force_pass_scroll_events = false
 
-[node name="Spacer2" type="Control" parent="VBoxContainer2" index="0" unique_id=1673557192]
-custom_minimum_size = Vector2(342, 16)
+[node name="FocusGrabber" parent="VBoxContainer2" index="0" unique_id=125641974 instance=ExtResource("3_5l8nu")]
+layout_mode = 2
+focus_mode = 2
+Priority = 3
+NodeToGiveFocusTo = NodePath("../HBoxContainer/CancelButton")
+GrabFocusWhenBecomingVisible = true
+
+[node name="Spacer2" type="Control" parent="VBoxContainer2" index="1" unique_id=1673557192]
+custom_minimum_size = Vector2(342, 15)
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer2" index="1" unique_id=666012127]
+[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer2" index="2" unique_id=666012127]
 custom_minimum_size = Vector2(275, 0)
 layout_mode = 2
 
@@ -68,8 +76,9 @@ layout_mode = 2
 custom_minimum_size = Vector2(240, 27)
 layout_mode = 2
 size_flags_vertical = 4
-focus_mode = 1
-mouse_filter = 1
+focus_neighbor_left = NodePath(".")
+focus_neighbor_right = NodePath("../RandomizeButton")
+mouse_force_pass_scroll_events = false
 theme_override_fonts/font = ExtResource("3_cgult")
 placeholder_text = "SPECIES_NAME_DOT_DOT_DOT"
 max_length = 100
@@ -83,6 +92,8 @@ custom_minimum_size = Vector2(31, 31)
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 4
+focus_neighbor_left = NodePath("../SpeciesName")
+focus_neighbor_right = NodePath(".")
 texture_normal = ExtResource("9")
 texture_pressed = ExtResource("10")
 texture_hover = ExtResource("12")
@@ -90,21 +101,21 @@ texture_disabled = ExtResource("11")
 ignore_texture_size = true
 stretch_mode = 5
 
-[node name="Spacer" type="Control" parent="VBoxContainer2" index="2" unique_id=275626661]
+[node name="Spacer" type="Control" parent="VBoxContainer2" index="3" unique_id=275626661]
 custom_minimum_size = Vector2(342, 16)
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="SpeciesDetails" parent="VBoxContainer2" index="3" unique_id=1584145580 instance=ExtResource("5")]
+[node name="SpeciesDetails" parent="VBoxContainer2" index="4" unique_id=1584145580 instance=ExtResource("5")]
 layout_mode = 2
 
-[node name="Description" parent="VBoxContainer2" index="4" unique_id=1233779701 instance=ExtResource("3")]
+[node name="Description" parent="VBoxContainer2" index="5" unique_id=1233779701 instance=ExtResource("3")]
 custom_minimum_size = Vector2(342, 44)
 layout_mode = 2
 fit_content = true
 ExtendedBbcode = "FOSSILISATION_EXPLANATION"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer2" index="5" unique_id=489759531]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer2" index="6" unique_id=489759531]
 layout_mode = 2
 
 [node name="Spacer" type="Control" parent="VBoxContainer2/HBoxContainer" index="0" unique_id=1320714783]
@@ -113,7 +124,12 @@ size_flags_horizontal = 3
 
 [node name="CancelButton" type="Button" parent="VBoxContainer2/HBoxContainer" index="1" unique_id=19476337]
 layout_mode = 2
-focus_mode = 0
+focus_neighbor_left = NodePath(".")
+focus_neighbor_top = NodePath("../../HBoxContainer2/SpeciesName")
+focus_neighbor_right = NodePath("../FossiliseButton")
+focus_neighbor_bottom = NodePath(".")
+focus_next = NodePath("../FossiliseButton")
+focus_previous = NodePath("../../HBoxContainer2/SpeciesName")
 theme_override_font_sizes/font_size = 18
 text = "CANCEL"
 
@@ -123,7 +139,9 @@ size_flags_horizontal = 3
 
 [node name="FossiliseButton" type="Button" parent="VBoxContainer2/HBoxContainer" index="3" unique_id=1766889639]
 layout_mode = 2
-focus_mode = 0
+focus_neighbor_left = NodePath("../CancelButton")
+focus_neighbor_bottom = NodePath(".")
+focus_previous = NodePath("../CancelButton")
 theme_override_fonts/font = ExtResource("10_wkor0")
 theme_override_font_sizes/font_size = 18
 text = "FOSSILISE"


### PR DESCRIPTION
**Brief Description of What This PR Does**

Switch FossilisationDialog scene to inherit from CustomWindow

The scene previously inherited from `CustomConfirmationDialog` while its script inherited from `CustomWindow`.  The scene-inherited children `VBoxContainer` and `FocusGrabber` were hidden and unused, making this pointless.

The change is straight-forward.

**Related Issues**

Closes https://github.com/Revolutionary-Games/Thrive/issues/4157

**Testing**

<img width="2560" height="1440" alt="Screenshot 2026-05-24 at 12 14 34" src="https://github.com/user-attachments/assets/c367dada-ebb3-4bd8-928d-edac52c790a3" />

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
