### PR TITLE
Compound conservation on mass budding

### DIFF
--- a/src/microbe_stage/ColonyCompoundBag.cs
+++ b/src/microbe_stage/ColonyCompoundBag.cs
@@ -164,6 +164,17 @@ public class ColonyCompoundBag : ICompoundStorage
             bag.ClearCompounds();
     }
 
+    /// <summary>
+    ///   Returns a dictionary that contains the combined compounds of the entire colony. The returned dictionary
+    ///   shouldn't be stored or modified.
+    /// </summary>
+    public Dictionary<Compound, float> GetCompoundDictionary()
+    {
+        FillSummedCompoundsBuffer(GetCompoundBags());
+
+        return summedCompoundsBuffer;
+    }
+
     private static bool IsUsefulInAnyCompoundBag(CompoundDefinition compound, List<CompoundBag> compoundBags)
     {
         foreach (var compoundBag in compoundBags)

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1147,16 +1147,6 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
 
         if (playerIsMulticellular)
         {
-            // If the player has a colony, all resources need to be transferred to the stem cell to avoid them being
-            // lost after other colony members are deleted
-            if (Player.TryGet<MicrobeColony>(out var colony))
-            {
-                foreach (var compound in colony.GetCompounds().GetCompoundDictionary())
-                {
-                    Player.Get<CompoundStorage>().Compounds.Compounds[compound.Key] = compound.Value;
-                }
-            }
-
             ref var multicellularSpeciesType = ref Player.Get<MulticellularSpeciesMember>();
 
             var resolvedTolerances = MicrobeEnvironmentalToleranceCalculations.ResolveToleranceValues(
@@ -1180,6 +1170,18 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
                      or MulticellularReproductionMethod.MassBudding)
             {
                 adjacencyBonus = multicellularSpeciesType.Species.GetAdjacencySpecializationBonus(0);
+            }
+
+            // If the player has a colony, all resources need to be transferred to the stem cell to avoid them being
+            // lost after other colony members are deleted
+            if (Player.TryGet<MicrobeColony>(out var colony))
+            {
+                growth.DelayedCompoundStorage ??= new Dictionary<Compound, float>();
+
+                foreach (var compound in colony.GetCompounds().GetCompoundDictionary())
+                {
+                    growth.DelayedCompoundStorage[compound.Key] = compound.Value;
+                }
             }
 
             var totalSpecializationBonus = multicellularSpeciesType.MulticellularCellType.CellTypeSpecializationBonus *

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1147,6 +1147,16 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
 
         if (playerIsMulticellular)
         {
+            // If the player has a colony, all resources need to be transferred to the stem cell to avoid them being
+            // lost after other colony members are deleted
+            if (Player.TryGet<MicrobeColony>(out var colony))
+            {
+                foreach (var compound in MicrobeColonyHelpers.GetCompounds(ref colony).GetCompoundDictionary())
+                {
+                    Player.Get<CompoundStorage>().Compounds.Compounds[compound.Key] = compound.Value;
+                }
+            }
+
             ref var multicellularSpeciesType = ref Player.Get<MulticellularSpeciesMember>();
 
             var resolvedTolerances = MicrobeEnvironmentalToleranceCalculations.ResolveToleranceValues(

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1151,7 +1151,7 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
             // lost after other colony members are deleted
             if (Player.TryGet<MicrobeColony>(out var colony))
             {
-                foreach (var compound in MicrobeColonyHelpers.GetCompounds(ref colony).GetCompoundDictionary())
+                foreach (var compound in colony.GetCompounds().GetCompoundDictionary())
                 {
                     Player.Get<CompoundStorage>().Compounds.Compounds[compound.Key] = compound.Value;
                 }

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1143,6 +1143,8 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
         // Update the player's cell
         ref var cellProperties = ref Player.Get<CellProperties>();
 
+        ref var compoundStorage = ref Player.Get<CompoundStorage>();
+
         bool playerIsMulticellular = Player.Has<MulticellularSpeciesMember>();
 
         if (playerIsMulticellular)
@@ -1176,11 +1178,11 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
             // lost after other colony members are deleted
             if (Player.TryGet<MicrobeColony>(out var colony))
             {
-                growth.DelayedCompoundStorage ??= new Dictionary<Compound, float>();
+                var compounds = compoundStorage.Compounds.Compounds;
 
                 foreach (var compound in colony.GetCompounds().GetCompoundDictionary())
                 {
-                    growth.DelayedCompoundStorage[compound.Key] = compound.Value;
+                    compounds[compound.Key] = compound.Value;
                 }
             }
 
@@ -1309,6 +1311,36 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
 
                 WorldSimulation.SpawnSystem.EnsureEntityLimitAfterPlayerReproduction(playerPosition, doNotDespawn);
             });
+        }
+
+        // After compounds are redistributed, send whatever was given to the player to the delayed storage.
+        // If the player's reproduction method isn't mass budding, just ensure that the compounds are under capacity.
+        if (playerIsMulticellular)
+        {
+            ref var multicellularSpeciesType = ref Player.Get<MulticellularSpeciesMember>();
+
+            var compounds = compoundStorage.Compounds.Compounds;
+
+            if (multicellularSpeciesType.Species.ReproductionMethod == MulticellularReproductionMethod.MassBudding)
+            {
+                ref var growth = ref Player.Get<MulticellularGrowth>();
+                growth.MassBuddingDelayedCompoundStorage ??= new Dictionary<Compound, float>();
+
+                foreach (var compound in compounds)
+                {
+                    growth.MassBuddingDelayedCompoundStorage[compound.Key] = compound.Value;
+                }
+
+                compounds.Clear();
+            }
+            else
+            {
+                foreach (var compound in compounds)
+                {
+                    compounds[compound.Key] = MathF.Min(compound.Value,
+                        compoundStorage.Compounds.GetCapacityForCompound(compound.Key, true));
+                }
+            }
         }
 
         // Handle the compound modes

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -820,7 +820,8 @@ public static class SpawnHelpers
                     {
                         // Making sure that if the species' reproduction method changes later on, this cell won't
                         // randomly try growing bud cells
-                        multicellularGrowth.SpawnedInitialMassBuddingCells = true;
+                        multicellularGrowth.SpawnedInitialMassBuddingCells
+                            = MulticellularGrowth.MassBuddingState.NotSpawned;
 
                         if (multicellularSpecies.ReproductionMethod == MulticellularReproductionMethod.Sporulation)
                             multicellularGrowth.IsASpore = true;
@@ -831,7 +832,7 @@ public static class SpawnHelpers
                     resolvedCellType = multicellularSpecies.ColonyRootCellType();
 
                     // Partially or fully grown colonies already have their bud grown
-                    multicellularGrowth.SpawnedInitialMassBuddingCells = true;
+                    multicellularGrowth.SpawnedInitialMassBuddingCells = MulticellularGrowth.MassBuddingState.Spawned;
                 }
 
                 // If grown as a full colony, or partial colony, we need to record the growth state here to not get

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -820,8 +820,7 @@ public static class SpawnHelpers
                     {
                         // Making sure that if the species' reproduction method changes later on, this cell won't
                         // randomly try growing bud cells
-                        multicellularGrowth.SpawnedInitialMassBuddingCells
-                            = MulticellularGrowth.MassBuddingState.NotSpawned;
+                        multicellularGrowth.MassBuddingState = MulticellularMassBuddingState.NotSpawned;
 
                         if (multicellularSpecies.ReproductionMethod == MulticellularReproductionMethod.Sporulation)
                             multicellularGrowth.IsASpore = true;
@@ -832,7 +831,7 @@ public static class SpawnHelpers
                     resolvedCellType = multicellularSpecies.ColonyRootCellType();
 
                     // Partially or fully grown colonies already have their bud grown
-                    multicellularGrowth.SpawnedInitialMassBuddingCells = MulticellularGrowth.MassBuddingState.Spawned;
+                    multicellularGrowth.MassBuddingState = MulticellularMassBuddingState.Spawned;
                 }
 
                 // If grown as a full colony, or partial colony, we need to record the growth state here to not get

--- a/src/multicellular_stage/MulticellularMassBuddingState.cs
+++ b/src/multicellular_stage/MulticellularMassBuddingState.cs
@@ -1,0 +1,6 @@
+public enum MulticellularMassBuddingState
+{
+    NotSpawned,
+    Spawning,
+    Spawned,
+}

--- a/src/multicellular_stage/MulticellularMassBuddingState.cs
+++ b/src/multicellular_stage/MulticellularMassBuddingState.cs
@@ -1,4 +1,4 @@
-public enum MulticellularMassBuddingState
+﻿public enum MulticellularMassBuddingState
 {
     NotSpawned,
     Spawning,

--- a/src/multicellular_stage/MulticellularMassBuddingState.cs.uid
+++ b/src/multicellular_stage/MulticellularMassBuddingState.cs.uid
@@ -1,0 +1,1 @@
+uid://b5nw2tm1yq4yv

--- a/src/multicellular_stage/components/MulticellularGrowth.cs
+++ b/src/multicellular_stage/components/MulticellularGrowth.cs
@@ -115,6 +115,15 @@ public struct MulticellularGrowth : IArchivableComponent
 
         writer.Write(IsASpore);
         writer.Write((int)MassBuddingState);
+
+        if (MassBuddingDelayedCompoundStorage != null)
+        {
+            writer.WriteObject(MassBuddingDelayedCompoundStorage);
+        }
+        else
+        {
+            writer.WriteNullObject();
+        }
     }
 }
 
@@ -156,6 +165,8 @@ public static class MulticellularGrowthHelpers
             if (version >= 4)
             {
                 instance.MassBuddingState = (MulticellularMassBuddingState)reader.ReadInt32();
+
+                instance.MassBuddingDelayedCompoundStorage = reader.ReadObjectOrNull<Dictionary<Compound, float>>();
             }
             else
             {

--- a/src/multicellular_stage/components/MulticellularGrowth.cs
+++ b/src/multicellular_stage/components/MulticellularGrowth.cs
@@ -51,7 +51,7 @@ public struct MulticellularGrowth : IArchivableComponent
 
     public bool IsASpore;
 
-    public MassBuddingState SpawnedInitialMassBuddingCells = MassBuddingState.NotSpawned;
+    public MulticellularMassBuddingState MassBuddingState = MulticellularMassBuddingState.NotSpawned;
 
     /// <summary>
     ///   What compounds need to be added after mass budding is done that otherwise would be over limit
@@ -69,13 +69,6 @@ public struct MulticellularGrowth : IArchivableComponent
 
         // This is updated by ReApplyCellTypeProperties when needed
         this.CalculateTotalBodyPlanCompounds(species);
-    }
-
-    public enum MassBuddingState
-    {
-        NotSpawned,
-        Spawning,
-        Spawned,
     }
 
     /// <summary>
@@ -121,7 +114,7 @@ public struct MulticellularGrowth : IArchivableComponent
         writer.Write(EnoughResourcesForBudding);
 
         writer.Write(IsASpore);
-        writer.Write((int)SpawnedInitialMassBuddingCells);
+        writer.Write((int)MassBuddingState);
     }
 }
 
