### PR TITLE
Added sent signalling command to entity debug labels

### DIFF
--- a/src/engine/DebugOverlays.EntityLabel.cs
+++ b/src/engine/DebugOverlays.EntityLabel.cs
@@ -10,6 +10,8 @@ using Godot;
 /// </summary>
 public partial class DebugOverlays
 {
+    private const float TextUpdateInterval = 0.2f;
+
     private readonly Dictionary<Entity, Label> entityLabels = new();
 
     private readonly HashSet<Entity> seenEntities = new();
@@ -39,6 +41,8 @@ public partial class DebugOverlays
     private IWorldSimulation? labelsActiveForSimulation;
 
     private bool showEntityLabels;
+
+    private double textUpdateTimer;
 
     private bool ShowEntityLabels
     {
@@ -190,13 +194,16 @@ public partial class DebugOverlays
         return true;
     }
 
-    private void UpdateEntityLabels()
+    private void UpdateEntityLabels(double delta)
     {
         if (!IsInstanceValid(activeCamera) || activeCamera is not { Current: true })
             activeCamera = GetViewport().GetCamera3D();
 
         if (activeCamera == null)
             return;
+
+        textUpdateTimer -= delta;
+        var updateText = textUpdateTimer <= 0;
 
         foreach (var pair in entityLabels)
         {
@@ -219,11 +226,17 @@ public partial class DebugOverlays
 
             label.Position = activeCamera.UnprojectPosition(position.Position);
 
-            var text = FormatEntityDebugLabel(entity);
+            if (updateText)
+            {
+                var newText = FormatEntityDebugLabel(entity);
 
-            if (label.Text != text)
-                label.Text = text;
+                if (label.Text != newText)
+                    label.Text = newText;
+            }
         }
+
+        if (updateText)
+            textUpdateTimer = TextUpdateInterval;
     }
 
     private void OnEntityAdded(Entity entity)
@@ -231,6 +244,7 @@ public partial class DebugOverlays
         var label = new Label();
         labelsLayer.AddChild(label);
         entityLabels.Add(entity, label);
+        label.Text = FormatEntityDebugLabel(entity);
 
         // This used to check for floating chunk, but now this just has to do with by checking a couple of components
         // that all chunks have at least one of. Projectile is still easy to check with the toxin damage source.

--- a/src/engine/DebugOverlays.EntityLabel.cs
+++ b/src/engine/DebugOverlays.EntityLabel.cs
@@ -50,6 +50,50 @@ public partial class DebugOverlays
         }
     }
 
+    public static string FormatEntityDebugLabel(Entity entity)
+    {
+        if (!entity.IsAliveAndNotNull())
+            return $"[{entity.Id}-{entity.Version}]";
+
+        // TODO: chunks used to have their label be $"[{entity}:{chunk.ChunkName}]".
+        // Chunk configuration is not currently saved so the chunk name is not really available.
+        string text;
+
+        if (entity.Has<SpeciesMember>())
+        {
+            var species = entity.Get<SpeciesMember>().Species;
+
+            text = $"[{entity.Id}-{entity.Version}:{species.Genus.Left(1)}.{species.Epithet.Left(4)}]";
+        }
+        else if (entity.Has<ReadableName>())
+        {
+            // TODO: localization support? Should all labels be re-initialized on language change?
+
+            // TODO: some entities would probably be fine with not displaying the entity reference before the
+            // readable name
+            text = $"[{entity.Id}-{entity.Version}:{entity.Get<ReadableName>().Name}]";
+        }
+        else
+        {
+            // Fallback to just showing the raw entity reference, nothing else can be shown
+            text = $"[{entity.Id}-{entity.Version}]";
+        }
+
+        // Showing signalling agent state for debugging AI
+        if (entity.Has<CommandSignaler>())
+        {
+            ref var signaler = ref entity.Get<CommandSignaler>();
+
+            if (signaler.Command != MicrobeSignalCommand.None)
+            {
+                // This is on a new line as otherwise things would be a bit long
+                text += $"\n{signaler.Command}";
+            }
+        }
+
+        return text;
+    }
+
     public void UpdateActiveEntities(IWorldSimulation worldSimulation)
     {
         if (!ShowEntityLabels)
@@ -175,33 +219,10 @@ public partial class DebugOverlays
 
             label.Position = activeCamera.UnprojectPosition(position.Position);
 
-            if (label.Text.Length > 0)
-                continue;
+            var text = FormatEntityDebugLabel(entity);
 
-            // Update names
-
-            // TODO: chunks used to have their label be $"[{entity}:{chunk.ChunkName}]"
-            // Chunk configuration is not currently saved so the chunk name is not really
-            if (entity.Has<SpeciesMember>())
-            {
-                var species = entity.Get<SpeciesMember>().Species;
-
-                label.Text = $"[{entity.Id}-{entity.Version}:{species.Genus.Left(1)}.{species.Epithet.Left(4)}]";
-                continue;
-            }
-
-            if (entity.Has<ReadableName>())
-            {
-                // TODO: localization support? Should all labels be re-initialized on language change?
-
-                // TODO: some entities would probably be fine with not displaying the entity reference before the
-                // readable name
-                label.Text = $"[{entity.Id}-{entity.Version}:{entity.Get<ReadableName>().Name}]";
-                continue;
-            }
-
-            // Fallback to just showing the raw entity reference, nothing else can be shown
-            label.Text = $"[{entity.Id}-{entity.Version}]";
+            if (label.Text != text)
+                label.Text = text;
         }
     }
 

