### PR TITLE
Fix incorrect slime jet score in auto-evo

### DIFF
--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -1103,10 +1103,6 @@ public class SimulationCache
         var slimeJetsCount = 0.0f;
         var mucocystsCount = 0;
         var pullingCiliasCount = 0.0f;
-        var slimeJetsMultiplier = 1.0f;
-        var slimeJetsMultiplierSum = 0.0f;
-        var slimeJetsMultiplierCount = 0;
-
         var hasOxytoxy = false;
         var hasCytotoxin = false;
         var hasMacrolide = false;
@@ -1242,15 +1238,13 @@ public class SimulationCache
                     defensivePilusCount += cellTypeDefensivePilusCount;
                     defensiveInjectisomeCount += cellTypeDefensiveInjectisomeCount;
                     mucocystsCount += cellTypeMucocystsCount;
-                    slimeJetsMultiplierSum += cellTypeSlimeJetsMultiplier;
-                    ++slimeJetsMultiplierCount;
 
                     // application of specializationBonus to appropriate scores
                     var specializationBonus = cellType.CellTypeSpecializationBonus *
                         CellBodyPlanInternalCalculations.GetAdjacencySpecializationBonusFromBodyPlan(cell, cells);
 
                     totalToxinAmount += cellTypeToxinAmount * specializationBonus;
-                    slimeJetsCount += cellTypeSlimeJetsCount * specializationBonus;
+                    slimeJetsCount += cellTypeSlimeJetsCount * specializationBonus * cellTypeSlimeJetsMultiplier;
                     pullingCiliasCount += cellTypePullingCiliasCount * specializationBonus;
                 }
             }
@@ -1290,10 +1284,7 @@ public class SimulationCache
         var defensivePilusScore = pilusScores.DefensivePilus;
         var defensiveInjectisomeScore = pilusScores.DefensiveInjectisome;
 
-        if (slimeJetsMultiplierCount > 0)
-            slimeJetsMultiplier = slimeJetsMultiplierSum / slimeJetsMultiplierCount;
         slimeJetScore *= slimeJetsCount;
-        slimeJetScore *= slimeJetsMultiplier;
 
         // bonus score for upgrades because auto-evo does not like adding them much
         injectisomeScore *= Constants.AUTO_EVO_ARTIFICIAL_UPGRADE_BONUS_SMALL;

--- a/test/auto_evo.tests/SimulationCachePredationToolsRawScoresTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationToolsRawScoresTests.cs
@@ -61,6 +61,47 @@ public class SimulationCachePredationToolsRawScoresTests
         AssertMulticellularRecomputedScores(recomputed);
     }
 
+    [TestCase]
+    public void MulticellularSlimeJetScoreIgnoresCellsWithoutSlimeJets()
+    {
+        var cache = CreateCache();
+        var simulationParameters = SimulationParameters.Instance;
+        var speciesWithoutSupport = CreateSlimeJetSpecies(103,
+            (CreateSlimeJetCellType(simulationParameters, "Misaligned", new Hex(4, 0)), new Hex(0, 0)));
+        var speciesWithSupport = CreateSlimeJetSpecies(104,
+            (CreateSlimeJetCellType(simulationParameters, "Misaligned", new Hex(4, 0)), new Hex(0, 0)),
+            (CreateSupportCellType(simulationParameters), new Hex(0, 1)));
+
+        var scoreWithoutSupport = cache.GetPredationToolsRawScores(speciesWithoutSupport);
+        var scoreWithSupport = cache.GetPredationToolsRawScores(speciesWithSupport);
+
+        AssertThat(scoreWithoutSupport.SlimeJetScore).IsEqual(0.0f);
+        AssertThat(scoreWithSupport.SlimeJetScore).IsEqual(scoreWithoutSupport.SlimeJetScore);
+
+        cache.Clear();
+
+        var recomputed = cache.GetPredationToolsRawScores(speciesWithSupport);
+        AssertThat(recomputed.SlimeJetScore).IsEqual(scoreWithSupport.SlimeJetScore);
+    }
+
+    [TestCase]
+    public void MulticellularSlimeJetScoreIsWeightedByJetContribution()
+    {
+        var cache = CreateCache();
+        var simulationParameters = SimulationParameters.Instance;
+        var alignedCellType = CreateSlimeJetCellType(simulationParameters, "Aligned", new Hex(0, 4), new Hex(0, 3));
+        var misalignedCellType = CreateSlimeJetCellType(simulationParameters, "Misaligned", new Hex(4, 0));
+        var species = CreateSlimeJetSpecies(105,
+            (alignedCellType, new Hex(0, 0)),
+            (misalignedCellType, new Hex(0, 1)));
+        alignedCellType.CellTypeSpecializationBonus = 2.0f;
+        misalignedCellType.CellTypeSpecializationBonus = 3.0f;
+
+        var scores = cache.GetPredationToolsRawScores(species);
+
+        AssertThat(scores.SlimeJetScore).IsEqual(Constants.AUTO_EVO_SLIME_JET_SCORE * 4.0f);
+    }
+
     private static SimulationCache CreateCache()
     {
         return new SimulationCache(new WorldGenerationSettings
@@ -115,6 +156,47 @@ public class SimulationCachePredationToolsRawScoresTests
         supportingCellType.CellTypeSpecializationBonus = 0.75f;
 
         return (species, contributingCellType);
+    }
+
+    private static MulticellularSpecies CreateSlimeJetSpecies(uint id,
+        params (CellType CellType, Hex Position)[] cells)
+    {
+        var species = new MulticellularSpecies(id, "Regression", $"SlimeJet{id}");
+
+        foreach (var (cellType, position) in cells)
+        {
+            species.ModifiableCellTypes.Add(cellType);
+            species.ModifiableGameplayCells.AddFast(new CellTemplate(cellType, position, 0),
+                new List<Hex>(), new List<Hex>());
+        }
+
+        species.OnEdited();
+        return species;
+    }
+
+    private static CellType CreateSlimeJetCellType(SimulationParameters simulationParameters, string name,
+        params Hex[] slimeJetPositions)
+    {
+        var cellType = new CellType(simulationParameters.GetMembrane("single"))
+        {
+            CellTypeName = name,
+        };
+        cellType.ModifiableOrganelles.Add(CreateOrganelle(simulationParameters, "cytoplasm", new Hex(0, 0)));
+
+        foreach (var slimeJetPosition in slimeJetPositions)
+            cellType.ModifiableOrganelles.Add(CreateOrganelle(simulationParameters, "slimeJet", slimeJetPosition));
+
+        return cellType;
+    }
+
+    private static CellType CreateSupportCellType(SimulationParameters simulationParameters)
+    {
+        var cellType = new CellType(simulationParameters.GetMembrane("single"))
+        {
+            CellTypeName = "Support",
+        };
+        cellType.ModifiableOrganelles.Add(CreateOrganelle(simulationParameters, "cytoplasm", new Hex(0, 0)));
+        return cellType;
     }
 
     private static void AddPredationToolOrganelles(OrganelleLayout<OrganelleTemplate> organelles,


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR fixes a bug that leads to incorrect slime jet scores in auto-evo. 

The current slime jet score formula is roughly:

$`Score_{old}=Base \times \sum_i(jetCount_i \times specialization_i) \times average(orientation_i)`$

While the new formula is:

$`Score_{new}=Base \times \sum_i(jetCount_i \times specialization_i \times orientation_i)`$

**Related Issues**

blocked by #7174

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
