### PR TITLE
refactor `GetPredationToolsRawScores()` in auto-evo

### DIFF
--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -794,7 +794,7 @@ public class SimulationCache
         throw new ArgumentException("Incompatible species type given");
     }
 
-    private PredationToolsRawScores GetPredationToolsRawScores(MicrobeSpecies microbeSpecies)
+    public PredationToolsRawScores GetPredationToolsRawScores(MicrobeSpecies microbeSpecies)
     {
         // Seems like this takes twice the amount of time from the predation score calculation if this is not cached,
         // so this should definitely use caching.
@@ -1029,7 +1029,7 @@ public class SimulationCache
         return predationToolsRawScores;
     }
 
-    private PredationToolsRawScores GetPredationToolsRawScores(MulticellularSpecies multicellularSpecies)
+    public PredationToolsRawScores GetPredationToolsRawScores(MulticellularSpecies multicellularSpecies)
     {
         // Seems like this takes twice the amount of time from the predation score calculation if this is not cached,
         // so this should definitely use caching.
@@ -2395,7 +2395,7 @@ public class SimulationCache
 #endif
 
     // helper for GetPredationToolsRawScores
-    private readonly record struct PredationToolsRawScores(float PilusScore,
+    public readonly record struct PredationToolsRawScores(float PilusScore,
         float InjectisomeScore,
         float DefensivePilusScore,
         float DefensiveInjectisomeScore,

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -805,6 +805,32 @@ public class SimulationCache
             return score;
         }
 
+        var predationToolsRawScores = CalculateMicrobePredationToolsRawScores(microbeSpecies);
+
+        cachedPredationToolsRawScores.Add(key, predationToolsRawScores);
+        return predationToolsRawScores;
+    }
+
+    public PredationToolsRawScores GetPredationToolsRawScores(MulticellularSpecies multicellularSpecies)
+    {
+        // Seems like this takes twice the amount of time from the predation score calculation if this is not cached,
+        // so this should definitely use caching.
+        var key = GetSpeciesCacheKey(multicellularSpecies);
+        ref var score = ref CollectionsMarshal.GetValueRefOrNullRef(cachedPredationToolsRawScores, key);
+        if (!Unsafe.IsNullRef(ref score))
+        {
+            return score;
+        }
+
+        var predationToolsRawScores =
+            CalculateMulticellularPredationToolsRawScores(multicellularSpecies);
+
+        cachedPredationToolsRawScores.Add(key, predationToolsRawScores);
+        return predationToolsRawScores;
+    }
+
+    private PredationToolsRawScores CalculateMicrobePredationToolsRawScores(MicrobeSpecies species)
+    {
         var averageToxicity = 0.0f;
         var totalToxicity = 0.0f;
         var totalToxinScore = 0.0f;
@@ -822,7 +848,7 @@ public class SimulationCache
         var mucocystsScore = Constants.AUTO_EVO_MUCOCYST_SCORE;
         var pullingCiliaModifier = 1.0f;
 
-        var organelles = microbeSpecies.Organelles.Organelles;
+        var organelles = species.Organelles.Organelles;
         var organelleCount = organelles.Count;
         var totalToxinOrganellesCount = 0;
         var totalToxinTypesCount = 0;
@@ -1005,7 +1031,7 @@ public class SimulationCache
         slimeJetScore *= slimeJetsMultiplier;
 
         // application of specializationBonus to appropriate scores (microbe, so only CellTypeSpecializationBonus)
-        var specializationBonus = microbeSpecies.CellTypeSpecializationBonus;
+        var specializationBonus = species.CellTypeSpecializationBonus;
 
         oxytoxyScore *= specializationBonus;
         cytotoxinScore *= specializationBonus;
@@ -1024,22 +1050,11 @@ public class SimulationCache
         var predationToolsRawScores = new PredationToolsRawScores(pilusScore, injectisomeScore, defensivePilusScore,
             defensiveInjectisomeScore, averageToxicity, oxytoxyScore, cytotoxinScore, macrolideScore,
             channelInhibitorScore, oxygenMetabolismInhibitorScore, slimeJetScore, mucocystsScore, pullingCiliaModifier);
-
-        cachedPredationToolsRawScores.Add(key, predationToolsRawScores);
         return predationToolsRawScores;
     }
 
-    public PredationToolsRawScores GetPredationToolsRawScores(MulticellularSpecies multicellularSpecies)
+    private PredationToolsRawScores CalculateMulticellularPredationToolsRawScores(MulticellularSpecies species)
     {
-        // Seems like this takes twice the amount of time from the predation score calculation if this is not cached,
-        // so this should definitely use caching.
-        var key = GetSpeciesCacheKey(multicellularSpecies);
-        ref var score = ref CollectionsMarshal.GetValueRefOrNullRef(cachedPredationToolsRawScores, key);
-        if (!Unsafe.IsNullRef(ref score))
-        {
-            return score;
-        }
-
         var averageToxicity = 0.0f;
         var totalToxicity = 0.0f;
         var totalToxinAmount = 0.0f;
@@ -1076,7 +1091,7 @@ public class SimulationCache
         var hasChannelInhibitor = false;
         var hasOxygenMetabolismInhibitor = false;
 
-        var cellTypes = multicellularSpecies.CellTypes;
+        var cellTypes = species.CellTypes;
         for (var i = 0; i < cellTypes.Count; ++i)
         {
             var cellType = cellTypes[i];
@@ -1191,7 +1206,7 @@ public class SimulationCache
             // will do for now
             totalToxinTypesCount += cellTypeToxinTypesCount;
 
-            var cells = multicellularSpecies.EditorCells;
+            var cells = species.EditorCells;
 
             foreach (var hex in cells)
             {
@@ -1300,8 +1315,6 @@ public class SimulationCache
         var predationToolsRawScores = new PredationToolsRawScores(pilusScore, injectisomeScore, defensivePilusScore,
             defensiveInjectisomeScore, averageToxicity, oxytoxyScore, cytotoxinScore, macrolideScore,
             channelInhibitorScore, oxygenMetabolismInhibitorScore, slimeJetScore, mucocystsScore, pullingCiliaModifier);
-
-        cachedPredationToolsRawScores.Add(key, predationToolsRawScores);
         return predationToolsRawScores;
     }
 

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -866,16 +866,47 @@ public class SimulationCache
             oxygenMetabolismInhibitorScore);
     }
 
+    private static PilusToolScores CalculatePilusToolScores(in PilusToolCounts counts)
+    {
+        var pilusScore = Constants.AUTO_EVO_PILUS_PREDATION_SCORE;
+        var injectisomeScore = Constants.AUTO_EVO_PILUS_PREDATION_SCORE;
+        var defensivePilusScore = Constants.AUTO_EVO_PILUS_DEFENSE_SCORE;
+        var defensiveInjectisomeScore = Constants.AUTO_EVO_PILUS_DEFENSE_SCORE;
+
+        if (counts.Pilus != 0 || counts.Injectisome != 0)
+        {
+            var pilusScale = MathF.Sqrt(counts.Pilus + counts.Injectisome) / (counts.Pilus + counts.Injectisome);
+            pilusScore *= counts.Pilus * pilusScale;
+            injectisomeScore *= counts.Injectisome * pilusScale;
+        }
+        else
+        {
+            pilusScore *= counts.Pilus;
+            injectisomeScore *= counts.Injectisome;
+        }
+
+        if (counts.DefensivePilus != 0 || counts.DefensiveInjectisome != 0)
+        {
+            var pilusScale = MathF.Sqrt(counts.DefensivePilus + counts.DefensiveInjectisome) /
+                (counts.DefensivePilus + counts.DefensiveInjectisome);
+            defensivePilusScore *= counts.DefensivePilus * pilusScale;
+            defensiveInjectisomeScore *= counts.DefensiveInjectisome * pilusScale;
+        }
+        else
+        {
+            defensivePilusScore *= counts.DefensivePilus;
+            defensiveInjectisomeScore *= counts.DefensiveInjectisome;
+        }
+
+        return new PilusToolScores(pilusScore, injectisomeScore, defensivePilusScore, defensiveInjectisomeScore);
+    }
+
     private PredationToolsRawScores CalculateMicrobePredationToolsRawScores(MicrobeSpecies species)
     {
         var averageToxicity = 0.0f;
         var totalToxicity = 0.0f;
         var totalToxinScore = 0.0f;
         var everyToxinScore = 0.0f;
-        var pilusScore = Constants.AUTO_EVO_PILUS_PREDATION_SCORE;
-        var injectisomeScore = Constants.AUTO_EVO_PILUS_PREDATION_SCORE;
-        var defensivePilusScore = Constants.AUTO_EVO_PILUS_DEFENSE_SCORE;
-        var defensiveInjectisomeScore = Constants.AUTO_EVO_PILUS_DEFENSE_SCORE;
         var slimeJetScore = Constants.AUTO_EVO_SLIME_JET_SCORE;
         var mucocystsScore = Constants.AUTO_EVO_MUCOCYST_SCORE;
         var pullingCiliaModifier = 1.0f;
@@ -1019,30 +1050,13 @@ public class SimulationCache
         pullingCiliaModifier *= 1 + MathF.Sqrt(pullingCiliasCount) * Constants.AUTO_EVO_PULL_CILIA_MODIFIER;
 
         // Having lots of extra pili also does not help, even if they are two different types
-        if (pilusCount != 0 || injectisomeCount != 0)
-        {
-            var pilusScale = MathF.Sqrt(pilusCount + injectisomeCount) / (pilusCount + injectisomeCount);
-            pilusScore *= pilusCount * pilusScale;
-            injectisomeScore *= injectisomeCount * pilusScale;
-        }
-        else
-        {
-            pilusScore *= pilusCount;
-            injectisomeScore *= injectisomeCount;
-        }
-
-        if (defensivePilusCount != 0 || defensiveInjectisomeCount != 0)
-        {
-            var pilusScale = MathF.Sqrt(defensivePilusCount + defensiveInjectisomeCount) /
-                (defensivePilusCount + defensiveInjectisomeCount);
-            defensivePilusScore *= defensivePilusCount * pilusScale;
-            defensiveInjectisomeScore *= defensiveInjectisomeCount * pilusScale;
-        }
-        else
-        {
-            defensivePilusScore *= defensivePilusCount;
-            defensiveInjectisomeScore *= defensiveInjectisomeCount;
-        }
+        var pilusCounts = new PilusToolCounts(pilusCount, injectisomeCount, defensivePilusCount,
+            defensiveInjectisomeCount);
+        var pilusScores = CalculatePilusToolScores(in pilusCounts);
+        var pilusScore = pilusScores.Pilus;
+        var injectisomeScore = pilusScores.Injectisome;
+        var defensivePilusScore = pilusScores.DefensivePilus;
+        var defensiveInjectisomeScore = pilusScores.DefensiveInjectisome;
 
         slimeJetScore *= slimeJetsCount;
         slimeJetScore *= slimeJetsMultiplier;
@@ -1076,10 +1090,6 @@ public class SimulationCache
         var totalToxicity = 0.0f;
         var totalToxinAmount = 0.0f;
         var everyToxinScore = 0.0f;
-        var pilusScore = Constants.AUTO_EVO_PILUS_PREDATION_SCORE;
-        var injectisomeScore = Constants.AUTO_EVO_PILUS_PREDATION_SCORE;
-        var defensivePilusScore = Constants.AUTO_EVO_PILUS_DEFENSE_SCORE;
-        var defensiveInjectisomeScore = Constants.AUTO_EVO_PILUS_DEFENSE_SCORE;
         var slimeJetScore = Constants.AUTO_EVO_SLIME_JET_SCORE;
         var mucocystsScore = Constants.AUTO_EVO_MUCOCYST_SCORE;
         var pullingCiliaModifier = 1.0f;
@@ -1272,30 +1282,13 @@ public class SimulationCache
         pullingCiliaModifier *= 1 + MathF.Sqrt(pullingCiliasCount) * Constants.AUTO_EVO_PULL_CILIA_MODIFIER;
 
         // Having lots of extra pili also does not help, even if they are two different types
-        if (pilusCount != 0 || injectisomeCount != 0)
-        {
-            var pilusScale = MathF.Sqrt(pilusCount + injectisomeCount) / (pilusCount + injectisomeCount);
-            pilusScore *= pilusCount * pilusScale;
-            injectisomeScore *= injectisomeCount * pilusScale;
-        }
-        else
-        {
-            pilusScore *= pilusCount;
-            injectisomeScore *= injectisomeCount;
-        }
-
-        if (defensivePilusCount != 0 || defensiveInjectisomeCount != 0)
-        {
-            var pilusScale = MathF.Sqrt(defensivePilusCount + defensiveInjectisomeCount) /
-                (defensivePilusCount + defensiveInjectisomeCount);
-            defensivePilusScore *= defensivePilusCount * pilusScale;
-            defensiveInjectisomeScore *= defensiveInjectisomeCount * pilusScale;
-        }
-        else
-        {
-            defensivePilusScore *= defensivePilusCount;
-            defensiveInjectisomeScore *= defensiveInjectisomeCount;
-        }
+        var pilusCounts = new PilusToolCounts(pilusCount, injectisomeCount, defensivePilusCount,
+            defensiveInjectisomeCount);
+        var pilusScores = CalculatePilusToolScores(in pilusCounts);
+        var pilusScore = pilusScores.Pilus;
+        var injectisomeScore = pilusScores.Injectisome;
+        var defensivePilusScore = pilusScores.DefensivePilus;
+        var defensiveInjectisomeScore = pilusScores.DefensiveInjectisome;
 
         if (slimeJetsMultiplierCount > 0)
             slimeJetsMultiplier = slimeJetsMultiplierSum / slimeJetsMultiplierCount;
@@ -2430,6 +2423,16 @@ public class SimulationCache
         float Macrolide,
         float ChannelInhibitor,
         float OxygenMetabolismInhibitor);
+
+    private readonly record struct PilusToolCounts(float Pilus,
+        float Injectisome,
+        float DefensivePilus,
+        float DefensiveInjectisome);
+
+    private readonly record struct PilusToolScores(float Pilus,
+        float Injectisome,
+        float DefensivePilus,
+        float DefensiveInjectisome);
 
     private readonly record struct PredatorCapabilities(PredationToolsRawScores ToolScores, bool CanEngulf);
 

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -829,17 +829,49 @@ public class SimulationCache
         return predationToolsRawScores;
     }
 
