### PR TITLE
Defer FadeOutActionSystem callback work to a queue for proper component access  

### DIFF
--- a/src/engine/common_components/TimedLife.cs
+++ b/src/engine/common_components/TimedLife.cs
@@ -6,7 +6,7 @@ using SharedBase.Archive;
 /// <summary>
 ///   Entities that despawn after a certain amount of time
 /// </summary>
-public struct TimedLife : IArchivableComponent
+public struct TimedLife(float timeToLiveRemaining) : IArchivableComponent
 {
     public const ushort SERIALIZATION_VERSION = 1;
 
@@ -21,36 +21,32 @@ public struct TimedLife : IArchivableComponent
     ///     re-apply it after the save is loaded.
     ///   </para>
     /// </remarks>
-    public OnTimeOver? CustomTimeOverCallback;
+    public OnTimeOver? CustomTimeOverCallback = null;
 
-    public float TimeToLiveRemaining;
+    public float TimeToLiveRemaining = timeToLiveRemaining;
 
     /// <summary>
     ///   When <see cref="FadeTimeRemainingSet"/> is true, this entity is fading out and the timed despawn system
     ///   will wait until this time is up as well
     /// </summary>
-    public float FadeTimeRemaining;
+    public float FadeTimeRemaining = -1;
 
-    public bool FadeTimeRemainingSet;
+    public bool FadeTimeRemainingSet = false;
 
-    public bool OnTimeOverTriggered;
+    public bool OnTimeOverTriggered = false;
 
-    public TimedLife(float timeToLiveRemaining)
-    {
-        CustomTimeOverCallback = null;
-        TimeToLiveRemaining = timeToLiveRemaining;
-
-        FadeTimeRemainingSet = false;
-        FadeTimeRemaining = -1;
-        OnTimeOverTriggered = false;
-    }
+    /// <summary>
+    ///   Pre-stored fade time from <see cref="FadeOutActions"/>, set when the callback is registered.
+    ///   Not serialized (transient state re-applied after load, like <see cref="CustomTimeOverCallback"/>).
+    /// </summary>
+    public float PreStoredFadeTime = -1;
 
     public delegate bool OnTimeOver(Entity entity, ref TimedLife timedLife);
 
-    public ushort CurrentArchiveVersion => SERIALIZATION_VERSION;
-    public ThriveArchiveObjectType ArchiveObjectType => ThriveArchiveObjectType.ComponentTimedLife;
+    public readonly ushort CurrentArchiveVersion => SERIALIZATION_VERSION;
+    public readonly ThriveArchiveObjectType ArchiveObjectType => ThriveArchiveObjectType.ComponentTimedLife;
 
-    public void WriteToArchive(ISArchiveWriter writer)
+    public readonly void WriteToArchive(ISArchiveWriter writer)
     {
         writer.Write(TimeToLiveRemaining);
         writer.Write(FadeTimeRemaining);

--- a/src/engine/common_components/TimedLife.cs
+++ b/src/engine/common_components/TimedLife.cs
@@ -36,10 +36,10 @@ public struct TimedLife(float timeToLiveRemaining) : IArchivableComponent
     public bool OnTimeOverTriggered = false;
 
     /// <summary>
-    ///   Pre-stored fade time from <see cref="FadeOutActions"/>, set when the callback is registered.
-    ///   Not serialized (transient state re-applied after load, like <see cref="CustomTimeOverCallback"/>).
+    ///   User data that the setter of <see cref="CustomTimeOverCallback"/> can use to store state.
+    ///   Not serialized (transient state re-applied after a load, like <see cref="CustomTimeOverCallback"/>).
     /// </summary>
-    public float PreStoredFadeTime = -1;
+    public float CustomTimeOverUserData1 = -1;
 
     public delegate bool OnTimeOver(Entity entity, ref TimedLife timedLife);
 

--- a/src/engine/common_systems/FadeOutActionSystem.cs
+++ b/src/engine/common_systems/FadeOutActionSystem.cs
@@ -1,7 +1,9 @@
 ﻿namespace Systems;
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Arch.Core;
 using Arch.Core.Extensions;
 using Arch.System;
@@ -10,28 +12,14 @@ using Godot;
 using World = Arch.Core.World;
 
 /// <summary>
-///   Handles fading out animations on entities
+///   Handles fading out animations on entities. When an entity's <see cref="TimedLife"/> expires, the registered
+///   callback enqueues the entity, and this system applies the fade-out effects (physics, particles, dissolve,
+///   compound venting) during its own update on the main thread.
 /// </summary>
 /// <remarks>
 ///   <para>
 ///     This is marked as reading the physics info as this does just some few simple physics actions on single
 ///     physics bodies. Same related to the spatial instance as this just can disable particles.
-///   </para>
-/// </remarks>
-/// <remarks>
-///   <para>
-///     This is really marked as needing to run on the main thread because this modifies particle emitter emitting
-///     setting of Godot. NOTE: the callback is currently ran on the system that triggers the fade out to start
-///     this has various implications. See the TODO in the next section.
-///   </para>
-/// </remarks>
-/// <remarks>
-///   <para>
-///     TODO: due to the way this accesses things through a callback, all the attributes here might need to be
-///     copied to any of the systems that may trigger the callback. Fortunately this doesn't do very extensive
-///     writes so for now this is likely fine. A better way would be to queue the callback to trigger on this system
-///     once this system runs again on the main thread. Once done properly <see cref="TimedLifeSystem"/> can be marked
-///     as not needing to run on the main thread.
 ///   </para>
 /// </remarks>
 [ReadsComponent(typeof(WorldPosition))]
@@ -48,6 +36,10 @@ public partial class FadeOutActionSystem : BaseSystem<World, float>
 
     private readonly TimedLife.OnTimeOver cachedDelegate;
 
+    private readonly Lock queueLock = new();
+    private Queue<Entity> pendingFadeOutEntities = new();
+    private Queue<Entity> processingEntities = new();
+
     // TODO: Constants.SYSTEM_EXTREME_ENTITIES_PER_THREAD
     public FadeOutActionSystem(IWorldSimulation worldSimulation, CompoundCloudSystem? compoundCloudSystem,
         World world) : base(world)
@@ -56,6 +48,21 @@ public partial class FadeOutActionSystem : BaseSystem<World, float>
         this.compoundCloudSystem = compoundCloudSystem;
 
         cachedDelegate = PerformTimeOverActions;
+    }
+
+    public override void BeforeUpdate(in float delta)
+    {
+        base.BeforeUpdate(in delta);
+
+        lock (queueLock)
+        {
+            (pendingFadeOutEntities, processingEntities) = (processingEntities, pendingFadeOutEntities);
+        }
+
+        while (processingEntities.Count > 0)
+        {
+            ApplyFadeOutActions(processingEntities.Dequeue());
+        }
     }
 
     [Query]
@@ -67,87 +74,64 @@ public partial class FadeOutActionSystem : BaseSystem<World, float>
 
         actions.CallbackRegistered = true;
 
-        // Register the callback which we use to trigger the actions for
+        timed.PreStoredFadeTime = actions.FadeTime;
         timed.CustomTimeOverCallback = cachedDelegate;
     }
 
     private bool PerformTimeOverActions(Entity entity, ref TimedLife timedLife)
     {
-        // This callback is triggered after this system has run already, so when debugging component access, this
-        // needs a slight modification
-        if (GenerateThreadedSystems.UseCheckedComponentAccess)
+        if (timedLife.PreStoredFadeTime <= 0)
         {
-            // To actually make this work for safety checking the following list *must* match the attributes on
-            // this class
-            // TODO: the following should actually be put as component accesses on any systems that may trigger
-            // the callback. See the TODO comment on this class.
-            ComponentAccessChecks.ReportAllowedAccessType<FadeOutActions>();
-            ComponentAccessChecks.ReportAllowedAccessType<CompoundStorage>();
-            ComponentAccessChecks.ReportAllowedAccessType<WorldPosition>();
-            ComponentAccessChecks.ReportAllowedAccessType<SpatialInstance>();
-            ComponentAccessChecks.ReportAllowedAccessType<Physics>();
-            ComponentAccessChecks.ReportAllowedAccessType<ManualPhysicsControl>();
-        }
-
-        try
-        {
-            ref var actions = ref entity.Get<FadeOutActions>();
-
-            if (actions.FadeTime <= 0)
-            {
-                // For now this indicates bad data, but in the future we might get some more custom "time over"
-                // actions
-                GD.PrintErr("Custom fade out actions fade time is zero");
-                return true;
-            }
-
-            // TODO: the following should probably be queued to run on the main thread to solve problems related to
-            // accessing random components from a random system that happens to run the custom callback
-
-            timedLife.FadeTimeRemaining = actions.FadeTime;
-            timedLife.FadeTimeRemainingSet = true;
-
-            if (actions.DisableCollisions)
-                PerformPhysicsOperations(entity, actions.DisableCollisions);
-
-            if (actions.RemoveVelocity || actions.RemoveAngularVelocity)
-            {
-                PerformManualPhysicsControlOperations(entity, actions.RemoveVelocity,
-                    actions.RemoveAngularVelocity);
-            }
-
-            if (actions.DisableParticles)
-                DisableParticleEmission(entity);
-
-            if (actions.UsesMicrobialDissolveEffect)
-            {
-                entity.StartDissolveAnimation(worldSimulation, true, false);
-            }
-
-            // Fade actions can be used without a cloud simulation
-            if (actions.VentCompounds && compoundCloudSystem != null)
-            {
-                if (entity.Has<CompoundStorage>() && entity.Has<WorldPosition>())
-                {
-                    ref var position = ref entity.Get<WorldPosition>();
-                    ref var storage = ref entity.Get<CompoundStorage>();
-
-                    storage.VentAllCompounds(position.Position, compoundCloudSystem);
-                }
-                else
-                {
-                    GD.PrintErr("Cannot vent compounds on fade as entity has no compound storage " +
-                        "(or world position is missing)");
-                }
-            }
-
-            // Fade started, don't destroy yet
-            return false;
-        }
-        catch (Exception e)
-        {
-            GD.PrintErr("Failed to perform custom fade out actions on timer over: ", e);
+            GD.PrintErr("Custom fade out actions fade time is zero");
             return true;
+        }
+
+        timedLife.FadeTimeRemaining = timedLife.PreStoredFadeTime;
+        timedLife.FadeTimeRemainingSet = true;
+
+        lock (queueLock)
+        {
+            pendingFadeOutEntities.Enqueue(entity);
+        }
+
+        return false;
+    }
+
+    private void ApplyFadeOutActions(Entity entity)
+    {
+        ref var actions = ref entity.Get<FadeOutActions>();
+
+        if (actions.DisableCollisions)
+            PerformPhysicsOperations(entity, actions.DisableCollisions);
+
+        if (actions.RemoveVelocity || actions.RemoveAngularVelocity)
+        {
+            PerformManualPhysicsControlOperations(entity, actions.RemoveVelocity,
+                actions.RemoveAngularVelocity);
+        }
+
+        if (actions.DisableParticles)
+            DisableParticleEmission(entity);
+
+        if (actions.UsesMicrobialDissolveEffect)
+        {
+            entity.StartDissolveAnimation(worldSimulation, true, false);
+        }
+
+        if (actions.VentCompounds && compoundCloudSystem != null)
+        {
+            if (entity.Has<CompoundStorage>() && entity.Has<WorldPosition>())
+            {
+                ref var position = ref entity.Get<WorldPosition>();
+                ref var storage = ref entity.Get<CompoundStorage>();
+
+                storage.VentAllCompounds(position.Position, compoundCloudSystem);
+            }
+            else
+            {
+                GD.PrintErr("Cannot vent compounds on fade as entity has no compound storage " +
+                    "(or world position is missing)");
+            }
         }
     }
 

