### PR TITLE
Limit corpse chunks to 6 (down from 20) and total chunks are less by 10%

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1275,11 +1275,10 @@ public static class Constants
     public const float GAMETE_MATE_CALL_TARGET_DISTANCE_SQUARED = 50 * 50;
 
     // Corpse info
-    public const int CORPSE_CHUNK_DIVISOR = 3;
+    public const int CORPSE_CHUNK_MINIMUM = 1;
+    public const int CORPSE_CHUNK_DIVISOR = 4;
     public const float CORPSE_CHUNK_AMOUNT_MULTIPLIER = 1.0f;
-    public const int CORPSE_CHUNK_AMOUNT_CAP = 20;
-    public const int CORPSE_CHUNK_AMOUNT_DIMINISH_AFTER = 8;
-    public const int CORPSE_CHUNK_AMOUNT_DIMINISH_MORE_AFTER = 16;
+    public const int CORPSE_CHUNK_AMOUNT_CAP = 6;
     public const string DEFAULT_CHUNK_MODEL_NAME = "cytoplasm";
 
     // TODO: remove the drag variables if https://github.com/Revolutionary-Games/Thrive/issues/4719 is not decided to

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -735,7 +735,7 @@ public static class Constants
     ///   value is higher as spawned and microbe corpse chunks have now their individual limits (so the real limit is
     ///   double this)
     /// </summary>
-    public const int FLOATING_CHUNK_MAX_COUNT = 50;
+    public const int FLOATING_CHUNK_MAX_COUNT = 45;
 
     public const float CHUNK_VENT_COMPOUND_MULTIPLIER = 5000.0f;
 

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1275,13 +1275,11 @@ public static class Constants
     public const float GAMETE_MATE_CALL_TARGET_DISTANCE_SQUARED = 50 * 50;
 
     // Corpse info
-    public const float CORPSE_COMPOUND_COMPENSATION = 85.0f;
     public const int CORPSE_CHUNK_DIVISOR = 3;
     public const float CORPSE_CHUNK_AMOUNT_MULTIPLIER = 1.0f;
     public const int CORPSE_CHUNK_AMOUNT_CAP = 20;
     public const int CORPSE_CHUNK_AMOUNT_DIMINISH_AFTER = 8;
     public const int CORPSE_CHUNK_AMOUNT_DIMINISH_MORE_AFTER = 16;
-    public const float CHUNK_ENGULF_COMPOUND_DIVISOR = 30.0f;
     public const string DEFAULT_CHUNK_MODEL_NAME = "cytoplasm";
 
     // TODO: remove the drag variables if https://github.com/Revolutionary-Games/Thrive/issues/4719 is not decided to