@@ -162,12 +155,12 @@ public static class MulticellularGrowthHelpers
         {
             if (version >= 4)
             {
-                instance.SpawnedInitialMassBuddingCells = (MulticellularGrowth.MassBuddingState)reader.ReadInt32();
+                instance.MassBuddingState = (MulticellularMassBuddingState)reader.ReadInt32();
             }
             else
             {
-                instance.SpawnedInitialMassBuddingCells = reader.ReadBool() ?
-                    MulticellularGrowth.MassBuddingState.Spawned : MulticellularGrowth.MassBuddingState.NotSpawned;
+                instance.MassBuddingState = reader.ReadBool() ?
+                    MulticellularMassBuddingState.Spawned : MulticellularMassBuddingState.NotSpawned;
             }
         }
 
@@ -237,7 +230,7 @@ public static class MulticellularGrowthHelpers
         // immediately. Same goes for a few more cells if the species uses the mass budding reproduction method,
         // but that is handled separately by MulticellularGrowthSystem
         multicellularGrowth.NextBodyPlanCellToGrowIndex = 1;
-        multicellularGrowth.SpawnedInitialMassBuddingCells = MulticellularGrowth.MassBuddingState.NotSpawned;
+        multicellularGrowth.MassBuddingState = MulticellularMassBuddingState.NotSpawned;
         multicellularGrowth.EnoughResourcesForBudding = false;
 
         multicellularGrowth.CompoundsNeededForNextCell = null;
