### PR TITLE
Fixed error when loading a species with outdated mass budding size

### DIFF
--- a/src/multicellular_stage/MulticellularSpecies.cs
+++ b/src/multicellular_stage/MulticellularSpecies.cs
@@ -11,7 +11,7 @@ using Systems;
 /// </summary>
 public class MulticellularSpecies : Species, IReadOnlyMulticellularSpecies, ISimulationPhotographable
 {
-    public const ushort SERIALIZATION_VERSION = 6;
+    public const ushort SERIALIZATION_VERSION = 7;
 
     private readonly Dictionary<BiomeConditions, Dictionary<Compound, (float TimeToFill, float Storage)>>
         cachedFillTimes = new();
@@ -222,6 +222,15 @@ public class MulticellularSpecies : Species, IReadOnlyMulticellularSpecies, ISim
         if (version >= 6)
         {
             instance.PlayerGamete = (GameteType)reader.ReadInt32();
+        }
+
+        if (version < 7)
+        {
+            // Fix old mass budding count to know about minimum size being 2
+            if (instance.MassBuddingCellCount < 2 && instance.ModifiableGameplayCells.Count > 1)
+            {
+                instance.MassBuddingCellCount = 2;
+            }
         }
 
         return instance;

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
@@ -15,6 +15,11 @@ public partial class CellBodyPlanEditorComponent
 
     private bool changingPlayerGameteTypeAutomatically;
 
+    /// <summary>
+    ///   When true, mass budding is automatically changing and no change actions are triggered.
+    /// </summary>
+    private bool loadingMassBuddingState;
+
     public void OnReproductionMethodSelected(int selectedOption)
     {
         var selectedMethod = ReproductionMethodIndexToValue(selectedOption);
@@ -73,6 +78,14 @@ public partial class CellBodyPlanEditorComponent
         // Allow the desired value to be higher than max (to handle the case of cell removal)
         if (newCellCount == maxValue && DesiredMassBuddingCellCount > maxValue)
             return;
+
+        if (loadingMassBuddingState)
+        {
+            var targetCount = (int)count;
+            GD.Print("Mass budding count changing during loading to: " + targetCount);
+            DesiredMassBuddingCellCount = Math.Min(targetCount, editedMicrobeCells.Count);
+            return;
+        }
 
         var action = new SingleEditorAction<MassBuddingCellCountActionData>(DoMassBuddingCellCountChangeAction,
             UndoMassBuddingCellCountChangeAction,
@@ -233,7 +246,10 @@ public partial class CellBodyPlanEditorComponent
 
         UpdateSpecialCellTypeDisplays();
         UpdateGameteDropdowns();
+
+        loadingMassBuddingState = true;
         UpdateMassBuddingCellCountSlider();
+        loadingMassBuddingState = false;
 
         UpdateCancelButtonVisibility();
     }

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
@@ -81,9 +81,10 @@ public partial class CellBodyPlanEditorComponent
 
         if (loadingMassBuddingState)
         {
-            var targetCount = (int)count;
+            var targetCount = Math.Clamp((int)count, Constants.MASS_BUDDING_MINIMUM_BUD_SIZE,
+                editedMicrobeCells.Count);
             GD.Print("Mass budding count changing during loading to: " + targetCount);
-            DesiredMassBuddingCellCount = Math.Min(targetCount, editedMicrobeCells.Count);
+            DesiredMassBuddingCellCount = targetCount;
             return;
         }
 
@@ -248,8 +249,14 @@ public partial class CellBodyPlanEditorComponent
         UpdateGameteDropdowns();
 
         loadingMassBuddingState = true;
-        UpdateMassBuddingCellCountSlider();
-        loadingMassBuddingState = false;
+        try
+        {
+            UpdateMassBuddingCellCountSlider();
+        }
+        finally
+        {
+            loadingMassBuddingState = false;
+        }
 
         UpdateCancelButtonVisibility();
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Needed as the minimum allowed size is now different and would otherwise cause editor load failures

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when loading older species archives by correcting invalid mass-budding counts.
  - Mass-budding settings now load reliably without creating unintended editor actions.
  - Slider values are constrained to the available number of cells during loading.
  - Loading now preserves valid mass-budding configurations and keeps related editor controls synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->