### PR TITLE
remove unused cell type's toxin score from auto-evo

### DIFF
--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -1117,6 +1117,21 @@ public class SimulationCache
         for (var i = 0; i < cellTypes.Count; ++i)
         {
             var cellType = cellTypes[i];
+            var cells = species.ModifiableEditorCells;
+            var cellTypeUsed = false;
+
+            for (var j = 0; j < cells.Count; ++j)
+            {
+                var cell = cells[j].Data;
+                if (cell != null && ReferenceEquals(cell.CellType, cellType))
+                {
+                    cellTypeUsed = true;
+                    break;
+                }
+            }
+
+            if (!cellTypeUsed)
+                continue;
 
             var cellTypeToxinAmount = 0.0f;
             var cellTypeToxinOrganellesCount = 0;
@@ -1227,8 +1242,6 @@ public class SimulationCache
             // There are likely more accurate ways to approximate the real gameplay effects in the future, but this
             // will do for now
             totalToxinTypesCount += cellTypeToxinTypesCount;
-
-            var cells = species.EditorCells;
 
             foreach (var hex in cells)
             {

--- a/test/auto_evo.tests/SimulationCachePredationToolsRawScoresTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationToolsRawScoresTests.cs
@@ -61,6 +61,42 @@ public class SimulationCachePredationToolsRawScoresTests
         AssertMulticellularRecomputedScores(recomputed);
     }
 
+    [TestCase]
+    public void MulticellularRawScoresIgnoreUnusedCellTypes()
+    {
+        var cache = CreateCache();
+        var (species, _) = CreateMulticellularSpecies(103);
+
+        // Normalize the manually assigned characterization bonuses before comparing mutation results.
+        species.OnEdited();
+        var baseline = cache.GetPredationToolsRawScores(species);
+
+        var simulationParameters = SimulationParameters.Instance;
+        var unusedCellType = CreateCytotoxinCellType(simulationParameters);
+        species.ModifiableCellTypes.Add(unusedCellType);
+        species.OnEdited();
+        cache.Clear();
+
+        var withUnusedCellType = cache.GetPredationToolsRawScores(species);
+        AssertThat(withUnusedCellType.CytotoxinScore).IsEqual(0.0f);
+        AssertThat(withUnusedCellType.OxytoxyScore).IsEqual(baseline.OxytoxyScore);
+        AssertRawScoresAreEqual(withUnusedCellType, baseline);
+
+        species.ModifiableGameplayCells.AddFast(new CellTemplate(unusedCellType, new Hex(1, 1), 0),
+            new List<Hex>(), new List<Hex>());
+
+        var editorCells = species.ModifiableEditorCells;
+        editorCells.Clear();
+        MulticellularLayoutHelpers.GenerateEditorLayoutFromGameplayLayout(editorCells, species.ModifiableGameplayCells,
+            new List<Hex>(), new List<Hex>());
+        species.OnEdited();
+        cache.Clear();
+
+        var withPlacedCellType = cache.GetPredationToolsRawScores(species);
+        AssertThat(withPlacedCellType.CytotoxinScore > 0.0f).IsTrue();
+        AssertThat(withPlacedCellType.OxytoxyScore).IsNotEqual(withUnusedCellType.OxytoxyScore);
+    }
+
     private static SimulationCache CreateCache()
     {
         return new SimulationCache(new WorldGenerationSettings
@@ -109,12 +145,30 @@ public class SimulationCachePredationToolsRawScoresTests
             new List<Hex>(), new List<Hex>());
         species.ModifiableGameplayCells.AddFast(new CellTemplate(supportingCellType, new Hex(0, 1), 0),
             new List<Hex>(), new List<Hex>());
+
         species.OnEdited();
 
         contributingCellType.CellTypeSpecializationBonus = 1.5f;
         supportingCellType.CellTypeSpecializationBonus = 0.75f;
 
         return (species, contributingCellType);
+    }
+
+    private static CellType CreateCytotoxinCellType(SimulationParameters simulationParameters)
+    {
+        var cellType = new CellType(simulationParameters.GetMembrane("single"))
+        {
+            CellTypeName = "Cytotoxin",
+        };
+        cellType.ModifiableOrganelles.Add(CreateOrganelle(simulationParameters, "cytoplasm", new Hex(0, 0)));
+
+        var cytotoxin = CreateToxinOrganelle(simulationParameters, new Hex(-4, 0));
+        var cytotoxinUpgrades = cytotoxin.ModifiableUpgrades!;
+        cytotoxinUpgrades.ModifiableUnlockedFeatures.Clear();
+        cytotoxinUpgrades.CustomUpgradeData = new ToxinUpgrades(ToxinType.Cytotoxin, 0.25f);
+        cellType.ModifiableOrganelles.Add(cytotoxin);
+
+        return cellType;
     }
 
     private static void AddPredationToolOrganelles(OrganelleLayout<OrganelleTemplate> organelles,
@@ -156,6 +210,24 @@ public class SimulationCachePredationToolsRawScoresTests
                 CustomUpgradeData = new ToxinUpgrades(ToxinType.Oxytoxy, 0.25f),
             },
         };
+    }
+
+    private static void AssertRawScoresAreEqual(SimulationCache.PredationToolsRawScores actual,
+        SimulationCache.PredationToolsRawScores expected)
+    {
+        AssertThat(actual.PilusScore).IsEqual(expected.PilusScore);
+        AssertThat(actual.InjectisomeScore).IsEqual(expected.InjectisomeScore);
+        AssertThat(actual.DefensivePilusScore).IsEqual(expected.DefensivePilusScore);
+        AssertThat(actual.DefensiveInjectisomeScore).IsEqual(expected.DefensiveInjectisomeScore);
+        AssertThat(actual.AverageToxicity).IsEqual(expected.AverageToxicity);
+        AssertThat(actual.OxytoxyScore).IsEqual(expected.OxytoxyScore);
+        AssertThat(actual.CytotoxinScore).IsEqual(expected.CytotoxinScore);
+        AssertThat(actual.MacrolideScore).IsEqual(expected.MacrolideScore);
+        AssertThat(actual.ChannelInhibitorScore).IsEqual(expected.ChannelInhibitorScore);
+        AssertThat(actual.OxygenMetabolismInhibitorScore).IsEqual(expected.OxygenMetabolismInhibitorScore);
+        AssertThat(actual.SlimeJetScore).IsEqual(expected.SlimeJetScore);
+        AssertThat(actual.MucocystsScore).IsEqual(expected.MucocystsScore);
+        AssertThat(actual.PullingCiliaModifier).IsEqual(expected.PullingCiliaModifier);
     }
 
     private static void AssertSpeciesCacheIdentityIsStable(Species species, uint expectedId, string expectedEpithet,


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR changed the toxin score's calculation: if a cell type contains a type of toxin but this cell type is not used in any cell, then the cell type's toxin won`'t contribute to the toxin score.

**Related Issues**

blocked by #7174

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multicellular species predation-tool scoring by attributing toxin effects to the cells that produce them.
  - Unused cell types no longer affect predation-tool scores.
  - Toxin combinations, shared toxins, and slime jets are now weighted more accurately.
  - Predation scores are recalculated correctly after species specialization or toxin changes.

- **Tests**
  - Added comprehensive coverage for predation scoring, cache updates, toxin isolation, and mixed-toxin behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->