@@ -615,7 +608,7 @@ public static class MulticellularGrowthHelpers
             GD.PrintErr($"Tried to spawn initial mass budding cells ({species.ReadableName}) while some colony"
                 + $" cells were already grown (x{multicellularGrowth.NextBodyPlanCellToGrowIndex})");
 
-            multicellularGrowth.SpawnedInitialMassBuddingCells = MulticellularGrowth.MassBuddingState.Spawned;
+            multicellularGrowth.MassBuddingState = MulticellularMassBuddingState.Spawned;
             return;
         }
 
@@ -625,6 +618,6 @@ public static class MulticellularGrowthHelpers
                 recorder, notifySpawnTo);
         }
 
-        multicellularGrowth.SpawnedInitialMassBuddingCells = MulticellularGrowth.MassBuddingState.Spawning;
+        multicellularGrowth.MassBuddingState = MulticellularMassBuddingState.Spawning;
     }
 }

--- a/src/multicellular_stage/components/MulticellularGrowth.cs
+++ b/src/multicellular_stage/components/MulticellularGrowth.cs
@@ -160,7 +160,8 @@ public static class MulticellularGrowthHelpers
             else
             {
                 instance.MassBuddingState = reader.ReadBool() ?
-                    MulticellularMassBuddingState.Spawned : MulticellularMassBuddingState.NotSpawned;
+                    MulticellularMassBuddingState.Spawned :
+                    MulticellularMassBuddingState.NotSpawned;
             }
         }
 