+    private static ToxinToolScores CalculateToxinToolScores(float averageToxicity, float everyToxinScore,
+        in ToxinPresence presence)
+    {
+        var oxytoxyScore = 0.0f;
+        var cytotoxinScore = 0.0f;
+        var macrolideScore = 0.0f;
+        var channelInhibitorScore = 0.0f;
+        var oxygenMetabolismInhibitorScore = 0.0f;
+
+        if (presence.HasOxytoxy)
+        {
+            oxytoxyScore = everyToxinScore * (Constants.OXYTOXY_DAMAGE / Constants.CYTOTOXIN_DAMAGE) *
+                MicrobeEmissionSystem.ToxinAmountMultiplierFromToxicity(averageToxicity, ToxinType.Oxytoxy);
+        }
+
+        if (presence.HasCytotoxin)
+        {
+            cytotoxinScore = everyToxinScore *
+                MicrobeEmissionSystem.ToxinAmountMultiplierFromToxicity(averageToxicity, ToxinType.Cytotoxin);
+        }
+
+        if (presence.HasMacrolide)
+            macrolideScore = everyToxinScore;
+        if (presence.HasChannelInhibitor)
+            channelInhibitorScore = everyToxinScore;
+        if (presence.HasOxygenMetabolismInhibitor)
+        {
+            oxygenMetabolismInhibitorScore = everyToxinScore *
+                (Constants.OXYGEN_INHIBITOR_DAMAGE / Constants.CYTOTOXIN_DAMAGE) *
+                MicrobeEmissionSystem.ToxinAmountMultiplierFromToxicity(averageToxicity,
+                    ToxinType.OxygenMetabolismInhibitor);
+        }
+
+        return new ToxinToolScores(oxytoxyScore, cytotoxinScore, macrolideScore, channelInhibitorScore,
+            oxygenMetabolismInhibitorScore);
+    }
+
     private PredationToolsRawScores CalculateMicrobePredationToolsRawScores(MicrobeSpecies species)
     {
         var averageToxicity = 0.0f;
         var totalToxicity = 0.0f;
         var totalToxinScore = 0.0f;
         var everyToxinScore = 0.0f;
-        var oxytoxyScore = 0.0f;
-        var cytotoxinScore = 0.0f;
-        var macrolideScore = 0.0f;
-        var channelInhibitorScore = 0.0f;
-        var oxygenMetabolismInhibitorScore = 0.0f;
         var pilusScore = Constants.AUTO_EVO_PILUS_PREDATION_SCORE;
         var injectisomeScore = Constants.AUTO_EVO_PILUS_PREDATION_SCORE;
         var defensivePilusScore = Constants.AUTO_EVO_PILUS_DEFENSE_SCORE;
@@ -973,29 +1005,14 @@ public class SimulationCache
             everyToxinScore = totalToxinScore / totalToxinTypesCount;
         }
 
