### PR TITLE
fix wrong sign in slime jet score calculation in auto-evo

### DIFF
--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -1945,7 +1945,7 @@ public class SimulationCache
             // Having Slime Jets can also help prey escape.
             if (preySlimeSpeed > predatorSpeed)
             {
-                catchScore += (preySlimeSpeed + 0.001f) / (predatorSpeed + 0.0001f);
+                catchScore -= (preySlimeSpeed + 0.001f) / (predatorSpeed + 0.0001f);
             }
 
             // prevent potential negative catchScore.

--- a/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
@@ -49,7 +49,33 @@ public class SimulationCachePredationScoreTests
 
         var score = CalculatePredationScore(predator, prey);
 
-        AssertThat(score).IsEqual(258.4216f);
+        AssertThat(score).IsEqual(61.029884f);
+    }
+
+    [TestCase]
+    public void PreySlimeJetPropulsionReducesCatchability()
+    {
+        var predator = CreateSlimeJetPredator(9);
+        var preyWithoutSlimeJet = CreatePrey(10, false);
+        var preyWithSlimeJet = CreatePrey(11, true);
+        var cache = new SimulationCache(new WorldGenerationSettings
+        {
+            Seed = 1,
+        });
+        var biome = SimulationParameters.Instance.GetBiome("aavolcanic_vent").Conditions;
+
+        var preyWithoutSlimeJetRawScores = cache.GetPredationToolsRawScores(preyWithoutSlimeJet);
+        var preyWithSlimeJetRawScores = cache.GetPredationToolsRawScores(preyWithSlimeJet);
+        var scoreAgainstPreyWithoutSlimeJet = cache.GetPredationScore(predator, preyWithoutSlimeJet, biome);
+        var scoreAgainstPreyWithSlimeJet = cache.GetPredationScore(predator, preyWithSlimeJet, biome);
+
+        AssertThat(preyWithoutSlimeJetRawScores.SlimeJetScore).IsEqual(0.0f);
+        AssertThat(preyWithSlimeJetRawScores.SlimeJetScore > 0.0f).IsTrue();
+        AssertThat(float.IsFinite(scoreAgainstPreyWithoutSlimeJet)).IsTrue();
+        AssertThat(float.IsFinite(scoreAgainstPreyWithSlimeJet)).IsTrue();
+        AssertThat(scoreAgainstPreyWithoutSlimeJet > 0.0f).IsTrue();
+        AssertThat(scoreAgainstPreyWithSlimeJet > 0.0f).IsTrue();
+        AssertThat(scoreAgainstPreyWithSlimeJet < scoreAgainstPreyWithoutSlimeJet).IsTrue();
     }
 
     private static float CalculatePredationScore(Species predator, Species prey)
@@ -81,6 +107,32 @@ public class SimulationCachePredationScoreTests
         }
 
         species.OnEdited();
+        return species;
+    }
+
+    private static MicrobeSpecies CreateSlimeJetPredator(uint id)
+    {
+        var simulationParameters = SimulationParameters.Instance;
+        var species = CreateMicrobe(id, "SlimeJetPredator", "cellulose", "cytoplasm");
+        species.Organelles.Add(new OrganelleTemplate(simulationParameters.GetOrganelleType("pilus"),
+            new Hex(0, -4), 0));
+        species.Organelles.Add(new OrganelleTemplate(simulationParameters.GetOrganelleType("slimeJet"),
+            new Hex(0, 4), 0));
+        species.OnEdited();
+
+        return species;
+    }
+
+    private static MicrobeSpecies CreatePrey(uint id, bool hasSlimeJet)
+    {
+        var simulationParameters = SimulationParameters.Instance;
+        var species = CreateMicrobe(id, hasSlimeJet ? "SlimeJetPrey" : "NoSlimeJetPrey", "cellulose",
+            "cytoplasm");
+        species.Organelles.Add(new OrganelleTemplate(
+            simulationParameters.GetOrganelleType(hasSlimeJet ? "slimeJet" : "chemoreceptor"), new Hex(0, 4), 0));
+        species.ModifiableBehaviour.Fear = 0;
+        species.OnEdited();
+
         return species;
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR fixes a sign problem that will cause wrong result in prey's slime jet catch score.

**Related Issues**

No related issue.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected predation scoring so prey with faster slime-jet propulsion are harder to catch.
  * Updated predation score calculations to reflect reduced catchability from slime-jet propulsion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->