### PR TITLE
Move anti-predation miche

### DIFF
--- a/src/auto-evo/AutoEvoGlobalCache.cs
+++ b/src/auto-evo/AutoEvoGlobalCache.cs
@@ -32,9 +32,11 @@ public class AutoEvoGlobalCache
 
     public readonly CompoundConversionEfficiencyPressure SunlightConversionEfficiencyPressure;
     public readonly EnvironmentalCompoundPressure SunlightCompoundPressure;
+    public readonly EnvironmentalCompoundEnergy SunlightCompoundEnergy;
 
     public readonly CompoundConversionEfficiencyPressure TemperatureConversionEfficiencyPressure;
     public readonly EnvironmentalCompoundPressure TemperatureCompoundPressure;
+    public readonly EnvironmentalCompoundEnergy TemperatureCompoundEnergy;
 
     public readonly CompoundConversionEfficiencyPressure RadiationConversionEfficiencyPressure;
     public readonly ChunkCompoundPressure RadioactiveChunkPressure;
@@ -90,6 +92,7 @@ public class AutoEvoGlobalCache
         SunlightConversionEfficiencyPressure =
             new CompoundConversionEfficiencyPressure(Compound.Sunlight, Compound.Glucose, true, 1.5f);
         SunlightCompoundPressure = new EnvironmentalCompoundPressure(Compound.Sunlight, Compound.Glucose, 20000, 2.0f);
+        SunlightCompoundEnergy = new EnvironmentalCompoundEnergy(Compound.Sunlight, 20000, 2.0f);
 
         RadiationConversionEfficiencyPressure =
             new CompoundConversionEfficiencyPressure(Compound.Radiation, Compound.ATP, true, 1.0f);
@@ -101,6 +104,7 @@ public class AutoEvoGlobalCache
             new CompoundConversionEfficiencyPressure(Compound.Temperature, Compound.Glucose, true, 1.5f);
         TemperatureCompoundPressure = new EnvironmentalCompoundPressure(Compound.Temperature, Compound.Glucose,
             100, 2.0f);
+        TemperatureCompoundEnergy = new EnvironmentalCompoundEnergy(Compound.Temperature, 20000, 2.0f);
         HasTemperature = !worldSettings.LAWK;
 
         PredatorRoot = new PredatorRoot(2.0f);

--- a/src/auto-evo/selection_pressure/EnvironmentalCompoundEnergy.cs
+++ b/src/auto-evo/selection_pressure/EnvironmentalCompoundEnergy.cs
@@ -1,0 +1,86 @@
+﻿namespace AutoEvo;
+
+using System;
+using SharedBase.Archive;
+
+public class EnvironmentalCompoundEnergy : SelectionPressure
+{
+    public const ushort SERIALIZATION_VERSION = 1;
+
+    // Needed for translation extraction
+    // ReSharper disable ArrangeObjectCreationWhenTypeEvident
+    private static readonly LocalizedString NameString = new LocalizedString("MICHE_ENVIRONMENTAL_COMPOUND_PRESSURE");
+
+    // ReSharper restore ArrangeObjectCreationWhenTypeEvident
+
+    private readonly CompoundDefinition compound;
+
+    private readonly float energyMultiplier;
+
+    public EnvironmentalCompoundEnergy(Compound compound, float energyMultiplier,
+        float weight) :
+        base(weight, [
+            new RemoveOrganelle(_ => true),
+        ])
+    {
+        this.compound = SimulationParameters.GetCompound(compound);
+
+        if (this.compound.IsCloud)
+            throw new ArgumentException("Given compound to environmental pressure is a cloud type");
+
+        this.energyMultiplier = energyMultiplier;
+    }
+
+    public override LocalizedString Name => NameString;
+
+    public override ushort CurrentArchiveVersion => SERIALIZATION_VERSION;
+
+    public override ArchiveObjectType ArchiveObjectType =>
+        (ArchiveObjectType)ThriveArchiveObjectType.EnvironmentalCompoundEnergy;
+
+    public static EnvironmentalCompoundEnergy ReadFromArchive(ISArchiveReader reader, ushort version,
+        int referenceId)
+    {
+        if (version is > SERIALIZATION_VERSION or <= 0)
+            throw new InvalidArchiveVersionException(version, SERIALIZATION_VERSION);
+
+        var instance = new EnvironmentalCompoundEnergy((Compound)reader.ReadInt32(),
+            reader.ReadFloat(), reader.ReadFloat());
+
+        instance.ReadBasePropertiesFromArchive(reader, 1);
+        return instance;
+    }
+
+    public override void WriteToArchive(ISArchiveWriter writer)
+    {
+        writer.Write((int)compound.ID);
+        writer.Write(energyMultiplier);
+        base.WriteToArchive(writer);
+    }
+
+    public override float Score(Species species, Patch patch, SimulationCache cache)
+    {
+        return 1;
+    }
+
+    public override float GetEnergy(Patch patch)
+    {
+        return patch.Biome.AverageCompounds[compound.ID].Ambient * energyMultiplier;
+    }
+
+    public override LocalizedString GetDescription()
+    {
+        return new LocalizedString("DISSOLVED_COMPOUND_FOOD_SOURCE",
+            new LocalizedString(compound.GetUntranslatedName()));
+    }
+
+    public Compound GetUsedCompoundType()
+    {
+        return compound.ID;
+    }
+
+    public override string ToString()
+    {
+        return $"{Name} ({compound.Name})";
+    }
+}