-        if (hasOxytoxy)
-        {
-            oxytoxyScore = everyToxinScore * (Constants.OXYTOXY_DAMAGE / Constants.CYTOTOXIN_DAMAGE) *
-                MicrobeEmissionSystem.ToxinAmountMultiplierFromToxicity(averageToxicity, ToxinType.Oxytoxy);
-        }
-
-        if (hasCytotoxin)
-        {
-            cytotoxinScore = everyToxinScore *
-                MicrobeEmissionSystem.ToxinAmountMultiplierFromToxicity(averageToxicity, ToxinType.Cytotoxin);
-        }
-
-        if (hasMacrolide)
-            macrolideScore = everyToxinScore;
-        if (hasChannelInhibitor)
-            channelInhibitorScore = everyToxinScore;
-        if (hasOxygenMetabolismInhibitor)
-        {
-            oxygenMetabolismInhibitorScore = everyToxinScore *
-                (Constants.OXYGEN_INHIBITOR_DAMAGE / Constants.CYTOTOXIN_DAMAGE) *
-                MicrobeEmissionSystem.ToxinAmountMultiplierFromToxicity(averageToxicity,
-                    ToxinType.OxygenMetabolismInhibitor);
-        }
+        var toxinPresence = new ToxinPresence(hasOxytoxy, hasCytotoxin, hasMacrolide, hasChannelInhibitor,
+            hasOxygenMetabolismInhibitor);
+        var toxinScores = CalculateToxinToolScores(averageToxicity, everyToxinScore, in toxinPresence);
+        var oxytoxyScore = toxinScores.Oxytoxy;
+        var cytotoxinScore = toxinScores.Cytotoxin;
+        var macrolideScore = toxinScores.Macrolide;
+        var channelInhibitorScore = toxinScores.ChannelInhibitor;
+        var oxygenMetabolismInhibitorScore = toxinScores.OxygenMetabolismInhibitor;
 
         // Having lots of mucocysts and pulling cilias doesn't really help much
         mucocystsScore *= MathF.Sqrt(mucocystsCount);
