### PR TITLE
Redid the entire microbe colony compound sharing logic (and added more tests)

### DIFF
--- a/src/general/base_stage/CreatureStageHUDBase.cs
+++ b/src/general/base_stage/CreatureStageHUDBase.cs
@@ -1012,7 +1012,7 @@ public abstract partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICr
         foreach (var (compound, bar) in compoundBars)
         {
             // Probably can save on performance here by not updating hidden bars and hoping that when bars become
-            // visible they will be updated immediately for the player to not notice
+            // visible, they will be updated immediately for the player to not notice
             if (!bar.Visible)
                 continue;
 

--- a/src/microbe_stage/ColonyCompoundBag.cs
+++ b/src/microbe_stage/ColonyCompoundBag.cs
@@ -170,7 +170,13 @@ public class ColonyCompoundBag : ICompoundStorage
             // We want to remove these amounts to not cause infinite compounds to accumulate
             foreach (var entry in summedCompoundsBuffer)
             {
-                var receiverCapacity = compoundCapacities[entry.Key];
+                // Just in case bad data goes in the dictionary somehow (avoid division by zero a few lines below)
+                if (entry.Value <= 0)
+                    continue;
+
+                // It should be impossible for no capacity to exist for a useful compound, but just in case we use 0
+                // as a fallback
+                var receiverCapacity = compoundCapacities.GetValueOrDefault(entry.Key, 0);
 
                 // Exclude already used space
                 foreach (var bag in bags)
@@ -180,6 +186,9 @@ public class ColonyCompoundBag : ICompoundStorage
                         receiverCapacity -= bag.GetCompoundAmount(entry.Key);
                     }
                 }
+
+                // If there is no space left, ensure things don't go negative
+                receiverCapacity = Math.Max(receiverCapacity, 0);
 
                 // Share the outgoing capacity across cells if there isn't enough space
                 var sendFactor = Math.Min(1, receiverCapacity / entry.Value);
@@ -232,6 +241,10 @@ public class ColonyCompoundBag : ICompoundStorage
 
         foreach (var entry in availableCompounds)
         {
+            // The above loop reports these errors but avoid causing problems when applying them then anyway.
+            if (!compoundCapacities.TryGetValue(entry.Key, out var totalCapacity) || totalCapacity <= 0)
+                continue;
+
             foreach (var bag in bags)
             {
                 var capacity = bag.GetCapacityForCompound(entry.Key);
@@ -241,7 +254,7 @@ public class ColonyCompoundBag : ICompoundStorage
                     continue;
 
                 // Other bags will grab a share according to their capacity
-                var targetLevel = availableCompounds[entry.Key] * (capacity / compoundCapacities[entry.Key]);
+                var targetLevel = entry.Value * (capacity / totalCapacity);
 
                 var difference = targetLevel - bag.GetCompoundAmount(entry.Key);
 
@@ -251,9 +264,16 @@ public class ColonyCompoundBag : ICompoundStorage
                 }
                 else
                 {
-                    // TODO: should we check the return value here to ensure enough was taken?
                     // We need to negate the value to get it to be positive for taking away compounds
-                    bag.TakeCompound(entry.Key, -difference);
+                    var taken = bag.TakeCompound(entry.Key, -difference);
+
+#if DEBUG
+                    var couldNotTake = -difference - taken;
+                    if (couldNotTake > MathUtils.EPSILON)
+                        GD.PrintErr($"Could not take expected compound amount while distributing {entry.Key}");
+#else
+                    _ = taken;
+#endif
                 }
             }
         }

--- a/src/microbe_stage/ColonyCompoundBag.cs
+++ b/src/microbe_stage/ColonyCompoundBag.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Arch.Core;
 using Arch.Core.Extensions;
 using Components;
