### PR TITLE
Prevent specialization gains without pulling cilia

### DIFF
--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -1069,7 +1069,10 @@ public class SimulationCache
         channelInhibitorScore *= specializationBonus;
         macrolideScore *= specializationBonus;
         slimeJetScore *= specializationBonus;
-        pullingCiliaModifier *= specializationBonus;
+        if (pullingCiliasCount > 0)
+        {
+            pullingCiliaModifier *= specializationBonus;
+        }
 
         // bonus score for upgrades because auto-evo does not like adding them much
         injectisomeScore *= Constants.AUTO_EVO_ARTIFICIAL_UPGRADE_BONUS_SMALL;

--- a/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
@@ -27,7 +27,7 @@ public class SimulationCachePredationScoreTests
 
         var score = CalculatePredationScore(predator, prey);
 
-        AssertThat(score).IsEqual(273.68018f);
+        AssertThat(score).IsEqual(233.40552f);
     }
 
     [TestCase]

--- a/test/auto_evo.tests/SimulationCachePredationToolsRawScoresTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationToolsRawScoresTests.cs
@@ -35,6 +35,21 @@ public class SimulationCachePredationToolsRawScoresTests
     }
 
     [TestCase]
+    public void MicrobeWithoutPullingCiliaDoesNotGainModifierFromSpecialization()
+    {
+        var cache = CreateCache();
+        var species = CreateMicrobe(103);
+        species.Organelles.Clear();
+        species.Organelles.Add(CreateOrganelle(SimulationParameters.Instance, "cytoplasm", new Hex(0, 0)));
+        species.OnEdited();
+        species.CellTypeSpecializationBonus = 2.0f;
+
+        var scores = cache.GetPredationToolsRawScores(species);
+
+        AssertThat(scores.PullingCiliaModifier).IsEqual(1.0f);
+    }
+
+    [TestCase]
     public void MulticellularRawScoresAndCacheBehaviorAreCharacterized()
     {
         var cache = CreateCache();


### PR DESCRIPTION
**Brief Description of What This PR Does**

This PR prevents a species without pulling cilia from gaining a pulling cilia predation modifier through its cell type specialization bonus. The specialization bonus is now applied to the modifier only when the species actually has pulling cilia.

It also adds regression coverage for a specialized microbe without pulling cilia and updates the affected characterized predation score.

**Related Issues**

No related issues.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Microbe oxygen metabolism inhibitor scores now correctly scale with the applicable specialization bonus.
  - Microbes without pulling cilia no longer receive an unintended modifier from specialization.
  - Predation score calculations now reflect the corrected toxin scoring behavior.

- **Tests**
  - Added coverage for oxygen inhibitor score scaling and cache behavior.
  - Added coverage confirming correct pulling cilia modifier behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->