### PR TITLE
Implement 2D spinner shader as alternative to rotating controls directly in LoadingScreen and ChemicalEquation

### DIFF
--- a/shaders/SpinnerVertex.gdshader
+++ b/shaders/SpinnerVertex.gdshader
@@ -1,0 +1,28 @@
+shader_type canvas_item;
+
+/*
+ * Manually spins a texture via the updating of uniform "rotation".
+ * UV rotation is done in vertex() so the math runs only at the quad's
+ * corners and gets interpolated across fragments.
+ */
+
+/* Range: [-TAU, TAU]. Clockwise as it increases, counter-clockwise as it decreases. */
+uniform float rotation = 0.0;
+
+/*
+ * Only override this for non-square spinners. UV space is normalized to
+ * [0, 1] on both axes, so rotating a non-square texture in UV space makes
+ * it wobble. Set this from the parent to the rect/tex (width, height) to fix
+ * that.
+ */
+uniform vec2 aspect = vec2(1.0);
+
+void vertex() {
+    float angle = -rotation;
+    mat2 rotationMatrix = mat2(vec2(cos(angle), -sin(angle)),
+        vec2(sin(angle), cos(angle)));
+
+    vec2 uv = (UV - vec2(0.5)) * aspect;
+    uv = uv * rotationMatrix;
+    UV = uv / aspect + vec2(0.5);
+}

--- a/shaders/SpinnerVertex.gdshader.uid
+++ b/shaders/SpinnerVertex.gdshader.uid
@@ -1,0 +1,1 @@
+uid://bul033somqtc6

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1688,7 +1688,7 @@ public static class Constants
 
     public const float MINIMUM_RUNNABLE_PROCESS_FRACTION = 0.00001f;
 
-    public const float DEFAULT_PROCESS_SPINNER_SPEED = 365.0f;
+    public const float DEFAULT_PROCESS_SPINNER_SPEED = MathF.PI * 2.0f;
     public const float DEFAULT_PROCESS_STATISTICS_AVERAGE_INTERVAL = 0.4f;
 
     public const int COLONY_SIZE_REQUIRED_FOR_MULTICELLULAR = 5;

--- a/src/engine/LoadingScreen.cs
+++ b/src/engine/LoadingScreen.cs
@@ -53,8 +53,8 @@ public partial class LoadingScreen : Control
     private string loadingDescription = string.Empty;
     private string? artDescription;
 
-    private double totalElapsed;
     private double elapsedSinceTipChange;
+    private float currentSpinnerRotation;
 
     private LoadingScreen()
     {
@@ -206,10 +206,11 @@ public partial class LoadingScreen : Control
             return;
         }
 
-        totalElapsed += delta;
         elapsedSinceTipChange += delta;
-        spinnerMaterial.SetShaderParameter(rotationName,
-            (float)(totalElapsed * SpinnerSpeed) % MathF.Tau);
+
+        currentSpinnerRotation += (float)(delta * SpinnerSpeed);
+        currentSpinnerRotation %= MathF.Tau;
+        spinnerMaterial.SetShaderParameter(rotationName, currentSpinnerRotation);
     }
 
     /// <summary>
@@ -343,7 +344,7 @@ public partial class LoadingScreen : Control
     private void OnBecomeVisible()
     {
         wasVisible = true;
-        totalElapsed = 0;
+        currentSpinnerRotation = 0;
 
         RandomizeContent();
 

--- a/src/engine/LoadingScreen.cs
+++ b/src/engine/LoadingScreen.cs
@@ -17,7 +17,9 @@ public partial class LoadingScreen : Control
 
     private readonly Random random = new();
 
-    private readonly List<(Action Action, double Delay)> postLoadingActions = new();
+    private readonly List<(Action Action, double Delay)> postLoadingActions = [];
+
+    private readonly StringName rotationName = new("rotation");
 
 #pragma warning disable CA2213
     [Export]
@@ -36,10 +38,12 @@ public partial class LoadingScreen : Control
     private CustomRichTextLabel? tipLabel;
 
     [Export]
-    private Control spinner = null!;
+    private TextureRect spinner = null!;
 
     [Export]
     private Timer randomizeTimer = null!;
+
+    private ShaderMaterial spinnerMaterial = null!;
 #pragma warning restore CA2213
 
     private bool wasVisible;
@@ -161,6 +165,8 @@ public partial class LoadingScreen : Control
 
     public override void _Ready()
     {
+        spinnerMaterial = (ShaderMaterial)spinner.Material;
+
         UpdateMessage();
         UpdateDescription();
         UpdateTip();
@@ -200,12 +206,10 @@ public partial class LoadingScreen : Control
             return;
         }
 
-        // Spin the spinner
         totalElapsed += delta;
-
         elapsedSinceTipChange += delta;
-
-        spinner.Rotation = (float)(totalElapsed * SpinnerSpeed) % MathF.Tau;
+        spinnerMaterial.SetShaderParameter(rotationName,
+            (float)(totalElapsed * SpinnerSpeed) % MathF.Tau);
     }
 
     /// <summary>
