### PR TITLE
Fix reversed channel inhibitor slowdown in auto-evo

### DIFF
--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -1533,6 +1533,7 @@ public class SimulationCache
         var predatorSprintTime = MathF.Max(predatorEnergyBalance.FinalBalance / predatorSprintConsumption, 0.0f);
 
         var preySprintSpeed = preySpeed * sprintMultiplier;
+        var slowedPreySprintSpeed = preySprintSpeed;
         var preySprintConsumption = sprintingStrain + preyHexSize * strainPerHex;
         var preySprintTime = MathF.Max(preyEnergyBalance.FinalBalance / preySprintConsumption, 0.0f);
 
@@ -1568,6 +1569,7 @@ public class SimulationCache
                     preyEnergyBalance.TotalMovement);
                 macrolideScore += channelInhibitorScore * (1 - channelInhibitorMovementFactor);
                 slowedPreySpeed *= channelInhibitorMovementFactor;
+                slowedPreySprintSpeed *= channelInhibitorMovementFactor;
             }
         }
 
@@ -1591,9 +1593,9 @@ public class SimulationCache
 
         var catchScore = CalculateCatchScores(canDigestPrey, in predatorToolScores, predatorSpeed, preySpeed,
             slowedProportion, slowedPreySpeed, predatorSprintSpeed, predatorSprintTime, preySprintSpeed,
-            preySprintTime, predatorSlimeSpeed, preySlimeSpeed, predatorRotationModifier, hasChemoreceptor,
-            preyIndividualCost, activityScore, focusScore, preyRotationModifier, preyOpportunismScore, preyFocusScore,
-            out var accidentalCatchScore);
+            slowedPreySprintSpeed, preySprintTime, predatorSlimeSpeed, preySlimeSpeed, predatorRotationModifier,
+            hasChemoreceptor, preyIndividualCost, activityScore, focusScore, preyRotationModifier,
+            preyOpportunismScore, preyFocusScore, out var accidentalCatchScore);
 
         pilusScore = CalculatePhysicalPredationScores(in predatorData, in preyData, in predatorToolScores,
             preyOxytoxyScore, preyOxygenMetabolismInhibitorScore, preyRotationModifier, preyFearScore,
@@ -1889,10 +1891,10 @@ public class SimulationCache
 
     private float CalculateCatchScores(bool canDigestPrey, in PredationToolsRawScores predatorToolScores,
         float predatorSpeed, float preySpeed, float slowedProportion, float slowedPreySpeed, float predatorSprintSpeed,
-        float predatorSprintTime, float preySprintSpeed, float preySprintTime, float predatorSlimeSpeed,
-        float preySlimeSpeed, float predatorRotationModifier, bool hasChemoreceptor, float preyIndividualCost,
-        float activityScore, float focusScore, float preyRotationModifier, float preyOpportunismScore,
-        float preyFocusScore, out float accidentalCatchScore)
+        float predatorSprintTime, float preySprintSpeed, float slowedPreySprintSpeed, float preySprintTime,
+        float predatorSlimeSpeed, float preySlimeSpeed, float predatorRotationModifier, bool hasChemoreceptor,
+        float preyIndividualCost, float activityScore, float focusScore, float preyRotationModifier,
+        float preyOpportunismScore, float preyFocusScore, out float accidentalCatchScore)
     {
         var pilusScore = predatorToolScores.PilusScore;
         var injectisomeScore = predatorToolScores.InjectisomeScore;
@@ -1937,7 +1939,14 @@ public class SimulationCache
             // Sprinting can also help prey escape.
             if (preySprintSpeed > predatorSpeed)
             {
-                catchScore -= (preySprintSpeed + 0.001f) / (predatorSpeed + 0.0001f) * preySprintTime;
+                catchScore -= (preySprintSpeed + 0.001f) / (predatorSpeed + 0.0001f) * preySprintTime *
+                    (1 - slowedProportion);
+            }
+
+            if (slowedPreySprintSpeed > predatorSpeed)
+            {
+                catchScore -= (slowedPreySprintSpeed + 0.001f) / (predatorSpeed + 0.0001f) * preySprintTime *
+                    slowedProportion;
             }
 
             // If you have Slime Jets, this can help you catch targets.

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -901,6 +901,15 @@ public class SimulationCache
         return new PilusToolScores(pilusScore, injectisomeScore, defensivePilusScore, defensiveInjectisomeScore);
     }
 
