### PR TITLE
Changed migrations to use a special readonly miche tree

### DIFF
--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -418,6 +418,8 @@ public class AutoEvoRun
             }
         }
 
+        // Start with concurrent steps. No two steps may modify the same miche tree at the same time
+
         foreach (var entry in map.Patches)
         {
             steps.Enqueue(new ModifyExistingSpecies(entry.Value, new SimulationCache(worldSettings), worldSettings,
@@ -428,6 +430,8 @@ public class AutoEvoRun
         {
             steps.Enqueue(new MigrateSpecies(species, map, worldSettings, new SimulationCache(worldSettings), random));
         }
+
+        // End concurrent steps.
 
         // The new populations don't depend on the mutations but will take into account changes in the miche tree.
         // This is so that when the player edits their species, the other species they are competing

--- a/src/auto-evo/Miche.cs
+++ b/src/auto-evo/Miche.cs
@@ -181,6 +181,9 @@ public class Miche : IArchivable
     {
         ThrowIfLocked();
 
+        if (Readonly)
+            throw new InvalidOperationException("This miche tree is readonly (and somehow not locked)");
+
         Children.Add(newChild);
         newChild.Parent = this;
     }

--- a/src/auto-evo/Miche.cs
+++ b/src/auto-evo/Miche.cs
@@ -52,6 +52,11 @@ public class Miche : IArchivable
         Pressure = pressure;
     }
 
+    /// <summary>
+    ///   If true, species cannot be inserted any more
+    /// </summary>
+    public bool Readonly { get; private set; }
+
     public ushort CurrentArchiveVersion => SERIALIZATION_VERSION;
     public ArchiveObjectType ArchiveObjectType => (ArchiveObjectType)ThriveArchiveObjectType.Miche;
     public bool CanBeReferencedInArchive => true;
@@ -186,7 +191,7 @@ public class Miche : IArchivable
     /// <param name="species">Species to try to insert</param>
     /// <param name="patch">Patch this miche is in for calculating scores</param>
     /// <param name="scoresSoFar">
-    ///   Scores generated so far. If not called recursively just pass in null. Not modified by this method.
+    ///   Scores generated so far. If not called recursively, just pass in null. Not modified by this method.
     /// </param>
     /// <param name="cache">Data cache for faster calculation</param>
     /// <param name="dry">If true the species is not inserted but only checked if it could be inserted</param>
@@ -198,6 +203,9 @@ public class Miche : IArchivable
     public bool InsertSpecies(Species species, Patch patch, Dictionary<Species, float>? scoresSoFar,
         SimulationCache cache, bool dry, InsertWorkingMemory workingMemory, int depth = 0)
     {
+        if (Readonly && !dry)
+            throw new InvalidOperationException("This miche tree is readonly and cannot be modified");
+
         var myScore = Pressure.Score(species, patch, cache);
 
         // Prune branch if species fails any pressures
@@ -248,7 +256,7 @@ public class Miche : IArchivable
         }
 
         // We check here to see if scores more than 0, because
-        // scores is relative to the inserted species
+        // scores are relative to the inserted species
         if (IsLeafNode())
         {
             if (newScores.TryGetValue(Occupant!, out var value))
@@ -312,6 +320,21 @@ public class Miche : IArchivable
             throw new InvalidOperationException("Miche is already locked");
 
         locked = true;
+    }
+
+    public void SetReadOnly()
+    {
+        if (Readonly)
+            return;
+
+        Readonly = true;
+        if (!locked)
+            Lock();
+
+        foreach (var child in Children)
+        {
+            child.SetReadOnly();
+        }
     }
 
     public override int GetHashCode()

--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -42,6 +42,11 @@ public class RunResults : IArchivable
     /// </summary>
     private readonly Dictionary<Patch, Miche> micheByPatch = new();
 
+    /// <summary>
+    ///   Miche-tree for readonly access. This is not saved.
+    /// </summary>
+    private readonly Dictionary<Patch, Miche> readonlyMicheByPatch = new();
+
     public enum NewSpeciesType
     {
         /// <summary>
@@ -118,6 +123,13 @@ public class RunResults : IArchivable
                 throw new InvalidOperationException("Patch already has a miche");
 
             miche.Lock();
+
+            lock (readonlyMicheByPatch)
+            {
+                var readonlyMiche = miche.DeepCopy();
+                readonlyMiche.SetReadOnly();
+                readonlyMicheByPatch[patch] = readonlyMiche;
+            }
         }
     }
 
@@ -525,7 +537,7 @@ public class RunResults : IArchivable
         world.Map.DiscardGameplayPopulations();
     }
 
-    public Miche GetMicheForPatch(Patch patch)
+    public Miche GetModifiableMicheForPatch(Patch patch)
     {
         lock (micheByPatch)
         {
@@ -536,12 +548,24 @@ public class RunResults : IArchivable
         }
     }
 
