### PR TITLE
Fix species save name in editor

### DIFF
--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -3015,6 +3015,7 @@ public partial class CellEditorComponent :
     private void OnSpeciesNameChanged(string newText)
     {
         newName = newText;
+        PauseMenu.Instance.SetNewSaveName(newName.Replace(' ', '_'));
 
         if (IsMulticellularEditor)
         {


### PR DESCRIPTION

Fixes #2875.

Updates the suggested save name when the species name is changed in the editor, instead of continuing to use the previously applied species name.

Tested by changing the species name while remaining in the editor and opening the save menu. Also tested names containing spaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the pause menu save name when editing a species name.
  * Spaces in species names are automatically replaced with underscores for compatible save names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->