### PR TITLE
Finish digestion when only oxytoxy is left (instead of being stuck digesting at 0 amount left)

### DIFF
--- a/src/microbe_stage/systems/EngulfedDigestionSystem.cs
+++ b/src/microbe_stage/systems/EngulfedDigestionSystem.cs
@@ -238,7 +238,11 @@ public partial class EngulfedDigestionSystem : BaseSystem<World, float>
                 }
 
                 var totalAvailable = storageAmount + additionalAmount;
-                totalAmountLeft += totalAvailable;
+
+                // Do not count toxin as being left when digesting as it just deals damage and is not interesting that
+                // way. We only want to keep digesting it when there's other stuff to gain.
+                if (compound != Compound.Oxytoxy)
+                    totalAmountLeft += totalAvailable;
 
                 if (totalAvailable <= 0)
                     continue;

--- a/src/microbe_stage/systems/EngulfingSystem.cs
+++ b/src/microbe_stage/systems/EngulfingSystem.cs
@@ -2035,9 +2035,10 @@ public partial class EngulfingSystem : BaseSystem<World, float>
         {
             // TODO: check if this code is bad now because it is not as easy to access the digestible property of a
             // compound (this doesn't use a local reference to the simulation parameters as that would cause a lambda
-            // capture)
+            // capture).
+            // Oxytoxy is not counted in digestion progress as it is just for dealing damage during the process.
             engulfable.InitialTotalEngulfableCompounds = engulfableEntity.Get<CompoundStorage>().Compounds
-                .Where(c => SimulationParameters.GetCompound(c.Key).Digestible)
+                .Where(c => SimulationParameters.GetCompound(c.Key).Digestible && c.Key != Compound.Oxytoxy)
                 .Sum(c => c.Value);
 
 #if DEBUG


### PR DESCRIPTION
**Brief Description of What This PR Does**
If something was engulfed that kept producing oxytoxy, then it could get stuck infinitely being just digested and taking toxin damage until ejected. This PR changes it so that oxytoxy is not counted in the progress and thus digestion ends when there's nothing useful to digest.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://community.revolutionarygamesstudio.com/t/zero-engulfed-matter-toxin-damage-bug-1-1-0-0-opengl-mode-customdifficulty-experimental-settings/9036

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
