### PR TITLE
Start a fresh auto-evo run when player becomes multicellular

### DIFF
--- a/src/general/GameWorld.cs
+++ b/src/general/GameWorld.cs
@@ -579,13 +579,17 @@ public class GameWorld : IArchivable
     /// <summary>
     ///   Stops and removes any auto-evo runs for this world
     /// </summary>
-    public void ResetAutoEvoRun()
+    /// <returns>True, when an auto-evo run was stopped and removed</returns>
+    public bool ResetAutoEvoRun()
     {
         if (autoEvo != null)
         {
             autoEvo.Abort();
             autoEvo = null;
+            return true;
         }
+
+        return false;
     }
 
     /// <summary>

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -992,6 +992,14 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
         if (WorldSimulation.Processing)
             throw new Exception("This shouldn't be ran while world is in the middle of a simulation");
 
+        // The player species changes type below, so any existing run has stale species data. This also needs to
+        // happen before the conversion because an in-progress run must not inspect the species while it is being
+        // changed.
+        if (GameWorld.ResetAutoEvoRun())
+        {
+            GD.Print("Aborted the existing auto-evo run before moving the player to the multicellular stage");
+        }
+
         GD.Print("Disbanding colony and becoming multicellular");
 
         // Move to multicellular always happens when the player is in a colony, so we force-disband that here before
@@ -1076,6 +1084,12 @@ public sealed partial class MicrobeStage : CreatureStageBase<Entity, MicrobeWorl
         GiveReproductionPopulationBonus();
 
         CurrentGame!.EnterPrototypes();
+
+        // See the comment in MicrobeStage.MoveToMacroscopic
+        if (GameWorld.ResetAutoEvoRun())
+        {
+            GD.Print("Aborted the existing auto-evo run before moving the player to the macroscopic stage");
+        }
 
         var modifiedSpecies = GameWorld.ChangeSpeciesToMacroscopic(Player.Get<SpeciesMember>().Species);
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

This ensures that the auto-evo results are the same and take initial player multicellularity into account. This makes behaviour consistent whether run auto-evo during gameplay option is on or off.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
there not being multicellular species immediately for players when going to multicellular

Also might fix a data modification error that auto-evo sometimes reports on going to multicellular

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - In-progress auto-evolution runs are now stopped when transitioning a species to multicellular or macroscopic stages.
  - Prevents auto-evolution from continuing with outdated species information during these transitions.
  - The game now reports when an active auto-evolution run was interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->