### PR TITLE
Lazy load save list items only when visible in scroll view

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1862,6 +1862,7 @@ public static class Constants
     public const string SAVE_BACKUP_SUFFIX = ".backup" + SAVE_EXTENSION_WITH_DOT;
 
     public const int SAVE_LIST_SCREENSHOT_HEIGHT = 720;
+    public const int SAVE_LIST_LAZY_LOAD_PADDING = 5;
     public const int FOSSILISED_PREVIEW_IMAGE_HEIGHT = 400;
 
     public const string FOSSIL_EXTENSION = "thrivefossil";

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -23,6 +23,8 @@ public partial class SaveList : ScrollContainer
     [Export]
     public bool LoadableItems = true;
 
+    private readonly List<SaveListItem> saveItemChildren = [];
+
 #pragma warning disable CA2213
     [Export]
     private Control loadingItem = null!;
@@ -77,8 +79,6 @@ public partial class SaveList : ScrollContainer
 
     private bool isLoadingSave;
 
-    private List<SaveListItem> saveItemChildren = [];
-
     private int previousFirstVisible = -1;
     private int previousLastVisible = -1;
     private bool needsInitialVisibilityCheck;
@@ -120,7 +120,6 @@ public partial class SaveList : ScrollContainer
 
         if (needsInitialVisibilityCheck && saveItemChildren.Count > 0 && saveItemChildren[0].Size.Y > 0)
         {
-            needsInitialVisibilityCheck = false;
             UpdateVisibleRange();
         }
 
@@ -438,6 +437,10 @@ public partial class SaveList : ScrollContainer
     {
         if (!IsVisibleInTree())
             return;
+
+        // This is reset here to ensure that if this were to somehow refresh while invisible, then the item visibility
+        // would be refreshed once this becomes visible.
+        needsInitialVisibilityCheck = false;
 
         int itemCount = saveItemChildren.Count;
         if (itemCount == 0)

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -81,7 +81,6 @@ public partial class SaveList : ScrollContainer
 
     private int previousFirstVisible = -1;
     private int previousLastVisible = -1;
-    private float cachedItemHeight = -1;
     private bool needsInitialVisibilityCheck;
 
     [Signal]
@@ -101,11 +100,7 @@ public partial class SaveList : ScrollContainer
         listItemScene = GD.Load<PackedScene>("res://src/saving/SaveListItem.tscn");
 
         GetVScrollBar().Connect(Range.SignalName.ValueChanged, Callable.From<double>(_ => UpdateVisibleRange()));
-        Connect(Control.SignalName.Resized, Callable.From(() =>
-        {
-            cachedItemHeight = -1;
-            UpdateVisibleRange();
-        }));
+        Connect(Control.SignalName.Resized, Callable.From(UpdateVisibleRange));
     }
 
     public override void _Process(double delta)
@@ -123,7 +118,7 @@ public partial class SaveList : ScrollContainer
         if (!isCurrentlyVisible)
             wasVisible = false;
 
-        if (needsInitialVisibilityCheck && GetItemHeight() > 0)
+        if (needsInitialVisibilityCheck && saveItemChildren.Count > 0 && saveItemChildren[0].Size.Y > 0)
         {
             needsInitialVisibilityCheck = false;
             UpdateVisibleRange();
@@ -207,7 +202,6 @@ public partial class SaveList : ScrollContainer
 
         previousFirstVisible = -1;
         previousLastVisible = -1;
-        cachedItemHeight = -1;
         needsInitialVisibilityCheck = false;
 
         saveItemChildren.Clear();
@@ -440,46 +434,44 @@ public partial class SaveList : ScrollContainer
         isLoadingSave = false;
     }
 
