### PR TITLE
Fixed major saving regression where organelle templates shared identity

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -649,6 +649,8 @@ public partial class CellEditorComponent :
             {
                 tolerancesEditor.OnEditorSpeciesSetup(Editor.EditedBaseSpecies);
             }
+
+            VerifyEditedOrganellesDoNotReferToOriginalData();
         }
 
         if (IsMulticellularEditor)
@@ -3540,6 +3542,28 @@ public partial class CellEditorComponent :
         if (chemosynthesis > 0.03)
         {
             AchievementEvents.ReportPlayerUsesChemosynthesis();
+        }
+    }
+
+    private void VerifyEditedOrganellesDoNotReferToOriginalData()
+    {
+        if (IsMacroscopicEditor || IsMulticellularEditor)
+        {
+            var cellProperties = Editor.EditedCellProperties;
+            if (cellProperties == null)
+                return;
+
+            foreach (var editedMicrobeOrganelle in editedMicrobeOrganelles)
+            {
+                foreach (var originalOrganelle in cellProperties.ModifiableOrganelles)
+                {
+                    if (ReferenceEquals(editedMicrobeOrganelle, originalOrganelle))
+                    {
+                        throw new InvalidOperationException(
+                            "Organelle is not from edited, about to modify original data!");
+                    }
+                }
+            }
         }
     }
 

--- a/src/saving/serializers/ReferenceResolver.cs
+++ b/src/saving/serializers/ReferenceResolver.cs
@@ -14,8 +14,16 @@ public class ReferenceResolver : IReferenceResolver
 {
     private readonly Dictionary<string, object> referenceToObject = new();
 
-    // JSON references represent object identity, not value equality. In particular, mutable editor clones can be equal
-    // to their source objects while still needing independent references.
+    /// <summary>
+    ///   Dictionary mapping objects to their JSON references.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     JSON references stored by this represent object identity, not value equality.
+    ///     In particular, mutable editor clones can be equal to their source objects while still needing independent
+    ///     references.
+    ///   </para>
+    /// </remarks>
     private readonly Dictionary<object, string> objectToReference = new(ReferenceEqualityComparer.Instance);
 
     private long referenceCounter;

--- a/src/saving/serializers/ReferenceResolver.cs
+++ b/src/saving/serializers/ReferenceResolver.cs
@@ -13,7 +13,10 @@ using Newtonsoft.Json.Serialization;
 public class ReferenceResolver : IReferenceResolver
 {
     private readonly Dictionary<string, object> referenceToObject = new();
-    private readonly Dictionary<object, string> objectToReference = new();
+
+    // JSON references represent object identity, not value equality. In particular, mutable editor clones can be equal
+    // to their source objects while still needing independent references.
+    private readonly Dictionary<object, string> objectToReference = new(ReferenceEqualityComparer.Instance);
 
     private long referenceCounter;
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

and that caused very strange issues in the multicellular editor

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Fixes weirdness in moving stuff in editor saves

Also prevents 1.6.0.0-rc1 editor saves made before this from loading, but anyway we planned to make those incompatible.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor validation to prevent edited cell components from accidentally sharing data with the original cell.
  * Added safeguards for macroscopic and multicellular editing scenarios, including cases where cell properties are unavailable.
  * Improved save and load reliability by preserving distinct object references correctly, helping prevent unintended changes to related objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->