### PR TITLE
Doubled lifetime of radioactive chunks

### DIFF
--- a/simulation_parameters/microbe_stage/biomes.json
+++ b/simulation_parameters/microbe_stage/biomes.json
@@ -464,6 +464,7 @@
           "VentAmount": 0,
           "Damages": 0,
           "DeleteOnTouch": false,
+          "LifetimeOverride": 300,
           "Compounds": {
             "radiation": {
               "Amount": 10000
@@ -3186,6 +3187,7 @@
           "VentAmount": 0,
           "Damages": 0,
           "DeleteOnTouch": false,
+          "LifetimeOverride": 300,
           "Compounds": {
             "radiation": {
               "Amount": 10000
@@ -4947,6 +4949,7 @@
           "VentAmount": 0,
           "Damages": 0,
           "DeleteOnTouch": false,
+          "LifetimeOverride": 300,
           "Compounds": {
             "radiation": {
               "Amount": 10000
@@ -5509,6 +5512,7 @@
           "VentAmount": 0,
           "Damages": 0,
           "DeleteOnTouch": false,
+          "LifetimeOverride": 300,
           "Compounds": {
             "radiation": {
               "Amount": 10000

--- a/src/microbe_stage/ChunkConfiguration.cs
+++ b/src/microbe_stage/ChunkConfiguration.cs
@@ -9,7 +9,7 @@ using SharedBase.Archive;
 /// </summary>
 public struct ChunkConfiguration : IEquatable<ChunkConfiguration>, IArchivable
 {
-    public const ushort SERIALIZATION_VERSION = 1;
+    public const ushort SERIALIZATION_VERSION = 2;
 
     public string Name;
 
@@ -60,6 +60,12 @@ public struct ChunkConfiguration : IEquatable<ChunkConfiguration>, IArchivable
     /// </summary>
     public string? DissolverEnzyme;
 
+    /// <summary>
+    ///   If above zero, this overrides the lifetime of this chunk if this is a timed chunk.
+    ///   Value is in seconds.
+    /// </summary>
+    public int LifetimeOverride;
+
     [JsonIgnore]
     public ushort CurrentArchiveVersion => SERIALIZATION_VERSION;
 
@@ -109,6 +115,7 @@ public struct ChunkConfiguration : IEquatable<ChunkConfiguration>, IArchivable
             Compounds = reader.ReadObjectOrNull<Dictionary<Compound, ChunkCompound>>(),
             EasterEgg = reader.ReadBool(),
             DissolverEnzyme = reader.ReadString(),
+            LifetimeOverride = version >= 2 ? reader.ReadInt32() : 0,
         };
     }
 
@@ -143,6 +150,7 @@ public struct ChunkConfiguration : IEquatable<ChunkConfiguration>, IArchivable
 
         writer.Write(EasterEgg);
         writer.Write(DissolverEnzyme);
+        writer.Write(LifetimeOverride);
     }
 
     public override bool Equals(object? obj)
@@ -176,6 +184,7 @@ public struct ChunkConfiguration : IEquatable<ChunkConfiguration>, IArchivable
             EasterEgg == other.EasterEgg &&
             DamageType == other.DamageType &&
             DissolverEnzyme == other.DissolverEnzyme &&
+            LifetimeOverride == other.LifetimeOverride &&
             Equals(Compounds, other.Compounds);
     }
 

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -494,13 +494,13 @@ public static class SpawnHelpers
         }
 
         // Chunks that don't dissolve naturally when running out of compounds, are despawned with a timer
-        // TODO: should this be forced if this chunk has no compounds? (at least ice shards probably wouldn't like
-        // this)
         if (timedLife)
         {
             commandRecorder.Set(entity, new TimedLife
             {
-                TimeToLiveRemaining = Constants.DESPAWNING_CHUNK_LIFETIME,
+                TimeToLiveRemaining = chunkType.LifetimeOverride > 0 ?
+                    chunkType.LifetimeOverride :
+                    Constants.DESPAWNING_CHUNK_LIFETIME,
             });
             commandRecorder.Set(entity, new FadeOutActions
             {

--- a/src/microbe_stage/systems/IrradiationSystem.cs
+++ b/src/microbe_stage/systems/IrradiationSystem.cs
@@ -59,7 +59,7 @@ public partial class IrradiationSystem(World world) : BaseSystem<World, float>(w
             if (source.Radius <= 0)
                 return;
 
-            // Setup detection when missing
+            // Set up detection when missing
             sensor.ActiveArea = CreateDetectorShape(source.Radius);
             sensor.ApplyNewShape = true;
         }


### PR DESCRIPTION
and put in a general system for other despawning chunks to also be able to override their lifetime

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