--- a/src/auto-evo/selection_pressure/EnvironmentalCompoundEnergy.cs.uid
+++ b/src/auto-evo/selection_pressure/EnvironmentalCompoundEnergy.cs.uid
@@ -1,0 +1,1 @@
+uid://dd6te8wcrvm22

--- a/src/auto-evo/selection_pressure/EnvironmentalCompoundPressure.cs
+++ b/src/auto-evo/selection_pressure/EnvironmentalCompoundPressure.cs
@@ -23,7 +23,6 @@ public class EnvironmentalCompoundPressure : SelectionPressure
     public EnvironmentalCompoundPressure(Compound compound, Compound createdCompound, float energyMultiplier,
         float weight) :
         base(weight, [
-            new RemoveOrganelle(_ => true),
             AddOrganelleAnywhere.ThatUseCompound(compound),
             new ChangeBehaviorScore(ChangeBehaviorScore.BehaviorAttribute.Activity, 50.0f),
             new ChangeBehaviorScore(ChangeBehaviorScore.BehaviorAttribute.Activity, -150.0f),
@@ -99,18 +98,13 @@ public class EnvironmentalCompoundPressure : SelectionPressure
 
     public override float GetEnergy(Patch patch)
     {
-        return patch.Biome.AverageCompounds[compound.ID].Ambient * energyMultiplier;
+        return 0;
     }
 
     public override LocalizedString GetDescription()
     {
         return new LocalizedString("DISSOLVED_COMPOUND_FOOD_SOURCE",
             new LocalizedString(compound.GetUntranslatedName()));
-    }
-
-    public Compound GetUsedCompoundType()
-    {
-        return compound.ID;
     }
 
     public override string ToString()

--- a/src/auto-evo/steps/GenerateMiche.cs
+++ b/src/auto-evo/steps/GenerateMiche.cs
@@ -146,11 +146,13 @@ public class GenerateMiche : IRunStep
             var sunlightMiche = new Miche(globalCache.SunlightConversionEfficiencyPressure);
             var generateATP = new Miche(globalCache.MinorGlucoseConversionEfficiencyPressure);
             var maintainGlucose = new Miche(globalCache.MaintainGlucose);
-            var avoidPredationMiche = new Miche(globalCache.GeneralAvoidPredationSelectionPressure);
             var envPressure = new Miche(globalCache.SunlightCompoundPressure);
+            var avoidPredationMiche = new Miche(globalCache.GeneralAvoidPredationSelectionPressure);
+            var envEnergy = new Miche(globalCache.SunlightCompoundEnergy);
 
-            avoidPredationMiche.AddChild(envPressure);
-            maintainGlucose.AddChild(avoidPredationMiche);
+            avoidPredationMiche.AddChild(envEnergy);
+            envPressure.AddChild(avoidPredationMiche);
+            maintainGlucose.AddChild(envPressure);
             generateATP.AddChild(maintainGlucose);
             sunlightMiche.AddChild(generateATP);
             lastGeneralMiche.AddChild(sunlightMiche);
@@ -167,11 +169,13 @@ public class GenerateMiche : IRunStep
             var tempSessilityMiche = new Miche(globalCache.TemperatureSessilityPressure);
             var generateATP = new Miche(globalCache.MinorGlucoseConversionEfficiencyPressure);
             var maintainGlucose = new Miche(globalCache.MaintainGlucose);
-            var avoidPredationMiche = new Miche(globalCache.GeneralAvoidPredationSelectionPressure);
             var tempCompPressure = new Miche(globalCache.TemperatureCompoundPressure);
+            var avoidPredationMiche = new Miche(globalCache.GeneralAvoidPredationSelectionPressure);
+            var tempCompEnergy = new Miche(globalCache.TemperatureCompoundEnergy);
 
-            avoidPredationMiche.AddChild(tempCompPressure);
-            tempSessilityMiche.AddChild(avoidPredationMiche);
+            avoidPredationMiche.AddChild(tempCompEnergy);
+            tempCompPressure.AddChild(avoidPredationMiche);
+            tempSessilityMiche.AddChild(tempCompPressure);
             maintainGlucose.AddChild(tempSessilityMiche);
             generateATP.AddChild(maintainGlucose);
             tempMiche.AddChild(generateATP);

--- a/src/auto-evo/steps/GenerateMiche.cs
+++ b/src/auto-evo/steps/GenerateMiche.cs
@@ -32,13 +32,11 @@ public class GenerateMiche : IRunStep
     {
         var rootMiche = new Miche(globalCache.RootPressure);
         var metabolicRoot = new Miche(globalCache.MetabolicStabilityPressure);
-        var avoidPredationMiche = new Miche(globalCache.GeneralAvoidPredationSelectionPressure);
         var energyConsumptionMiche = new Miche(globalCache.EnergyConsumptionPressure);
         var generatedMiche = new Miche(globalCache.EnvironmentalTolerancesPressure);
 
         rootMiche.AddChild(metabolicRoot);
-        metabolicRoot.AddChild(avoidPredationMiche);
-        avoidPredationMiche.AddChild(energyConsumptionMiche);
+        metabolicRoot.AddChild(energyConsumptionMiche);
         energyConsumptionMiche.AddChild(generatedMiche);
 
         // "Autotrophic" Miches
@@ -55,8 +53,10 @@ public class GenerateMiche : IRunStep
             glucoseAmount.Amount > 0)
         {
             var glucoseMiche = new Miche(globalCache.GlucoseConversionEfficiencyPressure);
-            glucoseMiche.AddChild(new Miche(globalCache.GlucoseCloudPressure));
+            var avoidPredationMiche = new Miche(globalCache.GeneralAvoidPredationSelectionPressure);
 
+            avoidPredationMiche.AddChild(new Miche(globalCache.GlucoseCloudPressure));
+            glucoseMiche.AddChild(avoidPredationMiche);
             lastGeneralMiche.AddChild(glucoseMiche);
         }
 
@@ -69,16 +69,18 @@ public class GenerateMiche : IRunStep
         if (hasSmallIronChunk || hasBigIronChunk)
         {
             var ironMiche = new Miche(globalCache.IronConversionEfficiencyPressure);
+            var avoidPredationMiche = new Miche(globalCache.GeneralAvoidPredationSelectionPressure);
 
             if (hasSmallIronChunk)
-                ironMiche.AddChild(new Miche(globalCache.SmallIronChunkPressure));
+                avoidPredationMiche.AddChild(new Miche(globalCache.SmallIronChunkPressure));
 
             if (hasBigIronChunk)
-                ironMiche.AddChild(new Miche(globalCache.BigIronChunkPressure));
+                avoidPredationMiche.AddChild(new Miche(globalCache.BigIronChunkPressure));
 
             // TODO: maybe allowing direct iron in a patch should also be considered (though not currently used by
             // any biome in the game)?
 
+            ironMiche.AddChild(avoidPredationMiche);
             lastGeneralMiche.AddChild(ironMiche);
         }
 
@@ -100,19 +102,21 @@ public class GenerateMiche : IRunStep
             var hydrogenSulfideMiche = new Miche(globalCache.HydrogenSulfideConversionEfficiencyPressure);
             var generateATP = new Miche(globalCache.MinorGlucoseConversionEfficiencyPressure);
             var maintainGlucose = new Miche(globalCache.MaintainGlucose);
+            var avoidPredationMiche = new Miche(globalCache.GeneralAvoidPredationSelectionPressure);
 
             if (hydrogenSulfideAmount.Amount > 0)
-                maintainGlucose.AddChild(new Miche(globalCache.HydrogenSulfideCloudPressure));
+                avoidPredationMiche.AddChild(new Miche(globalCache.HydrogenSulfideCloudPressure));
 
             if (hasSmallSulfurChunk)
-                maintainGlucose.AddChild(new Miche(globalCache.SmallSulfurChunkPressure));
+                avoidPredationMiche.AddChild(new Miche(globalCache.SmallSulfurChunkPressure));
 
             if (hasMediumSulfurChunk)
-                maintainGlucose.AddChild(new Miche(globalCache.MediumSulfurChunkPressure));
+                avoidPredationMiche.AddChild(new Miche(globalCache.MediumSulfurChunkPressure));
 
             if (hasLargeSulfurChunk)
-                maintainGlucose.AddChild(new Miche(globalCache.LargeSulfurChunkPressure));
+                avoidPredationMiche.AddChild(new Miche(globalCache.LargeSulfurChunkPressure));
 
+            maintainGlucose.AddChild(avoidPredationMiche);
             generateATP.AddChild(maintainGlucose);
             hydrogenSulfideMiche.AddChild(generateATP);
             lastGeneralMiche.AddChild(hydrogenSulfideMiche);
@@ -126,7 +130,10 @@ public class GenerateMiche : IRunStep
         if (hasRadioactiveChunk)
         {
             var radiationMiche = new Miche(globalCache.RadiationConversionEfficiencyPressure);
-            radiationMiche.AddChild(new Miche(globalCache.RadioactiveChunkPressure));
+            var avoidPredationMiche = new Miche(globalCache.GeneralAvoidPredationSelectionPressure);
+
+            avoidPredationMiche.AddChild(new Miche(globalCache.RadioactiveChunkPressure));
+            radiationMiche.AddChild(avoidPredationMiche);
 
             lastGeneralMiche.AddChild(radiationMiche);
         }
@@ -139,9 +146,11 @@ public class GenerateMiche : IRunStep
             var sunlightMiche = new Miche(globalCache.SunlightConversionEfficiencyPressure);
             var generateATP = new Miche(globalCache.MinorGlucoseConversionEfficiencyPressure);
             var maintainGlucose = new Miche(globalCache.MaintainGlucose);
+            var avoidPredationMiche = new Miche(globalCache.GeneralAvoidPredationSelectionPressure);
             var envPressure = new Miche(globalCache.SunlightCompoundPressure);
 
-            maintainGlucose.AddChild(envPressure);
+            avoidPredationMiche.AddChild(envPressure);
+            maintainGlucose.AddChild(avoidPredationMiche);
             generateATP.AddChild(maintainGlucose);
             sunlightMiche.AddChild(generateATP);
             lastGeneralMiche.AddChild(sunlightMiche);
@@ -158,9 +167,11 @@ public class GenerateMiche : IRunStep
             var tempSessilityMiche = new Miche(globalCache.TemperatureSessilityPressure);
             var generateATP = new Miche(globalCache.MinorGlucoseConversionEfficiencyPressure);
             var maintainGlucose = new Miche(globalCache.MaintainGlucose);
+            var avoidPredationMiche = new Miche(globalCache.GeneralAvoidPredationSelectionPressure);
             var tempCompPressure = new Miche(globalCache.TemperatureCompoundPressure);
 
-            tempSessilityMiche.AddChild(tempCompPressure);
+            avoidPredationMiche.AddChild(tempCompPressure);
+            tempSessilityMiche.AddChild(avoidPredationMiche);
             maintainGlucose.AddChild(tempSessilityMiche);
             generateATP.AddChild(maintainGlucose);
             tempMiche.AddChild(generateATP);
@@ -169,6 +180,7 @@ public class GenerateMiche : IRunStep
 
         var predationRoot = new Miche(globalCache.PredatorRoot);
         var predationGlucose = new Miche(globalCache.MinorGlucoseConversionEfficiencyPressure);
+        var avoidPredationMicheForPredators = new Miche(globalCache.GeneralAvoidPredationSelectionPressure);
         var supportedSpeciesCount = 0;
 
         // Per Target-Species Miches
@@ -180,7 +192,8 @@ public class GenerateMiche : IRunStep
             ++supportedSpeciesCount;
 
             // Predation Miches
-            predationGlucose.AddChild(new Miche(new PredationEffectivenessPressure(targetSpecies.Key, 8.0f)));
+            avoidPredationMicheForPredators.AddChild(new Miche(new PredationEffectivenessPressure(targetSpecies.Key,
+                8.0f)));
 
             // Endosymbiosis Miches
             if (targetSpecies.Key.PlayerSpecies && targetSpecies.Key.Endosymbiosis.StartedEndosymbiosis != null)
@@ -192,7 +205,10 @@ public class GenerateMiche : IRunStep
         }
 
         if (supportedSpeciesCount > 1)
+        {
+            predationGlucose.AddChild(avoidPredationMicheForPredators);
             predationRoot.AddChild(predationGlucose);
+        }
 
         generatedMiche.AddChild(predationRoot);
 

--- a/src/microbe_stage/editor/FoodChainDisplay.cs
+++ b/src/microbe_stage/editor/FoodChainDisplay.cs
@@ -436,8 +436,8 @@ public partial class FoodChainDisplay : Control
                         GraphNode.NodeType.CompoundCloud);
                     break;
 
