### PR TITLE
Revise method order in style guide

### DIFF
--- a/doc/style_guide.md
+++ b/doc/style_guide.md
@@ -489,8 +489,9 @@ Godot usage
   instead to detach them from parents automatically.
 
 - The order of Godot overridden methods in a class should be in the
-  following order: (class constructor), `_Ready`, `_ExitTree`, `_Process`,
-  `_Input`, `_UnhandledInput`, (other callbacks)
+  following order: (class constructor), `_Ready`, `_EnterTree`, 
+  `_ExitTree`, `_Process`, `_Notification`, `_Input`, `_UnhandledInput`, 
+  (other callbacks)
 
 - If you need to access parent objects, don't make a static public
   instance variables, instead pass callbacks etc. around to allow the


### PR DESCRIPTION
Updated the order of Godot overridden methods in the style guide to include '_EnterTree' and '_Notification' as specified in the common RewriteTool used by the format_test linter.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the style guide’s recommended ordering for Godot override methods.
  * Added `_EnterTree` after `_Ready` and `_Notification` after `_Process`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->