@@ -305,7 +309,7 @@ public partial class LoadingScreen : Control
         {
             if (OverrideTips.EndsWith("Tips"))
             {
-                gameStateName = OverrideTips.Substring(0, OverrideTips.Length - 4);
+                gameStateName = OverrideTips[..^4];
             }
             else
             {
@@ -324,6 +328,16 @@ public partial class LoadingScreen : Control
 
         artworkRect.Image = GD.Load<Texture2D>(artwork.ResourcePath);
         ArtDescription = artwork.BuildDescription(true);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            rotationName.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 
     private void OnBecomeVisible()

--- a/src/engine/LoadingScreen.tscn
+++ b/src/engine/LoadingScreen.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="Shader" uid="uid://lf6igwl1dy7j" path="res://shaders/UVFlipper.gdshader" id="6"]
 [ext_resource type="LabelSettings" uid="uid://bnhcbmq3brx0s" path="res://src/gui_common/fonts/Title-SemiBold-Normal.tres" id="6_rw556"]
 [ext_resource type="LabelSettings" uid="uid://fua052cwp5ap" path="res://src/gui_common/fonts/Body-Regular-AlmostSmaller.tres" id="7_dhkod"]
+[ext_resource type="Shader" uid="uid://bul033somqtc6" path="res://shaders/SpinnerVertex.gdshader" id="8_kw2xg"]
 [ext_resource type="Script" uid="uid://c0itxwsgtedpj" path="res://src/gui_common/CustomRichTextLabel.cs" id="9"]
 
 [sub_resource type="ShaderMaterial" id="1"]
@@ -18,6 +19,11 @@ colors = PackedColorArray(0.0117647, 0.027451, 0.0392157, 1, 0, 0, 0.00392157, 0
 
 [sub_resource type="GradientTexture2D" id="3"]
 gradient = SubResource("2")
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_3t0ay"]
+shader = ExtResource("8_kw2xg")
+shader_parameter/rotation = 0.0
+shader_parameter/aspect = Vector2(1, 1)
 
 [node name="LoadingScreen" type="Control" unique_id=1849056004 node_paths=PackedStringArray("artworkRect", "artDescriptionLabel", "loadingMessageLabel", "loadingDescriptionLabel", "tipLabel", "spinner", "randomizeTimer")]
 process_mode = 3
@@ -128,11 +134,11 @@ custom_minimum_size = Vector2(64, 64)
 layout_mode = 2
 
 [node name="TextureRect" type="TextureRect" parent="MarginContainer/HBoxContainer/Spinner/Control" unique_id=1639523462]
+material = SubResource("ShaderMaterial_3t0ay")
 custom_minimum_size = Vector2(64, 64)
 layout_mode = 0
 offset_right = 64.0
 offset_bottom = 64.0
-pivot_offset = Vector2(32, 32)
 texture = ExtResource("3")
 expand_mode = 1
 stretch_mode = 6

--- a/src/gui_common/ChemicalEquation.cs
+++ b/src/gui_common/ChemicalEquation.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Godot;
 
@@ -11,11 +12,13 @@ public partial class ChemicalEquation : CheckButton
     [Export]
     public LabelSettings DefaultTitleFont = null!;
 
+    private readonly StringName rotationName = new("rotation");
+
     [Export]
     private Label? title;
 
     [Export]
-    private TextureRect? spinner;
+    private TextureRect spinner = null!;
 
     [Export]
     private Control? spinnerController;
@@ -48,6 +51,8 @@ public partial class ChemicalEquation : CheckButton
     private Label? perSecondLabel;
     private Label? environmentSeparator;
     private CompoundListBox? environmentSection;
+
+    private ShaderMaterial spinnerMaterial = null!;
 #pragma warning restore CA2213
 
     private IProcessDisplayInfo? equationFromProcess;
@@ -179,6 +184,8 @@ public partial class ChemicalEquation : CheckButton
 
     public override void _Ready()
     {
+        spinnerMaterial = (ShaderMaterial)spinner.Material;
+
         UpdateEquation();
 
         RecalculateMinimumSize();
@@ -207,10 +214,8 @@ public partial class ChemicalEquation : CheckButton
                 currentSpinnerRotation += (float)delta * EquationFromProcess.CurrentSpeed * SpinnerBaseSpeed
                     * ExternalSpeedModifier;
 
-                // TODO: should we at some point subtract like 100000*360 from the spinner rotation to avoid float range
-                // exceeding?
-
-                spinner!.RotationDegrees = (int)currentSpinnerRotation % 360;
+                spinnerMaterial.SetShaderParameter(rotationName,
+                    currentSpinnerRotation % MathF.Tau);
             }
         }
 
@@ -226,6 +231,16 @@ public partial class ChemicalEquation : CheckButton
     public override void _Pressed()
     {
         ProcessEnabled = !ProcessEnabled;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            rotationName.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 
     private void OnTranslationsChanged()

--- a/src/gui_common/ChemicalEquation.cs
+++ b/src/gui_common/ChemicalEquation.cs
@@ -211,11 +211,12 @@ public partial class ChemicalEquation : CheckButton
             // scrolling works)
             if (!PauseManager.Instance.Paused)
             {
-                currentSpinnerRotation += (float)delta * EquationFromProcess.CurrentSpeed * SpinnerBaseSpeed
-                    * ExternalSpeedModifier;
+                double totalSpeed = EquationFromProcess.CurrentSpeed * SpinnerBaseSpeed * ExternalSpeedModifier;
+                float rotationDelta = (float)(delta * totalSpeed);
+                currentSpinnerRotation += rotationDelta;
+                currentSpinnerRotation %= MathF.Tau;
 
-                spinnerMaterial.SetShaderParameter(rotationName,
-                    currentSpinnerRotation % MathF.Tau);
+                spinnerMaterial.SetShaderParameter(rotationName, currentSpinnerRotation);
             }
         }
 

--- a/src/gui_common/ChemicalEquation.tscn
+++ b/src/gui_common/ChemicalEquation.tscn
@@ -8,6 +8,12 @@
 [ext_resource type="LabelSettings" uid="uid://4teclbsvoawb" path="res://src/gui_common/fonts/Body-Bold-Smaller-Red.tres" id="4_vbkf3"]
 [ext_resource type="Texture2D" uid="uid://bembxnxct020" path="res://assets/textures/gui/bevel/WhiteArrow.png" id="5_tr4hc"]
 [ext_resource type="FontFile" uid="uid://b62thy1er4r08" path="res://assets/fonts/Lato-Bold.ttf" id="5_wdgi7"]
+[ext_resource type="Shader" uid="uid://bul033somqtc6" path="res://shaders/SpinnerVertex.gdshader" id="7_1oc4h"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_l0qs4"]
+resource_local_to_scene = true
+shader = ExtResource("7_1oc4h")
+shader_parameter/rotation = 0.0
 
 [sub_resource type="Theme" id="1"]
 default_font = ExtResource("5_wdgi7")
@@ -66,11 +72,11 @@ custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
 
 [node name="Spinner" type="TextureRect" parent="MarginContainer/VBoxContainer/HBoxContainer/SpinnerNode" unique_id=1148069507]
+material = SubResource("ShaderMaterial_l0qs4")
 custom_minimum_size = Vector2(32, 32)
 layout_mode = 0
 offset_right = 32.0
 offset_bottom = 32.0
-pivot_offset = Vector2(16, 16)
 texture = ExtResource("3")
 expand_mode = 1
 stretch_mode = 5


### PR DESCRIPTION
**Brief Description of What This PR Does**

Implement 2D spinner shader as alternative to rotating controls directly in LoadingScreen and ChemicalEquation.

Add a vertex shader `SpinnerVertex.gdshader` that rotates textures, replacing the previous approach of rotating Control nodes directly, which is knowingly problematic in Godot. This shader is then applied to both the LoadingScreen spinner and the ChemicalEquation process speed icon.

This shader accepts a `rotation` uniform that allows the parent to act as an orchestrator to manually adjust rotation. This manual control is currently preferred due the spinning requiring rotation to be sped and slowed down (or completely stopped) at will -- this would be tricky with a `TIME * speed` approach because TIME just keeps incrementing, and would be out of sync next time speed stopped being non-zero, resulting in a visual snap.

The rotation is done in `vertex()` rather than `fragment()` so the rotation matrix is computed only at the quad's corners and interpolated across fragments. UV space is normalized to `[0, 1]` so for square spinners no extra information is needed... but an optional `aspect` uniform is exposed for non-squares to compensate for UV stretch. Defaults to `vec2(1.0)` so existing callers don't need to set it.

Boy Scout Rule:
  - Modernized some collection initializers
  - Modernized a substring accessor pattern
  - Change spinner type from `Control` to `TextureRect`, strong type is always preferred
  - Change spinner from nullable (`TextureRect?`) to non-nullable (`TextureRect`)

**Related Issues**

closes https://github.com/Revolutionary-Games/Thrive/issues/5023

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