--- a/src/multicellular_stage/components/MulticellularGrowth.cs
+++ b/src/multicellular_stage/components/MulticellularGrowth.cs
@@ -56,7 +56,7 @@ public struct MulticellularGrowth : IArchivableComponent
     /// <summary>
     ///   What compounds need to be added after mass budding is done that otherwise would be over limit
     /// </summary>
-    public Dictionary<Compound, float>? DelayedCompoundStorage;
+    public Dictionary<Compound, float>? MassBuddingDelayedCompoundStorage;
 
     public MulticellularGrowth(MulticellularSpecies species)
     {

--- a/src/multicellular_stage/components/MulticellularGrowth.cs
+++ b/src/multicellular_stage/components/MulticellularGrowth.cs
@@ -15,7 +15,7 @@ using Systems;
 /// </summary>
 public struct MulticellularGrowth : IArchivableComponent
 {
-    public const ushort SERIALIZATION_VERSION = 3;
+    public const ushort SERIALIZATION_VERSION = 4;
 
     /// <summary>
     ///   List of cells that need to be regrown, after being lost, in
@@ -51,7 +51,12 @@ public struct MulticellularGrowth : IArchivableComponent
 
     public bool IsASpore;
 
-    public bool SpawnedInitialMassBuddingCells;
+    public MassBuddingState SpawnedInitialMassBuddingCells = MassBuddingState.NotSpawned;
+
+    /// <summary>
+    ///   What compounds need to be added after mass budding is done that otherwise would be over limit
+    /// </summary>
+    public Dictionary<Compound, float>? DelayedCompoundStorage;
 
     public MulticellularGrowth(MulticellularSpecies species)
     {
@@ -64,6 +69,13 @@ public struct MulticellularGrowth : IArchivableComponent
 
         // This is updated by ReApplyCellTypeProperties when needed
         this.CalculateTotalBodyPlanCompounds(species);
+    }
+
+    public enum MassBuddingState
+    {
+        NotSpawned,
+        Spawning,
+        Spawned,
     }
 
     /// <summary>
@@ -109,7 +121,7 @@ public struct MulticellularGrowth : IArchivableComponent
         writer.Write(EnoughResourcesForBudding);
 
         writer.Write(IsASpore);
-        writer.Write(SpawnedInitialMassBuddingCells);
+        writer.Write((int)SpawnedInitialMassBuddingCells);
     }
 }
 
