### PR TITLE
Bump version number to full 1.6 release

### DIFF
--- a/Thrive.csproj
+++ b/Thrive.csproj
@@ -10,7 +10,7 @@
     <Nullable>enable</Nullable>
     <Company>Revolutionary Games Studio</Company>
     <Version>1.6.0.0</Version>
-    <InformationalVersion>-rc1</InformationalVersion>
+    <!--<InformationalVersion>-rc1</InformationalVersion>-->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <!-- Ignore the subproject source files -->

--- a/src/saving/CompatibleSaveVersions.cs
+++ b/src/saving/CompatibleSaveVersions.cs
@@ -14,7 +14,7 @@ public static class CompatibleSaveVersions
         KnownVersionCompatibilityMapping = new()
         {
             {
-                "1.6.0.0-rc1", [
+                "1.6.0.0", [
                     ("0.9.0.0", false), ("0.9.0.1", false),
                     ("0.9.1.0", true), ("0.9.1.1", true),
                     ("0.9.2.0", true), ("1.0.0.0", true),
@@ -22,6 +22,8 @@ public static class CompatibleSaveVersions
                     ("1.0.1.0", true), ("1.0.1.1", true),
                     ("1.1.0.0-rc1", true), ("1.1.0.0", true),
                     ("1.2.0.0-alpha", true), ("1.6.0.0-alpha", true),
+
+                    // NOTE: 1.6 is explicitly not compatible with the 1.6.0.0-rc1 as that changes organelle size
                 ]
             },
         };

--- a/src/saving/SaveHelper.cs
+++ b/src/saving/SaveHelper.cs
@@ -39,7 +39,7 @@ public static class SaveHelper
     /// </summary>
     /// <remarks>
     ///   <para>
-    ///     1.6.0.0 is here because it had old actomyosin size, so allowing loading it will cause many problems,
+    ///     1.6.0.0-rc1 is here because it had old actomyosin size, so allowing loading it will cause many problems,
     ///     so we disallow this specific version.
     ///   </para>
     /// </remarks>

--- a/src/saving/SaveHelper.cs
+++ b/src/saving/SaveHelper.cs
@@ -34,6 +34,20 @@ public static class SaveHelper
         "0.9.0.0",
     ];
 
+    /// <summary>
+    ///   Makes specific versions incompatible with the current version.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     1.6.0.0 is here because it had old actomyosin size, so allowing loading it will cause many problems,
+    ///     so we disallow this specific version.
+    ///   </para>
+    /// </remarks>
+    private static readonly List<string> SpecificIncompatibleVersions =
+    [
+        "1.6.0.0-rc1",
+    ];
+
     private static readonly IReadOnlyList<MainGameState> StagesAllowingPrototypeSaving =
     [
         MainGameState.MicrobeStage,
@@ -519,6 +533,14 @@ public static class SaveHelper
     /// <returns>True if certainly incompatible</returns>
     public static bool IsKnownIncompatible(string saveVersion)
     {
+        foreach (var specificIncompatibleVersion in SpecificIncompatibleVersions)
+        {
+            if (saveVersion == specificIncompatibleVersion)
+            {
+                return true;
+            }
+        }
+
         int currentVersionPlaceInList = -1;
         int savePlaceInList = -1;
 
@@ -551,7 +573,7 @@ public static class SaveHelper
 
         // If the current version and the save version don't fit in the same place in the save breakage points list
         // the save is either older or newer than the closes save breakage point to the current version.
-        // Basically if numbers don't match, we know that the save is incompatible.
+        // Basically, if numbers don't match, we know that the save is incompatible.
         return currentVersionPlaceInList != savePlaceInList;
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

and disallow 1.6.0-rc1 due to actomyosin change

Making this as a separate PR so that I do not forget that needed incompatibility change

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated version identification to remove the release-candidate suffix.
  * Improved saved-game compatibility handling for version 1.6.0.0.
  * Explicitly prevents loading saves from the incompatible 1.6.0.0 release candidate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->