### PR TITLE
Fix multicellular NPC root cell organelle reset

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -643,6 +643,24 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
         OnFinishLoading();
     }
 
+    internal static void ConvertMicrobeToMulticellular(Entity microbe, MulticellularSpecies multicellularSpecies,
+        CellType rootCellType, ResolvedMicrobeTolerances resolvedTolerances, float totalSpecializationBonus,
+        IWorldSimulation worldSimulation, List<Hex> workData1, List<Hex> workData2)
+    {
+        // Direct component setting is safe as the caller only invokes this outside a simulation update
+        microbe.Remove<MicrobeSpeciesMember>();
+        microbe.Set(new SpeciesMember(multicellularSpecies));
+        microbe.Add(new MulticellularSpeciesMember(multicellularSpecies, rootCellType, 0));
+        microbe.Add(new MulticellularGrowth(multicellularSpecies));
+
+        ref var environmentalEffects = ref microbe.Get<MicrobeEnvironmentalEffects>();
+        environmentalEffects.ApplyEffects(resolvedTolerances, totalSpecializationBonus, ref microbe.Get<BioProcesses>());
+
+        ref var cellProperties = ref microbe.Get<CellProperties>();
+        cellProperties.ReApplyCellTypeProperties(ref environmentalEffects, microbe, rootCellType,
+            multicellularSpecies, totalSpecializationBonus, worldSimulation, workData1, workData2);
+    }
+
     public override void StartNewGame()
     {
         CurrentGame = GameProperties.StartNewMicrobeGame(new WorldGenerationSettings());
@@ -1019,15 +1037,18 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
         bool playerHandled = false;
 
         var multicellularSpecies = GameWorld.ChangeSpeciesToMulticellular(previousSpecies, true);
+        var rootCellType = multicellularSpecies.ColonyRootCellType();
+        var resolvedTolerances = MicrobeEnvironmentalToleranceCalculations.ResolveToleranceValues(
+            MicrobeEnvironmentalToleranceCalculations.CalculateTolerances(multicellularSpecies, CurrentBiome));
+        var totalSpecializationBonus = rootCellType.CellTypeSpecializationBonus *
+            multicellularSpecies.GetAdjacencySpecializationBonus(0);
+        var workData1 = new List<Hex>();
+        var workData2 = new List<Hex>();
+
         foreach (var microbe in playerSpeciesMicrobes)
         {
-            // Direct component setting is safe as we verified above we aren't running during a simulation update
-            microbe.Remove<MicrobeSpeciesMember>();
-            microbe.Set(new SpeciesMember(multicellularSpecies));
-            microbe.Add(new MulticellularSpeciesMember(multicellularSpecies,
-                multicellularSpecies.ModifiableCellTypes[0], 0));
-
-            microbe.Add(new MulticellularGrowth(multicellularSpecies));
+            ConvertMicrobeToMulticellular(microbe, multicellularSpecies, rootCellType, resolvedTolerances,
+                totalSpecializationBonus, WorldSimulation, workData1, workData2);
 
             if (microbe.Has<PlayerMarker>())
                 playerHandled = true;

--- a/test/multicellular_stage.tests/MulticellularSpeciesTests.cs
+++ b/test/multicellular_stage.tests/MulticellularSpeciesTests.cs
@@ -1,6 +1,11 @@
 ﻿using System.Collections.Generic;
+using Arch.Core;
+using Arch.Core.Extensions;
+using Components;
 using GdUnit4;
+using Godot;
 using static GdUnit4.Assertions;
+using Test.Utils;
 
 [TestSuite]
 [RequireGodotRuntime]
@@ -46,5 +51,69 @@ public class MulticellularSpeciesTests
         AssertThat(clonedGameplayCellType).IsSame(clonedCellType);
         AssertThat(clonedEditorCellType).IsNotNull().IsSame(clonedCellType);
         AssertThat(cloned.ModifiableSporeCellType).IsSame(clonedCellType);
+    }
+
+    [TestCase]
+    public void TestMicrobeConversionUsesColonyRootCellType()
+    {
+        using var worldSimulation = new TestWorldSimulation();
+        var spawnEnvironment = new DummyMicrobeSpawnEnvironment();
+        var parameters = SimulationParameters.Instance;
+        var workData1 = new List<Hex>();
+        var workData2 = new List<Hex>();
+
+        var microbeSpecies = new MicrobeSpecies(1, "Test", "microbe")
+        {
+            MembraneType = parameters.GetMembrane("single"),
+            Colour = new Color(1, 1, 1),
+        };
+        microbeSpecies.Organelles.AddFast(
+            new OrganelleTemplate(parameters.GetOrganelleType("nucleus"), new Hex(0, 0), 0), workData1, workData2);
+        microbeSpecies.Organelles.AddFast(
+            new OrganelleTemplate(parameters.GetOrganelleType("cytoplasm"), new Hex(3, 0), 0), workData1, workData2);
+        microbeSpecies.Organelles.AddFast(
+            new OrganelleTemplate(parameters.GetOrganelleType("cytoplasm"), new Hex(4, 0), 0), workData1, workData2);
+        microbeSpecies.OnEdited();
+
+        var multicellularSpecies = new MulticellularSpecies(1, "Test", "multicellular");
+        var rootCellType = new CellType(parameters.GetMembrane("single"));
+        rootCellType.ModifiableOrganelles.Add(
+            new OrganelleTemplate(parameters.GetOrganelleType("nucleus"), new Hex(0, 0), 0));
+        multicellularSpecies.ModifiableCellTypes.Add(rootCellType);
+        multicellularSpecies.ModifiableGameplayCells.AddFast(new CellTemplate(rootCellType, new Hex(0, 0), 0),
+            workData1, workData2);
+        multicellularSpecies.OnEdited();
+
+        SpawnHelpers.SpawnMicrobe(worldSimulation, spawnEnvironment, microbeSpecies, Vector3.Zero, false,
+            GameteType.All);
+        worldSimulation.ProcessAll(0.1f);
+
+        var microbe =
+            new FirstEntityGrabber(new QueryDescription().WithAll<PlayerMarker>(), worldSimulation.EntitySystem).Found;
+        ref var organelles = ref microbe.Get<OrganelleContainer>();
+        organelles.AllOrganellesDivided = true;
+
+        AssertThat(organelles.Organelles).IsNotNull();
+        AssertThat(organelles.Organelles!.Count).IsEqual(3);
+
+        var totalSpecializationBonus = rootCellType.CellTypeSpecializationBonus *
+            multicellularSpecies.GetAdjacencySpecializationBonus(0);
+        var resolvedTolerances = new ResolvedMicrobeTolerances
+        {
+            ProcessSpeedModifier = 1,
+            OsmoregulationModifier = 1,
+            HealthModifier = 1,
+        };
+
+        MicrobeStage.ConvertMicrobeToMulticellular(microbe, multicellularSpecies, rootCellType, resolvedTolerances,
+            totalSpecializationBonus, worldSimulation, workData1, workData2);
+
+        AssertThat(microbe.Has<MicrobeSpeciesMember>()).IsFalse();
+        AssertThat(microbe.Get<MulticellularSpeciesMember>().MulticellularCellType).IsSame(rootCellType);
+
+        ref var convertedOrganelles = ref microbe.Get<OrganelleContainer>();
+        AssertThat(convertedOrganelles.Organelles!.Count).IsEqual(rootCellType.ModifiableOrganelles.Count);
+        AssertThat(convertedOrganelles.AllOrganellesDivided).IsFalse();
+        AssertThat(microbe.Get<MulticellularGrowth>().NextBodyPlanCellToGrowIndex).IsEqual(1);
     }
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

I reset converted player-species microbes to the colony root cell type. Previously, NPC cells could keep a pre-multicellular organelle layout and reproduction state; now their root layout is rebuilt during the stage conversion.

**Related Issues**

Fixes #7125

**Verification**

- Added regression coverage for a former microbe-stage cell with a stale organelle layout and division state.

**Progress Checklist**

- [ ] PR author has checked that this PR works as intended and does not break existing features.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person
- [ ] Final code review is passed and code conforms to the style guide.
