### PR TITLE
Made MP multiplier from difficulty settings apply to reproduction modes

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1221,7 +1221,7 @@ public static class Constants
     public const int SPORE_CELL_TYPE_CHANGE_COST = 10;
 
     public const int GAMETE_CELL_TYPE_CHANGE_COST = 10;
-    public const int MULTICELLULAR_ANISOGAMY_UPGRADE_COST = 50;
+    public const int MULTICELLULAR_ANISOGAMY_UPGRADE_COST = 55;
 
     public const int MASS_BUDDING_CELL_COUNT_CHANGE_COST = 10;
 

--- a/src/general/mutation_points/MulticellularSpeciesComparer.cs
+++ b/src/general/mutation_points/MulticellularSpeciesComparer.cs
@@ -175,6 +175,8 @@ public class MulticellularSpeciesComparer
 
         cost += oldCells.Count * Math.Min(Constants.CELL_REMOVE_COST * costMultiplier, maxSingleActionCost);
 
+        double reproductionCost = 0;
+
         if (speciesA.ReproductionMethod != speciesB.ReproductionMethod)
         {
             // Anisogamy "upgrade" cost if switching to that
@@ -182,45 +184,48 @@ public class MulticellularSpeciesComparer
             {
                 // If not switching from the base sexual reproduction, then the cost is even higher
                 if (speciesA.ReproductionMethod != MulticellularReproductionMethod.SexualIsogamy)
-                    cost += Constants.MULTICELLULAR_REPRODUCTION_METHOD_CHANGE_COST;
+                    reproductionCost += Constants.MULTICELLULAR_REPRODUCTION_METHOD_CHANGE_COST;
 
-                cost += Constants.MULTICELLULAR_ANISOGAMY_UPGRADE_COST;
+                // TODO: should this cost be *not* capped to the single action cost?
+                reproductionCost += Constants.MULTICELLULAR_ANISOGAMY_UPGRADE_COST;
 
                 // Upgrading doesn't let changing the original gamete cell for free.
                 // If upgrading from random mode, then the gamete A might be missing.
                 if (speciesA.GameteTypeA?.CellTypeName != speciesB.GameteTypeA?.CellTypeName)
-                    cost += Constants.GAMETE_CELL_TYPE_CHANGE_COST;
+                    reproductionCost += Constants.GAMETE_CELL_TYPE_CHANGE_COST;
             }
             else
             {
-                cost += Constants.MULTICELLULAR_REPRODUCTION_METHOD_CHANGE_COST;
+                reproductionCost += Constants.MULTICELLULAR_REPRODUCTION_METHOD_CHANGE_COST;
             }
         }
         else if (speciesA.ReproductionMethod == MulticellularReproductionMethod.Sporulation
                  && speciesA.SporeCellType!.CellTypeName != speciesB.SporeCellType?.CellTypeName)
         {
             // The reproduction method is sporulation (and it wasn't changed), but the spore cell type is different
-            cost += Constants.SPORE_CELL_TYPE_CHANGE_COST;
+            reproductionCost += Constants.SPORE_CELL_TYPE_CHANGE_COST;
         }
         else if (speciesA.ReproductionMethod == MulticellularReproductionMethod.SexualIsogamy
                  && speciesA.GameteTypeA!.CellTypeName != speciesB.GameteTypeA?.CellTypeName)
         {
-            cost += Constants.SPORE_CELL_TYPE_CHANGE_COST;
+            reproductionCost += Constants.SPORE_CELL_TYPE_CHANGE_COST;
         }
         else if (speciesA.ReproductionMethod == MulticellularReproductionMethod.SexualAnisogamy)
         {
             if (speciesA.GameteTypeA!.CellTypeName != speciesB.GameteTypeA?.CellTypeName)
-                cost += Constants.GAMETE_CELL_TYPE_CHANGE_COST;
+                reproductionCost += Constants.GAMETE_CELL_TYPE_CHANGE_COST;
 
             if (speciesA.GameteTypeB!.CellTypeName != speciesB.GameteTypeB?.CellTypeName)
-                cost += Constants.GAMETE_CELL_TYPE_CHANGE_COST;
+                reproductionCost += Constants.GAMETE_CELL_TYPE_CHANGE_COST;
         }
 
         if (speciesB.ReproductionMethod == MulticellularReproductionMethod.MassBudding)
         {
-            cost += MathF.Abs(speciesA.MassBuddingCellCount - speciesB.MassBuddingCellCount)
+            reproductionCost += MathF.Abs(speciesA.MassBuddingCellCount - speciesB.MassBuddingCellCount)
                 * Constants.MASS_BUDDING_CELL_COUNT_CHANGE_COST;
         }
