### PR TITLE
Show one more decimal in MP amounts

### DIFF
--- a/src/microbe_stage/editor/MutationPointsBar.cs
+++ b/src/microbe_stage/editor/MutationPointsBar.cs
@@ -82,7 +82,7 @@ public partial class MutationPointsBar : HBoxContainer
                 mutationPointsArrow.Show();
                 resultingMutationPointsLabel.Show();
 
-                currentMutationPointsLabel.Text = $"({currentMutationPoints:0.#}";
+                currentMutationPointsLabel.Text = $"({currentMutationPoints:0.##}";
                 resultingMutationPointsLabel.Text = $"{possibleMutationPoints:F0})";
             }
             else
@@ -90,7 +90,7 @@ public partial class MutationPointsBar : HBoxContainer
                 mutationPointsArrow.Hide();
                 resultingMutationPointsLabel.Hide();
 
-                currentMutationPointsLabel.Text = $"{currentMutationPoints:0.#}";
+                currentMutationPointsLabel.Text = $"{currentMutationPoints:0.##}";
             }
 
             // TODO: implement full support for free percentage symbol placement within the mutation points bar


### PR DESCRIPTION
so that problems with rounding don't mislead players to think they should be able to place something when they just barely don't have enough MP

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
sometimes not being able to place an organelle that costs 21 MP even though the bar shows 21 MP (due to rounding)

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
