### PR TITLE
Fixed some colony engulf checks and fixed component reattach to engulfer

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -90,6 +90,10 @@ search_in_file_extensions=PackedStringArray("gd", "shader", "cs")
 
 enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg")
 
+[gdunit4]
+
+ui/toolbar/run_overall=true
+
 [global]
 
 hardened=false

--- a/src/microbe_stage/components/MicrobeColony.cs
+++ b/src/microbe_stage/components/MicrobeColony.cs
@@ -648,9 +648,15 @@ public static class MicrobeColonyHelpers
     ///   Removes a member from this colony. If this is called directly check the usage of
     ///   <see cref="AttachedToEntityHelpers.EntityAttachRelationshipModifyLock"/>
     /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     This can optionally not remove the attached component if it is still needed. For example, when things are
+    ///     engulfed out of a colony.
+    ///   </para>
+    /// </remarks>
     /// <returns>True when the colony still exists. False if the entire colony was disbanded</returns>
     public static bool RemoveFromColonyAndDisbandIfEmpty(this ref MicrobeColony colony, in Entity colonyEntity,
-        Entity removedMember, CommandBuffer recorder)
+        Entity removedMember, CommandBuffer recorder, bool removeAttachedComponent = true)
     {
         if (colonyEntity.Has<MulticellularGrowth>())
         {
@@ -708,7 +714,8 @@ public static class MicrobeColonyHelpers
                 {
                     // Handle the normal cleanup here for the non-leader cells (we already queued delete of the
                     // entire colony component above)
-                    QueueRemoveFormerColonyMemberComponents(currentMember, recorder);
+                    QueueRemoveFormerColonyMemberComponents(currentMember, recorder,
+                        currentMember != removedMember || removeAttachedComponent);
                     leader = false;
                 }
 
@@ -721,7 +728,7 @@ public static class MicrobeColonyHelpers
         RemoveColonyMemberFromMemberList(ref colony, removedMember);
 
         if (!removedMemberIsLeader)
-            QueueRemoveFormerColonyMemberComponents(removedMember, recorder);
+            QueueRemoveFormerColonyMemberComponents(removedMember, recorder, removeAttachedComponent);
 
         OnColonyMemberRemoved(removedMember, removedMemberIsLeader);
 
@@ -838,7 +845,8 @@ public static class MicrobeColonyHelpers
     ///   Removes the given entity from the microbe colony it is in (if any)
     /// </summary>
     /// <returns>True on success</returns>
-    public static bool RemoveFromColony(in Entity entity, CommandBuffer entityCommandRecorder, bool verboseErrors)
+    public static bool RemoveFromColony(in Entity entity, CommandBuffer entityCommandRecorder, bool verboseErrors,
+        bool removeAttachedComponent = true)
     {
         lock (AttachedToEntityHelpers.EntityAttachRelationshipModifyLock)
         {
@@ -848,7 +856,8 @@ public static class MicrobeColonyHelpers
 
                 try
                 {
-                    colony.RemoveFromColonyAndDisbandIfEmpty(entity, entity, entityCommandRecorder);
+                    colony.RemoveFromColonyAndDisbandIfEmpty(entity, entity, entityCommandRecorder,
+                        removeAttachedComponent);
                 }
                 catch (Exception e)
                 {
@@ -870,7 +879,8 @@ public static class MicrobeColonyHelpers
 
                 try
                 {
-                    colony.RemoveFromColonyAndDisbandIfEmpty(member.ColonyLeader, entity, entityCommandRecorder);
+                    colony.RemoveFromColonyAndDisbandIfEmpty(member.ColonyLeader, entity, entityCommandRecorder,
+                        removeAttachedComponent);
                 }
                 catch (Exception e)
                 {
@@ -1642,10 +1652,12 @@ public static class MicrobeColonyHelpers
     ///   Removes the components from the detached entity that no longer should be on it
     /// </summary>
     private static void QueueRemoveFormerColonyMemberComponents(in Entity removedMember,
-        CommandBuffer recorder)
+        CommandBuffer recorder, bool removeAttachedComponent = true)
     {
         recorder.Remove<MicrobeColonyMember>(removedMember);
-        recorder.Remove<AttachedToEntity>(removedMember);
+
+        if (removeAttachedComponent)
+            recorder.Remove<AttachedToEntity>(removedMember);
 
         // Destroy temporary event callbacks if they exist
         if (removedMember.Has<MicrobeEventCallbacks>())

--- a/src/microbe_stage/systems/EngulfingSystem.cs
+++ b/src/microbe_stage/systems/EngulfingSystem.cs
@@ -255,6 +255,61 @@ public partial class EngulfingSystem : BaseSystem<World, float>
         engulfedObjectsToDelete.Clear();
     }
 
+    internal bool CheckStartEngulfingOnCandidate(ref CellProperties cellProperties,
+        ref Engulfer engulfer, ref SpeciesMember speciesMember, in Entity entity, in Entity engulfable)
+    {
+        var engulfCheckResult = cellProperties.CanEngulfObject(ref speciesMember, ref engulfer, engulfable);
+
+        if (!engulfable.Has<Engulfable>())
+        {
+            GD.PrintErr("Cannot start engulfing entity that passed engulf check as it is missing " +
+                "engulfable component");
+            return false;
+        }
+
+        if (engulfCheckResult == EngulfCheckResult.Ok)
+        {
+            // TODO: add some way for this to detect delay-added components so that this can't conflict with the
+            // binding system
+            lock (AttachedToEntityHelpers.EntityAttachRelationshipModifyLock)
+            {
+                ref var engulfableComponent = ref engulfable.Get<Engulfable>();
+
+                if (engulfableComponent.PhagocytosisStep != PhagocytosisPhase.None)
+                {
+                    throw new InvalidOperationException(
+                        "Detected something that is currently engulfed as being engulfable");
+                }
+
+                return IngestEngulfable(ref engulfer, ref cellProperties, entity, ref engulfableComponent,
+                    engulfable);
+            }
+        }
+
+        if (engulfCheckResult == EngulfCheckResult.IngestedMatterFull)
+        {
+            if (entity.Has<MicrobeEventCallbacks>())
+            {
+                ref var callbacks = ref entity.Get<MicrobeEventCallbacks>();
+
+                callbacks.OnEngulfmentStorageFull?.Invoke(entity);
+
+                entity.SendNoticeIfPossible(() =>
+                    new SimpleHUDMessage(Localization.Translate("NOTICE_ENGULF_STORAGE_FULL")));
+            }
+        }
+        else if (engulfCheckResult == EngulfCheckResult.TargetTooBig)
+        {
+            if (entity.Has<MicrobeEventCallbacks>())
+            {
+                entity.SendNoticeIfPossible(() =>
+                    new SimpleHUDMessage(Localization.Translate("NOTICE_ENGULF_SIZE_TOO_SMALL")));
+            }
+        }
+
+        return false;
+    }
+
     /// <summary>
     ///   Ingestion variant for taking an object that is engulfed by a different engulfer and adding it to this
     ///   engulfer. Needs to match the core operations in the fresh-ingest variant otherwise things will go very
@@ -1159,65 +1214,6 @@ public partial class EngulfingSystem : BaseSystem<World, float>
                 return;
             }
         }
-    }
-
-    /// <summary>
-    ///   This checks if we can start engulfing
-    /// </summary>
-    /// <returns>True if something started to be engulfed</returns>
-    private bool CheckStartEngulfingOnCandidate(ref CellProperties cellProperties,
-        ref Engulfer engulfer, ref SpeciesMember speciesMember, in Entity entity, in Entity engulfable)
-    {
-        var engulfCheckResult = cellProperties.CanEngulfObject(ref speciesMember, ref engulfer, engulfable);
-
-        if (!engulfable.Has<Engulfable>())
-        {
-            GD.PrintErr("Cannot start engulfing entity that passed engulf check as it is missing " +
-                "engulfable component");
-            return false;
-        }
-
-        if (engulfCheckResult == EngulfCheckResult.Ok)
-        {
-            // TODO: add some way for this to detect delay added components so that this can't conflict with the
-            // binding system
-            lock (AttachedToEntityHelpers.EntityAttachRelationshipModifyLock)
-            {
-                ref var engulfableComponent = ref engulfable.Get<Engulfable>();
-
-                if (engulfableComponent.PhagocytosisStep != PhagocytosisPhase.None)
-                {
-                    throw new InvalidOperationException(
-                        "Detected something that is currently engulfed as being engulfable");
-                }
-
-                return IngestEngulfable(ref engulfer, ref cellProperties, entity, ref engulfableComponent,
-                    engulfable);
-            }
-        }
-
-        if (engulfCheckResult == EngulfCheckResult.IngestedMatterFull)
-        {
-            if (entity.Has<MicrobeEventCallbacks>())
-            {
-                ref var callbacks = ref entity.Get<MicrobeEventCallbacks>();
-
-                callbacks.OnEngulfmentStorageFull?.Invoke(entity);
-
-                entity.SendNoticeIfPossible(() =>
-                    new SimpleHUDMessage(Localization.Translate("NOTICE_ENGULF_STORAGE_FULL")));
-            }
-        }
-        else if (engulfCheckResult == EngulfCheckResult.TargetTooBig)
-        {
-            if (entity.Has<MicrobeEventCallbacks>())
-            {
-                entity.SendNoticeIfPossible(() =>
-                    new SimpleHUDMessage(Localization.Translate("NOTICE_ENGULF_SIZE_TOO_SMALL")));
-            }
-        }
-
-        return false;
     }
 
     /// <summary>

--- a/src/microbe_stage/systems/EngulfingSystem.cs
+++ b/src/microbe_stage/systems/EngulfingSystem.cs
@@ -1266,8 +1266,7 @@ public partial class EngulfingSystem : BaseSystem<World, float>
         CommandBuffer? recorder = null;
 
         // Steal this cell from a colony if it is in a colony currently
-        // Right now this causes extra operations for deleting the attached component but avoiding that would
-        // complicate the code a lot here
+        // Preserve the attached component so it can be retargeted below.
         if (targetEntity.Has<MicrobeColonyMember>() || targetEntity.Has<MicrobeColony>())
         {
             recorder ??= worldSimulation.StartRecordingEntityCommands();

--- a/src/microbe_stage/systems/EngulfingSystem.cs
+++ b/src/microbe_stage/systems/EngulfingSystem.cs
@@ -1277,7 +1277,8 @@ public partial class EngulfingSystem : BaseSystem<World, float>
             // started but that may have been caused by my testing method of overriding the required size ratio (
             // in just one place so maybe some other later check then immediately canceled the engulf)
             // - hhyyrylainen
-            if (!MicrobeColonyHelpers.RemoveFromColony(targetEntity, recorder, true))
+            // We don't remove the attached component because we can retarget it to ourself
+            if (!MicrobeColonyHelpers.RemoveFromColony(targetEntity, recorder, true, false))
             {
                 GD.PrintErr("Failed to engulf a member of a cell colony (can't remove it)");
                 return false;

--- a/test/microbe_stage.tests/EngulfingColonyTests.cs
+++ b/test/microbe_stage.tests/EngulfingColonyTests.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using Arch.Core;
+using Arch.Core.Extensions;
+using Components;
+using GdUnit4;
+using Godot;
+using Systems;
+using Test.Utils;
+using static GdUnit4.Assertions;
+
+[TestSuite]
+[RequireGodotRuntime]
+public class EngulfingColonyTests
+{
+    [TestCase]
+    public void EngulfingAColonyMemberReplacesItsColonyAttachment()
+    {
+        using var setup = CreateSetup(0);
+
+        AssertThat(setup.EngulfingSystem.CheckStartEngulfingOnCandidate(ref setup.Engulfer.Get<CellProperties>(),
+            ref setup.Engulfer.Get<Engulfer>(), ref setup.Engulfer.Get<SpeciesMember>(), setup.Engulfer,
+            setup.Target)).IsTrue();
+
+        setup.World.ProcessAll(0.1f);
+
+        AssertThat(setup.Target.Has<MicrobeColonyMember>()).IsFalse();
+        AssertThat(setup.Target.Has<AttachedToEntity>()).IsTrue();
+        AssertThat(setup.Target.Get<AttachedToEntity>().AttachedTo).IsEqual(setup.Engulfer);
+        AssertThat(setup.Target.Get<Engulfable>().PhagocytosisStep).IsEqual(PhagocytosisPhase.Ingestion);
+    }
+
+    [TestCase]
+    public void FullEngulfmentStorageDoesNotDetachColonyMember()
+    {
+        using var setup = CreateSetup(9.5f);
+        bool storageFullReported = false;
+
+        setup.Engulfer.Get<MicrobeEventCallbacks>().OnEngulfmentStorageFull = _ => storageFullReported = true;
+
+        AssertThat(setup.EngulfingSystem.CheckStartEngulfingOnCandidate(ref setup.Engulfer.Get<CellProperties>(),
+            ref setup.Engulfer.Get<Engulfer>(), ref setup.Engulfer.Get<SpeciesMember>(), setup.Engulfer,
+            setup.Target)).IsFalse();
+
+        setup.World.ProcessAll(0.1f);
+
+        AssertThat(storageFullReported).IsTrue();
+        AssertThat(setup.Target.Has<MicrobeColonyMember>()).IsTrue();
+        AssertThat(setup.Target.Has<AttachedToEntity>()).IsTrue();
+        AssertThat(setup.Target.Get<AttachedToEntity>().AttachedTo).IsEqual(setup.ColonyLeader);
+        AssertThat(setup.Target.Get<Engulfable>().PhagocytosisStep).IsEqual(PhagocytosisPhase.None);
+    }
+
+    private static Setup CreateSetup(float usedEngulfingCapacity)
+    {
+        var world = new TestWorldSimulation();
+        var membraneType = SimulationParameters.Instance.GetMembrane("single");
+        var species = new MicrobeSpecies(1001, "Engulfer", "Test")
+        {
+            MembraneType = membraneType,
+        };
+
+        var engulfer = world.EntitySystem.Create(
+            new CellProperties
+            {
+                MembraneType = membraneType,
+                CreatedMembrane = CreateDummyMembrane(membraneType),
+                ShapeCreated = true,
+            },
+            new Engulfer
+            {
+                EngulfingSize = 10,
+                UsedEngulfingCapacity = usedEngulfingCapacity,
+                EngulfStorageSize = 10,
+            },
+            new SpeciesMember(species),
+            new WorldPosition(Vector3.Zero),
+            default(RenderPriorityOverride),
+            default(MicrobeEventCallbacks));
+
+        var colonyLeader = world.EntitySystem.Create(
+            default(CellProperties),
+            new CompoundStorage { Compounds = new CompoundBag(10) },
+            default(MicrobeControl),
+            default(Physics),
+            new WorldPosition(Vector3.Zero));
+
+        var target = world.EntitySystem.Create(
+            new EntityRadiusInfo(0.5f),
+            default(SpatialInstance),
+            new WorldPosition(Vector3.Zero),
+            default(Physics),
+            default(MicrobeControl),
+            new Engulfable(PhagocytosisPhase.None, Entity.Null)
+            {
+                BaseEngulfSize = 1,
+            },
+            new CompoundStorage { Compounds = new CompoundBag(10) },
+            new AttachedToEntity(colonyLeader, Vector3.One, Quaternion.Identity));
+
+        var colony = new MicrobeColony(colonyLeader, MicrobeState.Normal, colonyLeader, target);
+        colonyLeader.Add(colony);
+        target.Add(new MicrobeColonyMember(colonyLeader));
+
+        var engulfingSystem = new EngulfingSystem(world, new DummySpawnSystem(), world.EntitySystem);
+
+        return new Setup(world, engulfingSystem, engulfer, colonyLeader, target,
+            engulfer.Get<CellProperties>().CreatedMembrane!);
+    }
+
+    private static Membrane CreateDummyMembrane(MembraneType membraneType)
+    {
+        var points = new[]
+        {
+            new Vector2(-1, -1),
+            new Vector2(-1, 1),
+            new Vector2(1, 1),
+            new Vector2(1, -1),
+        };
+
+        var membrane = new Membrane();
+        membrane.MembraneData = new MembranePointData([Vector2.Zero], 1, membraneType, points);
+        return membrane;
+    }
+
+    private sealed record Setup(TestWorldSimulation World, EngulfingSystem EngulfingSystem, Entity Engulfer,
+        Entity ColonyLeader, Entity Target, Membrane Membrane) : IDisposable
+    {
+        public void Dispose()
+        {
+            World.Dispose();
+            Membrane.Free();
+        }
+    }
+}

--- a/test/microbe_stage.tests/EngulfingColonyTests.cs
+++ b/test/microbe_stage.tests/EngulfingColonyTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using Arch.Core;
 using Arch.Core.Extensions;
 using Components;
@@ -59,8 +60,7 @@ public class EngulfingColonyTests
             MembraneType = membraneType,
         };
 
-        var engulfer = world.EntitySystem.Create(
-            new CellProperties
+        var engulfer = world.EntitySystem.Create(new CellProperties
             {
                 MembraneType = membraneType,
                 CreatedMembrane = CreateDummyMembrane(membraneType),
@@ -77,15 +77,13 @@ public class EngulfingColonyTests
             default(RenderPriorityOverride),
             default(MicrobeEventCallbacks));
 
-        var colonyLeader = world.EntitySystem.Create(
-            default(CellProperties),
+        var colonyLeader = world.EntitySystem.Create(default(CellProperties),
             new CompoundStorage { Compounds = new CompoundBag(10) },
             default(MicrobeControl),
             default(Physics),
             new WorldPosition(Vector3.Zero));
 
-        var target = world.EntitySystem.Create(
-            new EntityRadiusInfo(0.5f),
+        var target = world.EntitySystem.Create(new EntityRadiusInfo(0.5f),
             default(SpatialInstance),
             new WorldPosition(Vector3.Zero),
             default(Physics),
@@ -117,8 +115,11 @@ public class EngulfingColonyTests
             new Vector2(1, -1),
         };
 
+        var hexPositions = ArrayPool<Vector2>.Shared.Rent(1);
+        hexPositions[0] = Vector2.Zero;
+
         var membrane = new Membrane();
-        membrane.MembraneData = new MembranePointData([Vector2.Zero], 1, membraneType, points);
+        membrane.MembraneData = new MembranePointData(hexPositions, 1, membraneType, points);
         return membrane;
     }
 
@@ -128,6 +129,7 @@ public class EngulfingColonyTests
         public void Dispose()
         {
             World.Dispose();
+            Membrane.MembraneData.Dispose();
             Membrane.Free();
         }
     }

--- a/test/microbe_stage.tests/EngulfingColonyTests.cs.uid
+++ b/test/microbe_stage.tests/EngulfingColonyTests.cs.uid
@@ -1,0 +1,1 @@
+uid://b58xdli5d08h6


### PR DESCRIPTION
**Brief Description of What This PR Does**

As apparently this part of the code had had a quite hidden bug for a while now

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://community.revolutionarygamesstudio.com/t/1-6-0-general-feedback-thread/9153/13?u=hhyyrylainen

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Engulfing colony members now correctly transfer their attachment to the engulfing microbe.
  - Colony membership and attachment are preserved when engulfment storage is full.

- **Bug Fixes**
  - Improved colony removal during engulfment to prevent unintended detachment.

- **Tests**
  - Added coverage for successful colony-member engulfment and full-storage scenarios.
  - Enabled the Godot test run toolbar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->