### PR TITLE
Made the main thread handle other tasks failing more safely

### DIFF
--- a/src/engine/TaskExecutor.cs
+++ b/src/engine/TaskExecutor.cs
@@ -200,7 +200,10 @@ public class TaskExecutor
     ///   ones queued from another thread while this method is executing) are complete, which may be unwanted in
     ///   some cases.
     /// </param>
-    public void RunTasks(List<Task> tasks, bool runExtraTasksOnCallingThread = false)
+    /// <param name="catchErrors">
+    ///   If set to true, then caught errors are shown to the player rather than letting them escape
+    /// </param>
+    public void RunTasks(List<Task> tasks, bool runExtraTasksOnCallingThread = false, bool catchErrors = false)
     {
         // Queue all but the first task
         Task? firstTask = null;
@@ -261,9 +264,25 @@ public class TaskExecutor
         // Wait for all given tasks to complete
         foreach (var task in mainThreadTaskStorage)
         {
-            // TODO: so apparently this Wait call can allocate memory, in SpinThenBlockingWait which eventually calls
-            // EnsureLockObjectCreated
-            task.Wait();
+            try
+            {
+                // TODO: so apparently this Wait call can allocate memory, in SpinThenBlockingWait which eventually
+                // calls EnsureLockObjectCreated
+                task.Wait();
+            }
+            catch (Exception e)
+            {
+                GD.PrintErr("Error encountered from a waited task on the primary waiting thread");
+
+                if (catchErrors)
+                {
+                    LogInterceptor.ForwardCaughtError(e, "Error from waited background task");
+                }
+                else
+                {
+                    throw;
+                }
+            }
         }
 
         mainThreadTaskStorage.Clear();

--- a/src/microbe_stage/CompoundCloudSystem.cs
+++ b/src/microbe_stage/CompoundCloudSystem.cs
@@ -475,7 +475,7 @@ public partial class CompoundCloudSystem : Node, IReadonlyCompoundClouds, ISaveL
             cloud.QueueDiffuseCloud(delta, tasks);
         }
 
-        executor.RunTasks(tasks);
+        executor.RunTasks(tasks, false, true);
         tasks.Clear();
 
         foreach (var cloud in clouds)
@@ -488,7 +488,7 @@ public partial class CompoundCloudSystem : Node, IReadonlyCompoundClouds, ISaveL
             cloud.QueueAdvectCloud(delta, tasks);
         }
 
-        executor.RunTasks(tasks);
+        executor.RunTasks(tasks, false, true);
 
         foreach (var cloud in clouds)
         {

--- a/src/tools/ThreadedRunSimulator.cs
+++ b/src/tools/ThreadedRunSimulator.cs
@@ -93,7 +93,7 @@ public class ThreadedRunSimulator
             lastNewBestFound = DateTime.UtcNow;
         }
 
-        // Wait for tasks to end, this is not time-critical threading here so this thread can be used to run
+        // Wait for tasks to end, this is not time-critical threading here, so this thread can be used to run
         // a bunch more tasks
         TaskExecutor.Instance.RunTasks(tasks, true);
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

and show them as unhandled errors to the player

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
When auto-evo was failing badly, it was interfering with the cloud diffusion tasks, so I made it so that the caller of wait tasks can decide whether it wants random tasks to throw or not

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability during compound cloud updates by catching and forwarding task errors instead of allowing them to interrupt processing.
  - Added clearer error logging for failures encountered while waiting for background tasks.

- **Refactor**
  - Task execution now supports configurable error-handling behavior while preserving existing default behavior.

- **Documentation**
  - Clarified an internal threading comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->