@@ -11,7 +12,16 @@ using Godot;
 public class ColonyCompoundBag : ICompoundStorage
 {
     private readonly object refreshListLock = new();
+
+    /// <summary>
+    ///   Used just for getting total compounds in the colony
+    /// </summary>
     private readonly Dictionary<Compound, float> summedCompoundsBuffer = new();
+
+    // These variables are for distributing compounds and are not always kept up to date
+    private readonly HashSet<Compound> usefulCompoundsBuffer = new();
+    private readonly Dictionary<Compound, float> availableCompounds = new();
+    private readonly Dictionary<Compound, float> compoundCapacities = new();
 
     private List<CompoundBag> colonyBags = new();
     private List<CompoundBag> bagBuilder = new();
@@ -73,15 +83,224 @@ public class ColonyCompoundBag : ICompoundStorage
     public void DistributeCompoundSurplus()
     {
         var bags = GetCompoundBags();
-        FillSummedCompoundsBuffer(bags);
 
-        foreach (var (compound, compoundAmount) in summedCompoundsBuffer)
+        GD.Print("Compound bag count: " + bags.Count);
+
+        usefulCompoundsBuffer.Clear();
+        availableCompounds.Clear();
+        compoundCapacities.Clear();
+
+        // Determine compounds that need sharing first
+        bool first = true;
+        foreach (var compoundBag in bags)
         {
-            var compoundDefinition = SimulationParameters.GetCompound(compound);
-            if (!TryPrepareCompoundDistribution(compound, compoundAmount, bags, compoundDefinition, out var ratio))
-                continue;
+            compoundBag.CopyUsefulToHash(usefulCompoundsBuffer, first);
+            first = false;
+        }
 
-            RedistributeCompoundAcrossBags(compound, compoundDefinition, ratio, bags);
+        // Don't share ATP
+        usefulCompoundsBuffer.Remove(Compound.ATP);
+
+        GD.Print("Useful compounds:");
+        foreach (var compound in usefulCompoundsBuffer)
+        {
+            GD.Print($" {compound}");
+        }
+
+        bool needsNonUsefulAdjustments = false;
+
+        // This is used as a sum of non-useful compounds
+        summedCompoundsBuffer.Clear();
+
+        // Then offer up the compounds
+        foreach (var bag in bags)
+        {
+            GD.Print("Next bag");
+
+            foreach (var bagCompound in bag.Compounds)
+            {
+                // Don't offer compounds to move that nobody finds useful in this colony
+                if (!usefulCompoundsBuffer.Contains(bagCompound.Key))
+                    continue;
+
+                if (bagCompound.Value <= 0)
+                    continue;
+
+                GD.Print($" Amount({bagCompound.Key}): {bagCompound.Value}");
+
+                // Has available compound, try to share with other bags
+                if (availableCompounds.TryGetValue(bagCompound.Key, out var availableAmount))
+                {
+                    availableCompounds[bagCompound.Key] = availableAmount + bagCompound.Value;
+                }
+                else
+                {
+                    availableCompounds.Add(bagCompound.Key, bagCompound.Value);
+                }
+
+                // If not useful, this will not receive any of this compound.
+                if (!bag.IsUseful(bagCompound.Key))
+                {
+                    // Store for later as we don't know yet how much of this compound other bags can take
+                    needsNonUsefulAdjustments = true;
+
+                    if (summedCompoundsBuffer.TryGetValue(bagCompound.Key, out var summedAmount))
+                    {
+                        summedCompoundsBuffer[bagCompound.Key] = summedAmount + bagCompound.Value;
+                    }
+                    else
+                    {
+                        summedCompoundsBuffer.Add(bagCompound.Key, bagCompound.Value);
+                    }
+                }
+            }
+
+            // Then capture capacities as the bag might not have every compound in it, so the above loop would miss
+            // them
+            foreach (var compound in usefulCompoundsBuffer)
+            {
+                // If not useful, don't participate in receiving this compound.
+                // The capacity check here returns 0 if the compound is not useful.
+                var bagCapacity = bag.GetCapacityForCompound(compound);
+                if (bagCapacity <= 0)
+                    continue;
+
+                GD.Print($" Capacity({compound}): {bagCapacity}");
+
+                // Report the capacity so that correct fraction of compound is received
+                if (compoundCapacities.TryGetValue(compound, out var capacity))
+                {
+                    compoundCapacities[compound] = capacity + bagCapacity;
+                }
+                else
+                {
+                    compoundCapacities.Add(compound, bagCapacity);
+                }
+            }
+        }
+
+        if (needsNonUsefulAdjustments)
+        {
+            // We want to remove these amounts to not cause infinite compounds to accumulate
+            foreach (var entry in summedCompoundsBuffer)
+            {
+                var receiverCapacity = compoundCapacities[entry.Key];
+
+                // Exclude already used space
+                foreach (var bag in bags)
+                {
+                    if (bag.IsUseful(entry.Key))
+                    {
+                        receiverCapacity -= bag.GetCompoundAmount(entry.Key);
+                    }
+                }
+
+                // Share the outgoing capacity across cells if there isn't enough space
+                var sendFactor = Math.Min(1, receiverCapacity / entry.Value);
+
+                GD.Print($"Not useful: {entry.Key}, available space: {receiverCapacity}");
+
+                // Then take as much from the sender bags as the receivers can take
+                foreach (var bag in bags)
+                {
+                    if (bag.IsUseful(entry.Key))
+                        continue;
+
+                    var amount = bag.GetCompoundAmount(entry.Key);
+                    if (amount <= 0)
+                        continue;
+
+                    // Take as much from the bag as can fit in receivers
+                    var toTake = Math.Min(receiverCapacity, amount * sendFactor);
+                    GD.Print($"Moving this amount of not useful out: {toTake}");
+
+                    // Share the outgoing capacity across cells if there isn't enough space
+                    /*if (receiverCapacity < entry.Value)
+                    {
+                        toTake *= amount / entry.Value;
+                        GD.Print($"To take adjustment to: {toTake}");
+                    }*/
+
+                    // If ran out of space, don't take anything.
+                    if (toTake > 0)
+                    {
+                        bag.TakeCompound(entry.Key, toTake);
+                        GD.Print($"Amount left in sender bag: {bag.GetCompoundAmount(entry.Key)}");
+                        receiverCapacity -= toTake;
+                    }
+
+                    // If we didn't take the full amount, then we need to reduce the number of compounds to share
+                    var couldNotShare = amount - toTake;
+                    if (couldNotShare > 0)
+                    {
+                        availableCompounds[entry.Key] -= couldNotShare;
+                        GD.Print($"Adjusted available compound down to: {availableCompounds[entry.Key]}");
+                    }
+
+                    GD.Print($"Finished one bag, capacity left: {receiverCapacity}");
+                }
+            }
+
+            summedCompoundsBuffer.Clear();
+        }
+
+        GD.Print("Compound capacities:");
+        foreach (var entry in compoundCapacities)
+        {
+            GD.Print($" {entry.Key}: {entry.Value}");
+        }
+
+        GD.Print("Compounds to share:");
+        foreach (var entry in availableCompounds)
+        {
+            GD.Print($" {entry.Key}: {entry.Value}");
+        }
+
+#if DEBUG
+        if (availableCompounds.ContainsKey(Compound.ATP))
+            throw new InvalidOperationException("ATP compound should not be shareable");
+#endif
+
+        foreach (var compound in usefulCompoundsBuffer)
+        {
+            if (!compoundCapacities.TryGetValue(compound, out var storage) || storage <= 0)
+                ReportZeroCapacityForUsefulCompoundOnce(SimulationParameters.GetCompound(compound));
+        }
+
+        // Now, we know how many shareable compounds there are and how much capacity there is for each compound.
+        // So we can give each eligible receiver their share.
+
+        foreach (var entry in availableCompounds)
+        {
+            GD.Print($"Amount of {entry.Key} to share: {entry.Value}");
+            foreach (var bag in bags)
+            {
+                var capacity = bag.GetCapacityForCompound(entry.Key);
+
+                // Don't participate if you can't receive the compound
+                if (capacity <= 0)
+                    continue;
+
+                // Other bags will grab a share according to their capacity
+                var targetLevel = availableCompounds[entry.Key] * (capacity / compoundCapacities[entry.Key]);
+
+                var difference = targetLevel - bag.GetCompoundAmount(entry.Key);
+
+                GD.Print($"Bag gets ({entry.Key}) {targetLevel} out of {entry.Value}. Adjustment: {difference}");
+
+                if (difference > 0)
+                {
+                    bag.AddCompound(entry.Key, difference);
+                }
+                else
+                {
+                    // TODO: should we check the return value here to ensure enough was taken?
+                    // We need to negate the value to get it to be positive for taking away compounds
+                    bag.TakeCompound(entry.Key, -difference);
+                }
+
+                GD.Print($" Resulting amount of {entry.Key}: {bag.GetCompoundAmount(entry.Key)}");
+            }
         }
     }
 
@@ -213,46 +432,6 @@ public class ColonyCompoundBag : ICompoundStorage
         }
     }
 
