### PR TITLE
Align Auto-Evo engulfment size thresholds with gameplay

### DIFF
--- a/src/auto-evo/selection_pressure/ChunkCompoundPressure.cs
+++ b/src/auto-evo/selection_pressure/ChunkCompoundPressure.cs
@@ -117,7 +117,7 @@ public class ChunkCompoundPressure : SelectionPressure
             nominalStorageCapacity = microbeSpecies.StorageCapacities.Nominal;
 
             if (microbeSpecies.CanEngulf &&
-                cache.GetBaseHexSizeForSpecies(microbeSpecies) > chunk.Size * Constants.ENGULF_SIZE_RATIO_REQ)
+                cache.GetBaseHexSizeForSpecies(microbeSpecies) >= chunk.Size * Constants.ENGULF_SIZE_RATIO_REQ)
             {
                 canEngulf = true;
             }
@@ -134,7 +134,7 @@ public class ChunkCompoundPressure : SelectionPressure
                     break;
 
                 if (cellType.MembraneType.CanEngulf &&
-                    cache.GetBaseHexSizeForCellType(cellType) > chunk.Size * Constants.ENGULF_SIZE_RATIO_REQ)
+                    cache.GetBaseHexSizeForCellType(cellType) >= chunk.Size * Constants.ENGULF_SIZE_RATIO_REQ)
                 {
                     foreach (var hex in multicellularSpecies.EditorCells)
                     {

--- a/src/auto-evo/selection_pressure/ReproductionCompoundPressure.cs
+++ b/src/auto-evo/selection_pressure/ReproductionCompoundPressure.cs
@@ -137,7 +137,7 @@ public class ReproductionCompoundPressure : SelectionPressure
             {
                 if (species is MicrobeSpecies)
                 {
-                    if (microbeCanEngulf && microbeBaseHexSize > chunk.Size * Constants.ENGULF_SIZE_RATIO_REQ)
+                    if (microbeCanEngulf && microbeBaseHexSize >= chunk.Size * Constants.ENGULF_SIZE_RATIO_REQ)
                         canEngulfChunk = true;
                 }
 
@@ -151,7 +151,7 @@ public class ReproductionCompoundPressure : SelectionPressure
                             break;
 
                         if (cellType.MembraneType.CanEngulf &&
-                            cache.GetBaseHexSizeForCellType(cellType) > chunk.Size * Constants.ENGULF_SIZE_RATIO_REQ)
+                            cache.GetBaseHexSizeForCellType(cellType) >= chunk.Size * Constants.ENGULF_SIZE_RATIO_REQ)
                         {
                             foreach (var hex in multicellularSpecies.EditorCells)
                             {

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -2216,7 +2216,7 @@ public class SimulationCache
                     {
                         ++cellCount;
                         if (cellType.MembraneType.CanEngulf &&
-                            cellTypeHexSize / preyData.SmallestHexSize >= Constants.ENGULF_SIZE_RATIO_REQ)
+                            cellTypeHexSize >= preyData.SmallestHexSize * Constants.ENGULF_SIZE_RATIO_REQ)
                         {
                             var cellEnzymesScore = GetEnzymesScore(cellType, preyData.DissolverEnzyme,
                                 cellTypeSpecializationBonus * CellBodyPlanInternalCalculations

--- a/src/auto-evo/simulation/SimulationCache.cs
+++ b/src/auto-evo/simulation/SimulationCache.cs
@@ -744,7 +744,7 @@ public class SimulationCache
                 continue;
 
             var cellTypeHexSize = GetBaseHexSizeForCellType(cellType);
-            if (cellTypeHexSize / preyHexSize <= Constants.ENGULF_SIZE_RATIO_REQ)
+            if (cellTypeHexSize < preyHexSize * Constants.ENGULF_SIZE_RATIO_REQ)
                 continue;
 
             var cellTypeSpecializationBonus = cellType.CellTypeSpecializationBonus;
@@ -2184,7 +2184,7 @@ public class SimulationCache
                     ++predatorOxygenUsingOrganellesCount;
             }
 
-            if (canEngulf && predatorHexSize / preyData.SmallestHexSize > Constants.ENGULF_SIZE_RATIO_REQ)
+            if (canEngulf && predatorHexSize >= preyData.SmallestHexSize * Constants.ENGULF_SIZE_RATIO_REQ)
             {
                 enzymesScore = GetEnzymesScore(microbePredator, preyData.DissolverEnzyme,
                     microbePredator.CellTypeSpecializationBonus);

--- a/test/auto_evo.tests/EngulfThresholdConsistencyTests.cs
+++ b/test/auto_evo.tests/EngulfThresholdConsistencyTests.cs
@@ -1,0 +1,217 @@
+﻿using System;
+using System.Collections.Generic;
+using AutoEvo;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+/// <summary>
+///   Tests that auto-evo engulf checks consistently include the exact size threshold.
+/// </summary>
+[TestSuite]
+[RequireGodotRuntime]
+public class EngulfThresholdConsistencyTests
+{
+    private enum ThresholdSpeciesKind
+    {
+        Microbe,
+        Multicellular,
+    }
+
+    [TestCase]
+    public void GetPredationScore_MicrobeAtExactThresholdCanPredate()
+    {
+        var predator = CreateMicrobe(1, "ThresholdPredator", 3);
+        var prey = CreateMicrobe(2, "ThresholdPrey", 2);
+        var cache = CreateCache();
+        var biome = SimulationParameters.Instance.GetBiome("aavolcanic_vent").Conditions;
+
+        var predatorSize = cache.GetBaseHexSizeForSpecies(predator);
+        var preySize = cache.GetBaseHexSizeForSpecies(prey);
+
+        AssertThat(predatorSize).IsEqual(preySize * Constants.ENGULF_SIZE_RATIO_REQ);
+
+        var coldScore = cache.GetPredationScore(predator, prey, biome);
+        AssertThat(coldScore).IsGreater(0.0f);
+
+        var warmScore = cache.GetPredationScore(predator, prey, biome);
+        AssertThat(warmScore).IsEqual(coldScore);
+    }
+
+    [TestCase]
+    public void GetEnzymesScore_MulticellularThresholdMatrixIsInclusive()
+    {
+        const float preySize = 2.0f;
+        var predator = CreateMulticellular(3, "ThresholdMulticellularPredator", 3);
+        var cache = CreateCache();
+
+        var predatorCellSize = cache.GetBaseHexSizeForCellType(predator.CellTypes[0]);
+        AssertThat(predatorCellSize).IsEqual(preySize * Constants.ENGULF_SIZE_RATIO_REQ);
+
+        var belowThreshold = cache.GetEnzymesScore(predator, Constants.LIPASE_ENZYME,
+            float.BitIncrement(preySize), 0.0f);
+        var atThreshold = cache.GetEnzymesScore(predator, Constants.LIPASE_ENZYME, preySize, 0.0f);
+        var aboveThreshold = cache.GetEnzymesScore(predator, Constants.LIPASE_ENZYME,
+            float.BitDecrement(preySize), 0.0f);
+
+        AssertThat(belowThreshold).IsEqual(0.0f);
+        AssertThat(atThreshold).IsGreater(0.0f);
+        AssertThat(atThreshold).IsEqual(aboveThreshold);
+    }
+
+    [TestCase]
+    public void ChunkCompoundPressure_MicrobeThresholdMatrixIsInclusive()
+    {
+        AssertChunkCompoundPressureThresholdMatrix(ThresholdSpeciesKind.Microbe);
+    }
+
+    [TestCase]
+    public void ChunkCompoundPressure_MulticellularThresholdMatrixIsInclusive()
+    {
+        AssertChunkCompoundPressureThresholdMatrix(ThresholdSpeciesKind.Multicellular);
+    }
+
+    [TestCase]
+    public void ReproductionCompoundPressure_MicrobeThresholdMatrixIsInclusive()
+    {
+        AssertReproductionCompoundPressureThresholdMatrix(ThresholdSpeciesKind.Microbe);
+    }
+
+    [TestCase]
+    public void ReproductionCompoundPressure_MulticellularThresholdMatrixIsInclusive()
+    {
+        AssertReproductionCompoundPressureThresholdMatrix(ThresholdSpeciesKind.Multicellular);
+    }
+
+    private static SimulationCache CreateCache()
+    {
+        return new SimulationCache(new WorldGenerationSettings
+        {
+            Seed = 1,
+        });
+    }
+
+    private static void AssertChunkCompoundPressureThresholdMatrix(ThresholdSpeciesKind speciesKind)
+    {
+        const float chunkSize = 2.0f;
+
+        var belowThreshold = CalculateChunkCompoundPressureScore(speciesKind, float.BitIncrement(chunkSize));
+        var atThreshold = CalculateChunkCompoundPressureScore(speciesKind, chunkSize);
+        var aboveThreshold = CalculateChunkCompoundPressureScore(speciesKind, float.BitDecrement(chunkSize));
+
+        AssertThat(atThreshold).IsEqual(aboveThreshold);
+        AssertThat(atThreshold).IsGreater(belowThreshold);
+    }
+
+    private static float CalculateChunkCompoundPressureScore(ThresholdSpeciesKind speciesKind, float chunkSize)
+    {
+        var (species, patch, cache) = CreatePressureFixture(speciesKind, chunkSize);
+        var pressure = new ChunkCompoundPressure("marineSnow", new LocalizedString("MARINE_SNOW"),
+            Compound.Glucose, Compound.ATP, false, 1.0f);
+
+        return pressure.Score(species, patch, cache);
+    }
+
+    private static void AssertReproductionCompoundPressureThresholdMatrix(ThresholdSpeciesKind speciesKind)
+    {
+        const float chunkSize = 2.0f;
+
+        var belowThreshold = CalculateReproductionCompoundPressureScore(speciesKind, float.BitIncrement(chunkSize));
+        var atThreshold = CalculateReproductionCompoundPressureScore(speciesKind, chunkSize);
+        var aboveThreshold = CalculateReproductionCompoundPressureScore(speciesKind, float.BitDecrement(chunkSize));
+
+        AssertThat(atThreshold).IsEqual(aboveThreshold);
+        AssertThat(atThreshold).IsGreater(belowThreshold);
+    }
+
+    private static float CalculateReproductionCompoundPressureScore(ThresholdSpeciesKind speciesKind, float chunkSize)
+    {
+        var (species, patch, cache) = CreatePressureFixture(speciesKind, chunkSize);
+        var pressure = new ReproductionCompoundPressure(Compound.Ammonia, false, 1.0f);
+
+        return pressure.Score(species, patch, cache);
+    }
+
+    private static (Species Species, Patch Patch, SimulationCache Cache) CreatePressureFixture(
+        ThresholdSpeciesKind speciesKind, float chunkSize)
+    {
+        var worldSettings = new WorldGenerationSettings
+        {
+            Seed = 1,
+            WorldSize = WorldGenerationSettings.WorldSizeEnum.Small,
+        };
+
+        var world = new GameWorld(worldSettings, CreateMicrobe(100, "PressurePlayer", 1));
+        var patch = world.Map.CurrentPatch!;
+        var chunk = SimulationParameters.Instance.GetBiome("mesopelagic").Conditions.Chunks["marineSnow"];
+        chunk.Size = chunkSize;
+        patch.Biome.Chunks = new Dictionary<string, ChunkConfiguration>
+        {
+            ["marineSnow"] = chunk,
+        };
+
+        Species species = speciesKind switch
+        {
+            ThresholdSpeciesKind.Microbe => CreateMicrobe(101, "PressureMicrobe", 6),
+            ThresholdSpeciesKind.Multicellular => CreateMulticellular(102, "PressureMulticellular", 3),
+            _ => throw new ArgumentOutOfRangeException(nameof(speciesKind), speciesKind, null),
+        };
+
+        var cache = new SimulationCache(worldSettings);
+        var engulferSize = speciesKind switch
+        {
+            ThresholdSpeciesKind.Microbe => cache.GetBaseHexSizeForSpecies((MicrobeSpecies)species),
+            ThresholdSpeciesKind.Multicellular =>
+                cache.GetBaseHexSizeForCellType(((MulticellularSpecies)species).CellTypes[0]),
+            _ => throw new ArgumentOutOfRangeException(nameof(speciesKind), speciesKind, null),
+        };
+
+        AssertThat(engulferSize).IsEqual(3.0f);
+        AssertThat(chunk.Size).IsEqual(chunkSize);
+
+        if (chunkSize > 2.0f)
+            AssertThat(chunk.Size * Constants.ENGULF_SIZE_RATIO_REQ).IsGreater(engulferSize);
+
+        return (species, patch, cache);
+    }
+
+    private static MicrobeSpecies CreateMicrobe(uint id, string epithet, int cytoplasmCount)
+    {
+        var simulationParameters = SimulationParameters.Instance;
+        var species = new MicrobeSpecies(id, "Threshold", epithet)
+        {
+            IsBacteria = true,
+            MembraneType = simulationParameters.GetMembrane("single"),
+        };
+
+        for (var i = 0; i < cytoplasmCount; ++i)
+        {
+            species.Organelles.Add(new OrganelleTemplate(simulationParameters.GetOrganelleType("cytoplasm"),
+                new Hex(i * 4, 0), 0));
+        }
+
+        species.OnEdited();
+        return species;
+    }
+
+    private static MulticellularSpecies CreateMulticellular(uint id, string epithet, int cytoplasmCount)
+    {
+        var simulationParameters = SimulationParameters.Instance;
+        var cellType = new CellType(simulationParameters.GetMembrane("single"))
+        {
+            CellTypeName = "ThresholdCell",
+        };
+
+        for (var i = 0; i < cytoplasmCount; ++i)
+        {
+            cellType.ModifiableOrganelles.Add(new OrganelleTemplate(simulationParameters.GetOrganelleType("cytoplasm"),
+                new Hex(i * 4, 0), 0));
+        }
+
+        var species = new MulticellularSpecies(id, "Threshold", epithet);
+        species.ModifiableCellTypes.Add(cellType);
+        species.ModifiableGameplayCells.AddFast(new CellTemplate(cellType, new Hex(0, 0), 0),
+            new List<Hex>(), new List<Hex>());
+        species.OnEdited();
+        return species;
+    }
+}

--- a/test/auto_evo.tests/EngulfThresholdConsistencyTests.cs
+++ b/test/auto_evo.tests/EngulfThresholdConsistencyTests.cs
@@ -22,6 +22,7 @@ public class EngulfThresholdConsistencyTests
     [TestCase]
     public void GetPredationScore_MicrobeAtExactThresholdCanPredate()
     {
+        using var world = ThriveWorld.Create();
         var predator = CreateMicrobe(1, "ThresholdPredator", 3);
         var prey = CreateMicrobe(2, "ThresholdPrey", 2);
         var cache = CreateCache();
@@ -31,7 +32,7 @@ public class EngulfThresholdConsistencyTests
         var preySize = cache.GetBaseHexSizeForSpecies(prey);
 
         AssertThat(predatorSize).IsEqual(preySize * Constants.ENGULF_SIZE_RATIO_REQ);
-        AssertThat(CheckGameplayEngulf(predator, predatorSize, preySize)).IsEqual(EngulfCheckResult.Ok);
+        AssertThat(CheckGameplayEngulf(world, predator, predatorSize, preySize)).IsEqual(EngulfCheckResult.Ok);
 
         var coldScore = cache.GetPredationScore(predator, prey, biome);
         AssertThat(coldScore).IsGreater(0.0f);
@@ -43,6 +44,7 @@ public class EngulfThresholdConsistencyTests
     [TestCase]
     public void GetPredationScore_MulticellularAtExactThresholdCanPredate()
     {
+        using var world = ThriveWorld.Create();
         var predator = CreateMulticellular(4, "ThresholdMulticellularPredator", 3);
         var prey = CreateMicrobe(5, "ThresholdPrey", 4);
         var cache = CreateCache();
@@ -54,7 +56,7 @@ public class EngulfThresholdConsistencyTests
         AssertThat(predatorCellSize).IsEqual(3.0f);
         AssertThat(preySize).IsEqual(2.0f);
         AssertThat(predatorCellSize).IsEqual(preySize * Constants.ENGULF_SIZE_RATIO_REQ);
-        AssertThat(CheckGameplayEngulf(predator, predatorCellSize, preySize)).IsEqual(EngulfCheckResult.Ok);
+        AssertThat(CheckGameplayEngulf(world, predator, predatorCellSize, preySize)).IsEqual(EngulfCheckResult.Ok);
 
         var coldScore = cache.GetPredationScore(predator, prey, biome);
         AssertThat(coldScore).IsGreater(0.0f);
@@ -67,15 +69,16 @@ public class EngulfThresholdConsistencyTests
     public void GetEnzymesScore_MulticellularThresholdMatrixIsInclusive()
     {
         const float preySize = 2.0f;
+        using var world = ThriveWorld.Create();
         var predator = CreateMulticellular(3, "ThresholdMulticellularPredator", 3);
         var cache = CreateCache();
 
         var predatorCellSize = cache.GetBaseHexSizeForCellType(predator.CellTypes[0]);
         AssertThat(predatorCellSize).IsEqual(preySize * Constants.ENGULF_SIZE_RATIO_REQ);
-        AssertThat(CheckGameplayEngulf(predator, predatorCellSize, float.BitIncrement(preySize)))
+        AssertThat(CheckGameplayEngulf(world, predator, predatorCellSize, float.BitIncrement(preySize)))
             .IsEqual(EngulfCheckResult.TargetTooBig);
-        AssertThat(CheckGameplayEngulf(predator, predatorCellSize, preySize)).IsEqual(EngulfCheckResult.Ok);
-        AssertThat(CheckGameplayEngulf(predator, predatorCellSize, float.BitDecrement(preySize)))
+        AssertThat(CheckGameplayEngulf(world, predator, predatorCellSize, preySize)).IsEqual(EngulfCheckResult.Ok);
+        AssertThat(CheckGameplayEngulf(world, predator, predatorCellSize, float.BitDecrement(preySize)))
             .IsEqual(EngulfCheckResult.Ok);
 
         var belowThreshold = cache.GetEnzymesScore(predator, Constants.LIPASE_ENZYME,
@@ -116,9 +119,9 @@ public class EngulfThresholdConsistencyTests
     /// <summary>
     ///   Calls the gameplay check with unused engulfing capacity and an unattached, undigested target.
     /// </summary>
-    private static EngulfCheckResult CheckGameplayEngulf(Species species, float engulferSize, float targetSize)
+    private static EngulfCheckResult CheckGameplayEngulf(World world, Species species, float engulferSize,
+        float targetSize)
     {
-        using var world = ThriveWorld.Create();
         var target = world.Create(new Engulfable(PhagocytosisPhase.None, Entity.Null)
         {
             BaseEngulfSize = targetSize,
@@ -153,18 +156,20 @@ public class EngulfThresholdConsistencyTests
     private static void AssertChunkCompoundPressureThresholdMatrix(ThresholdSpeciesKind speciesKind)
     {
         const float chunkSize = 2.0f;
+        using var world = ThriveWorld.Create();
 
-        var belowThreshold = CalculateChunkCompoundPressureScore(speciesKind, float.BitIncrement(chunkSize));
-        var atThreshold = CalculateChunkCompoundPressureScore(speciesKind, chunkSize);
-        var aboveThreshold = CalculateChunkCompoundPressureScore(speciesKind, float.BitDecrement(chunkSize));
+        var belowThreshold = CalculateChunkCompoundPressureScore(world, speciesKind, float.BitIncrement(chunkSize));
+        var atThreshold = CalculateChunkCompoundPressureScore(world, speciesKind, chunkSize);
+        var aboveThreshold = CalculateChunkCompoundPressureScore(world, speciesKind, float.BitDecrement(chunkSize));
 
         AssertThat(atThreshold).IsEqual(aboveThreshold);
         AssertThat(atThreshold).IsGreater(belowThreshold);
     }
 
-    private static float CalculateChunkCompoundPressureScore(ThresholdSpeciesKind speciesKind, float chunkSize)
+    private static float CalculateChunkCompoundPressureScore(World world, ThresholdSpeciesKind speciesKind,
+        float chunkSize)
     {
-        var (species, patch, cache) = CreatePressureFixture(speciesKind, chunkSize);
+        var (species, patch, cache) = CreatePressureFixture(world, speciesKind, chunkSize);
         var pressure = new ChunkCompoundPressure("marineSnow", new LocalizedString("MARINE_SNOW"),
             Compound.Glucose, Compound.ATP, false, 1.0f);
 
@@ -174,24 +179,28 @@ public class EngulfThresholdConsistencyTests
     private static void AssertReproductionCompoundPressureThresholdMatrix(ThresholdSpeciesKind speciesKind)
     {
         const float chunkSize = 2.0f;
+        using var world = ThriveWorld.Create();
 
-        var belowThreshold = CalculateReproductionCompoundPressureScore(speciesKind, float.BitIncrement(chunkSize));
-        var atThreshold = CalculateReproductionCompoundPressureScore(speciesKind, chunkSize);
-        var aboveThreshold = CalculateReproductionCompoundPressureScore(speciesKind, float.BitDecrement(chunkSize));
+        var belowThreshold = CalculateReproductionCompoundPressureScore(world, speciesKind,
+            float.BitIncrement(chunkSize));
+        var atThreshold = CalculateReproductionCompoundPressureScore(world, speciesKind, chunkSize);
+        var aboveThreshold = CalculateReproductionCompoundPressureScore(world, speciesKind,
+            float.BitDecrement(chunkSize));
 
         AssertThat(atThreshold).IsEqual(aboveThreshold);
         AssertThat(atThreshold).IsGreater(belowThreshold);
     }
 
-    private static float CalculateReproductionCompoundPressureScore(ThresholdSpeciesKind speciesKind, float chunkSize)
+    private static float CalculateReproductionCompoundPressureScore(World world, ThresholdSpeciesKind speciesKind,
+        float chunkSize)
     {
-        var (species, patch, cache) = CreatePressureFixture(speciesKind, chunkSize);
+        var (species, patch, cache) = CreatePressureFixture(world, speciesKind, chunkSize);
         var pressure = new ReproductionCompoundPressure(Compound.Ammonia, false, 1.0f);
 
         return pressure.Score(species, patch, cache);
     }
 
-    private static (Species Species, Patch Patch, SimulationCache Cache) CreatePressureFixture(
+    private static (Species Species, Patch Patch, SimulationCache Cache) CreatePressureFixture(World entityWorld,
         ThresholdSpeciesKind speciesKind, float chunkSize)
     {
         var worldSettings = new WorldGenerationSettings
@@ -227,7 +236,7 @@ public class EngulfThresholdConsistencyTests
 
         AssertThat(engulferSize).IsEqual(3.0f);
         AssertThat(chunk.Size).IsEqual(chunkSize);
-        AssertThat(CheckGameplayEngulf(species, engulferSize, chunkSize))
+        AssertThat(CheckGameplayEngulf(entityWorld, species, engulferSize, chunkSize))
             .IsEqual(chunkSize > 2.0f ? EngulfCheckResult.TargetTooBig : EngulfCheckResult.Ok);
 
         if (chunkSize > 2.0f)

--- a/test/auto_evo.tests/EngulfThresholdConsistencyTests.cs
+++ b/test/auto_evo.tests/EngulfThresholdConsistencyTests.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using Arch.Core;
 using AutoEvo;
+using Components;
 using GdUnit4;
 using static GdUnit4.Assertions;
 
 /// <summary>
-///   Tests that auto-evo engulf checks consistently include the exact size threshold.
+///   Tests that auto-evo engulf checks agree with gameplay at the exact size threshold.
 /// </summary>
 [TestSuite]
 [RequireGodotRuntime]
@@ -29,6 +31,30 @@ public class EngulfThresholdConsistencyTests
         var preySize = cache.GetBaseHexSizeForSpecies(prey);
 
         AssertThat(predatorSize).IsEqual(preySize * Constants.ENGULF_SIZE_RATIO_REQ);
+        AssertThat(CheckGameplayEngulf(predator, predatorSize, preySize)).IsEqual(EngulfCheckResult.Ok);
+
+        var coldScore = cache.GetPredationScore(predator, prey, biome);
+        AssertThat(coldScore).IsGreater(0.0f);
+
+        var warmScore = cache.GetPredationScore(predator, prey, biome);
+        AssertThat(warmScore).IsEqual(coldScore);
+    }
+
+    [TestCase]
+    public void GetPredationScore_MulticellularAtExactThresholdCanPredate()
+    {
+        var predator = CreateMulticellular(4, "ThresholdMulticellularPredator", 3);
+        var prey = CreateMicrobe(5, "ThresholdPrey", 4);
+        var cache = CreateCache();
+        var biome = SimulationParameters.Instance.GetBiome("aavolcanic_vent").Conditions;
+
+        var predatorCellSize = cache.GetBaseHexSizeForCellType(predator.CellTypes[0]);
+        var preySize = cache.GetBaseHexSizeForSpecies(prey);
+
+        AssertThat(predatorCellSize).IsEqual(3.0f);
+        AssertThat(preySize).IsEqual(2.0f);
+        AssertThat(predatorCellSize).IsEqual(preySize * Constants.ENGULF_SIZE_RATIO_REQ);
+        AssertThat(CheckGameplayEngulf(predator, predatorCellSize, preySize)).IsEqual(EngulfCheckResult.Ok);
 
         var coldScore = cache.GetPredationScore(predator, prey, biome);
         AssertThat(coldScore).IsGreater(0.0f);
@@ -46,6 +72,11 @@ public class EngulfThresholdConsistencyTests
 
         var predatorCellSize = cache.GetBaseHexSizeForCellType(predator.CellTypes[0]);
         AssertThat(predatorCellSize).IsEqual(preySize * Constants.ENGULF_SIZE_RATIO_REQ);
+        AssertThat(CheckGameplayEngulf(predator, predatorCellSize, float.BitIncrement(preySize)))
+            .IsEqual(EngulfCheckResult.TargetTooBig);
+        AssertThat(CheckGameplayEngulf(predator, predatorCellSize, preySize)).IsEqual(EngulfCheckResult.Ok);
+        AssertThat(CheckGameplayEngulf(predator, predatorCellSize, float.BitDecrement(preySize)))
+            .IsEqual(EngulfCheckResult.Ok);
 
         var belowThreshold = cache.GetEnzymesScore(predator, Constants.LIPASE_ENZYME,
             float.BitIncrement(preySize), 0.0f);
@@ -80,6 +111,35 @@ public class EngulfThresholdConsistencyTests
     public void ReproductionCompoundPressure_MulticellularThresholdMatrixIsInclusive()
     {
         AssertReproductionCompoundPressureThresholdMatrix(ThresholdSpeciesKind.Multicellular);
+    }
+
+    /// <summary>
+    ///   Calls the gameplay check with unused engulfing capacity and an unattached, undigested target.
+    /// </summary>
+    private static EngulfCheckResult CheckGameplayEngulf(Species species, float engulferSize, float targetSize)
+    {
+        using var world = ThriveWorld.Create();
+        var target = world.Create(new Engulfable(PhagocytosisPhase.None, Entity.Null)
+        {
+            BaseEngulfSize = targetSize,
+        });
+        var cellProperties = new CellProperties
+        {
+            MembraneType = species switch
+            {
+                MicrobeSpecies microbe => microbe.MembraneType,
+                MulticellularSpecies multicellular => multicellular.CellTypes[0].MembraneType,
+                _ => throw new ArgumentException("Unsupported test species", nameof(species)),
+            },
+        };
+        var speciesMember = new SpeciesMember(species);
+        var engulfer = new Engulfer
+        {
+            EngulfingSize = engulferSize,
+            EngulfStorageSize = 100.0f,
+        };
+
+        return cellProperties.CanEngulfObject(ref speciesMember, ref engulfer, target);
     }
 
     private static SimulationCache CreateCache()
@@ -167,6 +227,8 @@ public class EngulfThresholdConsistencyTests
 
         AssertThat(engulferSize).IsEqual(3.0f);
         AssertThat(chunk.Size).IsEqual(chunkSize);
+        AssertThat(CheckGameplayEngulf(species, engulferSize, chunkSize))
+            .IsEqual(chunkSize > 2.0f ? EngulfCheckResult.TargetTooBig : EngulfCheckResult.Ok);
 
         if (chunkSize > 2.0f)
             AssertThat(chunk.Size * Constants.ENGULF_SIZE_RATIO_REQ).IsGreater(engulferSize);

--- a/test/auto_evo.tests/EngulfThresholdConsistencyTests.cs.uid
+++ b/test/auto_evo.tests/EngulfThresholdConsistencyTests.cs.uid
@@ -1,0 +1,1 @@
+uid://cbv06074frv1b


### PR DESCRIPTION
**Brief Description of What This PR Does**

Align Auto-Evo engulfment checks with gameplay: an engulfer whose size is exactly the target size multiplied by `Constants.ENGULF_SIZE_RATIO_REQ` is eligible to engulf. Before the fix, for the same boundary, different equations are used in different places.

Auto-Evo currently rejects some exact-threshold engulfment opportunities that gameplay allows. This corrects that boundary mismatch in predation and chunk scoring.

**Related Issues**

No related issue.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cells exactly meeting the required size ratio can now engulf prey during auto-evolution.
  - Engulfment behavior is now consistent across predation, enzyme scoring, reproduction, and compound pressure calculations.
  - Size checks correctly distinguish values just below and above the threshold.
  - Gameplay and auto-evolution now agree on borderline engulfment eligibility.

- **Tests**
  - Added coverage for engulfment threshold behavior across microbe and multicellular species, including values immediately below, at, and above the threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->