### PR TITLE
Threshold miche

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -1508,6 +1508,8 @@ public static class Constants
     public const float AUTO_EVO_MUTATION_RIGIDITY_STEP = 0.35f;
     public const float AUTO_EVO_MUTATION_TOXICITY_STEP = 0.2f;
 
+    public const int AUTO_EVO_THRESHOLD_MICHE_MAX_SCORE = 1;
+
     public const int AUTO_EVO_MAX_MUTATION_RECURSIONS = 3;
 
     public const int AUTO_EVO_ORGANELLE_ADD_ATTEMPTS = 15;

--- a/src/auto-evo/selection_pressure/MaintainCompoundPressure.cs
+++ b/src/auto-evo/selection_pressure/MaintainCompoundPressure.cs
@@ -28,6 +28,8 @@ public class MaintainCompoundPressure : SelectionPressure
 
     public override ushort CurrentArchiveVersion => SERIALIZATION_VERSION;
 
+    public override bool IsThresholdPressure => true;
+
     public override ArchiveObjectType ArchiveObjectType =>
         (ArchiveObjectType)ThriveArchiveObjectType.MaintainCompoundPressure;
 

--- a/src/auto-evo/selection_pressure/MetabolicStabilityPressure.cs
+++ b/src/auto-evo/selection_pressure/MetabolicStabilityPressure.cs
@@ -25,6 +25,8 @@ public class MetabolicStabilityPressure : SelectionPressure
 
     public override ushort CurrentArchiveVersion => SERIALIZATION_VERSION;
 
+    public override bool IsThresholdPressure => true;
+
     public override ArchiveObjectType ArchiveObjectType =>
         (ArchiveObjectType)ThriveArchiveObjectType.MetabolicStabilityPressure;
 

--- a/src/auto-evo/selection_pressure/PredatorRoot.cs
+++ b/src/auto-evo/selection_pressure/PredatorRoot.cs
@@ -30,6 +30,8 @@ public class PredatorRoot : SelectionPressure
 
     public override ushort CurrentArchiveVersion => SERIALIZATION_VERSION;
 
+    public override bool IsThresholdPressure => true;
+
     public override ArchiveObjectType ArchiveObjectType =>
         (ArchiveObjectType)ThriveArchiveObjectType.PredatorRoot;
 

--- a/src/auto-evo/selection_pressure/SelectionPressure.cs
+++ b/src/auto-evo/selection_pressure/SelectionPressure.cs
@@ -24,6 +24,11 @@ public abstract class SelectionPressure : IArchivable
     public abstract ushort CurrentArchiveVersion { get; }
     public abstract ArchiveObjectType ArchiveObjectType { get; }
     public bool CanBeReferencedInArchive => true;
+    /// <summary>
+    ///   Does this SelectionPressure have a maximum score where it is pointless to attempt more mutations?
+    ///   If true, the maximum score should be set to <see cref="Constants.AUTO_EVO_THRESHOLD_MICHE_MAX_SCORE"/>.
+    /// </summary>
+    public virtual bool IsThresholdPressure => false;
 
     public abstract LocalizedString Name { get; }
 

--- a/src/auto-evo/selection_pressure/SelectionPressure.cs
+++ b/src/auto-evo/selection_pressure/SelectionPressure.cs
@@ -24,6 +24,7 @@ public abstract class SelectionPressure : IArchivable
     public abstract ushort CurrentArchiveVersion { get; }
     public abstract ArchiveObjectType ArchiveObjectType { get; }
     public bool CanBeReferencedInArchive => true;
+
     /// <summary>
     ///   Does this SelectionPressure have a maximum score where it is pointless to attempt more mutations?
     ///   If true, the maximum score should be set to <see cref="Constants.AUTO_EVO_THRESHOLD_MICHE_MAX_SCORE"/>.

--- a/src/auto-evo/selection_pressure/TemperatureSessilityPressure.cs
+++ b/src/auto-evo/selection_pressure/TemperatureSessilityPressure.cs
@@ -27,6 +27,8 @@ public class TemperatureSessilityPressure : SelectionPressure
 
     public override ushort CurrentArchiveVersion => SERIALIZATION_VERSION;
 
+    public override bool IsThresholdPressure => true;
+
     public override ArchiveObjectType ArchiveObjectType =>
         (ArchiveObjectType)ThriveArchiveObjectType.TemperatureSessilityPressure;
 

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -449,10 +449,24 @@ public class ModifyExistingSpecies : IRunStep
 
                 foreach (var speciesTuple in temporaryMutations1)
                 {
-                    // TODO: this seems like the longest part, so splitting this into multiple steps (maybe bundling
-                    // up mutation strategies) would be good to have the auto-evo steps flow more smoothly
-                    var mutated = mutationStrategy.MutationsOf(speciesTuple.Species, speciesTuple.MP, lawk, random,
-                        patch.Biome);
+                    // For SelectionPressures that have a maximum score, no reason to generate mutations for species
+                    // that already have the maximum score
+                    var produceMutations = true;
+                    if (currentMiche.Pressure.IsThresholdPressure)
+                    {
+                        var score = currentMiche.Pressure.Score(speciesTuple.Species, patch, cache);
+                        if (score >= Constants.AUTO_EVO_THRESHOLD_MICHE_MAX_SCORE)
+                            produceMutations = false;
+                    }
+
+                    var mutated = new List<Mutant>();
+                    if (produceMutations)
+                    {
+                        // TODO: this seems like the longest part, so splitting this into multiple steps (maybe bundling
+                        // up mutation strategies) would be good to have the auto-evo steps flow more smoothly
+                        mutated = mutationStrategy.MutationsOf(speciesTuple.Species, speciesTuple.MP, lawk, random,
+                            patch.Biome);
+                    }
 
                     if (mutated != null)
                     {

--- a/src/auto-evo/steps/ModifyExistingSpecies.cs
+++ b/src/auto-evo/steps/ModifyExistingSpecies.cs
@@ -459,7 +459,7 @@ public class ModifyExistingSpecies : IRunStep
                             produceMutations = false;
                     }
 
-                    var mutated = new List<Mutant>();
+                    List<Mutant>? mutated = null;
                     if (produceMutations)
                     {
                         // TODO: this seems like the longest part, so splitting this into multiple steps (maybe bundling


### PR DESCRIPTION
**Brief Description of What This PR Does**

Adds support to have some SelectionPressures/Miches not generate mutations for species that already have the highest possible score. This avoids creating more species that need more calculation of other scores.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Auto-evolution now recognizes threshold-based selection pressures for metabolic stability, temperature tolerance, predator-related pressures, and compound maintenance.
  * Species that reach the maximum score for an applicable threshold pressure are no longer assigned unnecessary mutations.
  * Added a threshold score used to determine when species have reached the maximum for these pressures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->