### PR TITLE
Reset growth on germination

### DIFF
--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -1213,16 +1213,23 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
 
             ref var growth = ref Player.Get<MulticellularGrowth>();
 
-            growth.IsASpore = false;
-
             if (multicellularSpeciesType.Species.ReproductionMethod == MulticellularReproductionMethod.Sporulation)
             {
+                // Returning from the editor turns the player into a new spore. Do not carry over the growth state
+                // from the colony that entered the editor, otherwise germination can treat the spore as a fully grown
+                // colony.
+                growth.ResetGrowthProgress();
                 growth.IsASpore = true;
             }
-            else if (multicellularSpeciesType.Species.ReproductionMethod is MulticellularReproductionMethod.Budding
-                     or MulticellularReproductionMethod.MassBudding)
+            else
             {
-                adjacencyBonus = multicellularSpeciesType.Species.GetAdjacencySpecializationBonus(0);
+                growth.IsASpore = false;
+
+                if (multicellularSpeciesType.Species.ReproductionMethod is MulticellularReproductionMethod.Budding
+                    or MulticellularReproductionMethod.MassBudding)
+                {
+                    adjacencyBonus = multicellularSpeciesType.Species.GetAdjacencySpecializationBonus(0);
+                }
             }
 
             // If the player has a colony, all resources need to be transferred to the stem cell to avoid them being

--- a/src/multicellular_stage/components/MulticellularGrowth.cs
+++ b/src/multicellular_stage/components/MulticellularGrowth.cs
@@ -242,14 +242,16 @@ public static class MulticellularGrowthHelpers
 
     /// <summary>
     ///   Resets all growth progress to grow the normal body plan. Used after exiting engulfment (which disbands the
-    ///   colony), as well as after returning from the edtior
+    ///   colony), as well as after returning from the editor
     /// </summary>
     public static void ResetGrowthProgress(this ref MulticellularGrowth multicellularGrowth)
     {
         // Start growing cells starting with the second one. The first one is the lead cell and gets spawned
-        // immediately. Same goes for a few more cells if the species uses the mass budding reproduction method,
+        // immediately. The same goes for a few more cells if the species uses the mass budding reproduction method,
         // but that is handled separately by MulticellularGrowthSystem
         multicellularGrowth.NextBodyPlanCellToGrowIndex = 1;
+        multicellularGrowth.LostPartsOfBodyPlan = null;
+        multicellularGrowth.ResumeBodyPlanAfterReplacingLost = null;
         multicellularGrowth.MassBuddingState = MulticellularMassBuddingState.NotSpawned;
         multicellularGrowth.EnoughResourcesForBudding = false;
 
@@ -594,6 +596,12 @@ public static class MulticellularGrowthHelpers
         ref var control = ref entity.Get<MicrobeControl>();
 
         control.GerminatingSpore = false;
+
+        // A spore can retain the growth state of the colony it was produced from. This is especially likely after
+        // returning from the editor, where the player is changed back into a spore, but the old colony still had its
+        // growth index. Germination always starts a new colony with only its initial cell grown.
+        // So to be sure that there can't be a bug with that, reset the growth progress here explicitly.
+        multicellularGrowth.ResetGrowthProgress();
 
         ref var cellProperties = ref entity.Get<CellProperties>();
 

--- a/test/multicellular_stage.tests/GrowthCompoundsMatchCalculation.cs
+++ b/test/multicellular_stage.tests/GrowthCompoundsMatchCalculation.cs
@@ -81,6 +81,13 @@ public class GrowthCompoundsMatchCalculation
 
         Assertions.AssertThat(microbe.Get<MulticellularGrowth>().IsFullyGrownMulticellular).IsFalse();
 
+        // Simulate a spore retaining the growth state of the colony it came from.
+        ref var staleGrowth = ref microbe.Get<MulticellularGrowth>();
+        staleGrowth.NextBodyPlanCellToGrowIndex = 15;
+        staleGrowth.EnoughResourcesForBudding = true;
+        staleGrowth.LostPartsOfBodyPlan = [2];
+        staleGrowth.ResumeBodyPlanAfterReplacingLost = 3;
+
         var calculatedGrowthNeeds = new Dictionary<Compound, float>();
         microbe.Get<OrganelleContainer>().CalculateTotalReproductionCompounds(microbe, species, calculatedGrowthNeeds);
 
@@ -92,6 +99,9 @@ public class GrowthCompoundsMatchCalculation
         // As the species has just one cell, it is fully grown
         // Assertions.AssertThat(microbe.Get<MulticellularGrowth>().IsFullyGrownMulticellular).IsFalse();
         Assertions.AssertThat(microbe.Get<MulticellularGrowth>().EnoughResourcesForBudding).IsFalse();
+        Assertions.AssertThat(microbe.Get<MulticellularGrowth>().NextBodyPlanCellToGrowIndex).IsEqual(1);
+        Assertions.AssertThat(microbe.Get<MulticellularGrowth>().LostPartsOfBodyPlan).IsNull();
+        Assertions.AssertThat(microbe.Get<MulticellularGrowth>().ResumeBodyPlanAfterReplacingLost).IsNull();
 
         // Make sure this didn't change in between
         var calculatedGrowthNeeds2 = new Dictionary<Compound, float>();


### PR DESCRIPTION
**Brief Description of What This PR Does**

Reset growth state when germinating (and when exiting the editor) to ensure that spore growth starts from the beginning. Note this should be safe to change but I have no clue how sporulation worked in the first place if this reset wasn't done...

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
https://discord.com/channels/228300288023461893/958598553389903913/1544198857372598313

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Returning from the editor as a sporulation species now starts the player as a fresh spore without carrying over previous colony growth progress.
  - Germinating a spore now starts a new colony with only its initial cell grown.
  - Stale body-plan recovery state is cleared when growth progress resets.
  - Budding and mass-budding species retain their intended growth and specialization behavior.

- **Tests**
  - Added coverage confirming that stale growth and body-plan state is reset during spore germination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->