### PR TITLE
Skip species over 25 cells entirely for generating mutations

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1489,6 +1489,7 @@ public static class Constants
     public const float AUTO_EVO_SIGNALLING_BONUS = 1.4f;
 
     public const int AUTO_EVO_MAX_CELL_COUNT = 20;
+    public const int AUTO_EVO_CUTOFF_CELL_COUNT = 25;
 
     public const int AI_FOLLOW_PLAYER_MIGRATION_TO_EMPTY_PATCH_THRESHOLD = 2;
 

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -357,7 +357,7 @@ public class ModifyExistingSpecies : IRunStep
     private void GetMutationsForSpecies(Species species, int speciesInPatch)
     {
         // We avoid auto-evo taking forever by skipping any (probably player) species that has far too many cells
-        if (species is MulticellularSpecies { EditorCells.Count: > Constants.AUTO_EVO_CUTOFF_CELL_COUNT })
+        if (species is MulticellularSpecies { GameplayCells.Count: > Constants.AUTO_EVO_CUTOFF_CELL_COUNT })
             return;
 
         double totalMP = Constants.BASE_MUTATION_POINTS * worldSettings.AIMutationMultiplier;

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -356,6 +356,10 @@ public class ModifyExistingSpecies : IRunStep
 
     private void GetMutationsForSpecies(Species species, int speciesInPatch)
     {
+        // We avoid auto-evo taking forever by skipping any (probably player) species that has far too many cells
+        if (species is MulticellularSpecies { EditorCells.Count: > Constants.AUTO_EVO_CUTOFF_CELL_COUNT })
+            return;
+
         double totalMP = Constants.BASE_MUTATION_POINTS * worldSettings.AIMutationMultiplier;
 
         generateMutationsWorkingMemory.Clear();


### PR DESCRIPTION
**Brief Description of What This PR Does**

Make auto-evo skip any Multicellular species of over 25 cells for generating mutations. This prevents an extreme amount of cloning calculations.

**Related Issues**

Player designs with an extreme number of cells make auto-evo work seemingly forever.

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-evolution now uses a species’ current cell count when skipping mutation generation for multicellular species exceeding the 25-cell limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->