-    private bool TryPrepareCompoundDistribution(Compound compound, float compoundAmount, List<CompoundBag> bags,
-        CompoundDefinition compoundDefinition, out float ratio)
-    {
-        ratio = 0;
-
-        if (!compoundDefinition.CanBeDistributed)
-            return false;
-
-        float compoundCapacity = 0;
-        var usefulInAnyBag = false;
-
-        foreach (var bag in bags)
-        {
-            bool isUseful = bag.IsUseful(compound);
-            if (!usefulInAnyBag && isUseful)
-                usefulInAnyBag = true;
-
-            // If a bag doesn't consider a compound useful, it won't take it, thus we would calculate things
-            // incorrectly (in RedistributeCompoundAcrossBags), so capacity is not given for non-useful compounds
-            if (!isUseful)
-                continue;
-
-            compoundCapacity += bag.GetCapacityForCompound(compound);
-        }
-
-        if (!usefulInAnyBag)
-            return false;
-
-        // This is just an error print, can be removed if no more NaN issues occur.
-        // See also CompoundBag.FixNaNCompounds, which fixes NaN values after they occur
-        if (compoundCapacity == 0)
-        {
-            ReportZeroCapacityForUsefulCompoundOnce(compoundDefinition);
-            return false;
-        }
-
-        ratio = compoundAmount / compoundCapacity;
-        return true;
-    }
-
     private void ReportZeroCapacityForUsefulCompoundOnce(CompoundDefinition compoundDefinition)
     {
         if (nanIssueReported)
@@ -261,27 +440,6 @@ public class ColonyCompoundBag : ICompoundStorage
         GD.PrintErr($"Compound {compoundDefinition.Name} is set to useful but has a Capacity of zero, " +
             "https://github.com/Revolutionary-Games/Thrive/issues/3201");
         nanIssueReported = true;
-    }
-
-    private void RedistributeCompoundAcrossBags(Compound compound, CompoundDefinition compoundDefinition,
-        float ratio, List<CompoundBag> bags)
-    {
-        foreach (var bag in bags)
-        {
-            if (!bag.IsUseful(compoundDefinition))
-                continue;
-
-            var expectedAmount = ratio * bag.GetCapacityForCompound(compound);
-            var surplus = bag.GetCompoundAmount(compound) - expectedAmount;
-
-            if (surplus > 0)
-            {
-                bag.TakeCompound(compound, surplus);
-                continue;
-            }
-
-            bag.AddCompound(compound, -surplus);
-        }
     }
 
     private List<CompoundBag> GetCompoundBags()

