### PR TITLE
Refresh multicellular specialization display on move action

### DIFF
--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.Callbacks.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.Callbacks.cs
@@ -104,6 +104,8 @@ public partial class CellBodyPlanEditorComponent
             UpdateAlreadyPlacedVisuals();
 
             // TODO: notify auto-evo prediction once that is done
+
+            UpdateSpecializationDisplay();
         }
         else
         {
@@ -120,6 +122,7 @@ public partial class CellBodyPlanEditorComponent
         data.MovedHex.Data.Position = data.OldLocation;
 
         UpdateAlreadyPlacedVisuals();
+        UpdateSpecializationDisplay();
     }
 
     [ArchiveAllowedMethod]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes cell moves not always triggering specialization recalculation

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/464846402732687391/465937305849298956/1509262736960524491

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