+    private static float CalculateChannelInhibitorMovementFactor(float inhibitedEnergyProduction,
+        float stationaryEnergyCost, float movementEnergyCost)
+    {
+        if (movementEnergyCost <= 0)
+            return 1;
+
+        return Math.Clamp((inhibitedEnergyProduction - stationaryEnergyCost) / movementEnergyCost, 0, 1);
+    }
+
     private PredationToolsRawScores CalculateMicrobePredationToolsRawScores(MicrobeSpecies species)
     {
         var averageToxicity = 0.0f;
@@ -1554,11 +1563,11 @@ public class SimulationCache
             // add (part of) the inhibitor score to macrolide score
             if (preyInhibitedPreyEnergyProduction < preyEnergyBalance.TotalConsumption)
             {
-                var channelInhibitorSlowFactor = Math.Min(
-                    Math.Max(preyInhibitedPreyEnergyProduction - preyOsmoregulationCost, 0) /
-                    preyEnergyBalance.TotalMovement, 1);
-                macrolideScore += channelInhibitorScore * channelInhibitorSlowFactor;
-                slowedPreySpeed *= 1 - channelInhibitorSlowFactor;
+                var channelInhibitorMovementFactor = CalculateChannelInhibitorMovementFactor(
+                    preyInhibitedPreyEnergyProduction, preyEnergyBalance.TotalConsumptionStationary,
+                    preyEnergyBalance.TotalMovement);
+                macrolideScore += channelInhibitorScore * (1 - channelInhibitorMovementFactor);
+                slowedPreySpeed *= channelInhibitorMovementFactor;
             }
         }
 

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -1938,7 +1938,10 @@ public class SimulationCache
                 predatorSprintTime;
 
             // Sprinting can also help prey escape.
-            catchScore -= CalculateSpeedAdvantage(preySprintSpeed, predatorSpeed) * preySprintTime;
+            catchScore -= CalculateSpeedAdvantage(preySprintSpeed, predatorSpeed) * preySprintTime *
+                (1 - slowedProportion);
+            catchScore -= CalculateSpeedAdvantage(slowedPreySprintSpeed, predatorSpeed) * preySprintTime *
+                slowedProportion;
 
             // If you have Slime Jets, this can help you catch targets.
             catchScore += CalculateSpeedAdvantage(predatorSlimeSpeed, preySpeed) * (1 - slowedProportion);

--- a/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
@@ -78,16 +78,105 @@ public class SimulationCachePredationScoreTests
         AssertThat(scoreAgainstPreyWithSlimeJet < scoreAgainstPreyWithoutSlimeJet).IsTrue();
     }
 