--- a/src/microbe_stage/ColonyCompoundBag.cs
+++ b/src/microbe_stage/ColonyCompoundBag.cs
@@ -84,8 +84,6 @@ public class ColonyCompoundBag : ICompoundStorage
     {
         var bags = GetCompoundBags();
 
-        GD.Print("Compound bag count: " + bags.Count);
-
         usefulCompoundsBuffer.Clear();
         availableCompounds.Clear();
         compoundCapacities.Clear();
@@ -101,12 +99,6 @@ public class ColonyCompoundBag : ICompoundStorage
         // Don't share ATP
         usefulCompoundsBuffer.Remove(Compound.ATP);
 
-        GD.Print("Useful compounds:");
-        foreach (var compound in usefulCompoundsBuffer)
-        {
-            GD.Print($" {compound}");
-        }
-
         bool needsNonUsefulAdjustments = false;
 
         // This is used as a sum of non-useful compounds
@@ -115,8 +107,6 @@ public class ColonyCompoundBag : ICompoundStorage
         // Then offer up the compounds
         foreach (var bag in bags)
         {
-            GD.Print("Next bag");
-
             foreach (var bagCompound in bag.Compounds)
             {
                 // Don't offer compounds to move that nobody finds useful in this colony
@@ -125,8 +115,6 @@ public class ColonyCompoundBag : ICompoundStorage
 
                 if (bagCompound.Value <= 0)
                     continue;
-
-                GD.Print($" Amount({bagCompound.Key}): {bagCompound.Value}");
 
                 // Has available compound, try to share with other bags
                 if (availableCompounds.TryGetValue(bagCompound.Key, out var availableAmount))
@@ -165,8 +153,6 @@ public class ColonyCompoundBag : ICompoundStorage
                 if (bagCapacity <= 0)
                     continue;
 
-                GD.Print($" Capacity({compound}): {bagCapacity}");
-
                 // Report the capacity so that correct fraction of compound is received
                 if (compoundCapacities.TryGetValue(compound, out var capacity))
                 {
@@ -198,8 +184,6 @@ public class ColonyCompoundBag : ICompoundStorage
                 // Share the outgoing capacity across cells if there isn't enough space
                 var sendFactor = Math.Min(1, receiverCapacity / entry.Value);
 
-                GD.Print($"Not useful: {entry.Key}, available space: {receiverCapacity}");
-
                 // Then take as much from the sender bags as the receivers can take
                 foreach (var bag in bags)
                 {
@@ -212,20 +196,11 @@ public class ColonyCompoundBag : ICompoundStorage
 
                     // Take as much from the bag as can fit in receivers
                     var toTake = Math.Min(receiverCapacity, amount * sendFactor);
-                    GD.Print($"Moving this amount of not useful out: {toTake}");
-
-                    // Share the outgoing capacity across cells if there isn't enough space
-                    /*if (receiverCapacity < entry.Value)
-                    {
-                        toTake *= amount / entry.Value;
-                        GD.Print($"To take adjustment to: {toTake}");
-                    }*/
 
                     // If ran out of space, don't take anything.
                     if (toTake > 0)
                     {
                         bag.TakeCompound(entry.Key, toTake);
-                        GD.Print($"Amount left in sender bag: {bag.GetCompoundAmount(entry.Key)}");
                         receiverCapacity -= toTake;
                     }
 
@@ -234,26 +209,11 @@ public class ColonyCompoundBag : ICompoundStorage
                     if (couldNotShare > 0)
                     {
                         availableCompounds[entry.Key] -= couldNotShare;
-                        GD.Print($"Adjusted available compound down to: {availableCompounds[entry.Key]}");
                     }
-
-                    GD.Print($"Finished one bag, capacity left: {receiverCapacity}");
                 }
             }
 
             summedCompoundsBuffer.Clear();
-        }
-
-        GD.Print("Compound capacities:");
-        foreach (var entry in compoundCapacities)
-        {
-            GD.Print($" {entry.Key}: {entry.Value}");
-        }
-
-        GD.Print("Compounds to share:");
-        foreach (var entry in availableCompounds)
-        {
-            GD.Print($" {entry.Key}: {entry.Value}");
         }
 
 #if DEBUG
@@ -272,7 +232,6 @@ public class ColonyCompoundBag : ICompoundStorage
 
         foreach (var entry in availableCompounds)
         {
-            GD.Print($"Amount of {entry.Key} to share: {entry.Value}");
             foreach (var bag in bags)
             {
                 var capacity = bag.GetCapacityForCompound(entry.Key);
@@ -286,8 +245,6 @@ public class ColonyCompoundBag : ICompoundStorage
 
                 var difference = targetLevel - bag.GetCompoundAmount(entry.Key);
 
-                GD.Print($"Bag gets ({entry.Key}) {targetLevel} out of {entry.Value}. Adjustment: {difference}");
-
                 if (difference > 0)
                 {
                     bag.AddCompound(entry.Key, difference);
@@ -298,8 +255,6 @@ public class ColonyCompoundBag : ICompoundStorage
                     // We need to negate the value to get it to be positive for taking away compounds
                     bag.TakeCompound(entry.Key, -difference);
                 }
-
-                GD.Print($" Resulting amount of {entry.Key}: {bag.GetCompoundAmount(entry.Key)}");
             }
         }
     }

--- a/src/microbe_stage/CompoundBag.cs
+++ b/src/microbe_stage/CompoundBag.cs
@@ -275,6 +275,23 @@ public class CompoundBag : ICompoundStorage, IEnumerable<KeyValuePair<Compound, 
         return usefulCompounds.Contains(compound);
     }
 