@@ -148,7 +160,15 @@ public static class MulticellularGrowthHelpers
 
         if (version >= 3)
         {
-            instance.SpawnedInitialMassBuddingCells = reader.ReadBool();
+            if (version >= 4)
+            {
+                instance.SpawnedInitialMassBuddingCells = (MulticellularGrowth.MassBuddingState)reader.ReadInt32();
+            }
+            else
+            {
+                instance.SpawnedInitialMassBuddingCells = reader.ReadBool() ?
+                    MulticellularGrowth.MassBuddingState.Spawned : MulticellularGrowth.MassBuddingState.NotSpawned;
+            }
         }
 
         return instance;
@@ -217,7 +237,7 @@ public static class MulticellularGrowthHelpers
         // immediately. Same goes for a few more cells if the species uses the mass budding reproduction method,
         // but that is handled separately by MulticellularGrowthSystem
         multicellularGrowth.NextBodyPlanCellToGrowIndex = 1;
-        multicellularGrowth.SpawnedInitialMassBuddingCells = false;
+        multicellularGrowth.SpawnedInitialMassBuddingCells = MulticellularGrowth.MassBuddingState.NotSpawned;
         multicellularGrowth.EnoughResourcesForBudding = false;
 
         multicellularGrowth.CompoundsNeededForNextCell = null;
@@ -595,7 +615,7 @@ public static class MulticellularGrowthHelpers
             GD.PrintErr($"Tried to spawn initial mass budding cells ({species.ReadableName}) while some colony"
                 + $" cells were already grown (x{multicellularGrowth.NextBodyPlanCellToGrowIndex})");
 
-            multicellularGrowth.SpawnedInitialMassBuddingCells = true;
+            multicellularGrowth.SpawnedInitialMassBuddingCells = MulticellularGrowth.MassBuddingState.Spawned;
             return;
         }
 
@@ -605,6 +625,6 @@ public static class MulticellularGrowthHelpers
                 recorder, notifySpawnTo);
         }
 
-        multicellularGrowth.SpawnedInitialMassBuddingCells = true;
+        multicellularGrowth.SpawnedInitialMassBuddingCells = MulticellularGrowth.MassBuddingState.Spawning;
     }
 }

--- a/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
+++ b/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
@@ -141,18 +141,18 @@ public partial class MulticellularGrowthSystem : BaseSystem<World, float>
             }
         }
 