-                case EnvironmentalCompoundPressure environmentalCompoundPressure:
-                    LinkToCompoundNode(ourNode, environmentalCompoundPressure.GetUsedCompoundType(),
+                case EnvironmentalCompoundEnergy environmentalCompoundEnergy:
+                    LinkToCompoundNode(ourNode, environmentalCompoundEnergy.GetUsedCompoundType(),
                         GraphNode.NodeType.EnvironmentalCompound);
                     break;
 

--- a/src/saving/ThriveArchiveObjectType.cs
+++ b/src/saving/ThriveArchiveObjectType.cs
@@ -327,6 +327,7 @@ public enum ThriveArchiveObjectType : uint
     GameteBCellTypeChangeActionData = 4407,
     ComponentGameteCell = 4408,
     ComponentMicrobeSex = 4409,
+    EnvironmentalCompoundEnergy = 4410,
 
     // Special flag types
     ExtendedOrganelleLayout = OrganelleLayout | ArchiveObjectType.ExtendedTypeFlag,

--- a/src/saving/serializers/ThriveArchiveManager.cs
+++ b/src/saving/serializers/ThriveArchiveManager.cs
@@ -537,6 +537,10 @@ public class ThriveArchiveManager : DefaultArchiveManager, ISaveContext
             typeof(GeneralAvoidPredationSelectionPressure), GeneralAvoidPredationSelectionPressure.ReadFromArchive);
         RegisterObjectType((ArchiveObjectType)ThriveArchiveObjectType.EnergyConsumptionPressure,
             typeof(EnergyConsumptionPressure), EnergyConsumptionPressure.ReadFromArchive);
+
+        // Energy "Pressures"
+        RegisterObjectType((ArchiveObjectType)ThriveArchiveObjectType.EnvironmentalCompoundEnergy,
+            typeof(EnvironmentalCompoundEnergy), EnvironmentalCompoundEnergy.ReadFromArchive);
     }
 
     private void RegisterEditor()


### PR DESCRIPTION
**Brief Description of What This PR Does**

Moves the general anti-predation miche from the root of the miche tree to near the ends of the branches in an attempt to reduce the calculation of predation scores. Likely at the cost of an increased total amount of attempted mutations.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Gameplay Improvements**
  * Improved how species respond to predation pressure across different energy and metabolic strategies.
  * Predation avoidance is now applied more consistently when multiple species are present and is not unnecessarily applied in single-species scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->