--- a/src/benchmark/DummySpawnSystem.cs
+++ b/src/benchmark/DummySpawnSystem.cs
@@ -9,6 +9,13 @@ public class DummySpawnSystem : ISpawnSystem
 {
     private readonly OnEntityAddedCallback? addTrackedCallback;
 
+    /// <summary>
+    ///   Create a new dummy spawner with a callback. Note: the callback triggers on spawn before the entity is added
+    ///   to the world, so its ID is not stable yet and cannot be stored.
+    /// </summary>
+    /// <param name="addTrackedCallback">
+    ///   Callback to run to allow customized actions on entity creation (called before it is finalized)
+    /// </param>
     public DummySpawnSystem(OnEntityAddedCallback? addTrackedCallback = null)
     {
         this.addTrackedCallback = addTrackedCallback;

--- a/src/microbe_stage/systems/MicrobeDeathSystem.cs
+++ b/src/microbe_stage/systems/MicrobeDeathSystem.cs
@@ -62,6 +62,31 @@ public partial class MicrobeDeathSystem : BaseSystem<World, float>
     /// </summary>
     public delegate Vector3 CustomizeSpawnedChunk(ref Vector3 position);
 
+    /// <summary>
+    ///   Calculates how many corpse chunks a cell with the specified number of hexes drops.
+    /// </summary>
+    public static int CalculateCorpseChunkCount(int hexCount)
+    {
+        int chunksToSpawn = Math.Max(1, hexCount / Constants.CORPSE_CHUNK_DIVISOR);
+
+        // Apply a soft cap to the number of chunks
+        if (chunksToSpawn > Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_AFTER)
+        {
+            chunksToSpawn = Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_AFTER +
+                (chunksToSpawn - Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_AFTER) / 2;
+        }
+
+        if (chunksToSpawn > Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_MORE_AFTER)
+        {
+            chunksToSpawn = Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_MORE_AFTER +
+                (chunksToSpawn - Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_MORE_AFTER) / 3;
+        }
+
+        // And then a hard maximum limit to not cause massive performance problems if there are for some reason huge
+        // cells that die
+        return Math.Min(chunksToSpawn, Constants.CORPSE_CHUNK_AMOUNT_CAP);
+    }
+
     public static void SpawnCorpseChunks(ref OrganelleContainer organelleContainer, CompoundBag compounds,
         ISpawnSystem spawnSystem, IWorldSimulation worldSimulation, CommandBuffer recorder,
         Vector3 basePosition, Random random, CustomizeSpawnedChunk? customizeCallback, bool isBacteria)
@@ -129,31 +154,10 @@ public partial class MicrobeDeathSystem : BaseSystem<World, float>
         var chunkName = Localization.Translate("CHUNK_CELL_CORPSE_PART");
 
         // Queues either 1 corpse chunk or a factor of the hexes
-        int chunksToSpawn = Math.Max(1, organelleContainer.HexCount / Constants.CORPSE_CHUNK_DIVISOR);
-
-        // Apply a soft cap to the number of chunks
-        if (chunksToSpawn > Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_AFTER)
-        {
-            chunksToSpawn = Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_AFTER +
-                (chunksToSpawn - Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_AFTER) / 2;
-        }
-
-        if (chunksToSpawn > Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_MORE_AFTER)
-        {
-            chunksToSpawn = Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_MORE_AFTER +
-                (chunksToSpawn - Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_MORE_AFTER) / 3;
-        }
-
-        // And then a hard maximum limit to not cause massive performance problems if there are for some reason huge
-        // cells that die
-        if (chunksToSpawn > Constants.CORPSE_CHUNK_AMOUNT_CAP)
-            chunksToSpawn = Constants.CORPSE_CHUNK_AMOUNT_CAP;
+        int chunksToSpawn = CalculateCorpseChunkCount(organelleContainer.HexCount);
 
         for (int i = 0; i < chunksToSpawn; ++i)
         {
-            // Amount of compound in one chunk
-            float amount = baseAmount;
-
             var positionAdded = new Vector3(random.Next(-2.0f, 2.0f), 0,
                 random.Next(-2.0f, 2.0f));
 
@@ -182,10 +186,7 @@ public partial class MicrobeDeathSystem : BaseSystem<World, float>
             {
                 var compoundValue = new ChunkConfiguration.ChunkCompound
                 {
-                    // Randomize the compound amount a bit so things "rot away"
-                    // TODO: make this proportional to chunk count to make performance-balancing chunks easier
-                    Amount = (entry.Value / (random.Next(amount / 3.0f, amount) *
-                        Constants.CHUNK_ENGULF_COMPOUND_DIVISOR)) * Constants.CORPSE_COMPOUND_COMPENSATION,
+                    Amount = entry.Value / chunksToSpawn,
                 };
 
                 chunkType.Compounds[entry.Key] = compoundValue;

--- a/src/microbe_stage/systems/MicrobeDeathSystem.cs
+++ b/src/microbe_stage/systems/MicrobeDeathSystem.cs
@@ -67,23 +67,13 @@ public partial class MicrobeDeathSystem : BaseSystem<World, float>
     /// </summary>
     public static int CalculateCorpseChunkCount(int hexCount)
     {
-        int chunksToSpawn = Math.Max(1, hexCount / Constants.CORPSE_CHUNK_DIVISOR);
+        var chunksToSpawn = Math.Max(Constants.CORPSE_CHUNK_MINIMUM,
+            hexCount / Constants.CORPSE_CHUNK_DIVISOR);
 
-        // Apply a soft cap to the number of chunks
-        if (chunksToSpawn > Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_AFTER)
-        {
-            chunksToSpawn = Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_AFTER +
-                (chunksToSpawn - Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_AFTER) / 2;
-        }
+        // Make the second chunk spawn early to show that deaths result in multiple chunks
+        if (hexCount >= 5 && chunksToSpawn < 2)
+            chunksToSpawn = 2;
 
-        if (chunksToSpawn > Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_MORE_AFTER)
-        {
-            chunksToSpawn = Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_MORE_AFTER +
-                (chunksToSpawn - Constants.CORPSE_CHUNK_AMOUNT_DIMINISH_MORE_AFTER) / 3;
-        }
-
-        // And then a hard maximum limit to not cause massive performance problems if there are for some reason huge
-        // cells that die
         return Math.Min(chunksToSpawn, Constants.CORPSE_CHUNK_AMOUNT_CAP);
     }
 

--- a/test/microbe_stage.tests/MicrobeDeathSystemTests.cs
+++ b/test/microbe_stage.tests/MicrobeDeathSystemTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using Arch.Core;
+using Arch.Core.Extensions;
+using Components;
+using GdUnit4;
+using Godot;
+using Systems;
+using Test.Utils;
+using static GdUnit4.Assertions;
+
+[TestSuite]
+[RequireGodotRuntime]
+public class MicrobeDeathSystemTests
+{
+    [TestCase]
+    public void CorpseChunksContainExpectedAmountOfCompounds()
+    {
+        using var world = new TestWorldSimulation();
+        var spawnEnvironment = new DummyMicrobeSpawnEnvironment();
+        var simulationParameters = SimulationParameters.Instance;
+        var species = new MicrobeSpecies(1, "Test", "corpse")
+        {
+            IsBacteria = true,
+            MembraneType = simulationParameters.GetMembrane("single"),
+            Colour = Colors.White,
+        };
+        species.Organelles.Add(new OrganelleTemplate(simulationParameters.GetOrganelleType("cytoplasm"),
+            new Hex(0, 0), 0));
+        species.OnEdited();
+
+        SpawnHelpers.SpawnMicrobe(world, spawnEnvironment, species, Vector3.Zero, false, GameteType.All);
+        world.ProcessAll(0.1f);
+
+        var microbe = new FirstEntityGrabber(new QueryDescription().WithAll<MicrobeSpeciesMember>(),
+            world.EntitySystem).Found;
+        ref var storage = ref microbe.Get<CompoundStorage>();
+
+        // Use all cloud compounds so the test covers both storage contents and organelle composition.
+        const float storedAmountPerCompound = 100.0f;
+        foreach (var compound in simulationParameters.GetCloudCompounds())
+            storage.Compounds.Compounds[compound.ID] = storedAmountPerCompound;
+
+        // Hack the hex count to make sure we get a lot of chunks.
+        ref var organelles = ref microbe.Get<OrganelleContainer>();
+        organelles.HexCount = 30;
+
+        var spawnSystem = new DummySpawnSystem();
+
+        world.EntitySystem.Query(new QueryDescription().WithAll<CompoundVenter, CompoundStorage>(), _ =>
+            throw new Exception("Chunks shouldn't exist yet)"));
+
+        var recorder = world.StartRecordingEntityCommands();
+        MicrobeDeathSystem.SpawnCorpseChunks(ref organelles, storage.Compounds, spawnSystem, world, recorder,
+            Vector3.Zero, new Random(1), null, true);
+        world.FinishRecordingEntityCommands(recorder);
+        world.ProcessAll(0.1f);
+
+        // Chunks only exists now, so grab them
+        var spawnedChunks = new List<Entity>();
+        world.EntitySystem.Query(new QueryDescription().WithAll<CompoundVenter, CompoundStorage>(),
+            spawnedChunks.Add);
+
+        if (spawnedChunks.Count < 0)
+            throw new InvalidOperationException("No chunks spawned / found");
+
+        // Calculate how much stuff will be released.
+        var expectedChunkCount = MicrobeDeathSystem.CalculateCorpseChunkCount(organelles.HexCount);
+        var expectedAmounts = new Dictionary<Compound, float>();
+        foreach (var compound in simulationParameters.GetCloudCompounds())
+        {
+            var released = storedAmountPerCompound * Constants.COMPOUND_RELEASE_FRACTION;
+            foreach (var organelle in organelles.Organelles!)
+            {
+                foreach (var composition in organelle.Definition.InitialComposition)
+                {
+                    if (composition.Key == compound.ID)
+                        released += composition.Value * Constants.COMPOUND_MAKEUP_RELEASE_FRACTION;
+                }
+            }
+
+            expectedAmounts[compound.ID] = released / expectedChunkCount;
+        }
+
+        // And verify that the chunks have the expected amounts.
+        AssertThat(spawnedChunks.Count).IsEqual(expectedChunkCount);
+        foreach (var chunk in spawnedChunks)
+        {
+            if (!chunk.IsAliveAndHas<CompoundStorage>())
+                throw new InvalidOperationException("Expected entity doesn't have compound storage");
+
+            var chunkCompounds = chunk.Get<CompoundStorage>().Compounds;
+            foreach (var expected in expectedAmounts)
+            {
+                AssertThat(chunkCompounds.GetCompoundAmount(expected.Key))
+                    .IsEqualApprox(expected.Value, 0.0001f);
+            }
+        }
+    }
+}

--- a/test/microbe_stage.tests/MicrobeDeathSystemTests.cs
+++ b/test/microbe_stage.tests/MicrobeDeathSystemTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Arch.Core;
 using Arch.Core.Extensions;
@@ -13,6 +13,19 @@ using static GdUnit4.Assertions;
 [RequireGodotRuntime]
 public class MicrobeDeathSystemTests
 {
+    [TestCase]
+    public void CorpseChunkCountScalesWithCellSize()
+    {
+        AssertThat(MicrobeDeathSystem.CalculateCorpseChunkCount(1))
+            .IsEqual(Constants.CORPSE_CHUNK_MINIMUM);
+        AssertThat(MicrobeDeathSystem.CalculateCorpseChunkCount(10)).IsEqual(2);
+        AssertThat(MicrobeDeathSystem.CalculateCorpseChunkCount(15)).IsEqual(3);
+        AssertThat(MicrobeDeathSystem.CalculateCorpseChunkCount(25))
+            .IsEqual(Constants.CORPSE_CHUNK_AMOUNT_CAP);
+        AssertThat(MicrobeDeathSystem.CalculateCorpseChunkCount(100))
+            .IsEqual(Constants.CORPSE_CHUNK_AMOUNT_CAP);
+    }
+
     [TestCase]
     public void CorpseChunksContainExpectedAmountOfCompounds()
     {

--- a/test/microbe_stage.tests/MicrobeDeathSystemTests.cs.uid
+++ b/test/microbe_stage.tests/MicrobeDeathSystemTests.cs.uid
@@ -1,0 +1,1 @@
+uid://7qw1k4x5bj6b


### PR DESCRIPTION
**Brief Description of What This PR Does**

This tries to improve the game performance by limiting chunks which have been noticed as quite a major performance hit on cell death.

This might slightly debuff scavenging currently, but makes it consistent (removes randomness from dropped chunks), but if that is found to be the case I can tweak up the compounds dropped on death with some multiplier.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [x] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Gameplay**
  * Adjusted corpse chunk generation to scale more consistently with cell size.
  * Corpse chunks now distribute released compounds evenly, improving predictability.
  * Reduced the maximum number of floating chunks and lowered the per-chunk compound amount cap.
  * Ensured corpse generation always produces at least one chunk and supports an earlier second chunk for larger cells.

* **Documentation**
  * Added documentation clarifying benchmark entity tracking callback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->