+    [TestCase]
+    public void ChannelInhibitorSlowFactorDecreasesAsMovementInhibitionIncreases()
+    {
+        var fullyFundedMovementScore = CalculateChannelInhibitorPredationScore(24.0f);
+        var halfFundedMovementScore = CalculateChannelInhibitorPredationScore(14.0f);
+        var unfundedMovementScore = CalculateChannelInhibitorPredationScore(4.0f);
+
+        AssertThat(float.IsFinite(fullyFundedMovementScore) && float.IsFinite(halfFundedMovementScore) &&
+            float.IsFinite(unfundedMovementScore)).IsTrue();
+        AssertThat(fullyFundedMovementScore < halfFundedMovementScore &&
+            halfFundedMovementScore < unfundedMovementScore).IsTrue();
+    }
+
+    [TestCase]
+    public void ChannelInhibitorMovementFundingUsesFullStationaryConsumption()
+    {
+        var allStationaryConsumptionIsOsmoregulation =
+            CalculateChannelInhibitorPredationScore(20.0f, 5.0f, 5.0f);
+        var stationaryConsumptionIncludesOtherProcesses =
+            CalculateChannelInhibitorPredationScore(20.0f, 0.0f, 5.0f);
+
+        AssertThat(float.IsFinite(allStationaryConsumptionIsOsmoregulation) &&
+            float.IsFinite(stationaryConsumptionIncludesOtherProcesses)).IsTrue();
+        AssertThat(stationaryConsumptionIncludesOtherProcesses)
+            .IsEqual(allStationaryConsumptionIsOsmoregulation);
+    }
+
+    [TestCase]
+    public void ChannelInhibitorDoesNotSlowSpeciesWithoutMovementCost()
+    {
+        var inhibitedBelowStationaryConsumption =
+            CalculateChannelInhibitorPredationScore(4.0f, 0.0f, 5.0f, 0.0f);
+        var productionAboveStationaryConsumption =
+            CalculateChannelInhibitorPredationScore(12.0f, 0.0f, 5.0f, 0.0f);
+
+        AssertThat(float.IsFinite(inhibitedBelowStationaryConsumption) &&
+            float.IsFinite(productionAboveStationaryConsumption)).IsTrue();
+        AssertThat(inhibitedBelowStationaryConsumption)
+            .IsEqual(productionAboveStationaryConsumption);
+    }
+
     private static float CalculatePredationScore(Species predator, Species prey)
     {
-        var worldSettings = new WorldGenerationSettings
-        {
-            Seed = 1,
-        };
-        var cache = new SimulationCache(worldSettings);
+        var cache = CreateCache();
         var biome = SimulationParameters.Instance.GetBiome("aavolcanic_vent").Conditions;
 
         return cache.GetPredationScore(predator, prey, biome);
+    }
+
+    private static float CalculateChannelInhibitorPredationScore(float totalProduction, float osmoregulation = 2.0f,
+        float stationaryConsumption = 2.0f, float movementConsumption = 10.0f)
+    {
+        var cache = CreateCache();
+        var predator = CreateChannelInhibitorPredator(9);
+        var prey = CreateMicrobe(10, "ChannelInhibitorPrey", "single", "cytoplasm");
+        prey.ModifiableBehaviour.Fear = Constants.MAX_SPECIES_FEAR;
+        prey.ModifiableBehaviour.Aggression = 0;
+
+        var rawScores = cache.GetPredationToolsRawScores(predator);
+        AssertThat(rawScores.ChannelInhibitorScore > 0.0f).IsTrue();
+        AssertThat(rawScores.MacrolideScore).IsEqual(0.0f);
+
+        var biome = SimulationParameters.Instance.GetBiome("aavolcanic_vent").Conditions;
+        var preyEnergyBalance = cache.GetEnergyBalanceForSpecies(prey, biome);
+        preyEnergyBalance.TotalProduction = totalProduction;
+        preyEnergyBalance.Osmoregulation = osmoregulation;
+        preyEnergyBalance.TotalConsumptionStationary = stationaryConsumption;
+        preyEnergyBalance.TotalMovement = movementConsumption;
+        preyEnergyBalance.TotalConsumption = stationaryConsumption + movementConsumption;
+        preyEnergyBalance.FinalBalance = 0.0f;
+        preyEnergyBalance.FinalBalanceStationary = 0.0f;
+
+        return cache.GetPredationScore(predator, prey, biome);
+    }
+
+    private static SimulationCache CreateCache()
+    {
+        return new SimulationCache(new WorldGenerationSettings
+        {
+            Seed = 1,
+        });
+    }
+
+    private static MicrobeSpecies CreateChannelInhibitorPredator(uint id)
+    {
+        var simulationParameters = SimulationParameters.Instance;
+        var species = CreateMicrobe(id, "ChannelInhibitorPredator", "single", "cytoplasm", "pilus");
+        species.Organelles.Add(new OrganelleTemplate(simulationParameters.GetOrganelleType("oxytoxy"),
+            new Hex(8, 0), 0)
+        {
+            ModifiableUpgrades = new OrganelleUpgrades
+            {
+                ModifiableUnlockedFeatures = [ToxinUpgradeNames.CHANNEL_INHIBITOR_UPGRADE_NAME],
+                CustomUpgradeData = new ToxinUpgrades(ToxinType.ChannelInhibitor, 0.0f),
+            },
+        });
+        species.OnEdited();
+
+        return species;
     }
 
     private static MicrobeSpecies CreateMicrobe(uint id, string epithet, string membrane,

--- a/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
@@ -79,7 +79,7 @@ public class SimulationCachePredationScoreTests
     }
 
     [TestCase]