+
+        cost += Math.Min(reproductionCost * costMultiplier, maxSingleActionCost);
 
         oldCells.Clear();
         newCells.Clear();

--- a/src/general/mutation_points/MulticellularSpeciesComparer.cs
+++ b/src/general/mutation_points/MulticellularSpeciesComparer.cs
@@ -186,8 +186,8 @@ public class MulticellularSpeciesComparer
                 if (speciesA.ReproductionMethod != MulticellularReproductionMethod.SexualIsogamy)
                     reproductionCost += Constants.MULTICELLULAR_REPRODUCTION_METHOD_CHANGE_COST;
 
-                // TODO: should this cost be *not* capped to the single action cost?
-                reproductionCost += Constants.MULTICELLULAR_ANISOGAMY_UPGRADE_COST;
+                // Note anisogamy upgrade cost is *not* capped to the single action cost!
+                cost += Math.Min(Constants.MULTICELLULAR_ANISOGAMY_UPGRADE_COST * costMultiplier, maxSingleActionCost);
 
                 // Upgrading doesn't let changing the original gamete cell for free.
                 // If upgrading from random mode, then the gamete A might be missing.

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
@@ -468,8 +468,9 @@ public partial class CellBodyPlanEditorComponent
             sexualAnisogamyUpgradeButton.Visible = true;
             sexualAnisogamyUpgradeButton.Text =
                 Localization.Translate("SEXUAL_REPRODUCTION_UPGRADE_ANISOGAMY")
-                    .FormatSafe(Math.Round(Constants.MULTICELLULAR_ANISOGAMY_UPGRADE_COST *
-                        Editor.CurrentGame.GameWorld.WorldSettings.MPMultiplier, 1));
+                    .FormatSafe(Math.Min(Constants.MAX_SINGLE_EDIT_MP_COST, Math.Round(
+                        Constants.MULTICELLULAR_ANISOGAMY_UPGRADE_COST *
+                        Editor.CurrentGame.GameWorld.WorldSettings.MPMultiplier, 1)));
 
             anisogamySettingsContainer.Visible = false;
             gameteSelectionALabel.Text = Localization.Translate("GAMETE_CELL_TYPE");

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
@@ -469,7 +469,7 @@ public partial class CellBodyPlanEditorComponent
             sexualAnisogamyUpgradeButton.Text =
                 Localization.Translate("SEXUAL_REPRODUCTION_UPGRADE_ANISOGAMY")
                     .FormatSafe(Math.Round(Constants.MULTICELLULAR_ANISOGAMY_UPGRADE_COST *
-                        Editor.CurrentGame.GameWorld.WorldSettings.MPMultiplier));
+                        Editor.CurrentGame.GameWorld.WorldSettings.MPMultiplier, 1));
 
             anisogamySettingsContainer.Visible = false;
             gameteSelectionALabel.Text = Localization.Translate("GAMETE_CELL_TYPE");


### PR DESCRIPTION
**Brief Description of What This PR Does**

as it for some reason wasn't included in that. All reproduction-related changes are combined into one and limited then to max single action cost to ensure that high cost doesn't block from swapping to a reproduction mode and then selecting a cell type.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

Anisogamy upgrade cost MP display not matching its actual cost

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
