### PR TITLE
Make sure the game is unpaused when finishing patch extinction

### DIFF
--- a/src/general/base_stage/CreatureStageHUDBase.cs
+++ b/src/general/base_stage/CreatureStageHUDBase.cs
@@ -600,6 +600,11 @@ public abstract partial class CreatureStageHUDBase<TStage> : HUDWithPausing, ICr
 
     public void HidePatchExtinctionBox()
     {
+        // The patch extinction box remains interactive while the game is paused. If the player paused using the HUD
+        // while making their choice, make sure that lock doesn't survive closing the box and leave the new patch
+        // permanently paused.
+        EnsureGameIsUnpausedForEditor();
+
         winExtinctBoxHolder.Hide();
         patchExtinctionBox?.Hide();
 

--- a/src/general/base_stage/HUDWithPausing.cs
+++ b/src/general/base_stage/HUDWithPausing.cs
@@ -45,7 +45,9 @@ public partial class HUDWithPausing : HUDBase
 
         GUICommon.Instance.PlayButtonPressSound();
 
-        Paused = !Paused;
+        // Use the state supplied by the button instead of toggling our state. This keeps the HUD pause lock in
+        // sync with the actual button state even when the button is pressed while another pause is active.
+        Paused = buttonState;
 
         if (Paused)
         {


### PR DESCRIPTION
**Brief Description of What This PR Does**

as otherwise there is apparently a bug where you can softlock into a paused state

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
I was unable to trigger this but there was a report: https://discord.com/channels/228300288023461893/958598553389903913/1543819381358858261 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the game remaining paused after closing the patch extinction dialog.
  * Improved pause button behavior so the displayed pause state stays synchronized when pauses are triggered elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->