-    public void ChannelInhibitorSlowFactorDecreasesAsMovementInhibitionIncreases()
+    public void ChannelInhibitorPredationScoreIncreasesAsMovementFundingDecreases()
     {
         var fullyFundedMovementScore = CalculateChannelInhibitorPredationScore(24.0f);
         var halfFundedMovementScore = CalculateChannelInhibitorPredationScore(14.0f);
@@ -119,6 +119,20 @@ public class SimulationCachePredationScoreTests
             .IsEqual(productionAboveStationaryConsumption);
     }
 
+    [TestCase]
+    public void ChannelInhibitorSlowsSprintEscapeSpeed()
+    {
+        var fullyFundedMovementWithoutSprint = CalculateChannelInhibitorPredationScore(24.0f);
+        var unfundedMovementWithoutSprint = CalculateChannelInhibitorPredationScore(4.0f);
+        var fullyFundedMovementWithSprint = CalculateChannelInhibitorPredationScore(24.0f, finalBalance: 1.0f);
+        var unfundedMovementWithSprint = CalculateChannelInhibitorPredationScore(4.0f, finalBalance: 1.0f);
+
+        var inhibitionBenefitWithoutSprint = unfundedMovementWithoutSprint - fullyFundedMovementWithoutSprint;
+        var inhibitionBenefitWithSprint = unfundedMovementWithSprint - fullyFundedMovementWithSprint;
+
+        AssertThat(inhibitionBenefitWithSprint > inhibitionBenefitWithoutSprint).IsTrue();
+    }
+
     private static float CalculatePredationScore(Species predator, Species prey)
     {
         var cache = CreateCache();
@@ -128,7 +142,7 @@ public class SimulationCachePredationScoreTests
     }
 
     private static float CalculateChannelInhibitorPredationScore(float totalProduction, float osmoregulation = 2.0f,
-        float stationaryConsumption = 2.0f, float movementConsumption = 10.0f)
+        float stationaryConsumption = 2.0f, float movementConsumption = 10.0f, float finalBalance = 0.0f)
     {
         var cache = CreateCache();
         var predator = CreateChannelInhibitorPredator(9);
@@ -147,7 +161,7 @@ public class SimulationCachePredationScoreTests
         preyEnergyBalance.TotalConsumptionStationary = stationaryConsumption;
         preyEnergyBalance.TotalMovement = movementConsumption;
         preyEnergyBalance.TotalConsumption = stationaryConsumption + movementConsumption;
-        preyEnergyBalance.FinalBalance = 0.0f;
+        preyEnergyBalance.FinalBalance = finalBalance;
         preyEnergyBalance.FinalBalanceStationary = 0.0f;
 
         return cache.GetPredationScore(predator, prey, biome);

--- a/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
@@ -95,9 +95,9 @@ public class SimulationCachePredationScoreTests
     public void ChannelInhibitorMovementFundingUsesFullStationaryConsumption()
     {
         var allStationaryConsumptionIsOsmoregulation =
-            CalculateChannelInhibitorPredationScore(20.0f, 5.0f, 5.0f);
+            CalculateChannelInhibitorPredationScore(14.0f, 5.0f, 5.0f);
         var stationaryConsumptionIncludesOtherProcesses =
-            CalculateChannelInhibitorPredationScore(20.0f, 0.0f, 5.0f);
+            CalculateChannelInhibitorPredationScore(14.0f, 0.0f, 5.0f);
 
         AssertThat(float.IsFinite(allStationaryConsumptionIsOsmoregulation) &&
             float.IsFinite(stationaryConsumptionIncludesOtherProcesses)).IsTrue();

--- a/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
@@ -122,10 +122,14 @@ public class SimulationCachePredationScoreTests
     [TestCase]
     public void ChannelInhibitorSlowsSprintEscapeSpeed()
     {
-        var fullyFundedMovementWithoutSprint = CalculateChannelInhibitorPredationScore(24.0f);
-        var unfundedMovementWithoutSprint = CalculateChannelInhibitorPredationScore(4.0f);
-        var fullyFundedMovementWithSprint = CalculateChannelInhibitorPredationScore(24.0f, finalBalance: 1.0f);
-        var unfundedMovementWithSprint = CalculateChannelInhibitorPredationScore(4.0f, finalBalance: 1.0f);
+        // Normal movement stays catchable, while sprinting lets the prey escape.
+        const float preyFear = Constants.MAX_SPECIES_FEAR * 0.25f;
+        var fullyFundedMovementWithoutSprint = CalculateChannelInhibitorPredationScore(24.0f, preyFear: preyFear);
+        var unfundedMovementWithoutSprint = CalculateChannelInhibitorPredationScore(4.0f, preyFear: preyFear);
+        var fullyFundedMovementWithSprint =
+            CalculateChannelInhibitorPredationScore(24.0f, finalBalance: 1.0f, preyFear: preyFear);
+        var unfundedMovementWithSprint =
+            CalculateChannelInhibitorPredationScore(4.0f, finalBalance: 1.0f, preyFear: preyFear);
 
         var inhibitionBenefitWithoutSprint = unfundedMovementWithoutSprint - fullyFundedMovementWithoutSprint;
         var inhibitionBenefitWithSprint = unfundedMovementWithSprint - fullyFundedMovementWithSprint;
@@ -142,12 +146,13 @@ public class SimulationCachePredationScoreTests
     }
 
     private static float CalculateChannelInhibitorPredationScore(float totalProduction, float osmoregulation = 2.0f,
-        float stationaryConsumption = 2.0f, float movementConsumption = 10.0f, float finalBalance = 0.0f)
+        float stationaryConsumption = 2.0f, float movementConsumption = 10.0f, float finalBalance = 0.0f,
+        float preyFear = Constants.MAX_SPECIES_FEAR)
     {
         var cache = CreateCache();
         var predator = CreateChannelInhibitorPredator(9);
         var prey = CreateMicrobe(10, "ChannelInhibitorPrey", "single", "cytoplasm");
-        prey.ModifiableBehaviour.Fear = Constants.MAX_SPECIES_FEAR;
+        prey.ModifiableBehaviour.Fear = preyFear;
         prey.ModifiableBehaviour.Aggression = 0;
 
         var rawScores = cache.GetPredationToolsRawScores(predator);


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR corrects the auto-evo predation speed adjustment for channel inhibitor toxins.

The previous calculation treated the remaining movement-energy funding as the slowdown amount, reversing the endpoint behavior: fully funded movement could be stopped while fully unfunded movement could remain unaffected. The updated calculation:

- subtracts all stationary ATP consumption before determining the energy available for movement;
- applies the remaining movement fraction directly to prey speed and its complement to slowdown scoring;
- safely handles species with zero movement cost;
- adds regression coverage for fully, partially, and unfunded movement, full stationary consumption, and zero movement cost.

**Related Issues**

No linked GitHub issue.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved predation scoring for stationary energy use and movement costs.
  * Corrected channel-inhibitor slowdown calculations, including prey sprint escape speed.
  * Improved multicellular slime-jet effects and corrected their impact on catch scores.
  * Adjusted channel-inhibitor scoring based on the resulting movement factor.
  * Corrected initial health handling in predation simulations.

* **Tests**
  * Added coverage for movement energy, stationary consumption, zero movement costs, sprint escape, and slime-jet catchability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->