### PR TITLE
Made pending membrane change clear only on action

### DIFF
--- a/src/multicellular_stage/editor/MulticellularEditor.cs
+++ b/src/multicellular_stage/editor/MulticellularEditor.cs
@@ -227,13 +227,9 @@ public partial class MulticellularEditor : EditorBase<EditorAction, MicrobeStage
 
     public override bool EnqueueAction(EditorAction action)
     {
-        if (specialMembraneToSwitchOnExit != null)
-        {
-            // Doing anything prevents membrane change from happening afterwards, just so there's no way to optimize MP
-            // usage by failing to change and then doing an edit and then succeeding
-            specialMembraneToSwitchOnExit = null;
-            GD.Print("Clearing pending membrane change as the player performed an action");
-        }
+        // Doing anything prevents membrane change from happening afterwards, just so there's no way to optimize MP
+        // usage by failing to change and then doing an edit and then succeeding
+        StopMembraneSwitchIfQueued();
 
         return base.EnqueueAction(action);
     }
@@ -288,6 +284,9 @@ public partial class MulticellularEditor : EditorBase<EditorAction, MicrobeStage
 
     public override void Redo()
     {
+        // Redo could be used to trigger a membrane switch in an unintended way, so we always clear it here
+        StopMembraneSwitchIfQueued();
+
         var cellType = history.GetRedoContext<CellType>();
 
         // If the action we're redoing should be done on another cell type,
@@ -664,6 +663,15 @@ public partial class MulticellularEditor : EditorBase<EditorAction, MicrobeStage
 
         // A light refresh of data to not have to do potentially very expensive repositioning algorithm
         EditedSpecies.NotifyMembraneTypeChanged();
+    }
+
+    private void StopMembraneSwitchIfQueued()
+    {
+        if (specialMembraneToSwitchOnExit != null)
+        {
+            specialMembraneToSwitchOnExit = null;
+            GD.Print("Clearing pending membrane change as the player performed an action");
+        }
     }
 
     private void OnRevealAllPatchesCheatUsed(object? sender, EventArgs args)

--- a/src/multicellular_stage/editor/MulticellularEditor.cs
+++ b/src/multicellular_stage/editor/MulticellularEditor.cs
@@ -227,9 +227,13 @@ public partial class MulticellularEditor : EditorBase<EditorAction, MicrobeStage
 
     public override bool EnqueueAction(EditorAction action)
     {
-        // Doing anything prevents membrane change from happening afterwards, just so there's no way to optimize MP
-        // usage by failing to change and then doing an edit and then succeeding
-        specialMembraneToSwitchOnExit = null;
+        if (specialMembraneToSwitchOnExit != null)
+        {
+            // Doing anything prevents membrane change from happening afterwards, just so there's no way to optimize MP
+            // usage by failing to change and then doing an edit and then succeeding
+            specialMembraneToSwitchOnExit = null;
+            GD.Print("Clearing pending membrane change as the player performed an action");
+        }
 
         return base.EnqueueAction(action);
     }
@@ -342,11 +346,13 @@ public partial class MulticellularEditor : EditorBase<EditorAction, MicrobeStage
 
         if (!OnFinishEditing(null))
         {
-            GD.Print("Couldn't exit the editor due to a problem and apply new membrane");
-            specialMembraneToSwitchOnExit = null;
+            // A failed finish attempt can be caused by a warning popup. Keep the membrane change pending so that
+            // confirming the warning can retry the exit and apply it. EnqueueAction clears this if the player
+            // performs an editor action before trying to exit again.
+            GD.Print("Couldn't exit the editor yet due to a problem; membrane change remains pending");
         }
 
-        // We can't unset the membrane in all cases as there's a timed animation on the exit and only then the callback
+        // We can't unset the membrane as there's a timed animation on the exit, and only then the callback
         // needing it will run
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

so that trying to exit and needing to dismiss ATP balance warnings allows the membrane change to still happen

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/228300288023461893/958598553389903913/1540866041843023942

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pending membrane changes during editor actions and redo operations.
  * Preserved pending membrane changes when exiting the editor fails, allowing warning confirmation to retry the change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->