### PR TITLE
fix-auto-evo-macrospecies

### DIFF
--- a/src/auto-evo/AutoEvoRun.cs
+++ b/src/auto-evo/AutoEvoRun.cs
@@ -428,6 +428,9 @@ public class AutoEvoRun
 
         foreach (var species in allSpecies)
         {
+            if (species is not MicrobeSpecies and not MulticellularSpecies)
+                continue;
+
             steps.Enqueue(new MigrateSpecies(species, map, worldSettings, new SimulationCache(worldSettings), random));
         }
 

--- a/src/auto-evo/Miche.cs
+++ b/src/auto-evo/Miche.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Godot;
@@ -192,6 +191,12 @@ public class Miche : IArchivable
     /// <summary>
     ///   Inserts a species into any spots on the tree where the species is a better fit than any current occupants
     /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     Top-level calls currently accept only <see cref="MicrobeSpecies"/> and
+    ///     <see cref="MulticellularSpecies"/>. Recursive calls reuse the species validated by the top-level call.
+    ///   </para>
+    /// </remarks>
     /// <param name="species">Species to try to insert</param>
     /// <param name="patch">Patch this miche is in for calculating scores</param>
     /// <param name="scoresSoFar">
@@ -204,14 +209,19 @@ public class Miche : IArchivable
     /// <returns>
     ///   Returns a bool based on if the species was inserted into a leaf node
     /// </returns>
+    /// <exception cref="ArgumentException">Thrown when a top-level call receives a non-cellular species</exception>
     public bool InsertSpecies(Species species, Patch patch, Dictionary<Species, float>? scoresSoFar,
         SimulationCache cache, bool dry, InsertWorkingMemory workingMemory, int depth = 0)
     {
         if (Readonly && !dry)
             throw new InvalidOperationException("This miche tree is readonly and cannot be modified");
 
-        if (depth == 0 && !IsSpeciesSupported(species))
-            return false;
+        if (depth == 0 && species is not MicrobeSpecies and not MulticellularSpecies)
+        {
+            throw new ArgumentException(
+                $"Species type {species.GetType().Name} is incompatible with cellular miche insertion",
+                nameof(species));
+        }
 
         var myScore = Pressure.Score(species, patch, cache);
 
@@ -360,11 +370,6 @@ public class Miche : IArchivable
         // TODO: as Occupant can change it should not be used as part of the hash code
         return Pressure.GetHashCode() * 131 ^ parentHash * 587 ^
             (Occupant == null ? 17 : Occupant.GetHashCode()) * 5171;
-    }
-
-    internal static bool IsSpeciesSupported([NotNullWhen(true)] Species? species)
-    {
-        return species is MicrobeSpecies or MulticellularSpecies;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/auto-evo/Miche.cs
+++ b/src/auto-evo/Miche.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Godot;
@@ -209,6 +210,9 @@ public class Miche : IArchivable
         if (Readonly && !dry)
             throw new InvalidOperationException("This miche tree is readonly and cannot be modified");
 
+        if (depth == 0 && !IsSpeciesSupported(species))
+            return false;
+
         var myScore = Pressure.Score(species, patch, cache);
 
         // Prune branch if species fails any pressures
@@ -356,6 +360,11 @@ public class Miche : IArchivable
         // TODO: as Occupant can change it should not be used as part of the hash code
         return Pressure.GetHashCode() * 131 ^ parentHash * 587 ^
             (Occupant == null ? 17 : Occupant.GetHashCode()) * 5171;
+    }
+
+    internal static bool IsSpeciesSupported([NotNullWhen(true)] Species? species)
+    {
+        return species is MicrobeSpecies or MulticellularSpecies;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/auto-evo/selection_pressure/GeneralAvoidPredationSelectionPressure.cs
+++ b/src/auto-evo/selection_pressure/GeneralAvoidPredationSelectionPressure.cs
@@ -83,6 +83,9 @@ public class GeneralAvoidPredationSelectionPressure : SelectionPressure
                 continue;
             }
 
+            if (!Miche.IsSpeciesSupported(predator.Key))
+                continue;
+
             var predationScore = cache.GetPredationScore(predator.Key, species, patch.Biome);
 
             if (predationScore <= 1)

