### PR TITLE
Constants optimization in Hex

### DIFF
--- a/src/general/Hex.cs
+++ b/src/general/Hex.cs
@@ -151,7 +151,7 @@ public struct Hex : IEquatable<Hex>, IComparable<Hex>
     public static Vector3 AxialToCartesian(Hex hex)
     {
         float x = hex.Q * Constants.DEFAULT_HEX_SIZE * 3.0f / 2.0f;
-        float z = Constants.DEFAULT_HEX_SIZE * MathF.Sqrt(3) * (hex.R + hex.Q / 2.0f);
+        float z = Constants.DEFAULT_HEX_SIZE * MathUtils.SQRT_3 * (hex.R + hex.Q / 2.0f);
         return new Vector3(x, 0, z);
     }
 
@@ -163,7 +163,7 @@ public struct Hex : IEquatable<Hex>, IComparable<Hex>
     {
         // Getting the cube coordinates.
         float cx = pos.X * (2.0f / 3.0f) / Constants.DEFAULT_HEX_SIZE;
-        float cy = pos.Z / (Constants.DEFAULT_HEX_SIZE * MathF.Sqrt(3)) - cx / 2.0f;
+        float cy = pos.Z / (Constants.DEFAULT_HEX_SIZE * MathUtils.SQRT_3) - cx / 2.0f;
         float cz = -(cx + cy);
 
         // Rounding the result.

--- a/src/general/utils/MathUtils.cs
+++ b/src/general/utils/MathUtils.cs
@@ -14,6 +14,7 @@ public static class MathUtils
     public const float RADIANS_TO_DEGREES = 180 / MathF.PI;
     public const double FULL_CIRCLE = Math.PI * 2;
     public const float RIGHT_ANGLE = MathF.PI / 2;
+    public const float SQRT_3 = 1.73205080757f;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int RoundToInt(float value)


### PR DESCRIPTION
Apparently using `MathF.Sqrt(3)` caused repeated recomputations, accounting for about the 4-10% of the whole auto-evo run-time in the Debug build. This PR simply replaces that with a precomputed constant.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Hex-grid coordinate conversions now use a shared square-root-of-three value, ensuring consistent calculations across conversion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->