### PR TITLE
Possible membrane null fix

### DIFF
--- a/src/microbe_stage/systems/MicrobeVisualsSystem.cs
+++ b/src/microbe_stage/systems/MicrobeVisualsSystem.cs
@@ -167,7 +167,7 @@ public partial class MicrobeVisualsSystem : BaseSystem<World, float>
                 entity.Get<MicrobeColonyMember>().ColonyLeader :
                 entity;
 
-            if (colonyLeader.Has<MulticellularGrowth>())
+            if (colonyLeader.IsAliveAndHas<MulticellularGrowth>())
             {
                 ref var growthOrder = ref colonyLeader.Get<MulticellularGrowth>();
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

In the log player provided:

"
ERROR: System.NullReferenceException: Object reference not set to an instance of an object.
ERROR:    at Arch.Core.World.Has[T](Entity entity) in /home/hhyyrylainen/Projects/Thrive/third_party/Arch/src/Arch/Core/World.cs:line 1112
ERROR:    at Arch.Core.Extensions.EntityExtensions.Has[T](Entity& entity) in /home/hhyyrylainen/Projects/Thrive/third_party/Arch/src/Arch/Core/Extensions/EntityExtensions.cs:line 114
ERROR:    at MicrobeWorldSimulation.OnProcessFixedWithThreads(Single delta) in /home/hhyyrylainen/Projects/Thrive/src/microbe_stage/MicrobeWorldSimulation.generated.cs:line 217
" 

this might happen when the colony leader entity dies but the colony member doesn't and the pending membrane generation job wants to be executed

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
