### PR TITLE
Update style guide with precomputed values advice

### DIFF
--- a/doc/style_guide.md
+++ b/doc/style_guide.md
@@ -406,6 +406,12 @@ Code style rules
   the explicit compare is required). So write code like this: `if
   (thing)` and not: `if (thing == true)`.
 
+- For constant-evaluated functions, prefer using precomputed values
+  instead of calling the relative math function. For example, instead
+  of using `Sqrt(2)`, use `1.41421356237` instead. If the constant is
+  used in multiple places, declare a `const` and use it in place of the
+  call sites.
+
 - Finally you should attempt to reach the abstract goal of clean
   code. Here are some concepts that are indicative of good code (and
   breaking these can be bad code): Liskov substitution principle,

--- a/doc/style_guide.md
+++ b/doc/style_guide.md
@@ -407,10 +407,12 @@ Code style rules
   (thing)` and not: `if (thing == true)`.
 
 - For constant-evaluated functions, prefer using precomputed values
-  instead of calling the relative math function. For example, instead
-  of using `Sqrt(2)`, use `1.41421356237` instead. If the constant is
-  used in multiple places, declare a `const` and use it in place of the
-  call sites.
+  instead of calling the corresponding math function. For example, instead
+  of using `Sqrt(2)`, use `SQRT_2` instead, where `SQRT_2` is a `const`
+  defined somewhere with the precomputed value.
+  The precomputed value must preserve the target type and required precision,
+  so if the original function returned `double`, the used `const` must also
+  be a `double` and have the same 64-bits float precision.
 
 - Finally you should attempt to reach the abstract goal of clean
   code. Here are some concepts that are indicative of good code (and


### PR DESCRIPTION
Added a guideline for using precomputed values in constant-evaluated functions.

Related to #7234, which is the reason why this style guide directive has been added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated code-style guidance for constant-evaluated functions to reference the corresponding math function.
  - Recommended using named constants, such as `SQRT_2`, instead of truncated literal values.
  - Clarified that precomputed values should preserve the target type and required precision, including 64-bit floating-point precision for `double` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->