### PR TITLE
Fixed entity labels causing problems when mass removed

### DIFF
--- a/src/engine/DebugOverlays.EntityLabel.cs
+++ b/src/engine/DebugOverlays.EntityLabel.cs
@@ -151,9 +151,19 @@ public partial class DebugOverlays
             ClearEntityLabels();
     }
 
+    private static bool IsEntityAliveAndHasWorldPosition(Entity entity)
+    {
+        if (entity == Entity.Null || entity.IsAllZero() || entity.WorldId < 0 || entity.WorldId >= World.Worlds.Length)
+            return false;
+
+        return entity.IsAliveAndHas<WorldPosition>();
+    }
+
     private bool UpdateLabelColour(Entity entity, Label label)
     {
-        if (!entity.IsAliveAndNotNull())
+        // Do not use EntityExtensions.IsAlive here. Labels can outlive the world they were created from, in which case
+        // Arch's global world lookup returns null and IsAlive throws instead of returning false.
+        if (!IsEntityAliveAndHasWorldPosition(entity))
         {
             label.LabelSettings = entityDeadFont;
             return false;
@@ -199,7 +209,7 @@ public partial class DebugOverlays
         if (!IsInstanceValid(activeCamera) || activeCamera is not { Current: true })
             activeCamera = GetViewport().GetCamera3D();
 
-        if (activeCamera == null)
+        if (activeCamera == null || !activeCamera.IsInsideTree())
             return;
 
         textUpdateTimer -= delta;

--- a/src/engine/DebugOverlays.EntityLabel.cs
+++ b/src/engine/DebugOverlays.EntityLabel.cs
@@ -153,8 +153,13 @@ public partial class DebugOverlays
 
     private static bool IsEntityAliveAndHasWorldPosition(Entity entity)
     {
-        if (entity == Entity.Null || entity.IsAllZero() || entity.WorldId < 0 || entity.WorldId >= World.Worlds.Length)
+        // The world null check here is against a disposed world that still has a valid index.
+        if (entity == Entity.Null || entity.IsAllZero() || entity.WorldId < 0 ||
+            entity.WorldId >= World.Worlds.Length ||
+            World.Worlds[entity.WorldId] == null!)
+        {
             return false;
+        }
 
         return entity.IsAliveAndHas<WorldPosition>();
     }
@@ -206,7 +211,7 @@ public partial class DebugOverlays
 
     private void UpdateEntityLabels(double delta)
     {
-        if (!IsInstanceValid(activeCamera) || activeCamera is not { Current: true })
+        if (!IsInstanceValid(activeCamera) || activeCamera is not { Current: true } || !activeCamera.IsInsideTree())
             activeCamera = GetViewport().GetCamera3D();
 
         if (activeCamera == null || !activeCamera.IsInsideTree())


### PR DESCRIPTION
**Brief Description of What This PR Does**

due to loading a save or exiting the game

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/464846402732687391/465937305849298956/1544410166374568019

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug entity labels to handle entities whose world is unavailable or disposed.
  * Prevented label updates for entities that are no longer alive or lack a valid world position.
  * Improved camera handling when the camera is outside the scene tree.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->