### PR TITLE
Fixed loading saves with unlock references to protoplasm

### DIFF
--- a/Thrive.sln.DotSettings
+++ b/Thrive.sln.DotSettings
@@ -767,6 +767,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=photosynthesizers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pili/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pilus/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Plasm/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=playthrough/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=podman/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pointwise/@EntryIndexedValue">True</s:Boolean>

--- a/simulation_parameters/SimulationParameters.cs
+++ b/simulation_parameters/SimulationParameters.cs
@@ -26,6 +26,10 @@ public partial class SimulationParameters : Node
     /// </summary>
     private readonly List<CompoundDefinition> compoundDefinitions = [];
 
+    // Old save compatibility helpers
+    private readonly Dictionary<string, OrganelleDefinition> dummyOrganelles = new();
+
+    // Main data dictionaries
     private Dictionary<string, MembraneType> membranes = null!;
     private Dictionary<string, Background> backgrounds = null!;
     private Dictionary<string, Biome> biomes = null!;
@@ -260,7 +264,20 @@ public partial class SimulationParameters : Node
 
     public OrganelleDefinition GetOrganelleType(string name)
     {
-        return organelles[name];
+        if (organelles.TryGetValue(name, out var organelle))
+            return organelle;
+
+        if (dummyOrganelles.TryGetValue(name, out var dummyOrganelle))
+        {
+            // Dummy organelles are meant to be loaded and then discarded and not kept around
+            if (dummyOrganelle.InternalName == name)
+                throw new InvalidOperationException("Dummy organelle name shouldn't match internal name");
+
+            GD.Print($"Using dummy organelle for {name}, this should be used for compatibility only");
+            return dummyOrganelle;
+        }
+
+        throw new Exception("Organelle not found: " + name);
     }
 
     /// <summary>
@@ -601,6 +618,16 @@ public partial class SimulationParameters : Node
             throw new InvalidOperationException("Ran out of BioProcess IDs");
 
         return ++bioProcessIdCounter;
+    }
+
+    public void RegisterDummyCompatibilityOrganelleForLoad(OrganelleDefinition dummyOrganelle, string name)
+    {
+        dummyOrganelles[name] = dummyOrganelle;
+    }
+
+    public void RemoveDummyCompatibilityOrganelles()
+    {
+        dummyOrganelles.Clear();
     }
 
     /// <summary>

--- a/src/general/statistics_tracking/ReproductionStatistic.cs
+++ b/src/general/statistics_tracking/ReproductionStatistic.cs
@@ -1,14 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Arch.Core;
 using Arch.Core.Extensions;
 using Components;