--- a/src/auto-evo/selection_pressure/GeneralAvoidPredationSelectionPressure.cs
+++ b/src/auto-evo/selection_pressure/GeneralAvoidPredationSelectionPressure.cs
@@ -1,5 +1,6 @@
 ﻿namespace AutoEvo;
 
+using System;
 using SharedBase.Archive;
 
 public class GeneralAvoidPredationSelectionPressure : SelectionPressure
@@ -73,6 +74,13 @@ public class GeneralAvoidPredationSelectionPressure : SelectionPressure
 
     public override float Score(Species species, Patch patch, SimulationCache cache)
     {
+        if (species is not MicrobeSpecies and not MulticellularSpecies)
+        {
+            throw new ArgumentException(
+                $"Species type {species.GetType().Name} is incompatible with cellular predation scoring",
+                nameof(species));
+        }
+
         var score = 1.0f;
         foreach (var predator in patch.SpeciesInPatch)
         {
@@ -83,7 +91,8 @@ public class GeneralAvoidPredationSelectionPressure : SelectionPressure
                 continue;
             }
 
-            if (!Miche.IsSpeciesSupported(predator.Key))
+            // Predators come from the complete patch species collection, not filtered Miche occupants.
+            if (predator.Key is not MicrobeSpecies and not MulticellularSpecies)
                 continue;
 
             var predationScore = cache.GetPredationScore(predator.Key, species, patch.Biome);

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -259,7 +259,7 @@ public static class MichePopulation
             node.BackTraversal(currentBackTraversal);
             foreach (var currentSpecies in species)
             {
-                if (currentSpecies is not MicrobeSpecies and not MulticellularSpecies)
+                if (!Miche.IsSpeciesSupported(currentSpecies))
                     continue;
 
                 var occupantSpecies = node.Occupant;
@@ -278,7 +278,7 @@ public static class MichePopulation
 
                     var occupantScore = 0.0f;
 
-                    if (occupantSpecies is MicrobeSpecies or MulticellularSpecies)
+                    if (Miche.IsSpeciesSupported(occupantSpecies))
                     {
                         occupantScore =
                             cache.GetPressureScore(currentMiche.Pressure, patch, occupantSpecies);
@@ -326,7 +326,7 @@ public static class MichePopulation
 
         foreach (var currentSpecies in species)
         {
-            if (currentSpecies is not MicrobeSpecies and not MulticellularSpecies)
+            if (!Miche.IsSpeciesSupported(currentSpecies))
             {
                 var population = simulationConfiguration.Results.GetPopulationInPatch(currentSpecies, patch);
                 populations.AddPopulationResultForSpecies(currentSpecies, patch, population);

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -257,12 +257,20 @@ public static class MichePopulation
 
             currentBackTraversal.Clear();
             node.BackTraversal(currentBackTraversal);
+
+            var occupantSpecies = node.Occupant;
+
+            if (occupantSpecies is not null and not MicrobeSpecies and not MulticellularSpecies)
+            {
+                throw new InvalidOperationException(
+                    $"Miche occupant type {occupantSpecies.GetType().Name} is incompatible with cellular population " +
+                    "scoring");
+            }
+
             foreach (var currentSpecies in species)
             {
-                if (!Miche.IsSpeciesSupported(currentSpecies))
+                if (currentSpecies is not MicrobeSpecies and not MulticellularSpecies)
                     continue;
-
-                var occupantSpecies = node.Occupant;
 
                 var traversalScore = 0.0f;
 
@@ -278,7 +286,7 @@ public static class MichePopulation
 
                     var occupantScore = 0.0f;
 
-                    if (Miche.IsSpeciesSupported(occupantSpecies))
+                    if (occupantSpecies != null)
                     {
                         occupantScore =
                             cache.GetPressureScore(currentMiche.Pressure, patch, occupantSpecies);
@@ -326,7 +334,7 @@ public static class MichePopulation
 
         foreach (var currentSpecies in species)
         {
-            if (!Miche.IsSpeciesSupported(currentSpecies))
+            if (currentSpecies is not MicrobeSpecies and not MulticellularSpecies)
             {
                 var population = simulationConfiguration.Results.GetPopulationInPatch(currentSpecies, patch);
                 populations.AddPopulationResultForSpecies(currentSpecies, patch, population);

--- a/src/auto-evo/steps/GenerateMiche.cs
+++ b/src/auto-evo/steps/GenerateMiche.cs
@@ -169,10 +169,16 @@ public class GenerateMiche : IRunStep
 
         var predationRoot = new Miche(globalCache.PredatorRoot);
         var predationGlucose = new Miche(globalCache.MinorGlucoseConversionEfficiencyPressure);
+        var supportedSpeciesCount = 0;
 
         // Per Target-Species Miches
         foreach (var targetSpecies in patch.SpeciesInPatch)
         {
+            if (!Miche.IsSpeciesSupported(targetSpecies.Key))
+                continue;
+
+            ++supportedSpeciesCount;
+
             // Predation Miches
             predationGlucose.AddChild(new Miche(new PredationEffectivenessPressure(targetSpecies.Key, 8.0f)));
 
@@ -185,7 +191,7 @@ public class GenerateMiche : IRunStep
             }
         }
 
-        if (patch.SpeciesInPatch.Count > 1)
+        if (supportedSpeciesCount > 1)
             predationRoot.AddChild(predationGlucose);
 
         generatedMiche.AddChild(predationRoot);

--- a/src/auto-evo/steps/GenerateMiche.cs
+++ b/src/auto-evo/steps/GenerateMiche.cs
@@ -174,7 +174,7 @@ public class GenerateMiche : IRunStep
         // Per Target-Species Miches
         foreach (var targetSpecies in patch.SpeciesInPatch)
         {
-            if (!Miche.IsSpeciesSupported(targetSpecies.Key))
+            if (targetSpecies.Key is not MicrobeSpecies and not MulticellularSpecies)
                 continue;
 
             ++supportedSpeciesCount;
@@ -209,6 +209,9 @@ public class GenerateMiche : IRunStep
 
         foreach (var species in patch.SpeciesInPatch.Keys)
         {
+            if (species is not MicrobeSpecies and not MulticellularSpecies)
+                continue;
+
             miche.InsertSpecies(species, patch, null, cache, false, insertWorkMemory);
         }
 

--- a/test/auto_evo.tests/MacroscopicSpeciesCompatibilityTests.cs
+++ b/test/auto_evo.tests/MacroscopicSpeciesCompatibilityTests.cs
@@ -1,0 +1,282 @@
+﻿using System.Collections.Generic;
+using AutoEvo;
+using GdUnit4;
+using SharedBase.Archive;
+using Xoshiro.PRNG64;
+using static GdUnit4.Assertions;
+
+[TestSuite]
+[RequireGodotRuntime]
+public class MacroscopicSpeciesCompatibilityTests
+{
+    private const long WorldSeed = 0x5EED;
+    private const long TestPopulation = 100;
+
+    [TestCase]
+    public void MicheInsert_MacroscopicSpeciesReturnsFalseBeforeScoring()
+    {
+        var fixture = CreateSpeciesFixture();
+        var cache = new SimulationCache(fixture.WorldSettings);
+        var pressure = new RecordingSelectionPressure();
+        var originalOccupant = fixture.Microbe;
+        var miche = new Miche(pressure)
+        {
+            Occupant = originalOccupant,
+        };
+
+        var inserted = miche.InsertSpecies(fixture.Macroscopic, fixture.Patch, null, cache, false,
+            new Miche.InsertWorkingMemory());
+
+        AssertThat(pressure.ScoreCalls).IsEqual(0);
+        AssertThat(inserted).IsFalse();
+        AssertThat(miche.Occupant).IsSame(originalOccupant);
+
+        AssertSupportedSpeciesReachesScoring(fixture.Microbe, fixture.Patch, cache);
+        AssertSupportedSpeciesReachesScoring(fixture.Multicellular, fixture.Patch, cache);
+    }
+
+    [TestCase]
+    public void GenerateMiche_MacroscopicOnlyPatchSkipsUnsupportedSpecies()
+    {
+        var fixture = CreateSpeciesFixture();
+        var cache = new SimulationCache(fixture.WorldSettings);
+        var results = new RunResults();
+        var generateMiche = new GenerateMiche(fixture.Patch, cache, fixture.World.AutoEvoGlobalCache);
+
+        var completed = generateMiche.RunStep(results);
+
+        var occupants = new HashSet<Species>();
+        results.GetModifiableMicheForPatch(fixture.Patch).GetOccupants(occupants);
+
+        AssertThat(completed).IsTrue();
+        AssertThat(occupants.Contains(fixture.Macroscopic)).IsFalse();
+    }
+
+    [TestCase]
+    public void GenerateMiche_MixedPatchExcludesMacroscopicPredationInputs()
+    {
+        var fixture = CreateSpeciesFixture();
+        fixture.Patch.SpeciesInPatch.Clear();
+        fixture.Patch.AddSpecies(fixture.Microbe, TestPopulation);
+        fixture.Patch.AddSpecies(fixture.Multicellular, TestPopulation);
+        fixture.Patch.AddSpecies(fixture.Macroscopic, TestPopulation);
+
+        var cache = new SimulationCache(fixture.WorldSettings);
+        var generateMiche = new GenerateMiche(fixture.Patch, cache, fixture.World.AutoEvoGlobalCache);
+        var generatedMiche = generateMiche.GenerateMicheTree(fixture.World.AutoEvoGlobalCache);
+        var predationPressures = new List<PredationEffectivenessPressure>();
+        CollectPredationPressures(generatedMiche, predationPressures);
+        var preySpecies = new HashSet<Species>();
+
+        foreach (var pressure in predationPressures)
+            preySpecies.Add(pressure.Prey);
+
+        AssertThat(predationPressures.Count).IsEqual(2);
+        AssertThat(preySpecies.Contains(fixture.Microbe)).IsTrue();
+        AssertThat(preySpecies.Contains(fixture.Multicellular)).IsTrue();
+        AssertThat(preySpecies.Contains(fixture.Macroscopic)).IsFalse();
+
+        var populatedMiche = generateMiche.PopulateMiche(generatedMiche);
+        var occupants = new HashSet<Species>();
+        populatedMiche.GetOccupants(occupants);
+
+        AssertThat(populatedMiche).IsSame(generatedMiche);
+        AssertThat(occupants.Contains(fixture.Macroscopic)).IsFalse();
+
+        var generalAvoidPressure = fixture.World.AutoEvoGlobalCache.GeneralAvoidPredationSelectionPressure;
+        AssertThat(generalAvoidPressure.Score(fixture.Microbe, fixture.Patch, cache) > 0).IsTrue();
+        AssertThat(generalAvoidPressure.Score(fixture.Multicellular, fixture.Patch, cache) > 0).IsTrue();
+    }
+
+    [TestCase]
+    public void GenerateMiche_OneSupportedSpeciesPlusMacroscopicDoesNotCreatePredationBranch()
+    {
+        var fixture = CreateSpeciesFixture();
+        fixture.Patch.SpeciesInPatch.Clear();
+        fixture.Patch.AddSpecies(fixture.Microbe, TestPopulation);
+        fixture.Patch.AddSpecies(fixture.Macroscopic, TestPopulation);
+
+        var cache = new SimulationCache(fixture.WorldSettings);
+        var generateMiche = new GenerateMiche(fixture.Patch, cache, fixture.World.AutoEvoGlobalCache);
+        var generatedMiche = generateMiche.GenerateMicheTree(fixture.World.AutoEvoGlobalCache);
+        var predationPressures = new List<PredationEffectivenessPressure>();
+        CollectPredationPressures(generatedMiche, predationPressures);
+
+        AssertThat(predationPressures.Count).IsEqual(0);
+    }
+
+    [TestCase]
+    public void MichePopulation_MacroscopicPopulationIsPreserved()
+    {
+        var fixture = CreateSpeciesFixture();
+        fixture.Patch.SpeciesInPatch.Clear();
+        fixture.Patch.AddSpecies(fixture.Microbe, TestPopulation);
+        fixture.Patch.AddSpecies(fixture.Macroscopic, TestPopulation);
+
+        var cache = new SimulationCache(fixture.WorldSettings);
+        var results = new RunResults();
+        var generateMiche = new GenerateMiche(fixture.Patch, cache, fixture.World.AutoEvoGlobalCache);
+        AssertThat(generateMiche.RunStep(results)).IsTrue();
+
+        var simulationConfiguration = new SimulationConfiguration(fixture.WorldSettings.AutoEvoConfiguration,
+            fixture.World.Map, fixture.WorldSettings)
+        {
+            Results = results,
+            CollectEnergyInformation = true,
+            PatchesToRun = new HashSet<Patch> { fixture.Patch },
+        };
+
+        MichePopulation.Simulate(simulationConfiguration, cache, new XoShiRo256starstar(WorldSeed));
+
+        AssertThat(results.GetPopulationInPatch(fixture.Macroscopic, fixture.Patch)).IsEqual(TestPopulation);
+
+        var microbeEnergyResults = results.GetPatchEnergyResults(fixture.Microbe);
+        AssertThat(microbeEnergyResults.ContainsKey(fixture.Patch)).IsTrue();
+        AssertThat(microbeEnergyResults[fixture.Patch].IndividualCost > 0).IsTrue();
+    }
+
+    [TestCase]
+    public void AutoEvoRun_AfterMacroscopicConversionCompletesMicheGenerationWithoutAbort()
+    {
+        var microbePlayer = CreateMicrobeSpecies(1, "player");
+        var world = new GameWorld(CreateWorldSettings(), microbePlayer);
+        var multicellularPlayer = world.ChangeSpeciesToMulticellular(microbePlayer, true);
+        var populationsBeforeConversion = new Dictionary<Patch, long>();
+
+        foreach (var patch in world.Map.Patches.Values)
+        {
+            if (patch.SpeciesInPatch.TryGetValue(multicellularPlayer, out var population))
+                populationsBeforeConversion.Add(patch, population);
+        }
+
+        AssertThat(populationsBeforeConversion.Count > 0).IsTrue();
+
+        var macroscopicPlayer = world.ChangeSpeciesToMacroscopic(multicellularPlayer);
+        AssertThat(world.PlayerSpecies).IsSame(macroscopicPlayer);
+
+        foreach (var (patch, population) in populationsBeforeConversion)
+        {
+            AssertThat(patch.SpeciesInPatch.ContainsKey(multicellularPlayer)).IsFalse();
+            AssertThat(patch.SpeciesInPatch.TryGetValue(macroscopicPlayer, out var convertedPopulation)).IsTrue();
+            AssertThat(convertedPopulation).IsEqual(population);
+        }
+
+        var run = new AutoEvoRun(world, world.AutoEvoGlobalCache);
+
+        run.OneStep();
+        AssertThat(run.Aborted).IsFalse();
+
+        for (var i = 0; i < world.Map.Patches.Count; ++i)
+        {
+            run.OneStep();
+            AssertThat(run.Aborted).IsFalse();
+        }
+    }
+
+    private static void AssertSupportedSpeciesReachesScoring(Species species, Patch patch, SimulationCache cache)
+    {
+        var pressure = new RecordingSelectionPressure();
+        var miche = new Miche(pressure);
+
+        var inserted = miche.InsertSpecies(species, patch, null, cache, false, new Miche.InsertWorkingMemory());
+
+        AssertThat(inserted).IsTrue();
+        AssertThat(pressure.ScoreCalls).IsEqual(1);
+        AssertThat(miche.Occupant).IsSame(species);
+    }
+
+    private static SpeciesFixture CreateSpeciesFixture()
+    {
+        var worldSettings = CreateWorldSettings();
+
+        var microbe = CreateMicrobeSpecies(1, "microbe");
+        var world = new GameWorld(worldSettings, microbe);
+        var multicellularSource = world.NewMicrobeSpecies("Test", "multicellular");
+        ConfigureMicrobeSpecies(multicellularSource);
+        var multicellular = world.ChangeSpeciesToMulticellular(multicellularSource, false);
+        var macroscopicSource = world.NewMicrobeSpecies("Test", "macroscopic");
+        ConfigureMicrobeSpecies(macroscopicSource);
+        var macroscopicIntermediate = world.ChangeSpeciesToMulticellular(macroscopicSource, false);
+        var macroscopic = world.ChangeSpeciesToMacroscopic(macroscopicIntermediate);
+        var patch = world.Map.CurrentPatch!;
+
+        patch.SpeciesInPatch.Clear();
+        patch.AddSpecies(macroscopic, TestPopulation);
+
+        return new SpeciesFixture(worldSettings, world, patch, microbe, multicellular, macroscopic);
+    }
+
+    private static WorldGenerationSettings CreateWorldSettings()
+    {
+        return new WorldGenerationSettings
+        {
+            Seed = WorldSeed,
+            WorldSize = WorldGenerationSettings.WorldSizeEnum.Small,
+        };
+    }
+
+    private static MicrobeSpecies CreateMicrobeSpecies(uint id, string epithet)
+    {
+        var microbe = new MicrobeSpecies(id, "Test", epithet);
+        ConfigureMicrobeSpecies(microbe);
+
+        return microbe;
+    }
+
+    private static void ConfigureMicrobeSpecies(MicrobeSpecies microbe)
+    {
+        var simulationParameters = SimulationParameters.Instance;
+        microbe.IsBacteria = false;
+        microbe.MembraneType = simulationParameters.GetMembrane("single");
+
+        microbe.Organelles.Add(new OrganelleTemplate(simulationParameters.GetOrganelleType("nucleus"),
+            new Hex(0, 0), 0));
+        microbe.Organelles.Add(new OrganelleTemplate(simulationParameters.GetOrganelleType("cytoplasm"),
+            new Hex(3, 0), 0));
+        microbe.OnEdited();
+    }
+
+    private static void CollectPredationPressures(Miche miche,
+        ICollection<PredationEffectivenessPressure> pressures)
+    {
+        if (miche.Pressure is PredationEffectivenessPressure predationPressure)
+            pressures.Add(predationPressure);
+
+        foreach (var child in miche.Children)
+        {
+            CollectPredationPressures(child, pressures);
+        }
+    }
+
+    private sealed record SpeciesFixture(WorldGenerationSettings WorldSettings, GameWorld World, Patch Patch,
+        MicrobeSpecies Microbe, MulticellularSpecies Multicellular, MacroscopicSpecies Macroscopic);
+
+    private sealed class RecordingSelectionPressure : SelectionPressure
+    {
+        private static readonly LocalizedString PressureName = new("TEST_RECORDING_SELECTION_PRESSURE");
+
+        public RecordingSelectionPressure() : base(1, [])
+        {
+        }
+
+        public int ScoreCalls { get; private set; }
+
+        public override LocalizedString Name => PressureName;
+
+        public override ushort CurrentArchiveVersion => 1;
+
+        public override ArchiveObjectType ArchiveObjectType =>
+            (ArchiveObjectType)ThriveArchiveObjectType.RootPressure;
+
+        public override float Score(Species species, Patch patch, SimulationCache cache)
+        {
+            ++ScoreCalls;
+            return 1;
+        }
+
+        public override float GetEnergy(Patch patch)
+        {
+            return 0;
+        }
+    }
+}

--- a/test/auto_evo.tests/MacroscopicSpeciesCompatibilityTests.cs
+++ b/test/auto_evo.tests/MacroscopicSpeciesCompatibilityTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using AutoEvo;
 using GdUnit4;
 using SharedBase.Archive;
@@ -13,7 +14,7 @@ public class MacroscopicSpeciesCompatibilityTests
     private const long TestPopulation = 100;
 
     [TestCase]
-    public void MicheInsert_MacroscopicSpeciesReturnsFalseBeforeScoring()
+    public void MicheInsert_MacroscopicSpeciesThrowsBeforeScoring()
     {
         var fixture = CreateSpeciesFixture();
         var cache = new SimulationCache(fixture.WorldSettings);
@@ -24,15 +25,39 @@ public class MacroscopicSpeciesCompatibilityTests
             Occupant = originalOccupant,
         };
 
-        var inserted = miche.InsertSpecies(fixture.Macroscopic, fixture.Patch, null, cache, false,
-            new Miche.InsertWorkingMemory());
+        AssertThrown(() => miche.InsertSpecies(fixture.Macroscopic, fixture.Patch, null, cache, false,
+                new Miche.InsertWorkingMemory()))
+            .IsInstanceOf<ArgumentException>()
+            .HasPropertyValue(nameof(ArgumentException.ParamName), "species")
+            .StartsWithMessage("Species type MacroscopicSpecies");
 
         AssertThat(pressure.ScoreCalls).IsEqual(0);
-        AssertThat(inserted).IsFalse();
         AssertThat(miche.Occupant).IsSame(originalOccupant);
 
         AssertSupportedSpeciesReachesScoring(fixture.Microbe, fixture.Patch, cache);
         AssertSupportedSpeciesReachesScoring(fixture.Multicellular, fixture.Patch, cache);
+    }
+
+    [TestCase]
+    public void AutoEvoRun_GatherInfoSchedulesOnlyCellularMigrations()
+    {
+        var fixture = CreateSpeciesFixture();
+        fixture.Patch.SpeciesInPatch.Clear();
+        fixture.Patch.AddSpecies(fixture.Microbe, TestPopulation);
+        fixture.Patch.AddSpecies(fixture.Multicellular, TestPopulation);
+        fixture.Patch.AddSpecies(fixture.Macroscopic, TestPopulation);
+
+        var run = new GatherInfoAutoEvoRun(fixture.World);
+        var steps = run.GatherSteps();
+        var migrationStepCount = 0;
+
+        foreach (var step in steps)
+        {
+            if (step is MigrateSpecies)
+                ++migrationStepCount;
+        }
+
+        AssertThat(migrationStepCount).IsEqual(2);
     }
 
     [TestCase]
@@ -59,9 +84,15 @@ public class MacroscopicSpeciesCompatibilityTests
         fixture.Patch.SpeciesInPatch.Clear();
         fixture.Patch.AddSpecies(fixture.Microbe, TestPopulation);
         fixture.Patch.AddSpecies(fixture.Multicellular, TestPopulation);
-        fixture.Patch.AddSpecies(fixture.Macroscopic, TestPopulation);
 
         var cache = new SimulationCache(fixture.WorldSettings);
+        var generalAvoidPressure = fixture.World.AutoEvoGlobalCache.GeneralAvoidPredationSelectionPressure;
+        var microbeScoreWithoutMacroscopicPredator = generalAvoidPressure.Score(fixture.Microbe, fixture.Patch, cache);
+        var multicellularScoreWithoutMacroscopicPredator =
+            generalAvoidPressure.Score(fixture.Multicellular, fixture.Patch, cache);
+
+        fixture.Patch.AddSpecies(fixture.Macroscopic, TestPopulation);
+
         var generateMiche = new GenerateMiche(fixture.Patch, cache, fixture.World.AutoEvoGlobalCache);
         var generatedMiche = generateMiche.GenerateMicheTree(fixture.World.AutoEvoGlobalCache);
         var predationPressures = new List<PredationEffectivenessPressure>();
@@ -83,9 +114,23 @@ public class MacroscopicSpeciesCompatibilityTests
         AssertThat(populatedMiche).IsSame(generatedMiche);
         AssertThat(occupants.Contains(fixture.Macroscopic)).IsFalse();
 
-        var generalAvoidPressure = fixture.World.AutoEvoGlobalCache.GeneralAvoidPredationSelectionPressure;
-        AssertThat(generalAvoidPressure.Score(fixture.Microbe, fixture.Patch, cache) > 0).IsTrue();
-        AssertThat(generalAvoidPressure.Score(fixture.Multicellular, fixture.Patch, cache) > 0).IsTrue();
+        AssertThat(generalAvoidPressure.Score(fixture.Microbe, fixture.Patch, cache))
+            .IsEqual(microbeScoreWithoutMacroscopicPredator);
+        AssertThat(generalAvoidPressure.Score(fixture.Multicellular, fixture.Patch, cache))
+            .IsEqual(multicellularScoreWithoutMacroscopicPredator);
+    }
+
+    [TestCase]
+    public void GeneralAvoidPredation_MacroscopicScoredSpeciesThrows()
+    {
+        var fixture = CreateSpeciesFixture();
+        var cache = new SimulationCache(fixture.WorldSettings);
+        var pressure = fixture.World.AutoEvoGlobalCache.GeneralAvoidPredationSelectionPressure;
+
+        AssertThrown(() => pressure.Score(fixture.Macroscopic, fixture.Patch, cache))
+            .IsInstanceOf<ArgumentException>()
+            .HasPropertyValue(nameof(ArgumentException.ParamName), "species")
+            .StartsWithMessage("Species type MacroscopicSpecies");
     }
 
     [TestCase]
@@ -133,6 +178,35 @@ public class MacroscopicSpeciesCompatibilityTests
         var microbeEnergyResults = results.GetPatchEnergyResults(fixture.Microbe);
         AssertThat(microbeEnergyResults.ContainsKey(fixture.Patch)).IsTrue();
         AssertThat(microbeEnergyResults[fixture.Patch].IndividualCost > 0).IsTrue();
+    }
+
+    [TestCase]
+    public void MichePopulation_InvalidOccupantThrows()
+    {
+        var fixture = CreateSpeciesFixture();
+        fixture.Patch.SpeciesInPatch.Clear();
+        fixture.Patch.AddSpecies(fixture.Microbe, TestPopulation);
+
+        var cache = new SimulationCache(fixture.WorldSettings);
+        var results = new RunResults();
+        var miche = new Miche(new RecordingSelectionPressure())
+        {
+            Occupant = fixture.Macroscopic,
+        };
+
+        results.AddNewMicheForPatch(fixture.Patch, miche);
+
+        var simulationConfiguration = new SimulationConfiguration(fixture.WorldSettings.AutoEvoConfiguration,
+            fixture.World.Map, fixture.WorldSettings)
+        {
+            Results = results,
+            PatchesToRun = new HashSet<Patch> { fixture.Patch },
+        };
+
+        AssertThrown(() => MichePopulation.Simulate(simulationConfiguration, cache,
+                new XoShiRo256starstar(WorldSeed)))
+            .IsInstanceOf<InvalidOperationException>()
+            .StartsWithMessage("Miche occupant type MacroscopicSpecies");
     }
 
     [TestCase]
@@ -250,6 +324,20 @@ public class MacroscopicSpeciesCompatibilityTests
 
     private sealed record SpeciesFixture(WorldGenerationSettings WorldSettings, GameWorld World, Patch Patch,
         MicrobeSpecies Microbe, MulticellularSpecies Multicellular, MacroscopicSpecies Macroscopic);
+
+    private sealed class GatherInfoAutoEvoRun : AutoEvoRun
+    {
+        public GatherInfoAutoEvoRun(GameWorld world) : base(world, world.AutoEvoGlobalCache)
+        {
+        }
+
+        public Queue<IRunStep> GatherSteps()
+        {
+            var steps = new Queue<IRunStep>();
+            GatherInfo(steps);
+            return steps;
+        }
+    }
 
     private sealed class RecordingSelectionPressure : SelectionPressure
     {

--- a/test/auto_evo.tests/MacroscopicSpeciesCompatibilityTests.cs.uid
+++ b/test/auto_evo.tests/MacroscopicSpeciesCompatibilityTests.cs.uid
@@ -1,0 +1,1 @@
+uid://5wwesv3t0p31


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR fix a bug that allow macroscopic species goes into auto-evo calculation, and causes error because auto-evo doesn't support such type of species.

I kept the LLM-generated unit tests because we might need them in the future, but these can be removed.

Note that I haven't test it with local save yet, but I can verify that once I get a save.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Auto-Evo compatibility with macroscopic species.
  - Unsupported species are excluded from migration, predation, and endosymbiosis calculations.
  - Macroscopic populations are preserved during simulation.
  - Invalid species inputs now produce clear errors instead of being silently rejected.
  - Auto-Evo continues successfully after species conversion.

- **Tests**
  - Added comprehensive coverage for mixed, macroscopic-only, converted-species, and invalid-occupant scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->