### PR TITLE
Made delay-spawned colony cells exempt from despawning

### DIFF
--- a/src/benchmark/DummySpawnSystem.cs
+++ b/src/benchmark/DummySpawnSystem.cs
@@ -39,7 +39,7 @@ public class DummySpawnSystem : ISpawnSystem
     }
 
     public void NotifyExternalEntitySpawned(in Entity entity, CommandBuffer commandBuffer, float despawnRadiusSquared,
-        float entityWeight)
+        float entityWeight, bool disallowDespawning = false)
     {
         addTrackedCallback?.Invoke(entity);
     }

--- a/src/microbe_stage/ISpawnSystem.cs
+++ b/src/microbe_stage/ISpawnSystem.cs
@@ -36,8 +36,9 @@ public interface ISpawnSystem
     ///   done to speed up distance checks).
     /// </param>
     /// <param name="entityWeight">How much "space" the entity takes up in the spawn system</param>
+    /// <param name="disallowDespawning">Whether despawning should be temporarily disallowed for this entity</param>
     public void NotifyExternalEntitySpawned(in Entity entity, CommandBuffer commandBuffer, float despawnRadiusSquared,
-        float entityWeight);
+        float entityWeight, bool disallowDespawning = false);
 
     /// <summary>
     ///   Checks if the approximate entity count is not too much over the entity limit

--- a/src/microbe_stage/systems/SpawnSystem.cs
+++ b/src/microbe_stage/systems/SpawnSystem.cs
@@ -659,11 +659,11 @@ public partial class SpawnSystem : BaseSystem<World, float>, ISpawnSystem, IArch
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void DespawnEntities(ref Spawned spawned, ref WorldPosition position, Entity entity)
     {
-        if (spawned.DisallowDespawning)
-            return;
-
         var entityWeight = spawned.EntityWeight;
         spawnedEntityWeight += entityWeight;
+
+        if (spawned.DisallowDespawning)
+            return;
 
         // Keep counting all entities to have an accurate count at the end of this loop, even if we are no
         // longer allowed to despawn things

--- a/src/microbe_stage/systems/SpawnSystem.cs
+++ b/src/microbe_stage/systems/SpawnSystem.cs
@@ -350,6 +350,9 @@ public partial class SpawnSystem : BaseSystem<World, float>, ISpawnSystem, IArch
             if (worldSimulation.IsQueuedForDeletion(entity))
                 return;
 
+            if (spawned.DisallowDespawning)
+                return;
+
             candidateDespawns.Add((entity, spawned.EntityWeight, position.Position));
         });
 

--- a/src/microbe_stage/systems/SpawnSystem.cs
+++ b/src/microbe_stage/systems/SpawnSystem.cs
@@ -253,7 +253,7 @@ public partial class SpawnSystem : BaseSystem<World, float>, ISpawnSystem, IArch
     }
 
     public void NotifyExternalEntitySpawned(in Entity entity, CommandBuffer commandBuffer, float despawnRadiusSquared,
-        float entityWeight)
+        float entityWeight, bool disallowDespawning = false)
     {
         if (entityWeight <= 0)
             throw new ArgumentException("weight needs to be positive", nameof(entityWeight));
@@ -262,6 +262,7 @@ public partial class SpawnSystem : BaseSystem<World, float>, ISpawnSystem, IArch
         {
             DespawnRadiusSquared = despawnRadiusSquared,
             EntityWeight = entityWeight,
+            DisallowDespawning = disallowDespawning,
         });
 
         // Update entity count estimate to keep this about up to date, this will be corrected within a few seconds

--- a/src/multicellular_stage/components/MulticellularGrowth.cs
+++ b/src/multicellular_stage/components/MulticellularGrowth.cs
@@ -189,7 +189,8 @@ public static class MulticellularGrowthHelpers
     /// </summary>
     public static void AddMulticellularGrowthCell(this ref MulticellularGrowth multicellularGrowth,
         in Entity entity, MulticellularSpecies species, IWorldSimulation worldSimulation,
-        IMicrobeSpawnEnvironment spawnEnvironment, CommandBuffer recorder, ISpawnSystem notifySpawnTo)
+        IMicrobeSpawnEnvironment spawnEnvironment, CommandBuffer recorder, ISpawnSystem notifySpawnTo,
+        bool disallowDespawning = false)
     {
         if (!entity.Has<MicrobeColony>())
         {
@@ -204,7 +205,7 @@ public static class MulticellularGrowthHelpers
         // colony it joins
         DelayedColonyOperationSystem.CreateDelayAttachedMicrobe(ref colonyPosition, entity,
             multicellularGrowth.NextBodyPlanCellToGrowIndex, cellTemplate, species, worldSimulation, spawnEnvironment,
-            recorder, notifySpawnTo, false);
+            recorder, notifySpawnTo, false, true, disallowDespawning);
 
         ++multicellularGrowth.NextBodyPlanCellToGrowIndex;
         multicellularGrowth.CompoundsNeededForNextCell = null;
@@ -636,7 +637,7 @@ public static class MulticellularGrowthHelpers
         for (int i = 0; i < species.MassBuddingCellCount - 1; ++i)
         {
             multicellularGrowth.AddMulticellularGrowthCell(entity, species, worldSimulation, spawnEnvironment,
-                recorder, notifySpawnTo);
+                recorder, notifySpawnTo, true);
         }
 
         multicellularGrowth.MassBuddingState = MulticellularMassBuddingState.Spawning;

