### PR TITLE
Made slime jet force framerate independent

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -546,7 +546,7 @@ public static class Constants
     /// <summary>
     ///   How much a cell's speed is increased when secreting slime (scaling with secreted compound amount)
     /// </summary>
-    public const float MUCILAGE_JET_FACTOR = 100000.0f;
+    public const float MUCILAGE_JET_FACTOR = 2000.0f;
 
     /// <summary>
     ///   Minimum stored slime needed to start secreting

--- a/src/microbe_stage/organelle_components/SlimeJetComponent.cs
+++ b/src/microbe_stage/organelle_components/SlimeJetComponent.cs
@@ -75,11 +75,11 @@ public class SlimeJetComponent : IOrganelleComponent
         if (!parentOrganelle.OrganelleAnimation.IsPlaying())
             parentOrganelle.OrganelleAnimation.Play(SlimeJetAnimationName);
 
-        // animationDirty is not set false here as otherwise we won't know when the playing stops and we need to
+        // animationDirty is not set false here as otherwise we won't know when the playing stops, and we need to
         // start the animation again to keep playing if the jet is active for long
     }
 
-    public void AddQueuedForce(in Entity entity, float slimeAmount)
+    public void AddQueuedForce(in Entity entity, float slimeAmount, float delta)
     {
         if (!Active)
         {
@@ -87,7 +87,10 @@ public class SlimeJetComponent : IOrganelleComponent
             return;
         }
 
-        queuedForce += CalculateMovementForce(entity, slimeAmount);
+        if (delta <= 0)
+            return;
+
+        queuedForce += CalculateMovementForce(entity, slimeAmount) / delta;
     }
 
     public void ConsumeMovementForce(out Vector3 force)

--- a/src/microbe_stage/systems/MicrobeEmissionSystem.cs
+++ b/src/microbe_stage/systems/MicrobeEmissionSystem.cs
@@ -349,7 +349,7 @@ public partial class MicrobeEmissionSystem : BaseSystem<World, float>
                 jet.Active = true;
 
                 // Queue movement force to be used by the movement system based on the amount of slime ejected
-                jet.AddQueuedForce(entity, slimeToSecrete);
+                jet.AddQueuedForce(entity, slimeToSecrete, delta);
             }
         }
         else

--- a/test/code_tests/MicrobeStage.Tests/SlimeJetFramerateTests.cs
+++ b/test/code_tests/MicrobeStage.Tests/SlimeJetFramerateTests.cs
@@ -1,0 +1,66 @@
+﻿namespace ThriveTest.MicrobeStage;
+
+using System;
+using Arch.Core;
+using Godot;
+using Xunit;
+
+public class SlimeJetFramerateTests
+{
+    [Fact]
+    public void SlimeJet_ForceIsNotFramerateDependent()
+    {
+        var world = World.Create();
+        var entity = world.Create();
+
+        var jet = new SlimeJetComponent
+        {
+            Active = true,
+        };
+
+        // 10 units of slime per second
+        float emissionRate = 10.0f;
+
+        // Scenario 1: 60 FPS (delta = 1/60)
+        float delta60 = 1.0f / 60.0f;
+        float slimePerFrame60 = emissionRate * delta60;
+        double slimeUsed60 = 0;
+
+        Vector3 totalForce60 = Vector3.Zero;
+        for (int i = 0; i < 60; ++i)
+        {
+            jet.AddQueuedForce(entity, slimePerFrame60, delta60);
+            jet.ConsumeMovementForce(out var force);
+
+            // Simulate the physics engine multiplying by delta once more
+            totalForce60 += force * delta60;
+
+            slimeUsed60 += slimePerFrame60;
+        }
+
+        // Scenario 2: 10 FPS (delta = 1/10)
+        float delta10 = 1.0f / 10.0f;
+        float slimePerFrame10 = emissionRate * delta10;
+        double slimeUsed10 = 0;
+
+        Vector3 totalForce10 = Vector3.Zero;
+        for (int i = 0; i < 10; ++i)
+        {
+            jet.AddQueuedForce(entity, slimePerFrame10, delta10);
+            jet.ConsumeMovementForce(out var force);
+
+            // Simulate the physics engine multiplying by delta once more
+            totalForce10 += force * delta10;
+
+            slimeUsed10 += slimePerFrame10;
+        }
+
+        // They should be equal now (assuming no bug)
+        Assert.Equal(totalForce60.Length(), totalForce10.Length(), 1.0f);
+
+        // And slime consumption should be the same
+        const int requiredMatchingDecimals = 5;
+        Assert.Equal(Math.Round(slimeUsed60, requiredMatchingDecimals),
+            Math.Round(slimeUsed10, requiredMatchingDecimals));
+    }
+}


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixes the slime jet force to not be framerate-dependent. I tried to match about the previous speed but this might be also a slight buff to the existing speed of slime jets.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
report about slime jet being much stronger when the game is capped to 30 FPS

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