-        if (growth.DelayedCompoundStorage != null && entity.Has<MicrobeColony>()
+        if (growth.MassBuddingDelayedCompoundStorage != null && entity.Has<MicrobeColony>()
             && (growth.MassBuddingState == MulticellularMassBuddingState.Spawned
                 || speciesData.Species.ReproductionMethod != MulticellularReproductionMethod.MassBudding))
         {
             var bag = entity.Get<MicrobeColony>().GetCompounds();
 
-            foreach (var compound in growth.DelayedCompoundStorage)
+            foreach (var compound in growth.MassBuddingDelayedCompoundStorage)
             {
                 bag.AddCompound(compound.Key, compound.Value);
             }
 
-            growth.DelayedCompoundStorage.Clear();
+            growth.MassBuddingDelayedCompoundStorage.Clear();
         }
 
         HandleMulticellularReproduction(ref growth, ref speciesData, compoundStorage.Compounds, ref organelleContainer,

--- a/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
+++ b/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
@@ -119,7 +119,7 @@ public partial class MulticellularGrowthSystem : BaseSystem<World, float>
             return;
 
         if (speciesData.Species.ReproductionMethod == MulticellularReproductionMethod.MassBudding
-            && !growth.SpawnedInitialMassBuddingCells)
+            && growth.SpawnedInitialMassBuddingCells == MulticellularGrowth.MassBuddingState.NotSpawned)
         {
             var recorder = worldSimulation.StartRecordingEntityCommands();
 
@@ -129,6 +129,30 @@ public partial class MulticellularGrowthSystem : BaseSystem<World, float>
             worldSimulation.FinishRecordingEntityCommands(recorder);
 
             return;
+        }
+
+        if (speciesData.Species.ReproductionMethod == MulticellularReproductionMethod.MassBudding
+            && growth.SpawnedInitialMassBuddingCells == MulticellularGrowth.MassBuddingState.Spawning)
+        {
+            if (entity.TryGet<MicrobeColony>(out var colony)
+                && colony.ColonyMembers.Length == speciesData.Species.MassBuddingCellCount)
+            {
+                growth.SpawnedInitialMassBuddingCells = MulticellularGrowth.MassBuddingState.Spawned;
+            }
+        }
+
+        if (growth.DelayedCompoundStorage != null && entity.Has<MicrobeColony>()
+            && (growth.SpawnedInitialMassBuddingCells == MulticellularGrowth.MassBuddingState.Spawned
+                || speciesData.Species.ReproductionMethod != MulticellularReproductionMethod.MassBudding))
+        {
+            var bag = entity.Get<MicrobeColony>().GetCompounds();
+
+            foreach (var compound in growth.DelayedCompoundStorage)
+            {
+                bag.AddCompound(compound.Key, compound.Value);
+            }
+
+            growth.DelayedCompoundStorage.Clear();
         }
 
         HandleMulticellularReproduction(ref growth, ref speciesData, compoundStorage.Compounds, ref organelleContainer,

--- a/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
+++ b/src/multicellular_stage/systems/MulticellularGrowthSystem.cs
@@ -119,7 +119,7 @@ public partial class MulticellularGrowthSystem : BaseSystem<World, float>
             return;
 
         if (speciesData.Species.ReproductionMethod == MulticellularReproductionMethod.MassBudding
-            && growth.SpawnedInitialMassBuddingCells == MulticellularGrowth.MassBuddingState.NotSpawned)
+            && growth.MassBuddingState == MulticellularMassBuddingState.NotSpawned)
         {
             var recorder = worldSimulation.StartRecordingEntityCommands();
 
@@ -132,17 +132,17 @@ public partial class MulticellularGrowthSystem : BaseSystem<World, float>
         }
 
         if (speciesData.Species.ReproductionMethod == MulticellularReproductionMethod.MassBudding
-            && growth.SpawnedInitialMassBuddingCells == MulticellularGrowth.MassBuddingState.Spawning)
+            && growth.MassBuddingState == MulticellularMassBuddingState.Spawning)
         {
             if (entity.TryGet<MicrobeColony>(out var colony)
                 && colony.ColonyMembers.Length == speciesData.Species.MassBuddingCellCount)
             {
-                growth.SpawnedInitialMassBuddingCells = MulticellularGrowth.MassBuddingState.Spawned;
+                growth.MassBuddingState = MulticellularMassBuddingState.Spawned;
             }
         }
 
         if (growth.DelayedCompoundStorage != null && entity.Has<MicrobeColony>()
-            && (growth.SpawnedInitialMassBuddingCells == MulticellularGrowth.MassBuddingState.Spawned
+            && (growth.MassBuddingState == MulticellularMassBuddingState.Spawned
                 || speciesData.Species.ReproductionMethod != MulticellularReproductionMethod.MassBudding))
         {
             var bag = entity.Get<MicrobeColony>().GetCompounds();


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes all resources conserve on exiting the editor. The problem was that some resources were stored in secondary colony members, which were deleted, also removing the compounds.

This PR fixes that by doing the following:
- Transferring compounds to the stem cell before secondary cells are deleted
- If the player uses mass budding, then these compounds are removed and re-added after the bud is fully formed to make sure they don't get capped

**Related Issues**

Closes #7071

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
