### PR TITLE
enhancement: show minimum tolerance change rather than perfect adjustment

### DIFF
--- a/src/microbe_stage/MicrobeEnvironmentalToleranceCalculations.cs
+++ b/src/microbe_stage/MicrobeEnvironmentalToleranceCalculations.cs
@@ -331,12 +331,12 @@ public static class MicrobeEnvironmentalToleranceCalculations
             if (data.PerfectTemperatureAdjustment < 0)
             {
                 resultCallback.Invoke(Localization.Translate("TOLERANCES_TOO_HIGH_TEMPERATURE")
-                    .FormatSafe(Math.Round(-data.PerfectTemperatureAdjustment, 1)));
+                    .FormatSafe(Math.Round(-data.MinimumTemperatureAdjustment, 1)));
             }
             else
             {
                 resultCallback.Invoke(Localization.Translate("TOLERANCES_TOO_LOW_TEMPERATURE")
-                    .FormatSafe(Math.Round(data.PerfectTemperatureAdjustment, 1)));
+                    .FormatSafe(Math.Round(data.MinimumTemperatureAdjustment, 1)));
             }
         }
 
@@ -346,12 +346,12 @@ public static class MicrobeEnvironmentalToleranceCalculations
             {
                 // TODO: show the numbers in megapascals when makes sense
                 resultCallback.Invoke(Localization.Translate("TOLERANCES_TOO_HIGH_PRESSURE")
-                    .FormatSafe(Math.Round(-data.PerfectPressureAdjustment / 1000, 1)));
+                    .FormatSafe(Math.Round(-data.MinimumPressureAdjustment / 1000, 1)));
             }
             else
             {
                 resultCallback.Invoke(Localization.Translate("TOLERANCES_TOO_LOW_PRESSURE")
-                    .FormatSafe(Math.Round(data.PerfectPressureAdjustment / 1000, 1)));
+                    .FormatSafe(Math.Round(data.MinimumPressureAdjustment / 1000, 1)));
             }
         }
 
@@ -584,6 +584,21 @@ public static class MicrobeEnvironmentalToleranceCalculations
             result.TemperatureScore = 1;
         }
 
+        if (patchTemperature > speciesTolerances.PreferredTemperature + speciesTolerances.TemperatureTolerance)
+        {
+            result.MinimumTemperatureAdjustment = result.PerfectTemperatureAdjustment -
+                speciesTolerances.TemperatureTolerance;
+        }
+        else if (patchTemperature < speciesTolerances.PreferredTemperature - speciesTolerances.TemperatureTolerance)
+        {
+            result.MinimumTemperatureAdjustment = result.PerfectTemperatureAdjustment +
+                speciesTolerances.TemperatureTolerance;
+        }
+        else
+        {
+            result.MinimumTemperatureAdjustment = 0.0f;
+        }
+
         var pressureMaximum = speciesTolerances.PressureMinimum + speciesTolerances.PressureTolerance;
 
         // Pressure
@@ -602,6 +617,8 @@ public static class MicrobeEnvironmentalToleranceCalculations
                     Constants.TOLERANCE_MAXIMUM_SURVIVABLE_PRESSURE_DIFFERENCE;
             }
 
+            result.MinimumPressureAdjustment = result.PerfectPressureAdjustment - speciesTolerances.PressureTolerance;
+
             missingSomething = true;
         }
         else if (patchPressure < speciesTolerances.PressureMinimum)
@@ -617,6 +634,8 @@ public static class MicrobeEnvironmentalToleranceCalculations
                 result.PressureScore = 1 - (speciesTolerances.PressureMinimum - patchPressure) /
                     Constants.TOLERANCE_MAXIMUM_SURVIVABLE_PRESSURE_DIFFERENCE;
             }
+
+            result.MinimumPressureAdjustment = result.PerfectPressureAdjustment;
 
             missingSomething = true;
         }
@@ -644,6 +663,8 @@ public static class MicrobeEnvironmentalToleranceCalculations
 
                 result.PressureScore = 1;
             }
+
+            result.MinimumPressureAdjustment = 0.0f;
         }
 
         // Oxygen Resistance

--- a/src/microbe_stage/ToleranceResult.cs
+++ b/src/microbe_stage/ToleranceResult.cs
@@ -18,9 +18,12 @@ public struct ToleranceResult
     /// </summary>
     public float TemperatureRangeSizeAdjustment;
 
+    public float MinimumTemperatureAdjustment;
+
     public double PressureScore;
     public float PerfectPressureAdjustment;
     public float PressureRangeSizeAdjustment;
+    public float MinimumPressureAdjustment;
 
     public double OxygenScore;
     public float PerfectOxygenAdjustment;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Instead of showing the difference from the patch's value and the preferred value, it shows the minimum amount that the preferred value needs to be changed.

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/eb740315-7654-441c-a6dd-2e7d15e4f5df" />
After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/926e89b2-d310-44d6-a5fd-2311e5f35446" />

**Related Issues**

closes #7011 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