+    public void CopyUsefulToHash(HashSet<Compound> target, bool copyDefaults = false)
+    {
+        foreach (var usefulCompound in usefulCompounds)
+        {
+            target.Add(usefulCompound);
+        }
+
+        if (copyDefaults)
+        {
+            foreach (var compound in SimulationParameters.Instance.GetAllCompounds().Values)
+            {
+                if (compound.IsAlwaysUseful)
+                    target.Add(compound.ID);
+            }
+        }
+    }
+
     /// <summary>
     ///   Checks if any of the given compounds are marked specifically useful. This uses List indexed access to avoid
     ///   interface-typed foreach allocations in hot paths.

--- a/test/microbe_stage.tests/ColonyCompoundBagTests.cs
+++ b/test/microbe_stage.tests/ColonyCompoundBagTests.cs
@@ -167,11 +167,12 @@ public class ColonyCompoundBagTests
         AssertThat(secondBag.GetCompoundAmount(Compound.Oxygen)).IsEqual(0.00101023586f);
         AssertThat(secondBag.GetCompoundAmount(Compound.ATP)).IsEqual(8.63854504f);
         AssertThat(secondBag.GetCompoundAmount(Compound.Ammonia)).IsEqual(0.00166848977f);
-        AssertThat(secondBag.GetCompoundAmount(Compound.Phosphates)).IsEqual(0.0929203779f);
+        AssertThat(secondBag.GetCompoundAmount(Compound.Phosphates)).IsEqual(0.092920385f);
 
         AssertThat(secondBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(10);
 
         // Make sure the oxytoxy can be consumed all (so that it isn't infinite)
+        float totalTaken = 0;
         for (int i = 0; i < 1000; ++i)
         {
             var taken1 = secondBag.TakeCompound(Compound.Oxytoxy, 0.1f);
@@ -179,11 +180,60 @@ public class ColonyCompoundBagTests
             if (taken1 <= 0)
                 break;
 
+            totalTaken += taken1;
             colonyBag.DistributeCompoundSurplus();
         }
 
         AssertThat(secondBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(0);
-        AssertThat(firstBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(2.8125f);
+
+        // In the new version of code, the old bag that doesn't consider it useful sends it to the other bag, so it
+        // itself ends up with zero
+        AssertThat(firstBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(0);
+        AssertThat(totalTaken).IsEqualApprox(12.8f, 0.1f);
+    }
+
+    [TestCase]
+    public void DistributeCompoundsSharesNonUsefulOxytoxyToOneThatCanUseIt()
+    {
+        using var world = ThriveWorld.Create();
+        var firstBag = CreateBag(10, Compound.Ammonia);
+        var secondBag = CreateBag(10, Compound.Ammonia, Compound.Oxytoxy);
+        var colonyBag = CreateColonyBag(world, firstBag, secondBag);
+
+        SetAmount(firstBag, Compound.Oxytoxy, 9.7f);
+        SetAmount(secondBag, Compound.Oxytoxy, 1.0f);
+
+        colonyBag.DistributeCompoundSurplus();
+
+        AssertThat(firstBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqualApprox(0.7f, 0.001f);
+        AssertThat(secondBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(10.0f);
+    }
+
+    [TestCase]
+    public void DistributeCompoundsSharesAsMuchNonUsefulCompoundAsPossible()
+    {
+        using var world = ThriveWorld.Create();
+        var firstBag = CreateBag(10, Compound.Ammonia);
+        var secondBag = CreateBag(10, Compound.Ammonia);
+        var thirdBag = CreateBag(10, Compound.Ammonia, Compound.Oxytoxy);
+        var colonyBag = CreateColonyBag(world, firstBag, secondBag, thirdBag);
+
+        SetAmount(firstBag, Compound.Oxytoxy, 8);
+        SetAmount(secondBag, Compound.Oxytoxy, 8);
+        SetAmount(thirdBag, Compound.Oxytoxy, 2);
+
+        colonyBag.DistributeCompoundSurplus();
+
+        AssertThat(firstBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(4);
+        AssertThat(secondBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(4);
+        AssertThat(thirdBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(10);
+        AssertThat(thirdBag.TakeCompound(Compound.Oxytoxy, 10)).IsEqual(10);
+
+        colonyBag.DistributeCompoundSurplus();
+
+        AssertThat(firstBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(0);
+        AssertThat(secondBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(0);
+        AssertThat(thirdBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(8);
     }
 
     private static CompoundBag CreateBag(float nominalCapacity, params Compound[] usefulCompounds)

--- a/test/microbe_stage.tests/ColonyCompoundBagTests.cs
+++ b/test/microbe_stage.tests/ColonyCompoundBagTests.cs
@@ -236,6 +236,45 @@ public class ColonyCompoundBagTests
         AssertThat(thirdBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(8);
     }
 
+    [TestCase]
+    public void DistributeCompoundsKeepsNonUsefulOnesWithoutAReceiver()
+    {
+        using var world = ThriveWorld.Create();
+        var firstBag = CreateBag(10, Compound.Ammonia);
+        var secondBag = CreateBag(10, Compound.Ammonia);
+        var thirdBag = CreateBag(10, Compound.Ammonia, Compound.Oxytoxy);
+        var colonyBag = CreateColonyBag(world, firstBag, secondBag, thirdBag);
+
+        SetAmount(firstBag, Compound.Oxytoxy, 7);
+        SetAmount(secondBag, Compound.Oxytoxy, 3);
+        SetAmount(thirdBag, Compound.Oxytoxy, 10);
+
+        colonyBag.DistributeCompoundSurplus();
+
+        AssertThat(firstBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(7);
+        AssertThat(secondBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(3);
+        AssertThat(thirdBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(10);
+    }
+
+    [TestCase]
+    public void DistributeCompoundsKeepsNonUsefulOnesWithoutCapacity()
+    {
+        using var world = ThriveWorld.Create();
+        var firstBag = CreateBag(10, Compound.Ammonia);
+        var secondBag = CreateBag(10, Compound.Ammonia);
+        var thirdBag = CreateBag(0, Compound.Ammonia, Compound.Oxytoxy);
+        var colonyBag = CreateColonyBag(world, firstBag, secondBag, thirdBag);
+
+        SetAmount(firstBag, Compound.Oxytoxy, 1);
+        SetAmount(secondBag, Compound.Oxytoxy, 2);
+
+        colonyBag.DistributeCompoundSurplus();
+
+        AssertThat(firstBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(1);
+        AssertThat(secondBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(2);
+        AssertThat(thirdBag.GetCompoundAmount(Compound.Oxytoxy)).IsEqual(0);
+    }
+
     private static CompoundBag CreateBag(float nominalCapacity, params Compound[] usefulCompounds)
     {
         var bag = new CompoundBag(nominalCapacity);


### PR DESCRIPTION
**Brief Description of What This PR Does**

This should ensure that situations where players see their oxytoxy amount above their storage max are much less common. This has been a bug and a "bug" that has been reported for the past two Thrive releases so I think this was worth it to fix. Thanks to the unit tests the new logic should basically be equivalent to the old one (given a bit of a rounding error of floats)

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved colony compound distribution so useful compounds are shared with capable colony members.
  * Prevented compound loss when no suitable receiver or available capacity exists.
  * Ensured excess non-useful compounds are redistributed where possible.

* **Tests**
  * Added coverage for compound sharing, capacity limits, and retention behavior.

* **Documentation**
  * Clarified when hidden resource bars are refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->