### PR TITLE
remove unnecessary HP offset in auto evo

### DIFF
--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -2048,7 +2048,7 @@ public class SimulationCache
         float smallestPreyHexSize;
         var dissolverEnzyme = Constants.LIPASE_ENZYME;
 
-        var preyHP = 1.0f;
+        var preyHP = 0.0f;
         float preyToxinResistance;
         float preyPhysicalResistance;
         float preyStorageNominal;
@@ -2166,7 +2166,7 @@ public class SimulationCache
         float membraneRigidityHitpointsModifier, bool canEngulf, in PreyPredationData preyData,
         out PredatorPredationData data)
     {
-        var predatorHP = 1.0f;
+        var predatorHP = 0.0f;
         float predatorToxinResistance;
         float predatorPhysicalResistance;
         float predatorStorageNominal;

--- a/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
@@ -52,6 +52,30 @@ public class SimulationCachePredationScoreTests
         AssertThat(score).IsEqual(258.4216f);
     }
 
+    [TestCase]
+    public void SingleCellMulticellularPreyVulnerabilityIsCharacterized()
+    {
+        var predator = CreateMicrobe(9, "ArmedAttacker", "cellulose", "cytoplasm", "pilus", "oxytoxy");
+        var prey = CreateSingleCellMulticellular(10, "SingleCellPrey", "single", "cytoplasm");
+
+        var score = CalculatePredationScore(predator, prey);
+
+        AssertThat(score).IsEqual(1.602617f);
+    }
+
+    [TestCase]
+    public void SingleCellMulticellularPredatorDurabilityIsCharacterized()
+    {
+        var predator = CreateMulticellularPredator(11);
+        var prey = CreateMicrobe(12, "ToxicDefender", "single", "cytoplasm", "oxytoxy");
+        prey.ModifiableBehaviour.Aggression = Constants.MAX_SPECIES_AGGRESSION;
+        prey.ModifiableBehaviour.Fear = 0;
+
+        var score = CalculatePredationScore(predator, prey);
+
+        AssertThat(score).IsEqual(10499.378f);
+    }
+
     private static float CalculatePredationScore(Species predator, Species prey)
     {
         var worldSettings = new WorldGenerationSettings
@@ -99,6 +123,32 @@ public class SimulationCachePredationScoreTests
         }
 
         var species = new MulticellularSpecies(id, "Characterization", "MulticellularPredator");
+        species.ModifiableCellTypes.Add(cellType);
+        species.ModifiableGameplayCells.AddFast(new CellTemplate(cellType, new Hex(0, 0), 0),
+            new List<Hex>(), new List<Hex>());
+        species.OnEdited();
+
+        return species;
+    }
+
+    private static MulticellularSpecies CreateSingleCellMulticellular(uint id, string epithet, string membrane,
+        params string[] organelles)
+    {
+        var simulationParameters = SimulationParameters.Instance;
+        var cellType = new CellType(simulationParameters.GetMembrane(membrane))
+        {
+            CellTypeName = epithet,
+            IsBacteria = true,
+            MembraneRigidity = 0,
+        };
+
+        for (var i = 0; i < organelles.Length; ++i)
+        {
+            cellType.ModifiableOrganelles.Add(new OrganelleTemplate(
+                simulationParameters.GetOrganelleType(organelles[i]), new Hex(i * 4, 0), 0));
+        }
+
+        var species = new MulticellularSpecies(id, "Characterization", epithet);
         species.ModifiableCellTypes.Add(cellType);
         species.ModifiableGameplayCells.AddFast(new CellTemplate(cellType, new Hex(0, 0), 0),
             new List<Hex>(), new List<Hex>());

--- a/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
@@ -52,30 +52,6 @@ public class SimulationCachePredationScoreTests
         AssertThat(score).IsEqual(258.4216f);
     }
 
-    [TestCase]
-    public void SingleCellMulticellularPreyVulnerabilityIsCharacterized()
-    {
-        var predator = CreateMicrobe(9, "ArmedAttacker", "cellulose", "cytoplasm", "pilus", "oxytoxy");
-        var prey = CreateSingleCellMulticellular(10, "SingleCellPrey", "single", "cytoplasm");
-
-        var score = CalculatePredationScore(predator, prey);
-
-        AssertThat(score).IsEqual(1.602617f);
-    }
-
-    [TestCase]
-    public void SingleCellMulticellularPredatorDurabilityIsCharacterized()
-    {
-        var predator = CreateMulticellularPredator(11);
-        var prey = CreateMicrobe(12, "ToxicDefender", "single", "cytoplasm", "oxytoxy");
-        prey.ModifiableBehaviour.Aggression = Constants.MAX_SPECIES_AGGRESSION;
-        prey.ModifiableBehaviour.Fear = 0;
-
-        var score = CalculatePredationScore(predator, prey);
-
-        AssertThat(score).IsEqual(10499.378f);
-    }
-
     private static float CalculatePredationScore(Species predator, Species prey)
     {
         var worldSettings = new WorldGenerationSettings
@@ -123,32 +99,6 @@ public class SimulationCachePredationScoreTests
         }
 
         var species = new MulticellularSpecies(id, "Characterization", "MulticellularPredator");
-        species.ModifiableCellTypes.Add(cellType);
-        species.ModifiableGameplayCells.AddFast(new CellTemplate(cellType, new Hex(0, 0), 0),
-            new List<Hex>(), new List<Hex>());
-        species.OnEdited();
-
-        return species;
-    }
-
-    private static MulticellularSpecies CreateSingleCellMulticellular(uint id, string epithet, string membrane,
-        params string[] organelles)
-    {
-        var simulationParameters = SimulationParameters.Instance;
-        var cellType = new CellType(simulationParameters.GetMembrane(membrane))
-        {
-            CellTypeName = epithet,
-            IsBacteria = true,
-            MembraneRigidity = 0,
-        };
-
-        for (var i = 0; i < organelles.Length; ++i)
-        {
-            cellType.ModifiableOrganelles.Add(new OrganelleTemplate(
-                simulationParameters.GetOrganelleType(organelles[i]), new Hex(i * 4, 0), 0));
-        }
-
-        var species = new MulticellularSpecies(id, "Characterization", epithet);
         species.ModifiableCellTypes.Add(cellType);
         species.ModifiableGameplayCells.AddFast(new CellTemplate(cellType, new Hex(0, 0), 0),
             new List<Hex>(), new List<Hex>());


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR removed an unnecessary HP offset when calculating auto evo scores.

**Related Issues**

Blocked by #7174

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated coverage for predation score calculations across diverse predator and prey configurations.
  - Added tests for predation tool score caching, confirming cached results remain stable until the cache is cleared and scores are recalculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->