@@ -1059,11 +1076,6 @@ public class SimulationCache
         var totalToxicity = 0.0f;
         var totalToxinAmount = 0.0f;
         var everyToxinScore = 0.0f;
-        var oxytoxyScore = 0.0f;
-        var cytotoxinScore = 0.0f;
-        var macrolideScore = 0.0f;
-        var channelInhibitorScore = 0.0f;
-        var oxygenMetabolismInhibitorScore = 0.0f;
         var pilusScore = Constants.AUTO_EVO_PILUS_PREDATION_SCORE;
         var injectisomeScore = Constants.AUTO_EVO_PILUS_PREDATION_SCORE;
         var defensivePilusScore = Constants.AUTO_EVO_PILUS_DEFENSE_SCORE;
@@ -1246,29 +1258,14 @@ public class SimulationCache
             everyToxinScore = totalToxinAmount * Constants.AUTO_EVO_TOXIN_PREDATION_SCORE / totalToxinTypesCount;
         }
 
-        if (hasOxytoxy)
-        {
-            oxytoxyScore = everyToxinScore * (Constants.OXYTOXY_DAMAGE / Constants.CYTOTOXIN_DAMAGE) *
-                MicrobeEmissionSystem.ToxinAmountMultiplierFromToxicity(averageToxicity, ToxinType.Oxytoxy);
-        }
-
-        if (hasCytotoxin)
-        {
-            cytotoxinScore = everyToxinScore *
-                MicrobeEmissionSystem.ToxinAmountMultiplierFromToxicity(averageToxicity, ToxinType.Cytotoxin);
-        }
-
-        if (hasMacrolide)
-            macrolideScore = everyToxinScore;
-        if (hasChannelInhibitor)
-            channelInhibitorScore = everyToxinScore;
-        if (hasOxygenMetabolismInhibitor)
-        {
-            oxygenMetabolismInhibitorScore = everyToxinScore *
-                (Constants.OXYGEN_INHIBITOR_DAMAGE / Constants.CYTOTOXIN_DAMAGE) *
-                MicrobeEmissionSystem.ToxinAmountMultiplierFromToxicity(averageToxicity,
-                    ToxinType.OxygenMetabolismInhibitor);
-        }
+        var toxinPresence = new ToxinPresence(hasOxytoxy, hasCytotoxin, hasMacrolide, hasChannelInhibitor,
+            hasOxygenMetabolismInhibitor);
+        var toxinScores = CalculateToxinToolScores(averageToxicity, everyToxinScore, in toxinPresence);
+        var oxytoxyScore = toxinScores.Oxytoxy;
+        var cytotoxinScore = toxinScores.Cytotoxin;
+        var macrolideScore = toxinScores.Macrolide;
+        var channelInhibitorScore = toxinScores.ChannelInhibitor;
+        var oxygenMetabolismInhibitorScore = toxinScores.OxygenMetabolismInhibitor;
 
         // Having lots of mucocysts and pulling cilias doesn't really help much
         mucocystsScore *= MathF.Sqrt(mucocystsCount);
