### PR TITLE
Multicast commands & SpanTokenizer fixes.

### DIFF
--- a/src/engine/console/CommandRegistry.cs
+++ b/src/engine/console/CommandRegistry.cs
@@ -171,7 +171,6 @@ public class CommandRegistry : IDisposable
         GD.PrintErr("Cannot register multicast commands before the command registry is initialised.");
 
         return false;
-
     }
 
     /// <summary>

--- a/src/engine/console/CommandRegistry.cs
+++ b/src/engine/console/CommandRegistry.cs
@@ -165,93 +165,13 @@ public class CommandRegistry : IDisposable
     public bool TryRegisterMulticastCommandListener<T>(T owner, string commandName)
         where T : notnull
     {
-        if (commands is null)
-        {
-            GD.PrintErr("Cannot register multicast commands before the command registry is initialised.");
+        if (HasLoaded())
+            return RegisterMulticastCommandListener(owner, commandName);
 
-            return false;
-        }
+        GD.PrintErr("Cannot register multicast commands before the command registry is initialised.");
 
-        if (commands.ContainsKey(commandName))
-        {
-            GD.PrintErr("Cannot register multicast command that overloads (has the same name of) a static" +
-                $"command. Please rename your multicast command. Current name: {commandName}");
+        return false;
 
-            return false;
-        }
-
-        if (!multicastCommands.TryGetValue(commandName, out var multicastCommandRegistry))
-        {
-            var type = owner.GetType();
-
-            // The command hasn't been registered yet, and we do so during runtime.
-            // Unlike static commands, multicast commands are instance members, so we only have class-specific
-            // overloads. Therefore, we only need to scan the methods in T.
-            multicastCommandRegistry = new MulticastCommandRegistry([], []);
-            multicastCommands.Add(commandName, multicastCommandRegistry);
-
-            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
-
-            foreach (var method in type.GetMethods(flags))
-            {
-                if (!method.IsDefined(typeof(MulticastCommandAttribute), true))
-                    continue;
-
-                foreach (var attribute in method.GetCustomAttributes<MulticastCommandAttribute>(true))
-                {
-                    var name = attribute.CommandName.ToLowerInvariant();
-
-                    if (name != commandName)
-                        continue;
-
-                    var isCheat = attribute.IsCheat;
-                    var command = new Command(method, name, isCheat, attribute.HelpText,
-                        new MulticastCommandParameters(attribute.MaxAllowedRegisteredInstances,
-                            attribute.FailOnTooManyInstances));
-
-                    multicastCommandRegistry.Overloads.Add(command);
-                }
-            }
-
-            if (multicastCommandRegistry.Overloads.Count == 0)
-            {
-                GD.PrintErr($"No command called {commandName} has been found for registration.");
-
-                multicastCommands.Remove(commandName);
-
-                return false;
-            }
-        }
-
-        if (multicastCommandRegistry.Overloads[0].MethodInfo.DeclaringType != owner.GetType())
-        {
-            GD.PrintErr("Attempted to register an overload outside the already registered class.");
-
-            return false;
-        }
-
-        foreach (var command in multicastCommandRegistry.Overloads)
-        {
-            var multicastParameters = command.MulticastParameters!;
-            var multicastAllowedInstances = multicastParameters.MaxAllowedRegisteredInstances;
-
-            if (multicastCommandRegistry.Owners.Count >= multicastAllowedInstances)
-            {
-                multicastParameters.Disabled = multicastParameters.FailOnTooManyInstances;
-
-                // This ignores command owner registration for *any* overload. This prevents having an owner list for
-                // each overload, which is much harder to maintain.
-                // If two overloads *must* have a different owner count, it is recommended to use a different command
-                // name instead.
-                return false;
-            }
-
-            multicastParameters.Disabled = false;
-        }
-
-        multicastCommandRegistry.Owners.Add(owner);
-
-        return true;
     }
 
     /// <summary>
@@ -637,6 +557,102 @@ public class CommandRegistry : IDisposable
     }
 
     /// <summary>
