### PR TITLE
Make AI use the binding agent

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1399,6 +1399,7 @@ public static class Constants
     public const float AI_ENGULF_STOP_DISTANCE = 0.8f;
 
     public const float AI_BECOME_AGGRESSIVE_DISTANCE_SQUARED = 120 * 120;
+    public const float AI_ENTER_BINDING_MODE_DISTANCE_SQUARED = 20 * 20;
     public const float AI_FOLLOW_DISTANCE_SQUARED = 60 * 60;
     public const float AI_FLEE_DISTANCE_SQUARED = 85 * 85;
     public const float AI_MOVE_DISTANCE_SQUARED = 240 * 240;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1399,7 +1399,6 @@ public static class Constants
     public const float AI_ENGULF_STOP_DISTANCE = 0.8f;
 
     public const float AI_BECOME_AGGRESSIVE_DISTANCE_SQUARED = 120 * 120;
-    public const float AI_ENTER_BINDING_MODE_DISTANCE_SQUARED = 20 * 20;
     public const float AI_FOLLOW_DISTANCE_SQUARED = 60 * 60;
     public const float AI_FLEE_DISTANCE_SQUARED = 85 * 85;
     public const float AI_MOVE_DISTANCE_SQUARED = 240 * 240;

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -448,7 +448,7 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
                                     control.SetStateColonyAware(entity, MicrobeState.Binding);
                                 }
                             }
