### PR TITLE
fix `slowedPreySpeed` init position

### DIFF
--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -1478,7 +1478,6 @@ public class SimulationCache
 
         var preySpeed = GetSpeedForSpecies(preySpecies);
         var preyRotationSpeed = GetRotationSpeedForSpecies(preySpecies);
-        var slowedPreySpeed = preySpeed;
         var preyEnergyBalance = GetEnergyBalanceForSpecies(preySpecies, biomeConditions);
         var preyOsmoregulationCost = preyEnergyBalance.Osmoregulation;
         var preyIndividualCost = MichePopulation.CalculateIndividualCost(preySpecies, biomeConditions, this);
@@ -1517,6 +1516,7 @@ public class SimulationCache
 
         // prey's effectiveness at running away depends on how quickly they choose to run away
         preySpeed *= preyFearScore * (1 - preyAggressionScore);
+        var slowedPreySpeed = preySpeed;
 
         // Sprinting calculations
         var predatorSprintSpeed = predatorSpeed * sprintMultiplier;


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR fix a bug that initial `slowedPreySpeed` with outdated `preySpeed` value.

**Related Issues**

no relate issues.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved predation simulation accuracy by ensuring prey speed reductions account for fear and aggression effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->