@@ -2421,6 +2418,18 @@ public class SimulationCache
         float SlimeJetScore,
         float MucocystsScore,
         float PullingCiliaModifier);
+
+    private readonly record struct ToxinPresence(bool HasOxytoxy,
+        bool HasCytotoxin,
+        bool HasMacrolide,
+        bool HasChannelInhibitor,
+        bool HasOxygenMetabolismInhibitor);
+
+    private readonly record struct ToxinToolScores(float Oxytoxy,
+        float Cytotoxin,
+        float Macrolide,
+        float ChannelInhibitor,
+        float OxygenMetabolismInhibitor);
 
     private readonly record struct PredatorCapabilities(PredationToolsRawScores ToolScores, bool CanEngulf);
 

--- a/test/auto_evo.tests/SimulationCachePredationToolsRawScoresTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationToolsRawScoresTests.cs
@@ -1,0 +1,236 @@
+﻿using System.Collections.Generic;
+using AutoEvo;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+[TestSuite]
+[RequireGodotRuntime]
+public class SimulationCachePredationToolsRawScoresTests
+{
+    [TestCase]
+    public void MicrobeRawScoresAndCacheBehaviorAreCharacterized()
+    {
+        var cache = CreateCache();
+        var species = CreateMicrobe(101);
+        var originalId = species.ID;
+        var originalEpithet = species.Epithet;
+        var originalAutoEvoAttemptCache = species.AutoEvoAttemptCache;
+
+        var initial = cache.GetPredationToolsRawScores(species);
+        AssertMicrobeInitialScores(initial);
+
+        species.CellTypeSpecializationBonus = 2.0f;
+        AssertSpeciesCacheIdentityIsStable(species, originalId, originalEpithet, originalAutoEvoAttemptCache);
+
+        var cached = cache.GetPredationToolsRawScores(species);
+        AssertMicrobeInitialScores(cached);
+
+        cache.Clear();
+
+        var recomputed = cache.GetPredationToolsRawScores(species);
+        AssertThat(recomputed.OxytoxyScore).IsNotEqual(initial.OxytoxyScore);
+        AssertThat(recomputed.SlimeJetScore).IsNotEqual(initial.SlimeJetScore);
+        AssertThat(recomputed.PullingCiliaModifier).IsNotEqual(initial.PullingCiliaModifier);
+        AssertMicrobeRecomputedScores(recomputed);
+    }
+
+    [TestCase]
+    public void MulticellularRawScoresAndCacheBehaviorAreCharacterized()
+    {
+        var cache = CreateCache();
+        var (species, contributingCellType) = CreateMulticellularSpecies(102);
+        var originalId = species.ID;
+        var originalEpithet = species.Epithet;
+        var originalAutoEvoAttemptCache = species.AutoEvoAttemptCache;
+
+        var initial = cache.GetPredationToolsRawScores(species);
+        AssertMulticellularInitialScores(initial);
+
+        contributingCellType.CellTypeSpecializationBonus = 2.25f;
+        AssertSpeciesCacheIdentityIsStable(species, originalId, originalEpithet, originalAutoEvoAttemptCache);
+
+        var cached = cache.GetPredationToolsRawScores(species);
+        AssertMulticellularInitialScores(cached);
+
+        cache.Clear();
+
+        var recomputed = cache.GetPredationToolsRawScores(species);
+        AssertThat(recomputed.OxytoxyScore).IsNotEqual(initial.OxytoxyScore);
+        AssertThat(recomputed.SlimeJetScore).IsNotEqual(initial.SlimeJetScore);
+        AssertThat(recomputed.PullingCiliaModifier).IsNotEqual(initial.PullingCiliaModifier);
+        AssertMulticellularRecomputedScores(recomputed);
+    }
+
+    private static SimulationCache CreateCache()
+    {
+        return new SimulationCache(new WorldGenerationSettings
+        {
+            Seed = 1,
+        });
+    }
+
+    private static MicrobeSpecies CreateMicrobe(uint id)
+    {
+        var simulationParameters = SimulationParameters.Instance;
+        var species = new MicrobeSpecies(id, "Characterization", "RawScoreMicrobe")
+        {
+            IsBacteria = true,
+            MembraneType = simulationParameters.GetMembrane("single"),
+        };
+
+        AddPredationToolOrganelles(species.Organelles, simulationParameters);
+        species.OnEdited();
+        species.CellTypeSpecializationBonus = 1.25f;
+
+        return species;
+    }
+
+    private static (MulticellularSpecies Species, CellType ContributingCellType) CreateMulticellularSpecies(uint id)
+    {
+        var simulationParameters = SimulationParameters.Instance;
+        var contributingCellType = new CellType(simulationParameters.GetMembrane("single"))
+        {
+            CellTypeName = "PredationTools",
+        };
+        AddPredationToolOrganelles(contributingCellType.ModifiableOrganelles, simulationParameters);
+
+        var supportingCellType = new CellType(simulationParameters.GetMembrane("single"))
+        {
+            CellTypeName = "Support",
+        };
+        supportingCellType.ModifiableOrganelles.Add(CreateOrganelle(simulationParameters, "cytoplasm", new Hex(0, 0)));
+
+        var species = new MulticellularSpecies(id, "Characterization", "RawScoreMulticellular");
+        species.ModifiableCellTypes.Add(contributingCellType);
+        species.ModifiableCellTypes.Add(supportingCellType);
+        species.ModifiableGameplayCells.AddFast(new CellTemplate(contributingCellType, new Hex(0, 0), 0),
+            new List<Hex>(), new List<Hex>());
+        species.ModifiableGameplayCells.AddFast(new CellTemplate(contributingCellType, new Hex(1, 0), 0),
+            new List<Hex>(), new List<Hex>());
+        species.ModifiableGameplayCells.AddFast(new CellTemplate(supportingCellType, new Hex(0, 1), 0),
+            new List<Hex>(), new List<Hex>());
+        species.OnEdited();
+
+        contributingCellType.CellTypeSpecializationBonus = 1.5f;
+        supportingCellType.CellTypeSpecializationBonus = 0.75f;
+
+        return (species, contributingCellType);
+    }
+
+    private static void AddPredationToolOrganelles(OrganelleLayout<OrganelleTemplate> organelles,
+        SimulationParameters simulationParameters)
+    {
+        organelles.Add(CreateOrganelle(simulationParameters, "cytoplasm", new Hex(0, 0)));
+        organelles.Add(CreateOrganelle(simulationParameters, "pilus", new Hex(0, -4)));
+        organelles.Add(CreateOrganelle(simulationParameters, "slimeJet", new Hex(0, 4)));
+        organelles.Add(CreateUpgradedOrganelle(simulationParameters, "cilia", new Hex(4, 0),
+            CiliaComponent.CILIA_PULL_UPGRADE_NAME));
+        organelles.Add(CreateToxinOrganelle(simulationParameters, new Hex(-4, 0)));
+    }
+
+    private static OrganelleTemplate CreateOrganelle(SimulationParameters simulationParameters, string internalName,
+        Hex position)
+    {
+        return new OrganelleTemplate(simulationParameters.GetOrganelleType(internalName), position, 0);
+    }
+
+    private static OrganelleTemplate CreateUpgradedOrganelle(SimulationParameters simulationParameters,
+        string internalName, Hex position, string upgrade)
+    {
+        return new OrganelleTemplate(simulationParameters.GetOrganelleType(internalName), position, 0)
+        {
+            ModifiableUpgrades = new OrganelleUpgrades
+            {
+                ModifiableUnlockedFeatures = [upgrade],
+            },
+        };
+    }
+
+    private static OrganelleTemplate CreateToxinOrganelle(SimulationParameters simulationParameters, Hex position)
+    {
+        return new OrganelleTemplate(simulationParameters.GetOrganelleType("oxytoxy"), position, 0)
+        {
+            ModifiableUpgrades = new OrganelleUpgrades
+            {
+                ModifiableUnlockedFeatures = [ToxinUpgradeNames.OXYTOXY_UPGRADE_NAME],
+                CustomUpgradeData = new ToxinUpgrades(ToxinType.Oxytoxy, 0.25f),
+            },
+        };
+    }
+
+    private static void AssertSpeciesCacheIdentityIsStable(Species species, uint expectedId, string expectedEpithet,
+        int expectedAutoEvoAttemptCache)
+    {
+        AssertThat(species.ID).IsEqual(expectedId);
+        AssertThat(species.Epithet).IsEqual(expectedEpithet);
+        AssertThat(species.AutoEvoAttemptCache).IsEqual(expectedAutoEvoAttemptCache);
+    }
+
+    private static void AssertMicrobeInitialScores(SimulationCache.PredationToolsRawScores scores)
+    {
+        AssertThat(scores.PilusScore).IsEqual(5000.0f);
+        AssertThat(scores.InjectisomeScore).IsEqual(0.0f);
+        AssertThat(scores.DefensivePilusScore).IsEqual(0.0f);
+        AssertThat(scores.DefensiveInjectisomeScore).IsEqual(0.0f);
+        AssertThat(scores.AverageToxicity).IsEqual(0.25f);
+        AssertThat(scores.OxytoxyScore).IsEqual(4334465.0f);
+        AssertThat(scores.CytotoxinScore).IsEqual(0.0f);
+        AssertThat(scores.MacrolideScore).IsEqual(0.0f);
+        AssertThat(scores.ChannelInhibitorScore).IsEqual(0.0f);
+        AssertThat(scores.OxygenMetabolismInhibitorScore).IsEqual(0.0f);
+        AssertThat(scores.SlimeJetScore).IsEqual(37.5f);
+        AssertThat(scores.MucocystsScore).IsEqual(0.0f);
+        AssertThat(scores.PullingCiliaModifier).IsEqual(2.25f);
+    }
+
+    private static void AssertMicrobeRecomputedScores(SimulationCache.PredationToolsRawScores scores)
+    {
+        AssertThat(scores.PilusScore).IsEqual(5000.0f);
+        AssertThat(scores.InjectisomeScore).IsEqual(0.0f);
+        AssertThat(scores.DefensivePilusScore).IsEqual(0.0f);
+        AssertThat(scores.DefensiveInjectisomeScore).IsEqual(0.0f);
+        AssertThat(scores.AverageToxicity).IsEqual(0.25f);
+        AssertThat(scores.OxytoxyScore).IsEqual(6935144.0f);
+        AssertThat(scores.CytotoxinScore).IsEqual(0.0f);
+        AssertThat(scores.MacrolideScore).IsEqual(0.0f);
+        AssertThat(scores.ChannelInhibitorScore).IsEqual(0.0f);
+        AssertThat(scores.OxygenMetabolismInhibitorScore).IsEqual(0.0f);
+        AssertThat(scores.SlimeJetScore).IsEqual(60.0f);
+        AssertThat(scores.MucocystsScore).IsEqual(0.0f);
+        AssertThat(scores.PullingCiliaModifier).IsEqual(3.6f);
+    }
+
+    private static void AssertMulticellularInitialScores(SimulationCache.PredationToolsRawScores scores)
+    {
+        AssertThat(scores.PilusScore).IsEqual(7071.068f);
+        AssertThat(scores.InjectisomeScore).IsEqual(0.0f);
+        AssertThat(scores.DefensivePilusScore).IsEqual(0.0f);
+        AssertThat(scores.DefensiveInjectisomeScore).IsEqual(0.0f);
+        AssertThat(scores.AverageToxicity).IsEqual(0.25f);
+        AssertThat(scores.OxytoxyScore).IsEqual(10922850.0f);
+        AssertThat(scores.CytotoxinScore).IsEqual(0.0f);
+        AssertThat(scores.MacrolideScore).IsEqual(0.0f);
+        AssertThat(scores.ChannelInhibitorScore).IsEqual(0.0f);
+        AssertThat(scores.OxygenMetabolismInhibitorScore).IsEqual(0.0f);
+        AssertThat(scores.SlimeJetScore).IsEqual(94.49999f);
+        AssertThat(scores.MucocystsScore).IsEqual(0.0f);
+        AssertThat(scores.PullingCiliaModifier).IsEqual(2.4198592f);
+    }
+
+    private static void AssertMulticellularRecomputedScores(SimulationCache.PredationToolsRawScores scores)
+    {
+        AssertThat(scores.PilusScore).IsEqual(7071.068f);
+        AssertThat(scores.InjectisomeScore).IsEqual(0.0f);
+        AssertThat(scores.DefensivePilusScore).IsEqual(0.0f);
+        AssertThat(scores.DefensiveInjectisomeScore).IsEqual(0.0f);
+        AssertThat(scores.AverageToxicity).IsEqual(0.25f);
+        AssertThat(scores.OxytoxyScore).IsEqual(16384275.0f);
+        AssertThat(scores.CytotoxinScore).IsEqual(0.0f);
+        AssertThat(scores.MacrolideScore).IsEqual(0.0f);
+        AssertThat(scores.ChannelInhibitorScore).IsEqual(0.0f);
+        AssertThat(scores.OxygenMetabolismInhibitorScore).IsEqual(0.0f);
+        AssertThat(scores.SlimeJetScore).IsEqual(141.75f);
+        AssertThat(scores.MucocystsScore).IsEqual(0.0f);
+        AssertThat(scores.PullingCiliaModifier).IsEqual(2.7389653f);
+    }
+}

--- a/test/auto_evo.tests/SimulationCachePredationToolsRawScoresTests.cs.uid
+++ b/test/auto_evo.tests/SimulationCachePredationToolsRawScoresTests.cs.uid
@@ -1,0 +1,1 @@
+﻿uid://b7m3v9k2p6xqf


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR refactors `GetPredationToolsRawScores()` method, and extracts 2 helper function for the 2 overloads of the function to reuse.

**Related Issues**

succeeds #7170 (should be merged after #7170 is merged)

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for predation scoring across predators with different abilities and body configurations.
  - Added tests validating raw predation-tool scores for microbial and multicellular species.
  - Verified score caching, cache reuse, cache clearing, species identity stability, and score recalculation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->