### PR TITLE
Fixed circular microbe chemoreceptor references

### DIFF
--- a/src/microbe_stage/OrganelleTemplate.cs
+++ b/src/microbe_stage/OrganelleTemplate.cs
@@ -68,11 +68,16 @@ public class OrganelleTemplate : IReadOnlyOrganelleTemplate, IPositionedOrganell
         if (version is > SERIALIZATION_VERSION or <= 0)
             throw new InvalidArchiveVersionException(version, SERIALIZATION_VERSION);
 
-        return new OrganelleTemplate(reader.ReadObject<OrganelleDefinition>(), reader.ReadHex(), reader.ReadInt32())
-        {
-            ModifiableUpgrades = reader.ReadObjectOrNull<OrganelleUpgrades>(),
-            IsEndosymbiont = version > 1 && reader.ReadBool(),
-        };
+        // Read the fields needed to construct the template first. The remaining fields can contain references back
+        // to the template's containing layout/species, so the template must be registered before reading them.
+        var instance = new OrganelleTemplate(reader.ReadObject<OrganelleDefinition>(), reader.ReadHex(),
+            reader.ReadInt32());
+        reader.ReportObjectConstructorDone(instance, referenceId);
+
+        // Especially the chemoreceptor upgrades can be troublesome!
+        instance.ModifiableUpgrades = reader.ReadObjectOrNull<OrganelleUpgrades>();
+        instance.IsEndosymbiont = version > 1 && reader.ReadBool();
+        return instance;
     }
 
     public void WriteToArchive(ISArchiveWriter writer)

--- a/test/microbe_stage.tests/MicrobeSavingTests.cs
+++ b/test/microbe_stage.tests/MicrobeSavingTests.cs
@@ -48,14 +48,14 @@ public class MicrobeSavingTests
         gameWorld.GenerationHistory.Add(0, new GenerationRecord(0, records));
 
         var manager = new ThriveArchiveManager();
-        var data = new MemoryStream();
-        var writer = new SArchiveMemoryWriter(data, manager, false);
+        using var data = new MemoryStream();
+        using var writer = new SArchiveMemoryWriter(data, manager, false);
 
         manager.OnStartNewWrite(writer);
         writer.WriteObject(gameWorld);
         manager.OnFinishWrite(writer);
 
-        var reader = new SArchiveMemoryReader(data, manager);
+        using var reader = new SArchiveMemoryReader(data, manager);
         data.Position = 0;
 
         manager.OnStartNewRead(reader);
@@ -69,6 +69,8 @@ public class MicrobeSavingTests
         var loadedB = (MicrobeSpecies)loadedWorld.Species[speciesB.ID];
         var loadedC = (MicrobeSpecies)loadedWorld.Species[speciesC.ID];
         AssertThat(loadedA.Organelles.Count).IsEqual(2);