--- a/src/engine/common_systems/FadeOutActionSystem.cs
+++ b/src/engine/common_systems/FadeOutActionSystem.cs
@@ -27,6 +27,7 @@ using World = Arch.Core.World;
 [WritesToComponent(typeof(CompoundStorage))]
 [WritesToComponent(typeof(Physics))]
 [WritesToComponent(typeof(ManualPhysicsControl))]
+[RunsAfter(typeof(TimedLifeSystem))]
 [RuntimeCost(0.25f)]
 [RunsOnMainThread]
 public partial class FadeOutActionSystem : BaseSystem<World, float>
@@ -74,19 +75,20 @@ public partial class FadeOutActionSystem : BaseSystem<World, float>
 
         actions.CallbackRegistered = true;
 
-        timed.PreStoredFadeTime = actions.FadeTime;
+        // Set up the callback which ensures the main processing happens in our context
+        timed.CustomTimeOverUserData1 = actions.FadeTime;
         timed.CustomTimeOverCallback = cachedDelegate;
     }
 
     private bool PerformTimeOverActions(Entity entity, ref TimedLife timedLife)
     {
-        if (timedLife.PreStoredFadeTime <= 0)
+        if (timedLife.CustomTimeOverUserData1 <= 0)
         {
-            GD.PrintErr("Custom fade out actions fade time is zero");
+            GD.PrintErr("Custom fade out actions fade time is zero, can't use deferred custom callback");
             return true;
         }
 
-        timedLife.FadeTimeRemaining = timedLife.PreStoredFadeTime;
+        timedLife.FadeTimeRemaining = timedLife.CustomTimeOverUserData1;
         timedLife.FadeTimeRemainingSet = true;
 
         lock (queueLock)
@@ -99,6 +101,12 @@ public partial class FadeOutActionSystem : BaseSystem<World, float>
 
     private void ApplyFadeOutActions(Entity entity)
     {
+        if (!entity.IsAliveAndHas<FadeOutActions>())
+        {
+            GD.PrintErr("Queued entity has no fade out actions: ", entity);
+            return;
+        }
+
         ref var actions = ref entity.Get<FadeOutActions>();
 
         if (actions.DisableCollisions)

--- a/src/engine/common_systems/TimedLifeSystem.cs
+++ b/src/engine/common_systems/TimedLifeSystem.cs
@@ -8,21 +8,10 @@ using Components;
 /// <summary>
 ///   System that deletes nodes that are in the timed group after their lifespan expires.
 /// </summary>
-/// <remarks>
-///   <para>
-///     See the TODOs on <see cref="FadeOutActionSystem"/> why this is marked as needing to run on the main thread.
-///   </para>
-/// </remarks>
 [RuntimeCost(0.25f)]
-[RunsOnMainThread]
-public partial class TimedLifeSystem : BaseSystem<World, float>
+public partial class TimedLifeSystem(IEntityContainer entityContainer, World world) : BaseSystem<World, float>(world)
 {
-    private readonly IEntityContainer entityContainer;
-
-    public TimedLifeSystem(IEntityContainer entityContainer, World world) : base(world)
-    {
-        this.entityContainer = entityContainer;
-    }
+    private readonly IEntityContainer entityContainer = entityContainer;
 
     /// <summary>
     ///   Despawns all timed entities

--- a/src/microbe_stage/MicrobeWorldSimulation.generated.cs
+++ b/src/microbe_stage/MicrobeWorldSimulation.generated.cs
@@ -22,109 +22,113 @@ public partial class MicrobeWorldSimulation
                 try
                 {
                     // Timeslot 1 on thread 2
-                    entitySignalingSystem.BeforeUpdate(delta);
-                    entitySignalingSystem.Update(delta);
-                    entitySignalingSystem.AfterUpdate(delta);
-                    MicrobeTerrainSystem.BeforeUpdate(delta);
-                    MicrobeTerrainSystem.Update(delta);
-                    MicrobeTerrainSystem.AfterUpdate(delta);
-                    countLimitedDespawnSystem.BeforeUpdate(delta);
-                    countLimitedDespawnSystem.Update(delta);
-                    countLimitedDespawnSystem.AfterUpdate(delta);
                     damageCooldownSystem.BeforeUpdate(delta);
                     damageCooldownSystem.Update(delta);
                     damageCooldownSystem.AfterUpdate(delta);
+                    MicrobeTerrainSystem.BeforeUpdate(delta);
+                    MicrobeTerrainSystem.Update(delta);
+                    MicrobeTerrainSystem.AfterUpdate(delta);
+                    entitySignalingSystem.BeforeUpdate(delta);
+                    entitySignalingSystem.Update(delta);
+                    entitySignalingSystem.AfterUpdate(delta);
+                    countLimitedDespawnSystem.BeforeUpdate(delta);
+                    countLimitedDespawnSystem.Update(delta);
+                    countLimitedDespawnSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
 
                     // Timeslot 2 on thread 2
-                    microbePhysicsCreationAndSizeSystem.BeforeUpdate(delta);
-                    microbePhysicsCreationAndSizeSystem.Update(delta);
-                    microbePhysicsCreationAndSizeSystem.AfterUpdate(delta);
-                    strainSystem.BeforeUpdate(delta);
-                    strainSystem.Update(delta);
-                    strainSystem.AfterUpdate(delta);
-                    barrier1.SignalAndWait();
-
-                    // Timeslot 3 on thread 2
-                    simpleShapeCreatorSystem.BeforeUpdate(delta);
-                    simpleShapeCreatorSystem.Update(delta);
-                    simpleShapeCreatorSystem.AfterUpdate(delta);
-                    spatialAnimationSystem.BeforeUpdate(delta);
-                    spatialAnimationSystem.Update(delta);
-                    spatialAnimationSystem.AfterUpdate(delta);
-                    microbeDivisionClippingSystem.BeforeUpdate(delta);
-                    microbeDivisionClippingSystem.Update(delta);
-                    microbeDivisionClippingSystem.AfterUpdate(delta);
-                    barrier1.SignalAndWait();
-
-                    // Timeslot 4 on thread 2
                     colonyCompoundDistributionSystem.BeforeUpdate(delta);
                     colonyCompoundDistributionSystem.Update(delta);
                     colonyCompoundDistributionSystem.AfterUpdate(delta);
+                    simpleShapeCreatorSystem.BeforeUpdate(delta);
+                    simpleShapeCreatorSystem.Update(delta);
+                    simpleShapeCreatorSystem.AfterUpdate(delta);
+                    microbeDivisionClippingSystem.BeforeUpdate(delta);
+                    microbeDivisionClippingSystem.Update(delta);
+                    microbeDivisionClippingSystem.AfterUpdate(delta);
+                    microbePhysicsCreationAndSizeSystem.BeforeUpdate(delta);
+                    microbePhysicsCreationAndSizeSystem.Update(delta);
+                    microbePhysicsCreationAndSizeSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
 
-                    // Timeslot 5 on thread 2
+                    // Timeslot 3 on thread 2
+                    spatialAnimationSystem.BeforeUpdate(delta);
+                    spatialAnimationSystem.Update(delta);
+                    spatialAnimationSystem.AfterUpdate(delta);
+                    irradiationSystem.BeforeUpdate(delta);
+                    irradiationSystem.Update(delta);
+                    irradiationSystem.AfterUpdate(delta);
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 4 on thread 2
                     physicsCollisionManagementSystem.BeforeUpdate(delta);
                     physicsCollisionManagementSystem.Update(delta);
                     physicsCollisionManagementSystem.AfterUpdate(delta);
-                    barrier1.SignalAndWait();
-
-                    // Timeslot 6 on thread 2
-                    damageOnTouchSystem.BeforeUpdate(delta);
-                    damageOnTouchSystem.Update(delta);
-                    damageOnTouchSystem.AfterUpdate(delta);
-                    toxinCollisionSystem.BeforeUpdate(delta);
-                    toxinCollisionSystem.Update(delta);
-                    toxinCollisionSystem.AfterUpdate(delta);
                     pilusDamageSystem.BeforeUpdate(delta);
                     pilusDamageSystem.Update(delta);
                     pilusDamageSystem.AfterUpdate(delta);
+                    toxinCollisionSystem.BeforeUpdate(delta);
+                    toxinCollisionSystem.Update(delta);
+                    toxinCollisionSystem.AfterUpdate(delta);
+                    microbeTemporaryEffectsSystem.BeforeUpdate(delta);
+                    microbeTemporaryEffectsSystem.Update(delta);
+                    microbeTemporaryEffectsSystem.AfterUpdate(delta);
+                    damageOnTouchSystem.BeforeUpdate(delta);
+                    damageOnTouchSystem.Update(delta);
+                    damageOnTouchSystem.AfterUpdate(delta);
+                    microbeCollisionSoundSystem.BeforeUpdate(delta);
+                    microbeCollisionSoundSystem.Update(delta);
+                    microbeCollisionSoundSystem.AfterUpdate(delta);
+                    barrier1.SignalAndWait();
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 6 on thread 2
+                    disallowPlayerBodySleepSystem.BeforeUpdate(delta);
+                    disallowPlayerBodySleepSystem.Update(delta);
+                    disallowPlayerBodySleepSystem.AfterUpdate(delta);
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 7 on thread 2
                     physicsUpdateAndPositionSystem.BeforeUpdate(delta);
                     physicsUpdateAndPositionSystem.Update(delta);
                     physicsUpdateAndPositionSystem.AfterUpdate(delta);
                     attachedEntityPositionSystem.BeforeUpdate(delta);
                     attachedEntityPositionSystem.Update(delta);
                     attachedEntityPositionSystem.AfterUpdate(delta);
-                    microbeCollisionSoundSystem.BeforeUpdate(delta);
-                    microbeCollisionSoundSystem.Update(delta);
-                    microbeCollisionSoundSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
-
-                    // Timeslot 7 on thread 2
-                    osmoregulationAndHealingSystem.BeforeUpdate(delta);
-                    osmoregulationAndHealingSystem.Update(delta);
-                    osmoregulationAndHealingSystem.AfterUpdate(delta);
-                    radiationDamageSystem.BeforeUpdate(delta);
-                    radiationDamageSystem.Update(delta);
-                    radiationDamageSystem.AfterUpdate(delta);
-                    microbeTemporaryEffectsSystem.BeforeUpdate(delta);
-                    microbeTemporaryEffectsSystem.Update(delta);
-                    microbeTemporaryEffectsSystem.AfterUpdate(delta);
-                    barrier1.SignalAndWait();
-
-                    // Timeslot 8 on thread 2
-                    siderophoreSystem.BeforeUpdate(delta);
-                    siderophoreSystem.Update(delta);
-                    siderophoreSystem.AfterUpdate(delta);
-                    allCompoundsVentingSystem.BeforeUpdate(delta);
-                    allCompoundsVentingSystem.Update(delta);
-                    allCompoundsVentingSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
 
                     // Timeslot 9 on thread 2
-                    multicellularGrowthSystem.BeforeUpdate(delta);
-                    multicellularGrowthSystem.Update(delta);
-                    multicellularGrowthSystem.AfterUpdate(delta);
                     engulfedDigestionSystem.BeforeUpdate(delta);
                     engulfedDigestionSystem.Update(delta);
                     engulfedDigestionSystem.AfterUpdate(delta);
-                    engulfedHandlingSystem.BeforeUpdate(delta);
-                    engulfedHandlingSystem.Update(delta);
-                    engulfedHandlingSystem.AfterUpdate(delta);
+                    siderophoreSystem.BeforeUpdate(delta);
+                    siderophoreSystem.Update(delta);
+                    siderophoreSystem.AfterUpdate(delta);
+                    osmoregulationAndHealingSystem.BeforeUpdate(delta);
+                    osmoregulationAndHealingSystem.Update(delta);
+                    osmoregulationAndHealingSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
+
+                    // Timeslot 10 on thread 2
+                    SpawnSystem.BeforeUpdate(delta);
+                    SpawnSystem.Update(delta);
+                    SpawnSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
 
                     // Timeslot 11 on thread 2
+                    multicellularGrowthSystem.BeforeUpdate(delta);
+                    multicellularGrowthSystem.Update(delta);
+                    multicellularGrowthSystem.AfterUpdate(delta);
+                    colonyStatsUpdateSystem.BeforeUpdate(delta);
+                    colonyStatsUpdateSystem.Update(delta);
+                    colonyStatsUpdateSystem.AfterUpdate(delta);
+                    radiationDamageSystem.BeforeUpdate(delta);
+                    radiationDamageSystem.Update(delta);
+                    radiationDamageSystem.AfterUpdate(delta);
+                    engulfedHandlingSystem.BeforeUpdate(delta);
+                    engulfedHandlingSystem.Update(delta);
+                    engulfedHandlingSystem.AfterUpdate(delta);
                     organelleComponentFetchSystem.BeforeUpdate(delta);
                     organelleComponentFetchSystem.Update(delta);
                     organelleComponentFetchSystem.AfterUpdate(delta);
@@ -135,51 +139,42 @@ public partial class MicrobeWorldSimulation
                     barrier1.SignalAndWait();
 
                     // Timeslot 13 on thread 2
-                    microbeEmissionSystem.BeforeUpdate(delta);
-                    microbeEmissionSystem.Update(delta);
-                    microbeEmissionSystem.AfterUpdate(delta);
-                    barrier1.SignalAndWait();
-
-                    // Timeslot 14 on thread 2
-                    SpawnSystem.BeforeUpdate(delta);
-                    SpawnSystem.Update(delta);
-                    SpawnSystem.AfterUpdate(delta);
-                    barrier1.SignalAndWait();
-
-                    // Timeslot 15 on thread 2
                     microbeMovementSoundSystem.BeforeUpdate(delta);
                     microbeMovementSoundSystem.Update(delta);
                     microbeMovementSoundSystem.AfterUpdate(delta);
-                    colonyStatsUpdateSystem.BeforeUpdate(delta);
-                    colonyStatsUpdateSystem.Update(delta);
-                    colonyStatsUpdateSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
 
-                    // Timeslot 16 on thread 2
-                    colonyBindingSystem.BeforeUpdate(delta);
-                    colonyBindingSystem.Update(delta);
-                    colonyBindingSystem.AfterUpdate(delta);
+                    // Timeslot 14 on thread 2
                     microbeDeathSystem.BeforeUpdate(delta);
                     microbeDeathSystem.Update(delta);
                     microbeDeathSystem.AfterUpdate(delta);
+                    microbeEventCallbackSystem.BeforeUpdate(delta);
+                    microbeEventCallbackSystem.Update(delta);
+                    microbeEventCallbackSystem.AfterUpdate(delta);
+                    physicsBodyControlSystem.BeforeUpdate(delta);
+                    physicsBodyControlSystem.Update(delta);
+                    physicsBodyControlSystem.AfterUpdate(delta);
+                    colonyBindingSystem.BeforeUpdate(delta);
+                    colonyBindingSystem.Update(delta);
+                    colonyBindingSystem.AfterUpdate(delta);
                     delayedColonyOperationSystem.BeforeUpdate(delta);
                     delayedColonyOperationSystem.Update(delta);
                     delayedColonyOperationSystem.AfterUpdate(delta);
                     microbeFlashingSystem.BeforeUpdate(delta);
                     microbeFlashingSystem.Update(delta);
                     microbeFlashingSystem.AfterUpdate(delta);
-                    physicsBodyControlSystem.BeforeUpdate(delta);
-                    physicsBodyControlSystem.Update(delta);
-                    physicsBodyControlSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
 
-                    // Timeslot 17 on thread 2
-                    microbeEventCallbackSystem.BeforeUpdate(delta);
-                    microbeEventCallbackSystem.Update(delta);
-                    microbeEventCallbackSystem.AfterUpdate(delta);
+                    // Timeslot 15 on thread 2
                     damageSoundSystem.BeforeUpdate(delta);
                     damageSoundSystem.Update(delta);
                     damageSoundSystem.AfterUpdate(delta);
+                    barrier1.SignalAndWait();
+
+                    // Timeslot 16 on thread 2
+                    allCompoundsVentingSystem.BeforeUpdate(delta);
+                    allCompoundsVentingSystem.Update(delta);
+                    allCompoundsVentingSystem.AfterUpdate(delta);
                     barrier1.SignalAndWait();
 
                     barrier1.SignalAndWait();
@@ -206,6 +201,15 @@ public partial class MicrobeWorldSimulation
             collisionShapeLoaderSystem.BeforeUpdate(delta);
             collisionShapeLoaderSystem.Update(delta);
             collisionShapeLoaderSystem.AfterUpdate(delta);
+            mucocystSystem.BeforeUpdate(delta);
+            mucocystSystem.Update(delta);
+            mucocystSystem.AfterUpdate(delta);
+            pathBasedSceneLoader.BeforeUpdate(delta);
+            pathBasedSceneLoader.Update(delta);
+            pathBasedSceneLoader.AfterUpdate(delta);
+            predefinedVisualLoaderSystem.BeforeUpdate(delta);
+            predefinedVisualLoaderSystem.Update(delta);
+            predefinedVisualLoaderSystem.AfterUpdate(delta);
             endosymbiontOrganelleSystem.BeforeUpdate(delta);
             endosymbiontOrganelleSystem.Update(delta);
             endosymbiontOrganelleSystem.AfterUpdate(delta);
@@ -215,87 +219,69 @@ public partial class MicrobeWorldSimulation
             barrier1.SignalAndWait();
 
             // Timeslot 2 on thread 1
-            pathBasedSceneLoader.BeforeUpdate(delta);
-            pathBasedSceneLoader.Update(delta);
-            pathBasedSceneLoader.AfterUpdate(delta);
+            animationControlSystem.BeforeUpdate(delta);
+            animationControlSystem.Update(delta);
+            animationControlSystem.AfterUpdate(delta);
+            entityMaterialFetchSystem.BeforeUpdate(delta);
+            entityMaterialFetchSystem.Update(delta);
+            entityMaterialFetchSystem.AfterUpdate(delta);
+            cellBurstEffectSystem.BeforeUpdate(delta);
+            cellBurstEffectSystem.Update(delta);
+            cellBurstEffectSystem.AfterUpdate(delta);
+            TimedLifeSystem.BeforeUpdate(delta);
+            TimedLifeSystem.Update(delta);
+            TimedLifeSystem.AfterUpdate(delta);
+            microbeRenderPrioritySystem.BeforeUpdate(delta);
+            microbeRenderPrioritySystem.Update(delta);
+            microbeRenderPrioritySystem.AfterUpdate(delta);
+            strainSystem.BeforeUpdate(delta);
+            strainSystem.Update(delta);
+            strainSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 3 on thread 1
-            irradiationSystem.BeforeUpdate(delta);
-            irradiationSystem.Update(delta);
-            irradiationSystem.AfterUpdate(delta);
-            compoundAbsorptionSystem.BeforeUpdate(delta);
-            compoundAbsorptionSystem.Update(delta);
-            compoundAbsorptionSystem.AfterUpdate(delta);
-            barrier1.SignalAndWait();
-
-            // Timeslot 4 on thread 1
             physicsBodyCreationSystem.BeforeUpdate(delta);
             physicsBodyCreationSystem.Update(delta);
             physicsBodyCreationSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
+            // Timeslot 4 on thread 1
+            compoundAbsorptionSystem.BeforeUpdate(delta);
+            compoundAbsorptionSystem.Update(delta);
+            compoundAbsorptionSystem.AfterUpdate(delta);
+            barrier1.SignalAndWait();
+
             // Timeslot 5 on thread 1
-            microbeHeatAccumulationSystem.BeforeUpdate(delta);
-            microbeHeatAccumulationSystem.Update(delta);
-            microbeHeatAccumulationSystem.AfterUpdate(delta);
-            mucocystSystem.BeforeUpdate(delta);
-            mucocystSystem.Update(delta);
-            mucocystSystem.AfterUpdate(delta);
-            barrier1.SignalAndWait();
-
-            // Timeslot 6 on thread 1
-            ProcessSystem.BeforeUpdate(delta);
-            ProcessSystem.Update(delta);
-            ProcessSystem.AfterUpdate(delta);
-            barrier1.SignalAndWait();
-
-            // Timeslot 7 on thread 1
             physicsBodyDisablingSystem.BeforeUpdate(delta);
             physicsBodyDisablingSystem.Update(delta);
             physicsBodyDisablingSystem.AfterUpdate(delta);
-            predefinedVisualLoaderSystem.BeforeUpdate(delta);
-            predefinedVisualLoaderSystem.Update(delta);
-            predefinedVisualLoaderSystem.AfterUpdate(delta);
-            animationControlSystem.BeforeUpdate(delta);
-            animationControlSystem.Update(delta);
-            animationControlSystem.AfterUpdate(delta);
-            disallowPlayerBodySleepSystem.BeforeUpdate(delta);
-            disallowPlayerBodySleepSystem.Update(delta);
-            disallowPlayerBodySleepSystem.AfterUpdate(delta);
-            entityMaterialFetchSystem.BeforeUpdate(delta);
-            entityMaterialFetchSystem.Update(delta);
-            entityMaterialFetchSystem.AfterUpdate(delta);
-            soundListenerSystem.BeforeUpdate(delta);
-            soundListenerSystem.Update(delta);
-            soundListenerSystem.AfterUpdate(delta);
-            cellBurstEffectSystem.BeforeUpdate(delta);
-            cellBurstEffectSystem.Update(delta);
-            cellBurstEffectSystem.AfterUpdate(delta);
-            microbeRenderPrioritySystem.BeforeUpdate(delta);
-            microbeRenderPrioritySystem.Update(delta);
-            microbeRenderPrioritySystem.AfterUpdate(delta);
-            intercellularMatrixSystem.BeforeUpdate(delta);
-            intercellularMatrixSystem.Update(delta);
-            intercellularMatrixSystem.AfterUpdate(delta);
-            CameraFollowSystem.BeforeUpdate(delta);
-            CameraFollowSystem.Update(delta);
-            CameraFollowSystem.AfterUpdate(delta);
-            TimedLifeSystem.BeforeUpdate(delta);
-            TimedLifeSystem.Update(delta);
-            TimedLifeSystem.AfterUpdate(delta);
-            barrier1.SignalAndWait();
-
-            // Timeslot 8 on thread 1
             engulfingSystem.BeforeUpdate(delta);
             engulfingSystem.Update(delta);
             engulfingSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
+            // Timeslot 6 on thread 1
+            microbeHeatAccumulationSystem.BeforeUpdate(delta);
+            microbeHeatAccumulationSystem.Update(delta);
+            microbeHeatAccumulationSystem.AfterUpdate(delta);
+            barrier1.SignalAndWait();
+
+            // Timeslot 7 on thread 1
+            ProcessSystem.BeforeUpdate(delta);
+            ProcessSystem.Update(delta);
+            ProcessSystem.AfterUpdate(delta);
+            barrier1.SignalAndWait();
+
+            // Timeslot 8 on thread 1
+            unneededCompoundVentingSystem.BeforeUpdate(delta);
+            unneededCompoundVentingSystem.Update(delta);
+            unneededCompoundVentingSystem.AfterUpdate(delta);
+            barrier1.SignalAndWait();
+
             // Timeslot 9 on thread 1
-            FluidCurrentsSystem.BeforeUpdate(delta);
-            FluidCurrentsSystem.Update(delta);
-            FluidCurrentsSystem.AfterUpdate(delta);
+            spatialAttachSystem.BeforeUpdate(delta);
+            spatialAttachSystem.Update(delta);
+            spatialAttachSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 10 on thread 1
@@ -305,9 +291,15 @@ public partial class MicrobeWorldSimulation
             barrier1.SignalAndWait();
 
             // Timeslot 11 on thread 1
-            unneededCompoundVentingSystem.BeforeUpdate(delta);
-            unneededCompoundVentingSystem.Update(delta);
-            unneededCompoundVentingSystem.AfterUpdate(delta);
+            soundListenerSystem.BeforeUpdate(delta);
+            soundListenerSystem.Update(delta);
+            soundListenerSystem.AfterUpdate(delta);
+            CameraFollowSystem.BeforeUpdate(delta);
+            CameraFollowSystem.Update(delta);
+            CameraFollowSystem.AfterUpdate(delta);
+            FluidCurrentsSystem.BeforeUpdate(delta);
+            FluidCurrentsSystem.Update(delta);
+            FluidCurrentsSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
             // Timeslot 12 on thread 1
@@ -319,27 +311,21 @@ public partial class MicrobeWorldSimulation
                 microbeAI.AfterUpdate(delta);
             }
 
-            barrier1.SignalAndWait();
-
-            // Timeslot 13 on thread 1
-            spatialAttachSystem.BeforeUpdate(delta);
-            spatialAttachSystem.Update(delta);
-            spatialAttachSystem.AfterUpdate(delta);
-            barrier1.SignalAndWait();
-
-            // Timeslot 14 on thread 1
+            microbeEmissionSystem.BeforeUpdate(delta);
+            microbeEmissionSystem.Update(delta);
+            microbeEmissionSystem.AfterUpdate(delta);
             microbeMovementSystem.BeforeUpdate(delta);
             microbeMovementSystem.Update(delta);
             microbeMovementSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
-            // Timeslot 15 on thread 1
+            // Timeslot 13 on thread 1
             organelleTickSystem.BeforeUpdate(delta);
             organelleTickSystem.Update(delta);
             organelleTickSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
-            // Timeslot 16 on thread 1
+            // Timeslot 14 on thread 1
             entityLightSystem.BeforeUpdate(delta);
             entityLightSystem.Update(delta);
             entityLightSystem.AfterUpdate(delta);
@@ -348,7 +334,7 @@ public partial class MicrobeWorldSimulation
             spatialPositionSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
-            // Timeslot 17 on thread 1
+            // Timeslot 15 on thread 1
             fadeOutActionSystem.BeforeUpdate(delta);
             fadeOutActionSystem.Update(delta);
             fadeOutActionSystem.AfterUpdate(delta);
@@ -357,10 +343,16 @@ public partial class MicrobeWorldSimulation
             physicsSensorSystem.AfterUpdate(delta);
             barrier1.SignalAndWait();
 
-            // Timeslot 18 on thread 1
+            // Timeslot 16 on thread 1
             soundEffectSystem.BeforeUpdate(delta);
             soundEffectSystem.Update(delta);
             soundEffectSystem.AfterUpdate(delta);
+            barrier1.SignalAndWait();
+
+            // Timeslot 17 on thread 1
+            intercellularMatrixSystem.BeforeUpdate(delta);
+            intercellularMatrixSystem.Update(delta);
+            intercellularMatrixSystem.AfterUpdate(delta);
 
             barrier1.SignalAndWait();
         }
@@ -561,6 +553,9 @@ public partial class MicrobeWorldSimulation
             spatialPositionSystem.BeforeUpdate(delta);
             spatialPositionSystem.Update(delta);
             spatialPositionSystem.AfterUpdate(delta);
+            cellBurstEffectSystem.BeforeUpdate(delta);
+            cellBurstEffectSystem.Update(delta);
+            cellBurstEffectSystem.AfterUpdate(delta);
             countLimitedDespawnSystem.BeforeUpdate(delta);
             countLimitedDespawnSystem.Update(delta);
             countLimitedDespawnSystem.AfterUpdate(delta);
@@ -576,6 +571,9 @@ public partial class MicrobeWorldSimulation
             microbeDeathSystem.BeforeUpdate(delta);
             microbeDeathSystem.Update(delta);
             microbeDeathSystem.AfterUpdate(delta);
+            TimedLifeSystem.BeforeUpdate(delta);
+            TimedLifeSystem.Update(delta);
+            TimedLifeSystem.AfterUpdate(delta);
             fadeOutActionSystem.BeforeUpdate(delta);
             fadeOutActionSystem.Update(delta);
             fadeOutActionSystem.AfterUpdate(delta);
@@ -603,9 +601,6 @@ public partial class MicrobeWorldSimulation
             soundListenerSystem.BeforeUpdate(delta);
             soundListenerSystem.Update(delta);
             soundListenerSystem.AfterUpdate(delta);
-            cellBurstEffectSystem.BeforeUpdate(delta);
-            cellBurstEffectSystem.Update(delta);
-            cellBurstEffectSystem.AfterUpdate(delta);
             microbeRenderPrioritySystem.BeforeUpdate(delta);
             microbeRenderPrioritySystem.Update(delta);
             microbeRenderPrioritySystem.AfterUpdate(delta);
@@ -615,9 +610,6 @@ public partial class MicrobeWorldSimulation
             CameraFollowSystem.BeforeUpdate(delta);
             CameraFollowSystem.Update(delta);
             CameraFollowSystem.AfterUpdate(delta);
-            TimedLifeSystem.BeforeUpdate(delta);
-            TimedLifeSystem.Update(delta);
-            TimedLifeSystem.AfterUpdate(delta);
             FluidCurrentsSystem.BeforeUpdate(delta);
             FluidCurrentsSystem.Update(delta);
             FluidCurrentsSystem.AfterUpdate(delta);
@@ -713,6 +705,7 @@ public partial class MicrobeWorldSimulation
         engulfingSystem.Initialize();
         spatialAttachSystem.Initialize();
         spatialPositionSystem.Initialize();
+        cellBurstEffectSystem.Initialize();
         mucocystSystem.Initialize();
         allCompoundsVentingSystem.Initialize();
         engulfedDigestionSystem.Initialize();
@@ -734,6 +727,7 @@ public partial class MicrobeWorldSimulation
         microbeAI.Initialize();
         microbeEmissionSystem.Initialize();
         microbeDeathSystem.Initialize();
+        TimedLifeSystem.Initialize();
         fadeOutActionSystem.Initialize();
         physicsBodyDisablingSystem.Initialize();
         microbeTemporaryEffectsSystem.Initialize();
@@ -754,11 +748,9 @@ public partial class MicrobeWorldSimulation
         microbeCollisionSoundSystem.Initialize();
         soundEffectSystem.Initialize();
         soundListenerSystem.Initialize();
-        cellBurstEffectSystem.Initialize();
         microbeRenderPrioritySystem.Initialize();
         intercellularMatrixSystem.Initialize();
         CameraFollowSystem.Initialize();
-        TimedLifeSystem.Initialize();
         FluidCurrentsSystem.Initialize();
         colourAnimationSystem.Initialize();
         microbeShaderSystem.Initialize();


### PR DESCRIPTION
**Brief Description of What This PR Does**

Defer `FadeOutActionSystem` callback work to a queue for proper component access

The callback registered by `FadeOutActionSystem` was executing heavy work (physics, particles, dissolve, compound venting) inline during `TimedLifeSystem`'s update, bypassing the ECS component access declarations. 

Now the callback only enqueues the entity, and `FadeOutActionSystem` processes the queue in BeforeUpdate within its own thread context. This allows `TimedLifeSystem to run off the main thread.

The callback sets the fade timer and enqueues the entity, and the heavy work is deferred to `FadeOutActionSystem.BeforeUpdate` where component access attributes are properly declared. To avoid reading `FadeOutActions` from the callback (wrong thread context), the fade time is pre-stored into `TimedLife` at registration time.

The queue uses a swap pattern to keep lock scope minimal. Additionally, entities can't be destroyed between enqueue and processing because these actions are out of phase (while being in sync).

Boy Scout Rule (in the files I touched):
- Used primary constructor in classes I touched, where possible and benefitial
- Added readonly to property accessors that could use it
- In FadeOutActionSystem, replaced object lock with `System.Threading.Lock`. It's smaller && faster && makes the intent explicit

**Related Issues**

Closes https://github.com/Revolutionary-Games/Thrive/issues/4886

**Testing**

https://github.com/user-attachments/assets/86009440-9ea4-4cbb-8819-8051676d52b6

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