+    public Miche GetReadOnlyMicheForPatch(Patch patch)
+    {
+        lock (readonlyMicheByPatch)
+        {
+            if (!readonlyMicheByPatch.TryGetValue(patch, out var miche))
+                throw new ArgumentException("Readonly miche not found for " + patch.Name + " in MicheByPatch");
+
+            return miche;
+        }
+    }
+
     /// <summary>
     ///   Returns the miche by patch dictionary. Only for inspecting data after a run as this is not safe at all.
     /// </summary>
     /// <remarks>
     ///   <para>
-    ///     This should not be used in AutoEvo code, prefer <see cref="GetMicheForPatch"/>.
+    ///     This should not be used in AutoEvo code, prefer <see cref="GetModifiableMicheForPatch"/> or the readonly
+    ///     variant.
     ///   </para>
     /// </remarks>
     public Dictionary<Patch, Miche> InspectPatchMicheData()

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -210,7 +210,7 @@ public static class MichePopulation
         bool trackEnergy = simulationConfiguration.CollectEnergyInformation;
 
         // Note that this modifies the miche tree while simulating
-        var miche = populations.GetMicheForPatch(patch);
+        var miche = populations.GetModifiableMicheForPatch(patch);
 
         var species = new HashSet<Species>();
 

--- a/src/auto-evo/steps/MigrateSpecies.cs
+++ b/src/auto-evo/steps/MigrateSpecies.cs
@@ -122,7 +122,10 @@ public class MigrateSpecies : IRunStep
                 continue;
 
             --attemptsLeft;
-            var targetMiche = results.GetMicheForPatch(target);
+
+            // We get a readonly copy of the miche tree to avoid hitting into a problem where a species mutation
+            // generation was just processing the patch and ended up modifying it
+            var targetMiche = results.GetReadOnlyMicheForPatch(target);
 
             // Calculate random amount of population to send
             var moveAmount = (long)random.Next(population * Constants.AUTO_EVO_MINIMUM_MOVE_POPULATION_FRACTION,

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -105,10 +105,10 @@ public class ModifyExistingSpecies : IRunStep
 
     public bool RunStep(RunResults results)
     {
-        // Setup miche data if missing
+        // Set up miche data if missing
         if (miche == null)
         {
-            miche = results.GetMicheForPatch(patch);
+            miche = results.GetModifiableMicheForPatch(patch);
 
             miche.GetOccupants(speciesWorkMemory);
 

--- a/src/auto-evo/steps/RegisterNewSpecies.cs
+++ b/src/auto-evo/steps/RegisterNewSpecies.cs
@@ -24,7 +24,7 @@ public class RegisterNewSpecies : IRunStep
         var currentSpecies = new HashSet<Species>();
         foreach (var patch in world.Map.Patches)
         {
-            results.GetMicheForPatch(patch.Value).GetOccupants(currentSpecies);
+            results.GetModifiableMicheForPatch(patch.Value).GetOccupants(currentSpecies);
         }
 
         var extinctSpecies = new HashSet<Species>();

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -3294,7 +3294,7 @@ public partial class CellEditorComponent :
             UpdateAutoEvoPredictionDetailsText();
         }
 
-        predictionMiches = results.GetMicheForPatch(Editor.CurrentPatch);
+        predictionMiches = results.GetModifiableMicheForPatch(Editor.CurrentPatch);
     }
 
     private void CreateAutoEvoPredictionDetailsText(

--- a/src/microbe_stage/editor/FoodChainDisplay.cs
+++ b/src/microbe_stage/editor/FoodChainDisplay.cs
@@ -78,7 +78,10 @@ public partial class FoodChainDisplay : Control
         // TODO: reuse possible nodes
         graphNodes.Clear();
 
-        var micheTree = autoEvoResults.GetMicheForPatch(forPatch);
+        // The modifiable miche is the final one that was used to calculate real populations.
+        // So it should be fully accurate here. However, there's reports every now and then about non-sensical food
+        // chain displays.
+        var micheTree = autoEvoResults.GetModifiableMicheForPatch(forPatch);
 
         var seenSpecies = new HashSet<Species>();
 

--- a/src/microbe_stage/editor/MicrobeEditorPatchMap.cs
+++ b/src/microbe_stage/editor/MicrobeEditorPatchMap.cs
@@ -79,7 +79,7 @@ public partial class MicrobeEditorPatchMap : PatchMapEditorComponent<IEditorWith
             return;
         }
 
-        micheViewer.ShowMiches(patch, Editor.PreviousAutoEvoResults.GetMicheForPatch(patch),
+        micheViewer.ShowMiches(patch, Editor.PreviousAutoEvoResults.GetModifiableMicheForPatch(patch),
             Editor.CurrentGame.GameWorld.WorldSettings);
     }
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

creates a secondary miche tree that is readonly for concurrent operations that might access any miche

this should resolve a data race condition

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
closes #6441

Note that I only *suspect* this fixes the problem as after a discussion this was the only reasonable thing we were able to come up with as to what might cause the error

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
