### PR TITLE
Added despawning of player gametes after exiting the editor

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1090,8 +1090,8 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
 
         WorldSimulation.CameraFollowSystem.Disabled = false;
 
-        // When true, another cell is spawned next to the player that they scientifically speaking would have split
-        // from
+        // When true, another cell is spawned next to the player that, scientifically speaking, the player would have
+        // split from
         bool spawnAnotherCell = true;
 
         // If using sexual reproduction, do not spawn another member as we came from a gamete merge
@@ -1351,6 +1351,9 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
             HUD.ShowEnvironmentPanel();
             environmentPanelAutomaticallyOpened = true;
         }
+
+        // Despawn player gametes to prevent accidentally immediately triggering the editor entry again
+        DespawnPlayerGametes();
 
         if (TutorialState.Enabled && !TutorialState.ProcessPanelTutorial.Complete)
         {
@@ -2402,6 +2405,20 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
                 TransitionManager.Instance.AddSequence(ScreenFade.FadeType.FadeOut, 0.3f, MoveToEditor, false);
             }
         }
+    }
+
+    private void DespawnPlayerGametes()
+    {
+        OnStopGameteMerge();
+
+        WorldSimulation.EntitySystem.Query<GameteCell>(new QueryDescription().WithAll<GameteCell>(),
+            (entity, ref gamete) =>
+            {
+                if (gamete.IsPlayer)
+                {
+                    WorldSimulation.DestroyEntity(entity);
+                }
+            });
     }
 
     private void ClearResolvedTolerancesCache()


### PR DESCRIPTION
**Brief Description of What This PR Does**

So that they shouldn't be able to trigger another immediate editor entry

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