-    private float GetItemHeight()
-    {
-        if (cachedItemHeight > 0)
-            return cachedItemHeight;
-
-        if (saveItemChildren.Count == 0)
-            return -1;
-
-        var firstItem = saveItemChildren[0];
-        float height = firstItem.Size.Y;
-
-        if (height <= 0)
-            return -1;
-
-        cachedItemHeight = height + savesList.GetThemeConstant("separation");
-        return cachedItemHeight;
-    }
-
     private void UpdateVisibleRange()
     {
         if (!IsVisibleInTree())
-            return;
-
-        float itemHeight = GetItemHeight();
-        if (itemHeight <= 0)
             return;
 
         int itemCount = saveItemChildren.Count;
         if (itemCount == 0)
             return;
 
-        var firstItem = saveItemChildren[0];
-        float itemsStartY = firstItem.GlobalPosition.Y - GlobalPosition.Y + ScrollVertical;
+        float scrollTop = ScrollVertical;
+        float scrollBottom = scrollTop + Size.Y;
 
-        int first = Math.Max(0, (int)Math.Floor((ScrollVertical - itemsStartY) / itemHeight));
-        int last = Math.Min(itemCount - 1, (int)Math.Floor((ScrollVertical + Size.Y - itemsStartY) / itemHeight));
+        int first = -1;
+        int last = -1;
+        for (int i = 0; i < itemCount; ++i)
+        {
+            var item = saveItemChildren[i];
+            float itemTop = item.Position.Y;
+            float itemBottom = itemTop + item.Size.Y;
+
+            if (itemBottom > scrollTop && itemTop < scrollBottom)
+            {
+                if (first < 0)
+                    first = i;
+
+                last = i;
+            }
+            else if (first >= 0)
+            {
+                break;
+            }
+        }
+
+        if (first < 0)
+            return;
 
         int paddedFirst = Math.Max(0, first - Constants.SAVE_LIST_LAZY_LOAD_PADDING);
         int paddedLast = Math.Min(itemCount - 1, last + Constants.SAVE_LIST_LAZY_LOAD_PADDING);
-
         if (paddedFirst == previousFirstVisible && paddedLast == previousLastVisible)
             return;
 

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Godot;
+using Range = Godot.Range;
 
 /// <summary>
 ///   A widget containing a list of saves
@@ -77,6 +77,8 @@ public partial class SaveList : ScrollContainer
 
     private bool isLoadingSave;
 
+    private List<SaveListItem> saveItemChildren = [];
+
     private int previousFirstVisible = -1;
     private int previousLastVisible = -1;
     private float cachedItemHeight = -1;
@@ -98,7 +100,7 @@ public partial class SaveList : ScrollContainer
     {
         listItemScene = GD.Load<PackedScene>("res://src/saving/SaveListItem.tscn");
 
-        GetVScrollBar().Connect(Godot.Range.SignalName.ValueChanged, Callable.From<double>(_ => UpdateVisibleRange()));
+        GetVScrollBar().Connect(Range.SignalName.ValueChanged, Callable.From<double>(_ => UpdateVisibleRange()));
         Connect(Control.SignalName.Resized, Callable.From(() =>
         {
             cachedItemHeight = -1;
@@ -173,6 +175,7 @@ public partial class SaveList : ScrollContainer
 
                 item.SaveName = save;
                 savesList.AddChild(item);
+                saveItemChildren.Add(item);
             }
         }
         else
@@ -187,7 +190,7 @@ public partial class SaveList : ScrollContainer
 
     public IEnumerable<SaveListItem> GetSelectedItems()
     {
-        foreach (var child in savesList.GetChildren().OfType<SaveListItem>())
+        foreach (var child in saveItemChildren)
         {
             if (child.Selectable && child.Selected)
                 yield return child;
@@ -207,6 +210,7 @@ public partial class SaveList : ScrollContainer
         cachedItemHeight = -1;
         needsInitialVisibilityCheck = false;
 
+        saveItemChildren.Clear();
         savesList.QueueFreeChildren();
 
         loadingItem.Visible = true;
@@ -441,10 +445,10 @@ public partial class SaveList : ScrollContainer
         if (cachedItemHeight > 0)
             return cachedItemHeight;
 
-        if (savesList.GetChildCount() == 0)
+        if (saveItemChildren.Count == 0)
             return -1;
 
-        var firstItem = savesList.GetChild<SaveListItem>(0);
+        var firstItem = saveItemChildren[0];
         float height = firstItem.Size.Y;
 
         if (height <= 0)
@@ -463,11 +467,11 @@ public partial class SaveList : ScrollContainer
         if (itemHeight <= 0)
             return;
 
-        int itemCount = savesList.GetChildCount();
+        int itemCount = saveItemChildren.Count;
         if (itemCount == 0)
             return;
 
-        var firstItem = savesList.GetChild<SaveListItem>(0);
+        var firstItem = saveItemChildren[0];
         float itemsStartY = firstItem.GlobalPosition.Y - GlobalPosition.Y + ScrollVertical;
 
         int first = Math.Max(0, (int)Math.Floor((ScrollVertical - itemsStartY) / itemHeight));
@@ -487,19 +491,19 @@ public partial class SaveList : ScrollContainer
 
         for (int i = paddedFirst; i <= paddedLast; ++i)
         {
-            savesList.GetChild<SaveListItem>(i).TriggerLoad();
+            saveItemChildren[i].TriggerLoad();
         }
 
         if (oldFirst >= 0)
         {
             for (int i = oldFirst; i < paddedFirst; ++i)
             {
-                savesList.GetChild<SaveListItem>(i).CancelLoad();
+                saveItemChildren[i].CancelLoad();
             }
 
             for (int i = paddedLast + 1; i <= oldLast; ++i)
             {
-                savesList.GetChild<SaveListItem>(i).CancelLoad();
+                saveItemChildren[i].CancelLoad();
             }
         }
     }

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -98,12 +98,12 @@ public partial class SaveList : ScrollContainer
     {
         listItemScene = GD.Load<PackedScene>("res://src/saving/SaveListItem.tscn");
 
-        GetVScrollBar().ValueChanged += _ => UpdateVisibleRange();
-        Resized += () =>
+        GetVScrollBar().Connect(Godot.Range.SignalName.ValueChanged, Callable.From<double>(_ => UpdateVisibleRange()));
+        Connect(Control.SignalName.Resized, Callable.From(() =>
         {
             cachedItemHeight = -1;
             UpdateVisibleRange();
-        };
+        }));
     }
 
     public override void _Process(double delta)

--- a/src/saving/SaveList.cs
+++ b/src/saving/SaveList.cs
@@ -77,6 +77,11 @@ public partial class SaveList : ScrollContainer
 
     private bool isLoadingSave;
 
+    private int previousFirstVisible = -1;
+    private int previousLastVisible = -1;
+    private float cachedItemHeight = -1;
+    private bool needsInitialVisibilityCheck;
+
     [Signal]
     public delegate void OnSelectedChangedEventHandler();
 
@@ -92,6 +97,13 @@ public partial class SaveList : ScrollContainer
     public override void _Ready()
     {
         listItemScene = GD.Load<PackedScene>("res://src/saving/SaveListItem.tscn");
+
+        GetVScrollBar().ValueChanged += _ => UpdateVisibleRange();
+        Resized += () =>
+        {
+            cachedItemHeight = -1;
+            UpdateVisibleRange();
+        };
     }
 
     public override void _Process(double delta)
@@ -108,6 +120,12 @@ public partial class SaveList : ScrollContainer
 
         if (!isCurrentlyVisible)
             wasVisible = false;
+
+        if (needsInitialVisibilityCheck && GetItemHeight() > 0)
+        {
+            needsInitialVisibilityCheck = false;
+            UpdateVisibleRange();
+        }
 
         if (!refreshing)
             return;
@@ -164,6 +182,7 @@ public partial class SaveList : ScrollContainer
 
         loadingItem.Visible = false;
         refreshing = false;
+        needsInitialVisibilityCheck = true;
     }
 
     public IEnumerable<SaveListItem> GetSelectedItems()
@@ -182,6 +201,11 @@ public partial class SaveList : ScrollContainer
 
         refreshing = true;
         refreshedAtLeastOnce = true;
+
+        previousFirstVisible = -1;
+        previousLastVisible = -1;
+        cachedItemHeight = -1;
+        needsInitialVisibilityCheck = false;
 
         savesList.QueueFreeChildren();
 
@@ -410,5 +434,73 @@ public partial class SaveList : ScrollContainer
         EmitSignal(SignalName.OnSaveLoaded, saveToBeLoaded);
         saveToBeLoaded = null;
         isLoadingSave = false;
+    }
+
+    private float GetItemHeight()
+    {
+        if (cachedItemHeight > 0)
+            return cachedItemHeight;
+
+        if (savesList.GetChildCount() == 0)
+            return -1;
+
+        var firstItem = savesList.GetChild<SaveListItem>(0);
+        float height = firstItem.Size.Y;
+
+        if (height <= 0)
+            return -1;
+
+        cachedItemHeight = height + savesList.GetThemeConstant("separation");
+        return cachedItemHeight;
+    }
+
+    private void UpdateVisibleRange()
+    {
+        if (!IsVisibleInTree())
+            return;
+
+        float itemHeight = GetItemHeight();
+        if (itemHeight <= 0)
+            return;
+
+        int itemCount = savesList.GetChildCount();
+        if (itemCount == 0)
+            return;
+
+        var firstItem = savesList.GetChild<SaveListItem>(0);
+        float itemsStartY = firstItem.GlobalPosition.Y - GlobalPosition.Y + ScrollVertical;
+
+        int first = Math.Max(0, (int)Math.Floor((ScrollVertical - itemsStartY) / itemHeight));
+        int last = Math.Min(itemCount - 1, (int)Math.Floor((ScrollVertical + Size.Y - itemsStartY) / itemHeight));
+
+        int paddedFirst = Math.Max(0, first - Constants.SAVE_LIST_LAZY_LOAD_PADDING);
+        int paddedLast = Math.Min(itemCount - 1, last + Constants.SAVE_LIST_LAZY_LOAD_PADDING);
+
+        if (paddedFirst == previousFirstVisible && paddedLast == previousLastVisible)
+            return;
+
+        int oldFirst = previousFirstVisible;
+        int oldLast = previousLastVisible;
+
+        previousFirstVisible = paddedFirst;
+        previousLastVisible = paddedLast;
+
+        for (int i = paddedFirst; i <= paddedLast; ++i)
+        {
+            savesList.GetChild<SaveListItem>(i).TriggerLoad();
+        }
+
+        if (oldFirst >= 0)
+        {
+            for (int i = oldFirst; i < paddedFirst; ++i)
+            {
+                savesList.GetChild<SaveListItem>(i).CancelLoad();
+            }
+
+            for (int i = paddedLast + 1; i <= oldLast; ++i)
+            {
+                savesList.GetChild<SaveListItem>(i).CancelLoad();
+            }
+        }
     }
 }

