### PR TITLE
Make Actomyosin not an externalOrganelle

### DIFF
--- a/simulation_parameters/microbe_stage/organelles.json
+++ b/simulation_parameters/microbe_stage/organelles.json
@@ -1492,7 +1492,6 @@
       "ModelPath": "Armature/Skeleton3D/Actomyosin",
       "AnimationPlayerPath": "AnimationPlayer"
     },
-    "PositionedExternally": true,
     "Name": "ACTOMYOSIN",
     "Description": "ACTOMYOSIN_DESCRIPTION",
     "ProcessesDescription": "ACTOMYOSIN_PROCESSES_DESCRIPTION",


### PR DESCRIPTION
**Brief Description of What This PR Does**

Removed the json trigger that makes Actomyosin be placed externally.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the actomyosin organelle’s positioning behavior in microbe-stage simulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->