### PR TITLE
Fix evolutionary tree node selection when generation history has gaps

### DIFF
--- a/src/thriveopedia/pages/ThriveopediaEvolutionaryTreePage.cs
+++ b/src/thriveopedia/pages/ThriveopediaEvolutionaryTreePage.cs
@@ -14,7 +14,11 @@ using Godot;
 /// </remarks>
 public partial class ThriveopediaEvolutionaryTreePage : ThriveopediaPage, IThriveopediaPage
 {
-    private readonly List<Dictionary<uint, Species>> speciesHistoryList = new();
+    /// <summary>
+    ///   Full species data keyed by generation number. This is not a list indexed by generation as the generation
+    ///   history can have gaps in it (see <see cref="GenerationRecord.GetFullSpeciesRecord"/>).
+    /// </summary>
+    private readonly Dictionary<int, Dictionary<uint, Species>> speciesHistory = new();
 
 #pragma warning disable CA2213
     [Export]
@@ -82,14 +86,14 @@ public partial class ThriveopediaEvolutionaryTreePage : ThriveopediaPage, IThriv
         {
             CurrentGame.GameWorld.BuildEvolutionaryTree(evolutionaryTree);
 
-            speciesHistoryList.Clear();
+            speciesHistory.Clear();
 
             foreach (var generation in CurrentGame.GameWorld.GenerationHistory)
             {
                 var updatedSpeciesData = generation.Value.AllSpeciesData.ToDictionary(s => s.Key,
                     s => GenerationRecord
                         .GetFullSpeciesRecord(s.Key, generation.Key, CurrentGame.GameWorld.GenerationHistory).Species);
-                speciesHistoryList.Add(updatedSpeciesData);
+                speciesHistory[generation.Key] = updatedSpeciesData;
             }
         }
         catch (Exception e)
@@ -109,6 +113,14 @@ public partial class ThriveopediaEvolutionaryTreePage : ThriveopediaPage, IThriv
 
     private void EvolutionaryTreeNodeSelected(int generation, uint id)
     {
-        speciesDetailsPanelWithFossilisation.PreviewSpecies = speciesHistoryList[generation][id];
+        if (!speciesHistory.TryGetValue(generation, out var generationSpecies) ||
+            !generationSpecies.TryGetValue(id, out var species))
+        {
+            GD.PrintErr($"No data for species {id} in generation {generation} to show for the selected tree node");
+            speciesDetailsPanelWithFossilisation.PreviewSpecies = null;
+            return;
+        }
+
+        speciesDetailsPanelWithFossilisation.PreviewSpecies = species;
     }
 }


### PR DESCRIPTION
**Brief Description of What This PR Does**

The Thriveopedia evolutionary tree page kept the full species data in a `List` that was filled by iterating `GenerationHistory`, and then indexed that list with the generation number of the clicked tree node. When the history has a gap (the save attached to the issue is missing generation 33, so the game prints "World history is out of order, expected generation 33 but got 34"), the list positions no longer match the generation numbers: every node after the gap resolves to the wrong generation, and a node in the last generation indexes one past the end and throws the `ArgumentOutOfRangeException` from the issue.

This keys the species data by generation number instead, the same way `GenerationHistory` itself is keyed, and makes the node selection handler print an error and clear the preview instead of throwing if a generation or species is ever missing. The underlying reason the generation went missing is not touched here, that is still #6032.

Tested with the save from the issue: before the change clicking a node in the last generation column raised the exception at line 112, after the change clicking nodes in the last two generations shows the matching species in the details panel. To load that save on current master I had to change its `ThriveVersion` from `1.6.0.0-rc1` to `1.6.0.0` in `info.json`, because rc1 saves are on the explicit incompatibility list now; the archive contents were not modified. Code-only unit tests pass (102/102) and the changed file passes the cleanupcode and inspectcode checks locally.

**Related Issues**

closes #7184

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evolutionary tree selection handling when species or generation data is unavailable.
  * The species preview is now cleared and an error is reported instead of causing a lookup failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->