### PR TITLE
Reset sporulation reproduction to normal on old save load

### DIFF
--- a/src/multicellular_stage/MulticellularSpecies.cs
+++ b/src/multicellular_stage/MulticellularSpecies.cs
@@ -11,7 +11,7 @@ using Systems;
 /// </summary>
 public class MulticellularSpecies : Species, IReadOnlyMulticellularSpecies, ISimulationPhotographable
 {
-    public const ushort SERIALIZATION_VERSION = 7;
+    public const ushort SERIALIZATION_VERSION = 8;
 
     private readonly Dictionary<BiomeConditions, Dictionary<Compound, (float TimeToFill, float Storage)>>
         cachedFillTimes = new();
@@ -231,6 +231,14 @@ public class MulticellularSpecies : Species, IReadOnlyMulticellularSpecies, ISim
             {
                 instance.MassBuddingCellCount = 2;
             }
+        }
+
+        if (version < 8)
+        {
+            // Old sporulation data can reference a cell type that is taken up by the body plan
+            instance.ModifiableSporeCellType = null;
+            if (instance.ReproductionMethod == MulticellularReproductionMethod.Sporulation)
+                instance.ReproductionMethod = MulticellularReproductionMethod.Budding;
         }
 
         return instance;

--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.cs
@@ -12,7 +12,7 @@ public partial class CellBodyPlanEditorComponent :
     HexEditorComponentBase<MulticellularEditor, CombinedEditorAction, EditorAction, HexWithData<CellTemplate>,
         MulticellularSpecies>, IArchiveUpdatable
 {
-    public const ushort SERIALIZATION_VERSION = 8;
+    public const ushort SERIALIZATION_VERSION = 9;
 
     [Export]
     public int MaxToleranceWarnings = 3;
@@ -645,6 +645,16 @@ public partial class CellBodyPlanEditorComponent :
         if (version >= 8)
         {
             SelectedGameteTypeForPlayer = (GameteType)reader.ReadInt32();
+        }
+
+        if (version < 9)
+        {
+            // Unset sporulation as it can be problematic
+            sporeCellType = null;
+            if (ReproductionMethod == MulticellularReproductionMethod.Sporulation)
+            {
+                ReproductionMethod = MulticellularReproductionMethod.Budding;
+            }
         }
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

as sporulation now is not allowed t obe part of the body plan, so loading such state will cause various issues, so we prevent that by resetting some state instead.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Fixes errors loading previous saves in the editor and editor saying invalid data on trying to exit.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of older multicellular archives.
  * Legacy sporulation cell types are now cleared when necessary.
  * Older archives using sporulation reproduction are automatically converted to budding.
* **Compatibility**
  * Updated archive format handling to support the latest serialization versions while preserving compatibility with existing saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->