--- a/src/saving/SaveListItem.cs
+++ b/src/saving/SaveListItem.cs
@@ -58,6 +58,7 @@ public partial class SaveListItem : PanelContainer
     private int versionDifference;
 
     private bool loadingData;
+    private bool dataLoaded;
     private SaveInfoAndScreenshot? saveInfoLoadTask;
 
     private bool highlighted;
@@ -112,7 +113,6 @@ public partial class SaveListItem : PanelContainer
                 return;
 
             saveName = value;
-            LoadSaveData();
             UpdateName();
         }
     }
@@ -262,6 +262,7 @@ public partial class SaveListItem : PanelContainer
         }
 
         loadingData = false;
+        dataLoaded = true;
     }
 
     public override void _GuiInput(InputEvent @event)
@@ -279,6 +280,26 @@ public partial class SaveListItem : PanelContainer
                 OnSelect();
             }
         }
+    }
+
+    public void TriggerLoad()
+    {
+        if (dataLoaded || loadingData || saveInfoLoadTask != null)
+            return;
+
+        LoadSaveData();
+    }
+
+    public void CancelLoad()
+    {
+        if (dataLoaded || saveInfoLoadTask == null)
+            return;
+
+        if (!saveInfoLoadTask.Loaded)
+            ResourceManager.Instance.CancelLoad(saveInfoLoadTask);
+
+        saveInfoLoadTask = null;
+        loadingData = false;
     }
 
     public void LoadThisSave()