--- a/src/multicellular_stage/systems/DelayedColonyOperationSystem.cs
+++ b/src/multicellular_stage/systems/DelayedColonyOperationSystem.cs
@@ -21,6 +21,7 @@ using Godot;
 [WritesToComponent(typeof(Physics))]
 [WritesToComponent(typeof(OrganelleContainer))]
 [WritesToComponent(typeof(BioProcesses))]
+[WritesToComponent(typeof(Spawned))]
 [ReadsComponent(typeof(MulticellularSpeciesMember))]
 [ReadsComponent(typeof(WorldPosition))]
 [ReadsComponent(typeof(CompoundStorage))]
@@ -59,7 +60,8 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
     public static void CreateDelayAttachedMicrobe(ref WorldPosition colonyPosition, in Entity colonyEntity,
         int colonyTargetIndex, CellTemplate cellTemplate, MulticellularSpecies species,
         IWorldSimulation worldSimulation, IMicrobeSpawnEnvironment spawnEnvironment,
-        CommandBuffer recorder, ISpawnSystem notifySpawnTo, bool giveStartingCompounds, bool playAnimation = true)
+        CommandBuffer recorder, ISpawnSystem notifySpawnTo, bool giveStartingCompounds, bool playAnimation = true,
+        bool disallowDespawning = false)
     {
         if (colonyTargetIndex == 0)
             throw new ArgumentException("Cannot delay add the root colony cell");
@@ -97,7 +99,8 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
 
         // Register with the spawn system to allow this entity to despawn if it gets cut off from the colony later
         // or attaching fails
-        notifySpawnTo.NotifyExternalEntitySpawned(member, recorder, Constants.MICROBE_DESPAWN_RADIUS_SQUARED, weight);
+        notifySpawnTo.NotifyExternalEntitySpawned(member, recorder, Constants.MICROBE_DESPAWN_RADIUS_SQUARED, weight,
+            disallowDespawning);
 
         recorder.Add(member, attachPosition);
 
@@ -271,6 +274,14 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
     {
         var parentIndex = colony.CalculateSensibleParentIndexForMulticellular(ref entity.Get<AttachedToEntity>());
         colony.FinishQueuedMemberAdd(colonyEntity, parentIndex, entity, targetMemberIndex, recorder);
+
+        // Mass-budding cells (and other delay-spawned colony members) are protected from spawn cleanup only until
+        // they are safely part of the colony.
+        if (entity.Has<Spawned>())
+        {
+            ref var spawned = ref entity.Get<Spawned>();
+            spawned.DisallowDespawning = false;
+        }
     }
 
     private void OnHasEntity(Entity entity)

--- a/src/multicellular_stage/systems/DelayedColonyOperationSystem.cs
+++ b/src/multicellular_stage/systems/DelayedColonyOperationSystem.cs
@@ -268,7 +268,7 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
              ++i)
         {
             CreateDelayAttachedMicrobe(ref parentPosition, entity, i, species.Species.ModifiableGameplayCells[i],
-                species.Species, worldSimulation, spawnEnvironment, recorder, spawnSystem, true, playAnimation);
+                species.Species, worldSimulation, spawnEnvironment, recorder, spawnSystem, true, playAnimation, true);
 
             added = true;
         }

--- a/src/multicellular_stage/systems/DelayedColonyOperationSystem.cs
+++ b/src/multicellular_stage/systems/DelayedColonyOperationSystem.cs
@@ -157,12 +157,14 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
                 if (!pair.Delayed.FinishAttachingToColony.IsAlive())
                 {
                     GD.PrintErr("Delayed attach target entity is dead, ignoring attach request");
+                    AllowDelayedEntityDespawning(pair.Cell);
                     continue;
                 }
 
                 if (!pair.Delayed.FinishAttachingToColony.Has<MicrobeColony>())
                 {
                     GD.PrintErr("Delayed attach target entity is missing colony, ignoring attach request");
+                    AllowDelayedEntityDespawning(pair.Cell);
                     continue;
                 }
 
@@ -173,6 +175,15 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
             attachmentOrder.Clear();
 
             worldSimulation.FinishRecordingEntityCommands(recorder);
+        }
+    }
+
+    private void AllowDelayedEntityDespawning(in Entity entity)
+    {
+        if (entity.IsAliveAndHas<Spawned>())
+        {
+            ref var spawned = ref entity.Get<Spawned>();
+            spawned.DisallowDespawning = false;
         }
     }
 
@@ -277,11 +288,7 @@ public partial class DelayedColonyOperationSystem : BaseSystem<World, float>
 
         // Mass-budding cells (and other delay-spawned colony members) are protected from spawn cleanup only until
         // they are safely part of the colony.
-        if (entity.Has<Spawned>())
-        {
-            ref var spawned = ref entity.Get<Spawned>();
-            spawned.DisallowDespawning = false;
-        }
+        AllowDelayedEntityDespawning(entity);
     }
 
     private void OnHasEntity(Entity entity)


### PR DESCRIPTION
**Brief Description of What This PR Does**

which should hopefully fix the random mass budding problem

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

This might fix mass budding sometimes missing cells

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for protecting externally spawned entities from automatic despawning.
  * Mass-budding cells remain protected while attaching to a colony.
  * Protected entities are included in population estimates without being removed.
* **Bug Fixes**
  * Temporary despawn protection is now cleared when colony attachment fails.
* **Improvements**
  * Spawn and colony-growth operations consistently preserve despawning preferences across delayed actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->