-                            else if (!entity.Has<MicrobeColonyMember>())
+                            else
                             {
                                 control.SetStateColonyAware(entity, MicrobeState.Binding);
                             }

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -444,10 +444,11 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
                             atpLevel >= compounds.GetCapacityForCompound(Compound.ATP) * 0.5f &&
                             signalerDistanceSquared < Constants.AI_ENTER_BINDING_MODE_DISTANCE_SQUARED)
                         {
-                            if (rcfe.Has<MicrobeColony>() && !entity.Has<MicrobeColony>())
+                            if (rcfe.Has<MicrobeColony>())
                             {
-                                // Don't bind if colony is already at size needed for multicellular
-                                if (rcfe.Get<MicrobeColony>().ColonyMembers.Length
+                                // Don't bind if it would lead to two colonies merging and/or
+                                // colony is already at size needed for multicellular
+                                if (!entity.Has<MicrobeColony>() && rcfe.Get<MicrobeColony>().ColonyMembers.Length
                                     < Constants.COLONY_SIZE_REQUIRED_FOR_MULTICELLULAR)
                                 {
                                     control.SetStateColonyAware(entity, MicrobeState.Binding);

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -743,7 +743,7 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
         {
             if (entity.Has<MicrobeColony>())
             {
-                if (entity.Get<MicrobeColony>().ColonyMembers.Length <=
+                if (entity.Get<MicrobeColony>().ColonyMembers.Length <
                     Constants.COLONY_SIZE_REQUIRED_FOR_MULTICELLULAR)
                 {
                     signaling.QueuedSignalingCommand = MicrobeSignalCommand.MoveToMe;

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -413,7 +413,7 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
         // Use signaling agent if I have any and am not receiving a command, with a small chance per think method call
         if (organelles.HasSignalingAgent && random.NextSingle() < Constants.AI_SIGNALING_CHANCE && !signalExists)
         {
-            UseSignalingAgent(ref position, ref organelles, atpLevel, compounds, speciesAggression,
+            UseSignalingAgent(in entity, ref position, ref organelles, atpLevel, compounds, speciesAggression,
                 ref signaling, random, ref ourSpecies);
         }
 
@@ -733,15 +733,27 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
         }
     }
 
-    private void UseSignalingAgent(ref WorldPosition position, ref OrganelleContainer organelles, float atpLevel,
-        CompoundBag compounds, float speciesAggression, ref CommandSignaler signaling, Random random,
+    private void UseSignalingAgent(in Entity entity, ref WorldPosition position, ref OrganelleContainer organelles,
+        float atpLevel, CompoundBag compounds, float speciesAggression, ref CommandSignaler signaling, Random random,
         ref SpeciesMember ourSpecies)
     {
         // Has binding agent and ATP is at least half capacity
         if (organelles.HasBindingAgent && atpLevel >= compounds.GetCapacityForCompound(Compound.ATP) * 0.5f)
         {
-            signaling.QueuedSignalingCommand = MicrobeSignalCommand.MoveToMe;
-            return;
+            if (entity.Has<MicrobeColony>())
+            {
+                if (entity.Get<MicrobeColony>().ColonyMembers.Length <=
+                    Constants.COLONY_SIZE_REQUIRED_FOR_MULTICELLULAR)
+                {
+                    signaling.QueuedSignalingCommand = MicrobeSignalCommand.MoveToMe;
+                    return;
+                }
+            }
+            else
+            {
+                signaling.QueuedSignalingCommand = MicrobeSignalCommand.MoveToMe;
+                return;
+            }
         }
 
         var shouldBeAggressive = RollCheck(speciesAggression, Constants.MAX_SPECIES_AGGRESSION, random);

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -314,11 +314,6 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
 
         control.Sprinting = false;
 
-        if (entity.Has<MicrobeColony>() && control.State == MicrobeState.Binding)
-        {
-            control.SetStateColonyAware(entity, MicrobeState.Normal);
-        }
-
         // If nothing is engulfing me right now, see if there's something that might want to hunt me
         (Entity Entity, Vector3 Position, float EngulfSize)? predator =
             GetNearestPredatorItem(ref health, ref ourSpecies, ref engulfer, ref position, speciesFear);
@@ -431,24 +426,24 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
             {
                 case MicrobeSignalCommand.MoveToMe:
                 {
-                    var rcfe = signaling.ReceivedCommandFromEntity;
+                    var signaler = signaling.ReceivedCommandFromEntity;
 
                     // TODO: should these use signaling.ReceivedCommandSource ? As that's where the chemical signal
                     // was smelled from
-                    if (rcfe.IsAliveAndHas<WorldPosition>())
+                    if (signaler.IsAliveAndHas<WorldPosition>())
                     {
                         ai.MoveToLocation(signalerPosition, ref control, entity);
 
                         if (organelles.HasBindingAgent &&
-                            rcfe.Get<OrganelleContainer>().HasBindingAgent &&
+                            signaler.Get<OrganelleContainer>().HasBindingAgent &&
                             atpLevel >= compounds.GetCapacityForCompound(Compound.ATP) * 0.5f &&
                             signalerDistanceSquared < Constants.AI_ENTER_BINDING_MODE_DISTANCE_SQUARED)
                         {
-                            if (rcfe.Has<MicrobeColony>())
+                            if (signaler.Has<MicrobeColony>())
                             {
                                 // Don't bind if it would lead to two colonies merging and/or
                                 // colony is already at size needed for multicellular
-                                if (!entity.Has<MicrobeColony>() && rcfe.Get<MicrobeColony>().ColonyMembers.Length
+                                if (!entity.Has<MicrobeColony>() && signaler.Get<MicrobeColony>().ColonyMembers.Length
                                     < Constants.COLONY_SIZE_REQUIRED_FOR_MULTICELLULAR)
                                 {
                                     control.SetStateColonyAware(entity, MicrobeState.Binding);

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -413,7 +413,8 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
         // Use signaling agent if I have any and am not receiving a command, with a small chance per think method call
         if (organelles.HasSignalingAgent && random.NextSingle() < Constants.AI_SIGNALING_CHANCE && !signalExists)
         {
-            UseSignalingAgent(ref position, ref organelles, speciesAggression, ref signaling, random, ref ourSpecies);
+            UseSignalingAgent(ref position, ref organelles, atpLevel, compounds, speciesAggression,
+                ref signaling, random, ref ourSpecies);
         }
 
         // Follow received commands if we have them
@@ -425,11 +426,33 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
             {
                 case MicrobeSignalCommand.MoveToMe:
                 {
+                    var rcfe = signaling.ReceivedCommandFromEntity;
+
                     // TODO: should these use signaling.ReceivedCommandSource ? As that's where the chemical signal
                     // was smelled from
-                    if (signaling.ReceivedCommandFromEntity.IsAliveAndHas<WorldPosition>())
+                    if (rcfe.IsAliveAndHas<WorldPosition>())
                     {
                         ai.MoveToLocation(signalerPosition, ref control, entity);
+
+                        if (organelles.HasBindingAgent &&
+                            rcfe.Get<OrganelleContainer>().HasBindingAgent &&
+                            atpLevel >= compounds.GetCapacityForCompound(Compound.ATP) * 0.5f)
+                        {
+                            if (rcfe.Has<MicrobeColony>())
+                            {
+                                // Don't bind if colony is already at size needed for multicellular
+                                if (rcfe.Get<MicrobeColony>().ColonyMembers.Length
+                                    < Constants.COLONY_SIZE_REQUIRED_FOR_MULTICELLULAR)
+                                {
+                                    control.SetStateColonyAware(entity, MicrobeState.Binding);
+                                }
+                            }
+                            else
+                            {
+                                control.SetStateColonyAware(entity, MicrobeState.Binding);
+                            }
+                        }
+
                         return;
                     }
 
@@ -710,17 +733,16 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
         }
     }
 
-    private void UseSignalingAgent(ref WorldPosition position, ref OrganelleContainer organelles,
-        float speciesAggression, ref CommandSignaler signaling, Random random, ref SpeciesMember ourSpecies)
+    private void UseSignalingAgent(ref WorldPosition position, ref OrganelleContainer organelles, float atpLevel,
+        CompoundBag compounds, float speciesAggression, ref CommandSignaler signaling, Random random,
+        ref SpeciesMember ourSpecies)
     {
         // Has binding agent and ATP is at least half capacity
-        // TODO: comment out once AI can use the binding agent
-        // Parameters to add: (float atpLevel, CompoundBag compounds)
-        // if (organelles.HasBindingAgent && atpLevel >= compounds.GetCapacityForCompound(Compound.ATP) * 0.5f)
-        // {
-        //     signaling.QueuedSignalingCommand = MicrobeSignalCommand.MoveToMe;
-        //     return;
-        // }
+        if (organelles.HasBindingAgent && atpLevel >= compounds.GetCapacityForCompound(Compound.ATP) * 0.5f)
+        {
+            signaling.QueuedSignalingCommand = MicrobeSignalCommand.MoveToMe;
+            return;
+        }
 
         var shouldBeAggressive = RollCheck(speciesAggression, Constants.MAX_SPECIES_AGGRESSION, random);
         var speciesMembers = GetSpeciesMembers(ourSpecies.Species);

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -448,7 +448,7 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
                                     control.SetStateColonyAware(entity, MicrobeState.Binding);
                                 }
                             }
-                            else
+                            else if (!entity.Has<MicrobeColonyMember>())
                             {
                                 control.SetStateColonyAware(entity, MicrobeState.Binding);
                             }

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -314,6 +314,11 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
 
         control.Sprinting = false;
 
+        if (entity.Has<MicrobeColony>() && control.State == MicrobeState.Binding)
+        {
+            control.SetStateColonyAware(entity, MicrobeState.Normal);
+        }
+
         // If nothing is engulfing me right now, see if there's something that might want to hunt me
         (Entity Entity, Vector3 Position, float EngulfSize)? predator =
             GetNearestPredatorItem(ref health, ref ourSpecies, ref engulfer, ref position, speciesFear);
@@ -439,7 +444,7 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
                             atpLevel >= compounds.GetCapacityForCompound(Compound.ATP) * 0.5f &&
                             signalerDistanceSquared < Constants.AI_ENTER_BINDING_MODE_DISTANCE_SQUARED)
                         {
-                            if (rcfe.Has<MicrobeColony>())
+                            if (rcfe.Has<MicrobeColony>() && !entity.Has<MicrobeColony>())
                             {
                                 // Don't bind if colony is already at size needed for multicellular
                                 if (rcfe.Get<MicrobeColony>().ColonyMembers.Length
@@ -738,8 +743,10 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
         float atpLevel, CompoundBag compounds, float speciesAggression, ref CommandSignaler signaling, Random random,
         ref SpeciesMember ourSpecies)
     {
-        // Has binding agent and ATP is at least half capacity
-        if (organelles.HasBindingAgent && atpLevel >= compounds.GetCapacityForCompound(Compound.ATP) * 0.5f)
+        // Has binding agent, ATP is at least half capacity, and isn't receiving move to me command
+        if (organelles.HasBindingAgent &&
+            atpLevel >= compounds.GetCapacityForCompound(Compound.ATP) * 0.5f &&
+            signaling.ReceivedCommand != MicrobeSignalCommand.MoveToMe)
         {
             if (entity.Has<MicrobeColony>())
             {

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -436,7 +436,8 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
 
                         if (organelles.HasBindingAgent &&
                             rcfe.Get<OrganelleContainer>().HasBindingAgent &&
-                            atpLevel >= compounds.GetCapacityForCompound(Compound.ATP) * 0.5f)
+                            atpLevel >= compounds.GetCapacityForCompound(Compound.ATP) * 0.5f &&
+                            signalerDistanceSquared < Constants.AI_ENTER_BINDING_MODE_DISTANCE_SQUARED)
                         {
                             if (rcfe.Has<MicrobeColony>())
                             {

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -414,7 +414,7 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
         if (organelles.HasSignalingAgent && random.NextSingle() < Constants.AI_SIGNALING_CHANCE && !signalExists)
         {
             UseSignalingAgent(in entity, ref position, ref organelles, atpLevel, compounds, speciesAggression,
-                ref signaling, random, ref ourSpecies);
+                ref signaling, random, ref control, ref ourSpecies);
         }
 
         // Follow received commands if we have them
@@ -432,12 +432,7 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
                     // was smelled from
                     if (signaler.IsAliveAndHas<WorldPosition>())
                     {
-                        ai.MoveToLocation(signalerPosition, ref control, entity);
-
-                        if (organelles.HasBindingAgent &&
-                            signaler.Get<OrganelleContainer>().HasBindingAgent &&
-                            atpLevel >= compounds.GetCapacityForCompound(Compound.ATP) * 0.5f &&
-                            signalerDistanceSquared < Constants.AI_ENTER_BINDING_MODE_DISTANCE_SQUARED)
+                        if (organelles.HasBindingAgent && signaler.Get<OrganelleContainer>().HasBindingAgent)
                         {
                             if (signaler.Has<MicrobeColony>())
                             {
@@ -446,13 +441,17 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
                                 if (!entity.Has<MicrobeColony>() && signaler.Get<MicrobeColony>().ColonyMembers.Length
                                     < Constants.COLONY_SIZE_REQUIRED_FOR_MULTICELLULAR)
                                 {
-                                    control.SetStateColonyAware(entity, MicrobeState.Binding);
+                                    ai.MoveToLocation(signalerPosition, ref control, entity);
                                 }
                             }
                             else
                             {
-                                control.SetStateColonyAware(entity, MicrobeState.Binding);
+                                ai.MoveToLocation(signalerPosition, ref control, entity);
                             }
+                        }
+                        else
+                        {
+                            ai.MoveToLocation(signalerPosition, ref control, entity);
                         }
 
                         return;
@@ -710,7 +709,10 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
         }
 
         // There is no reason to be engulfing at this stage
-        control.SetStateColonyAware(entity, MicrobeState.Normal);
+        if (control.State != MicrobeState.Binding)
+        {
+            control.SetStateColonyAware(entity, MicrobeState.Normal);
+        }
 
         // If the microbe has radiation protection it means it has melanosomes and can stay near the radioactive chunks
         // to produce ATP
@@ -737,7 +739,7 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
 
     private void UseSignalingAgent(in Entity entity, ref WorldPosition position, ref OrganelleContainer organelles,
         float atpLevel, CompoundBag compounds, float speciesAggression, ref CommandSignaler signaling, Random random,
-        ref SpeciesMember ourSpecies)
+        ref MicrobeControl control, ref SpeciesMember ourSpecies)
     {
         // Has binding agent, ATP is at least half capacity, and isn't receiving move to me command
         if (organelles.HasBindingAgent &&
@@ -750,12 +752,14 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
                     Constants.COLONY_SIZE_REQUIRED_FOR_MULTICELLULAR)
                 {
                     signaling.QueuedSignalingCommand = MicrobeSignalCommand.MoveToMe;
+                    control.SetStateColonyAware(entity, MicrobeState.Binding);
                     return;
                 }
             }
             else
             {
                 signaling.QueuedSignalingCommand = MicrobeSignalCommand.MoveToMe;
+                control.SetStateColonyAware(entity, MicrobeState.Binding);
                 return;
             }
         }

--- a/src/microbe_stage/systems/MicrobeAISystem.cs
+++ b/src/microbe_stage/systems/MicrobeAISystem.cs
@@ -444,7 +444,7 @@ public partial class MicrobeAISystem : BaseSystem<World, float>, ISpeciesMemberL
                                     ai.MoveToLocation(signalerPosition, ref control, entity);
                                 }
                             }
-                            else
+                            else if (!entity.Has<MicrobeColony>())
                             {
                                 ai.MoveToLocation(signalerPosition, ref control, entity);
                             }


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR makes the microbe AI use the binding agent to create colonies, and makes the AI signal the move to me command for binding purposes.

**Related Issues**

Rathalos said this would be a good and fun change.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved colony behavior during binding so cells retain their binding state appropriately.
  * Refined responses to movement signals, preventing colony members from moving toward incompatible binding targets.
  * Added eligibility checks for cells responding to binding signals, including energy, available agents, active commands, and colony size.
  * Improved binding-state transitions so cells remain in binding mode when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->