--- a/src/engine/DebugOverlays.cs
+++ b/src/engine/DebugOverlays.cs
@@ -77,7 +77,7 @@ public partial class DebugOverlays : Control
 
         // Entity label
         if (showEntityLabels)
-            UpdateEntityLabels();
+            UpdateEntityLabels(delta);
 
         // Performance metrics
         if (performanceMetrics.Visible)

--- a/test/engine.tests/EntityLabelTests.cs
+++ b/test/engine.tests/EntityLabelTests.cs
@@ -1,0 +1,85 @@
+﻿using Arch.Core.Extensions;
+using Components;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+/// <summary>
+///   Verifies that entity labels are formatted correctly based on entity data.
+/// </summary>
+[TestSuite]
+[RequireGodotRuntime]
+public class EntityLabelTests
+{
+    [TestCase]
+    public void EntityLabel_RawEntityFormat()
+    {
+        using var world = ThriveWorld.Create();
+        var entity = world.Create();
+
+        AssertThat(DebugOverlays.FormatEntityDebugLabel(entity)).IsEqual($"[{entity.Id}-{entity.Version}]");
+    }
+
+    [TestCase]
+    public void EntityLabel_ReadableNameFormat()
+    {
+        using var world = ThriveWorld.Create();
+
+        // We don't want translation extraction to find this, so we have a separate string
+        const string testName = "TestEntity";
+
+        var entity = world.Create(new ReadableName(new LocalizedString(testName)));
+
+        AssertThat(DebugOverlays.FormatEntityDebugLabel(entity))
+            .IsEqual($"[{entity.Id}-{entity.Version}:{testName}]");
+    }
+
+    [TestCase]
+    public void EntityLabel_SpeciesMemberFormat()
+    {
+        using var world = ThriveWorld.Create();
+        var species = new MicrobeSpecies(1, "Organism", "prima");
+        var entity = world.Create(new SpeciesMember(species));
+
+        AssertThat(DebugOverlays.FormatEntityDebugLabel(entity)).IsEqual($"[{entity.Id}-{entity.Version}:O.prim]");
+    }
+
+    [TestCase]
+    public void EntityLabel_MicrobeSignalNoneNotAppended()
+    {
+        using var world = ThriveWorld.Create();
+        var species = new MicrobeSpecies(1, "Organism", "prima");
+        var entity = world.Create(new SpeciesMember(species),
+            new CommandSignaler
+            {
+                Command = MicrobeSignalCommand.None,
+            });
+
+        AssertThat(DebugOverlays.FormatEntityDebugLabel(entity)).IsEqual($"[{entity.Id}-{entity.Version}:O.prim]");
+    }
+
+    [TestCase]
+    public void EntityLabel_MicrobeSignalAppendedWhenNotNone()
+    {
+        using var world = ThriveWorld.Create();
+        var species = new MicrobeSpecies(1, "Organism", "prima");
+        var entity = world.Create(new SpeciesMember(species),
+            new CommandSignaler
+            {
+                Command = MicrobeSignalCommand.CallMate,
+            });
+
+        AssertThat(DebugOverlays.FormatEntityDebugLabel(entity))
+            .IsEqual($"[{entity.Id}-{entity.Version}:O.prim]\nCallMate");
+
+        ref var signaler = ref entity.Get<CommandSignaler>();
+        signaler.Command = MicrobeSignalCommand.MoveToMe;
+
+        AssertThat(DebugOverlays.FormatEntityDebugLabel(entity))
+            .IsEqual($"[{entity.Id}-{entity.Version}:O.prim]\nMoveToMe");
+
+        signaler.Command = MicrobeSignalCommand.None;
+
+        AssertThat(DebugOverlays.FormatEntityDebugLabel(entity))
+            .IsEqual($"[{entity.Id}-{entity.Version}:O.prim]");
+    }
+}

--- a/test/engine.tests/EntityLabelTests.cs.uid
+++ b/test/engine.tests/EntityLabelTests.cs.uid
@@ -1,0 +1,1 @@
+uid://cb7fq1d1kt6pe


### PR DESCRIPTION
for easier AI debugging related to commands

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved debug entity labels with clearer readable names, species details, and raw-reference fallbacks.
  - Labels now show relevant microbe command signals while omitting empty signal states.
  - Debug labels refresh automatically when entity details or signal states change.

- **Bug Fixes**
  - Corrected label handling for dead entities and changing entity information.

- **Tests**
  - Added coverage for entity naming, species labels, signal display, and label updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->