### PR DESCRIPTION
**Brief Description of What This PR Does**

Lazy load save list items only when visible in scroll view

Currently `SaveList` loads all filenames of saves, instantiates a Control node for each, and asynchronously loads its metadata (save info + screenshot). This is a waste of compute and memory as it loads data for entries that are not in the player's screen.

This changes `SaveList` to only trigger data loading for items currently visible in the scroll container (plus a small buffer of 5 items above and below, adjustable). Since Godot has no built-in way to detect when a Control node is visible within a ScrollContainer, the visible range is calculated using index math from ScrollVertical and item height. This check runs only when the scroll position changes (via the VScrollBar's ValueChanged signal) or on resize. 

Lastly, items that scroll out of range have their in-progress loads cancelled via `ResourceManager.CancelLoad`. This is _absolutely_ essential, makes sure fast scrolling doesn't clog the queue with work for items the player already passed (and haven't loaded before that). Items that already finished loading are left alone. `CancelLoad` and `TriggerLoad` both check a `dataLoaded` flag to avoid redundant work.

**Related Issues**

Resolves #6986. This change also significantly increased speed-to-render of the bottom-most saves. Compare before:

https://github.com/user-attachments/assets/84560520-8eb0-4eab-bb01-7a008c7aba61

With after:

https://github.com/user-attachments/assets/db631f17-b2aa-49e9-bd33-8641af94bed2

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