+        AssertThat(loadedB.Organelles.Count).IsEqual(2);
+        AssertThat(loadedC.Organelles.Count).IsEqual(2);
         AssertThat(((ChemoreceptorUpgrades)loadedA.Organelles.Organelles[1].ModifiableUpgrades!.CustomUpgradeData!)
             .TargetSpecies).IsSame(loadedB);
         AssertThat(((ChemoreceptorUpgrades)loadedB.Organelles.Organelles[1].ModifiableUpgrades!.CustomUpgradeData!)

--- a/test/microbe_stage.tests/MicrobeSavingTests.cs
+++ b/test/microbe_stage.tests/MicrobeSavingTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using AutoEvo;
+using GdUnit4;
+using Godot;
+using Saving.Serializers;
+using SharedBase.Archive;
+using static GdUnit4.Assertions;
+
+[TestSuite]
+[RequireGodotRuntime]
+public class MicrobeSavingTests
+{
+    [TestCase]
+    public void TestSavingMicrobeChemoreceptorSpeciesReferenceCycle()
+    {
+        var membraneType = SimulationParameters.Instance.GetMembrane("single");
+        var cytoplasm = SimulationParameters.Instance.GetOrganelleType("cytoplasm");
+        var chemoreceptor = SimulationParameters.Instance.GetOrganelleType("chemoreceptor");
+
+        var speciesA = CreateSpecies(1, "A", membraneType, cytoplasm, chemoreceptor);
+        var speciesB = CreateSpecies(2, "B", membraneType, cytoplasm, chemoreceptor);
+        var speciesC = CreateSpecies(3, "C", membraneType, cytoplasm, chemoreceptor);
+
+        // This is the important shape: while reading a species' organelle list, its upgrade data reads another
+        // species, which in turn reads another organelle list. The final reference points back to the first species.
+        SetChemoreceptorTarget(speciesA, speciesB);
+        SetChemoreceptorTarget(speciesB, speciesC);
+        SetChemoreceptorTarget(speciesC, speciesA);
+
+        speciesA.BecomePlayerSpecies();
+        var gameWorld = new GameWorld(new WorldGenerationSettings(), speciesA);
+        var firstPatch = gameWorld.Map.CurrentPatch ?? throw new Exception("No patch");
+        firstPatch.AddSpecies(speciesA, 10);
+        firstPatch.AddSpecies(speciesB, 20);
+        firstPatch.AddSpecies(speciesC, 30);
+        gameWorld.RegisterAutoEvoCreatedSpecies(speciesB);
+        gameWorld.RegisterAutoEvoCreatedSpecies(speciesC);
+
+        var records = new Dictionary<uint, SpeciesRecordLite>
+        {
+            { speciesA.ID, new SpeciesRecordLite(speciesA.Population, (Species)speciesA.Clone()) },
+            { speciesB.ID, new SpeciesRecordLite(speciesB.Population, (Species)speciesB.Clone()) },
+            { speciesC.ID, new SpeciesRecordLite(speciesC.Population, (Species)speciesC.Clone()) },
+        };
+        gameWorld.GenerationHistory.Clear();
+        gameWorld.GenerationHistory.Add(0, new GenerationRecord(0, records));
+
+        var manager = new ThriveArchiveManager();
+        var data = new MemoryStream();
+        var writer = new SArchiveMemoryWriter(data, manager, false);
+
+        manager.OnStartNewWrite(writer);
+        writer.WriteObject(gameWorld);
+        manager.OnFinishWrite(writer);
+
+        var reader = new SArchiveMemoryReader(data, manager);
+        data.Position = 0;
+
+        manager.OnStartNewRead(reader);
+        var loadedWorld = reader.ReadObjectOrNull<GameWorld>();
+        manager.OnFinishRead(reader);
+
+        AssertThat(loadedWorld).IsNotNull();
+        AssertThat(loadedWorld!.Species.Count).IsEqual(3);
+
+        var loadedA = (MicrobeSpecies)loadedWorld.Species[speciesA.ID];
+        var loadedB = (MicrobeSpecies)loadedWorld.Species[speciesB.ID];
+        var loadedC = (MicrobeSpecies)loadedWorld.Species[speciesC.ID];
+        AssertThat(loadedA.Organelles.Count).IsEqual(2);
+        AssertThat(((ChemoreceptorUpgrades)loadedA.Organelles.Organelles[1].ModifiableUpgrades!.CustomUpgradeData!)
+            .TargetSpecies).IsSame(loadedB);
+        AssertThat(((ChemoreceptorUpgrades)loadedB.Organelles.Organelles[1].ModifiableUpgrades!.CustomUpgradeData!)
+            .TargetSpecies).IsSame(loadedC);
+        AssertThat(((ChemoreceptorUpgrades)loadedC.Organelles.Organelles[1].ModifiableUpgrades!.CustomUpgradeData!)
+            .TargetSpecies).IsSame(loadedA);
+    }
+
+    private static MicrobeSpecies CreateSpecies(uint id, string name, MembraneType membraneType,
+        OrganelleDefinition cytoplasm, OrganelleDefinition chemoreceptor)
+    {
+        var species = new MicrobeSpecies(id, name, "Species")
+        {
+            IsBacteria = true,
+            MembraneType = membraneType,
+        };
+        species.Organelles.Add(new OrganelleTemplate(cytoplasm, new Hex(0, 0), 0));
+        species.Organelles.Add(new OrganelleTemplate(chemoreceptor, new Hex(1, 0), 0));
+        return species;
+    }
+
+    private static void SetChemoreceptorTarget(MicrobeSpecies species, MicrobeSpecies target)
+    {
+        species.Organelles.Organelles[1].ModifiableUpgrades = new OrganelleUpgrades
+        {
+            CustomUpgradeData = new ChemoreceptorUpgrades(Compound.Invalid, target, 1000, 1, Colors.White),
+        };
+    }
+}

--- a/test/microbe_stage.tests/MicrobeSavingTests.cs.uid
+++ b/test/microbe_stage.tests/MicrobeSavingTests.cs.uid
@@ -1,0 +1,1 @@
+uid://ctnalkxyvksp1


### PR DESCRIPTION
**Brief Description of What This PR Does**

As apparently the microbe stage can have the exact same bug as multicellular

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microbe save and load handling for organelle templates with referenced upgrades.
  * Fixed restoration of cyclic chemoreceptor species references when loading saved microbes.
  * Saved microbes with interconnected species references now reload more reliably.

* **Tests**
  * Added coverage for saving and reloading multiple species with circular chemoreceptor references.
  * Verified that organelles and their linked species are preserved after loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->