+using Godot;
 using SharedBase.Archive;
 
 public class ReproductionStatistic : IStatistic, IArchiveUpdatable
 {
-    public const ushort SERIALIZATION_VERSION = 1;
+    public const ushort SERIALIZATION_VERSION = 2;
 
     public int TimesReproduced { get; private set; }
 
@@ -60,7 +62,38 @@ public class ReproductionStatistic : IStatistic, IArchiveUpdatable
 
         TimesReproduced = reader.ReadInt32();
         ReproducedInBiomes = reader.ReadObject<Dictionary<Biome, int>>();
-        ReproducedWithOrganelle = reader.ReadObject<Dictionary<OrganelleDefinition, ReproductionOrganelleData>>();
+
+        if (version < 2)
+        {
+            // We need to allow dummy-loading protoplasm and then remove it.
+            // The instance won't match the one used in UnlockProgress, so the internal name has to match for us to
+            // also remove the dummy protoplasm reference in reproduction statistics.
+            var dummyPlasm = new OrganelleDefinition
+            {
+                InternalName = "dummy_protoplasm",
+                Name = "dummy_protoplasm",
+            };
+
+            SimulationParameters.Instance.RegisterDummyCompatibilityOrganelleForLoad(dummyPlasm, "protoplasm");
+
+            ReproducedWithOrganelle = reader.ReadObject<Dictionary<OrganelleDefinition, ReproductionOrganelleData>>();
+
+            SimulationParameters.Instance.RemoveDummyCompatibilityOrganelles();
+
+            var keys = ReproducedWithOrganelle.Keys.Where(o => o.InternalName == dummyPlasm.InternalName).ToList();
+
+            foreach (var key in keys)
+            {
+                if (ReproducedWithOrganelle.Remove(key))
+                {
+                    GD.Print("Loaded and removed old protoplasm reference in reproduction statistics");
+                }
+            }
+        }
+        else
+        {
+            ReproducedWithOrganelle = reader.ReadObject<Dictionary<OrganelleDefinition, ReproductionOrganelleData>>();
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/microbe_stage/OrganelleDefinition.cs
+++ b/src/microbe_stage/OrganelleDefinition.cs
@@ -23,7 +23,7 @@ public class OrganelleDefinition : RegistryType, IPlayerReadableName
 #pragma warning restore CA1001
 {
     /// <summary>
-    ///   User readable name
+    ///   User-readable name
     /// </summary>
     [TranslateFrom(nameof(untranslatedName))]
     public string Name = null!;
@@ -70,7 +70,7 @@ public class OrganelleDefinition : RegistryType, IPlayerReadableName
     public bool AutoEvoCanPlace = true;
 
     /// <summary>
-    ///   If set to true this part is unimplemented and isn't loadable (and not all properties are required)
+    ///   If set to true, this part is unimplemented and isn't loadable (and not all properties are required)
     /// </summary>
     public bool Unimplemented;
 

--- a/src/microbe_stage/organelle_unlocks/UnlockProgress.cs
+++ b/src/microbe_stage/organelle_unlocks/UnlockProgress.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Godot;
 using SharedBase.Archive;
 using UnlockConstraints;
 
@@ -8,11 +9,11 @@ using UnlockConstraints;
 /// </summary>
 public class UnlockProgress : IArchiveUpdatable
 {
-    public const ushort SERIALIZATION_VERSION = 1;
+    public const ushort SERIALIZATION_VERSION = 2;
 
     /// <summary>
     ///   The organelles that the player can use.
-    ///   The default value is the by default unlocked organelles (ones without a condition)
+    ///   The default value is, by-default, unlocked organelles (ones without a condition)
     /// </summary>
     private readonly HashSet<OrganelleDefinition> unlockedOrganelles =
         SimulationParameters.Instance.GetAllOrganelles().Where(o => o.UnlockConditions == null)
@@ -53,7 +54,7 @@ public class UnlockProgress : IArchiveUpdatable
     }
 
     /// <summary>
-    ///   Undoes an organelle unlock. Should be used sparingly, for example good to use when the user can undo an
+    ///   Undoes an organelle unlock. Should be used sparingly, for example, good to use when the user can undo an
     ///   action that unlocked something
     /// </summary>
     /// <returns>True when could be performed, false if the organelle was not marked as unlocked</returns>
@@ -126,9 +127,34 @@ public class UnlockProgress : IArchiveUpdatable
             throw new InvalidArchiveVersionException(version, SERIALIZATION_VERSION);
 
         unlockedOrganelles.Clear();
-        foreach (var item in reader.ReadObject<HashSet<OrganelleDefinition>>())
+
+        if (version < 2)
         {
-            unlockedOrganelles.Add(item);
+            // We need to allow dummy-loading protoplasm and then remove it
+            var dummyPlasm = new OrganelleDefinition
+            {
+                InternalName = "dummy_protoplasm",
+                Name = "dummy_protoplasm",
+            };
+
+            SimulationParameters.Instance.RegisterDummyCompatibilityOrganelleForLoad(dummyPlasm, "protoplasm");
+
+            foreach (var item in reader.ReadObject<HashSet<OrganelleDefinition>>())
+            {
+                unlockedOrganelles.Add(item);
+            }
+
+            SimulationParameters.Instance.RemoveDummyCompatibilityOrganelles();
+
+            if (unlockedOrganelles.RemoveWhere(o => o.InternalName == dummyPlasm.InternalName) > 0)
+                GD.Print("Loaded and removed old protoplasm reference in unlocks");
+        }
+        else
+        {
+            foreach (var item in reader.ReadObject<HashSet<OrganelleDefinition>>())
+            {
+                unlockedOrganelles.Add(item);
+            }
         }
 
         recentlyUnlocked.Clear();


### PR DESCRIPTION
as that was accidentally going there even if in gameplay protoplasm couldn't be used for years now

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Oopsie by me where the protoplasm removal actually did break saves...

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