+    ///   Registration path that skips the loaded check. Used by <see cref="RegisterCommands"/> to register the
+    ///   built-in listeners while the loading task is still running.
+    /// </summary>
+    private bool RegisterMulticastCommandListener<T>(T owner, string commandName)
+        where T : notnull
+    {
+        if (commands is null)
+        {
+            GD.PrintErr("Cannot register multicast commands before the command registry is initialised.");
+
+            return false;
+        }
+
+        if (commands.ContainsKey(commandName))
+        {
+            GD.PrintErr("Cannot register multicast command that overloads (has the same name of) a static" +
+                $"command. Please rename your multicast command. Current name: {commandName}");
+
+            return false;
+        }
+
+        if (!multicastCommands.TryGetValue(commandName, out var multicastCommandRegistry))
+        {
+            var type = owner.GetType();
+
+            // The command hasn't been registered yet, and we do so during runtime.
+            // Unlike static commands, multicast commands are instance members, so we only have class-specific
+            // overloads. Therefore, we only need to scan the methods in T.
+            multicastCommandRegistry = new MulticastCommandRegistry([], []);
+            multicastCommands.Add(commandName, multicastCommandRegistry);
+
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
+            foreach (var method in type.GetMethods(flags))
+            {
+                if (!method.IsDefined(typeof(MulticastCommandAttribute), true))
+                    continue;
+
+                foreach (var attribute in method.GetCustomAttributes<MulticastCommandAttribute>(true))
+                {
+                    var name = attribute.CommandName.ToLowerInvariant();
+
+                    if (name != commandName)
+                        continue;
+
+                    var isCheat = attribute.IsCheat;
+                    var command = new Command(method, name, isCheat, attribute.HelpText,
+                        new MulticastCommandParameters(attribute.MaxAllowedRegisteredInstances,
+                            attribute.FailOnTooManyInstances));
+
+                    multicastCommandRegistry.Overloads.Add(command);
+                }
+            }
+
+            if (multicastCommandRegistry.Overloads.Count == 0)
+            {
+                GD.PrintErr($"No command called {commandName} has been found for registration.");
+
+                multicastCommands.Remove(commandName);
+
+                return false;
+            }
+        }
+
+        if (multicastCommandRegistry.Overloads[0].MethodInfo.DeclaringType != owner.GetType())
+        {
+            GD.PrintErr("Attempted to register an overload outside the already registered class.");
+
+            return false;
+        }
+
+        foreach (var command in multicastCommandRegistry.Overloads)
+        {
+            var multicastParameters = command.MulticastParameters!;
+            var multicastAllowedInstances = multicastParameters.MaxAllowedRegisteredInstances;
+
+            if (multicastCommandRegistry.Owners.Count >= multicastAllowedInstances)
+            {
+                multicastParameters.Disabled = multicastParameters.FailOnTooManyInstances;
+
+                // This ignores command owner registration for *any* overload. This prevents having an owner list for
+                // each overload, which is much harder to maintain.
+                // If two overloads *must* have a different owner count, it is recommended to use a different command
+                // name instead.
+                return false;
+            }
+
+            multicastParameters.Disabled = false;
+        }
+
+        multicastCommandRegistry.Owners.Add(owner);
+
+        return true;
+    }
+
+    /// <summary>
     ///   Lazily calls RegisterCommands. I found RegisterCommands to be a potential bottleneck in a future bigger
     ///   codebase, so I prefer deferring this loading process, which is non-critical, to a separate task, even though
     ///   right now it shouldn't take more than half a second.
@@ -659,8 +675,7 @@ public class CommandRegistry : IDisposable
 
         var tempDict = new Dictionary<string, List<Command>>();
 
-        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic |
-            BindingFlags.Static | BindingFlags.Instance;
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
 
         foreach (var assembly in assemblies)
         {
@@ -712,7 +727,7 @@ public class CommandRegistry : IDisposable
         foreach (var commandsArray in commands.Values)
         {
             foreach (var command in commandsArray)
-                TryRegisterMulticastCommandListener(command, "commands");
+                RegisterMulticastCommandListener(command, "commands");
         }
 
         GD.Print($"CommandRegistry: Loaded. Command groups: {commands.Count}.");

--- a/src/engine/console/SpanTokenizer.cs
+++ b/src/engine/console/SpanTokenizer.cs
@@ -26,7 +26,7 @@ public ref struct SpanTokenizer(ReadOnlySpan<char> input)
         {
             isQuoted = true;
 
-            var end = remaining[1..].IndexOf('"');
+            var end = IndexOfUnescapedQuote(remaining[1..]);
 
             // unclosed quote, take everything
             if (end == -1)
@@ -57,5 +57,35 @@ public ref struct SpanTokenizer(ReadOnlySpan<char> input)
         }
 
         return true;
+    }
+
+    /// <summary>
+    ///   Finds the first quote that is not escaped by a backslash. A quote is escaped only when it is preceded by an
+    ///   odd amount of backslashes, as an even amount means the backslashes escape each other.
+    /// </summary>
+    private static int IndexOfUnescapedQuote(ReadOnlySpan<char> content)
+    {
+        int searchStart = 0;
+
+        while (searchStart < content.Length)
+        {
+            var index = content[searchStart..].IndexOf('"');
+
+            if (index == -1)
+                return -1;
+
+            index += searchStart;
+
+            int backslashes = 0;
+            while (index - backslashes > 0 && content[index - backslashes - 1] == '\\')
+                ++backslashes;
+
+            if (backslashes % 2 == 0)
+                return index;
+
+            searchStart = index + 1;
+        }
+
+        return -1;
     }
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

Fixed:
- Multicast commands showing error `MulticastCommandAttribute can't be used on static methods` even when correctly declared on instance methods.
- [Multicast commands could be registered before the `CommandRegistry` was initialised](https://github.com/Revolutionary-Games/Thrive/pull/7145#discussion_r3822630134).
- [SpanTokenizer matched quote-enclosed strings with escaped quotes `\"`](https://github.com/Revolutionary-Games/Thrive/pull/7145#discussion_r3822630140).

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of quoted command arguments, including quotes preceded by backslashes.
  * Prevented malformed quoted input from being parsed incorrectly.
  * Improved command discovery so only valid static commands are registered.
  * Ensured built-in multicast commands load reliably during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->