### PR TITLE
Add public-API SimulationCache regression baseline tests

### DIFF
--- a/test/auto_evo.tests/SimulationCachePredationRoleTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationRoleTests.cs
@@ -1,0 +1,299 @@
+﻿using System;
+using AutoEvo;
+using GdUnit4;
+using static GdUnit4.Assertions;
+using static SimulationCacheTestFixtures;
+
+/// <summary>
+///   Public final-score characterizations, with one organelle or upgrade delta per matched pair.
+///   Raw scores only guard which tool is activated; final scores are the lasting regression seam.
+/// </summary>
+[TestSuite]
+[RequireGodotRuntime]
+public class SimulationCachePredationRoleTests
+{
+    [TestCase(false, false, false, 0.0f, 15.367006f)]
+    [TestCase(false, false, true, 0.0f, 46.101017f)]
+    [TestCase(false, true, false, 0.0f, 28.612566f)]
+    [TestCase(false, true, true, 0.0f, 85.8377f)]
+    [TestCase(true, false, false, 0.0f, 0.6317793f)]
+    [TestCase(true, false, true, 0.0f, 1.895338f)]
+    [TestCase(true, true, false, 0.0f, 8.119033f)]
+    [TestCase(true, true, true, 0.0f, 24.357098f)]
+    public void OffensivePilusAcrossSpeciesPairings(bool multicellularPredator, bool multicellularPrey,
+        bool injectisome, float expectedControl, float expectedArmed)
+    {
+        var control = CreateRoleSpecies(201, multicellularPredator);
+        var armed = CreateRoleSpecies(202, multicellularPredator,
+            CreateOrganelle("pilus", new Hex(0, -4), injectisome ? Constants.PILUS_INJECTISOME_UPGRADE_NAME : null));
+        var prey = CreateRoleSpecies(203, multicellularPrey);
+        var initial = GetRaw(control);
+        var changed = GetRaw(armed);
+        AssertRawBits(changed,
+            injectisome ?
+                initial with { InjectisomeScore = changed.InjectisomeScore } :
+                initial with { PilusScore = changed.PilusScore });
+        AssertThat(injectisome ? changed.InjectisomeScore > 0 : changed.PilusScore > 0).IsTrue();
+
+        AssertScorePair(control, prey, armed, prey, expectedControl, expectedArmed);
+    }
+
+    [TestCase(false, false, 0.6317793f, 0.044224553f)]
+    [TestCase(false, true, 0.6317793f, 0.022112276f)]
+    [TestCase(true, false, 5.6066546f, 1.0482321f)]
+    [TestCase(true, true, 5.6066546f, 0.52411604f)]
+    public void RearPilusOnFleeingPrey(bool multicellular, bool injectisome,
+        float expectedControl, float expectedDefended)
+    {
+        var predator = CreateRoleSpecies(211, false, CreateOrganelle("pilus", new Hex(0, -4)));
+        var control = CreateRoleSpecies(212, multicellular);
+        var defended = CreateRoleSpecies(213, multicellular,
+            CreateOrganelle("pilus", new Hex(0, 4), injectisome ? Constants.PILUS_INJECTISOME_UPGRADE_NAME : null));
+        control.ModifiableBehaviour.Fear = defended.ModifiableBehaviour.Fear = Constants.MAX_SPECIES_FEAR;
+        control.ModifiableBehaviour.Aggression = defended.ModifiableBehaviour.Aggression = 0;
+        var initial = GetRaw(control);
+        var changed = GetRaw(defended);
+        AssertRawBits(changed,
+            injectisome ?
+                initial with { DefensiveInjectisomeScore = changed.DefensiveInjectisomeScore } :
+                initial with { DefensivePilusScore = changed.DefensivePilusScore });
+        AssertThat(injectisome ? changed.DefensiveInjectisomeScore > 0 : changed.DefensivePilusScore > 0).IsTrue();
+
+        AssertScorePair(predator, control, predator, defended,
+            expectedControl, expectedDefended);
+    }
+
+    [TestCase(false, ToxinType.Oxytoxy, 9.939762f, 9.953802f)]
+    [TestCase(false, ToxinType.Cytotoxin, 9.939762f, 9.303881f)]
+    [TestCase(false, ToxinType.Macrolide, 9.939762f, 42.95154f)]
+    [TestCase(false, ToxinType.ChannelInhibitor, 9.939762f, 10.09164f)]
+    [TestCase(false, ToxinType.OxygenMetabolismInhibitor, 9.939762f, 9.93459f)]
+    [TestCase(true, ToxinType.Oxytoxy, 0.31303066f, 0.33341095f)]
+    [TestCase(true, ToxinType.Cytotoxin, 0.31303066f, 0.32250232f)]
+    [TestCase(true, ToxinType.Macrolide, 0.31303066f, 14.746543f)]
+    [TestCase(true, ToxinType.ChannelInhibitor, 0.31303066f, 0.3350402f)]
+    [TestCase(true, ToxinType.OxygenMetabolismInhibitor, 0.31303066f, 0.3331734f)]
+    public void SinglePredatorToxin(bool multicellular, ToxinType toxin,
+        float expectedControl, float expectedArmed)
+    {
+        // The pilus keeps the catch path reachable for macrolide, which cannot kill on its own.
+        // Replace one cytoplasm with a toxin organelle at the same hex: adding it would recenter the pilus.
+        var control = CreateRoleSpecies(221, multicellular, CreateOrganelle("pilus", new Hex(0, -4)),
+            CreateOrganelle("cytoplasm", new Hex(4, 0)));
+        var armed = CreateRoleSpecies(222, multicellular, CreateOrganelle("pilus", new Hex(0, -4)),
+            CreateToxin(new Hex(4, 0), toxin));
+        var prey = CreateRoleSpecies(223, multicellular);
+        prey.ModifiableBehaviour.Fear = Constants.MAX_SPECIES_FEAR * 0.25f;
+        prey.ModifiableBehaviour.Aggression = 0;
+        var initial = GetRaw(control);
+        var changed = GetRaw(armed);
+        var expectedRaw = toxin switch
+        {
+            ToxinType.Oxytoxy => initial with { OxytoxyScore = changed.OxytoxyScore },
+            ToxinType.Cytotoxin => initial with { CytotoxinScore = changed.CytotoxinScore },
+            ToxinType.Macrolide => initial with { MacrolideScore = changed.MacrolideScore },
+            ToxinType.ChannelInhibitor => initial with { ChannelInhibitorScore = changed.ChannelInhibitorScore },
+            ToxinType.OxygenMetabolismInhibitor =>
+                initial with { OxygenMetabolismInhibitorScore = changed.OxygenMetabolismInhibitorScore },
+            _ => throw new ArgumentOutOfRangeException(nameof(toxin)),
+        };
+        AssertRawBits(changed, expectedRaw);
+        AssertThat(changed.OxytoxyScore + changed.CytotoxinScore + changed.MacrolideScore +
+            changed.ChannelInhibitorScore + changed.OxygenMetabolismInhibitorScore > 0).IsTrue();
+
+        var biome = CreateBiome();
+        var oxygen = biome.Compounds[Compound.Oxygen];
+        oxygen.Ambient = 1;
+        biome.ChangeableCompounds[Compound.Oxygen] = oxygen;
+        AssertScorePair(control, prey, armed, prey,
+            expectedControl, expectedArmed, biome);
+    }
+
+    [TestCase(false, false, 15.367006f, 0.11534659f)]
+    [TestCase(false, true, 15.367006f, 0.88910663f)]
+    [TestCase(true, false, 28.612566f, 10.973157f)]
+    [TestCase(true, true, 28.612566f, 1.986625f)]
+    public void PreySlimeOrMucocystDefence(bool multicellular, bool mucocyst,
+        float expectedControl, float expectedDefended)
+    {
+        var predator = CreateRoleSpecies(231, false, CreateOrganelle("pilus", new Hex(0, -4)));
+        var control = CreateRoleSpecies(232, multicellular);
+        var defended = CreateRoleSpecies(233, multicellular,
+            CreateOrganelle("slimeJet", new Hex(0, 4), mucocyst ? SlimeJetComponent.MUCOCYST_UPGRADE_NAME : null));
+        var initial = GetRaw(control);
+        var changed = GetRaw(defended);
+        AssertRawBits(changed,
+            mucocyst ?
+                initial with { MucocystsScore = changed.MucocystsScore } :
+                initial with { SlimeJetScore = changed.SlimeJetScore });
+        AssertThat(mucocyst ? changed.MucocystsScore > 0 : changed.SlimeJetScore > 0).IsTrue();
+
+        AssertScorePair(predator, control, predator, defended,
+            expectedControl, expectedDefended);
+    }
+
+    [TestCase(false, 11.885521f, 22.295465f)]
+    [TestCase(true, 0.6260613f, 2.0284386f)]
+    public void PredatorPullingCiliaUpgrade(bool multicellular, float expectedControl, float expectedPulling)
+    {
+        var control = CreateRoleSpecies(241, multicellular, CreateOrganelle("pilus", new Hex(0, -4)),
+            CreateOrganelle("cilia", new Hex(4, 0)));
+        var pulling = CreateRoleSpecies(242, multicellular, CreateOrganelle("pilus", new Hex(0, -4)),
+            CreateOrganelle("cilia", new Hex(4, 0), CiliaComponent.CILIA_PULL_UPGRADE_NAME));
+        var prey = CreateRoleSpecies(243, false);
+        var initial = GetRaw(control);
+        var changed = GetRaw(pulling);
+        AssertRawBits(changed, initial with { PullingCiliaModifier = changed.PullingCiliaModifier });
+        AssertBits(initial.PullingCiliaModifier, 1.0f);
+        AssertThat(changed.PullingCiliaModifier > 1).IsTrue();
+
+        AssertScorePair(control, prey, pulling, prey, expectedControl, expectedPulling);
+    }
+
+    [TestCase(false, 0.17904808f, 0.16923125f)]
+    [TestCase(true, 0.17904808f, 0.16923125f)]
+    public void PredatorToxicityAtFixedToxinTypeAndAmount(bool multicellular,
+        float expectedControl, float expectedToxic)
+    {
+        // Toxicity changes both damage and hit chance, so characterize the final result without choosing a direction.
+        var control = CreateRoleSpecies(251, multicellular, CreateToxin(new Hex(4, 0), ToxinType.Cytotoxin));
+        var toxic = CreateRoleSpecies(252, multicellular, CreateToxin(new Hex(4, 0), ToxinType.Cytotoxin, 0.25f));
+        var prey = CreateRoleSpecies(253, false);
+        var initial = GetRaw(control);
+        var changed = GetRaw(toxic);
+        AssertBits(initial.AverageToxicity, 0);
+        AssertBits(changed.AverageToxicity, 0.25f);
+        AssertRawBits(changed, initial with
+        {
+            AverageToxicity = changed.AverageToxicity,
+            CytotoxinScore = changed.CytotoxinScore,
+        });
+
+        AssertScorePair(control, prey, toxic, prey, expectedControl, expectedToxic);
+    }
+
+    [TestCase(false, false)]
+    [TestCase(false, true)]
+    [TestCase(true, false)]
+    [TestCase(true, true)]
+    public void ClearRecomputesNestedToxinCacheForANewOpponent(bool multicellular, bool specialization)
+    {
+        var toxin = CreateToxin(new Hex(4, 0), ToxinType.Cytotoxin);
+        var predator = CreateRoleSpecies(261, multicellular, toxin);
+        var firstPrey = CreateRoleSpecies(262, false);
+        var secondPrey = CreateRoleSpecies(263, false);
+        var thirdPrey = CreateRoleSpecies(264, false);
+        var biome = CreateBiome();
+        var cache = CreateCache();
+        var id = predator.ID;
+        var epithet = predator.Epithet;
+        var attempt = predator.AutoEvoAttemptCache;
+        var initial = cache.GetPredationScore(predator, firstPrey, biome);
+
+        // Mutate either toxicity or specialization, preserving the species' cache identity.
+        if (specialization)
+        {
+            if (predator is MicrobeSpecies microbe)
+                microbe.CellTypeSpecializationBonus = 2.0f;
+            else
+                ((MulticellularSpecies)predator).ModifiableCellTypes[0].CellTypeSpecializationBonus = 2.0f;
+        }
+        else
+        {
+            toxin.ModifiableUpgrades!.CustomUpgradeData = new ToxinUpgrades(ToxinType.Cytotoxin, 0.25f);
+        }
+
+        AssertThat(predator.ID).IsEqual(id);
+        AssertThat(predator.Epithet).IsEqual(epithet);
+        AssertThat(predator.AutoEvoAttemptCache).IsEqual(attempt);
+        AssertBits(cache.GetPredationScore(predator, firstPrey, biome), initial);
+        var staleForNewOpponent = cache.GetPredationScore(predator, secondPrey, biome);
+        var fresh = CreateCache().GetPredationScore(predator, thirdPrey, biome);
+        AssertDifferentBits(fresh, initial);
+        AssertDifferentBits(staleForNewOpponent, fresh);
+
+        // Specialization also changes uncached storage, so a new pair can mix stale and current data.
+        if (!specialization)
+            AssertBits(staleForNewOpponent, initial);
+
+        cache.Clear();
+
+        // This pair has never been queried: an outer-cache hit cannot conceal stale nested tool data.
+        AssertBits(cache.GetPredationScore(predator, thirdPrey, biome), fresh);
+        AssertBits(cache.GetPredationScore(predator, firstPrey, biome), fresh);
+        AssertBits(cache.GetPredationScore(predator, thirdPrey, biome), fresh);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void SelfPredationRemainsZero(bool multicellular)
+    {
+        var species = CreateRoleSpecies(271, multicellular, CreateOrganelle("pilus", new Hex(0, -4)));
+        AssertPredationLifecycle(species, species, 0);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void UnsupportedSpeciesIsRejectedInEitherRole(bool multicellular)
+    {
+        var supported = CreateRoleSpecies(281, multicellular);
+        var unsupported = new MacroscopicSpecies(282, "Characterization", "Unsupported");
+        var cache = CreateCache();
+        var biome = CreateBiome();
+        for (var i = 0; i < 2; ++i)
+        {
+            AssertThrown(() => cache.GetPredationScore(unsupported, supported, biome))
+                .IsInstanceOf<ArgumentException>();
+            AssertThrown(() => cache.GetPredationScore(supported, unsupported, biome))
+                .IsInstanceOf<ArgumentException>();
+            cache.Clear();
+        }
+    }
+
+    private static Species CreateRoleSpecies(uint id, bool multicellular, params OrganelleTemplate[] tools)
+    {
+        // Identical cytoplasm core and membrane; callers provide only the organelle delta they need.
+        if (multicellular)
+        {
+            var cellType = CreateCellType("Role", "cellulose", CreateOrganelle("cytoplasm", new Hex(0, 0)));
+            foreach (var organelle in tools)
+                cellType.ModifiableOrganelles.Add(organelle);
+
+            return CreateMulticellular(id, "Role", (cellType, new Hex(0, 0)));
+        }
+
+        var species = CreateMicrobe(id, "Role", "cellulose", "cytoplasm");
+        foreach (var organelle in tools)
+            species.Organelles.Add(organelle);
+
+        species.OnEdited();
+        return species;
+    }
+
+    private static SimulationCache.PredationToolsRawScores GetRaw(Species species)
+    {
+        var cache = CreateCache();
+        return species switch
+        {
+            MicrobeSpecies microbe => cache.GetPredationToolsRawScores(microbe),
+            MulticellularSpecies multicellular => cache.GetPredationToolsRawScores(multicellular),
+            _ => throw new ArgumentException("Unsupported test fixture", nameof(species)),
+        };
+    }
+
+    private static void AssertScorePair(Species controlPredator, Species controlPrey,
+        Species changedPredator, Species changedPrey, float expectedControl, float expectedChanged,
+        BiomeConditions? biome = null)
+    {
+        biome ??= CreateBiome();
+        var control = CreateCache().GetPredationScore(controlPredator, controlPrey, biome);
+        var changed = CreateCache().GetPredationScore(changedPredator, changedPrey, biome);
+        AssertBits(control, expectedControl);
+        AssertBits(changed, expectedChanged);
+        AssertThat(float.IsFinite(control)).IsTrue();
+        AssertThat(float.IsFinite(changed)).IsTrue();
+        AssertDifferentBits(changed, control);
+        AssertPredationLifecycle(controlPredator, controlPrey, expectedControl, biome);
+        AssertPredationLifecycle(changedPredator, changedPrey, expectedChanged, biome);
+    }
+}

--- a/test/auto_evo.tests/SimulationCachePredationRoleTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationRoleTests.cs
@@ -194,9 +194,13 @@ public class SimulationCachePredationRoleTests
         if (specialization)
         {
             if (predator is MicrobeSpecies microbe)
+            {
                 microbe.CellTypeSpecializationBonus = 2.0f;
+            }
             else
+            {
                 ((MulticellularSpecies)predator).ModifiableCellTypes[0].CellTypeSpecializationBonus = 2.0f;
+            }
         }
         else
         {

--- a/test/auto_evo.tests/SimulationCachePredationRoleTests.cs.uid
+++ b/test/auto_evo.tests/SimulationCachePredationRoleTests.cs.uid
@@ -1,0 +1,1 @@
+uid://c0durkmdama5h

--- a/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationScoreTests.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
-using AutoEvo;
+﻿using AutoEvo;
 using GdUnit4;
 using static GdUnit4.Assertions;
+using static SimulationCacheTestFixtures;
 
 [TestSuite]
 [RequireGodotRuntime]
@@ -13,9 +13,7 @@ public class SimulationCachePredationScoreTests
         var predator = CreateMicrobe(1, "NoTools", "cellulose", "cytoplasm");
         var prey = CreateMicrobe(2, "NoToolsPrey", "single", "cytoplasm");
 
-        var score = CalculatePredationScore(predator, prey);
-
-        AssertThat(score).IsEqual(0.0f);
+        AssertPredationLifecycle(predator, prey, 0.0f);
     }
 
     [TestCase]
@@ -25,9 +23,7 @@ public class SimulationCachePredationScoreTests
             "cytoplasm", "cytoplasm", "cytoplasm", "cytoplasm");
         var prey = CreateMicrobe(4, "Engulfed", "single", "cytoplasm");
 
-        var score = CalculatePredationScore(predator, prey);
-
-        AssertThat(score).IsEqual(233.40552f);
+        AssertPredationLifecycle(predator, prey, 233.40552f);
     }
 
     [TestCase]
@@ -36,9 +32,7 @@ public class SimulationCachePredationScoreTests
         var predator = CreateMicrobe(5, "Armed", "cellulose", "cytoplasm", "pilus", "oxytoxy");
         var prey = CreateMicrobe(6, "ArmouredPrey", "cellulose", "cytoplasm");
 
-        var score = CalculatePredationScore(predator, prey);
-
-        AssertThat(score).IsEqual(0.17211556f);
+        AssertPredationLifecycle(predator, prey, 0.17211556f);
     }
 
     [TestCase]
@@ -47,9 +41,7 @@ public class SimulationCachePredationScoreTests
         var predator = CreateMulticellularPredator(7);
         var prey = CreateMicrobe(8, "MulticellularPrey", "single", "cytoplasm");
 
-        var score = CalculatePredationScore(predator, prey);
-
-        AssertThat(score).IsEqual(61.029884f);
+        AssertPredationLifecycle(predator, prey, 61.029884f);
     }
 
     [TestCase]
@@ -80,38 +72,6 @@ public class SimulationCachePredationScoreTests
         AssertThat(scoreAgainstPreyWithSlimeJet < scoreAgainstPreyWithoutSlimeJet).IsTrue();
     }
 
-    private static float CalculatePredationScore(Species predator, Species prey)
-    {
-        var worldSettings = new WorldGenerationSettings
-        {
-            Seed = 1,
-        };
-        var cache = new SimulationCache(worldSettings);
-        var biome = SimulationParameters.Instance.GetBiome("aavolcanic_vent").Conditions;
-
-        return cache.GetPredationScore(predator, prey, biome);
-    }
-
-    private static MicrobeSpecies CreateMicrobe(uint id, string epithet, string membrane,
-        params string[] organelles)
-    {
-        var simulationParameters = SimulationParameters.Instance;
-        var species = new MicrobeSpecies(id, "Characterization", epithet)
-        {
-            IsBacteria = true,
-            MembraneType = simulationParameters.GetMembrane(membrane),
-        };
-
-        for (var i = 0; i < organelles.Length; ++i)
-        {
-            species.Organelles.Add(new OrganelleTemplate(simulationParameters.GetOrganelleType(organelles[i]),
-                new Hex(i * 4, 0), 0));
-        }
-
-        species.OnEdited();
-        return species;
-    }
-
     private static MicrobeSpecies CreateSlimeJetPredator(uint id)
     {
         var simulationParameters = SimulationParameters.Instance;
@@ -140,24 +100,12 @@ public class SimulationCachePredationScoreTests
 
     private static MulticellularSpecies CreateMulticellularPredator(uint id)
     {
-        var simulationParameters = SimulationParameters.Instance;
-        var cellType = new CellType(simulationParameters.GetMembrane("single"))
-        {
-            CellTypeName = "Predator",
-        };
+        var cellType = CreateCellType("Predator", "single",
+            CreateOrganelle("cytoplasm", new Hex(0, 0)),
+            CreateOrganelle("cytoplasm", new Hex(4, 0)),
+            CreateOrganelle("cytoplasm", new Hex(8, 0)),
+            CreateOrganelle("cytoplasm", new Hex(12, 0)));
 
-        for (var i = 0; i < 4; ++i)
-        {
-            cellType.ModifiableOrganelles.Add(new OrganelleTemplate(simulationParameters.GetOrganelleType("cytoplasm"),
-                new Hex(i * 4, 0), 0));
-        }
-
-        var species = new MulticellularSpecies(id, "Characterization", "MulticellularPredator");
-        species.ModifiableCellTypes.Add(cellType);
-        species.ModifiableGameplayCells.AddFast(new CellTemplate(cellType, new Hex(0, 0), 0),
-            new List<Hex>(), new List<Hex>());
-        species.OnEdited();
-
-        return species;
+        return CreateMulticellular(id, "MulticellularPredator", (cellType, new Hex(0, 0)));
     }
 }

--- a/test/auto_evo.tests/SimulationCachePredationToolsRawScoresTests.cs
+++ b/test/auto_evo.tests/SimulationCachePredationToolsRawScoresTests.cs
@@ -2,6 +2,7 @@
 using AutoEvo;
 using GdUnit4;
 using static GdUnit4.Assertions;
+using static SimulationCacheTestFixtures;
 
 [TestSuite]
 [RequireGodotRuntime]
@@ -25,13 +26,17 @@ public class SimulationCachePredationToolsRawScoresTests
         var cached = cache.GetPredationToolsRawScores(species);
         AssertMicrobeInitialScores(cached);
 
+        var fresh = CreateCache().GetPredationToolsRawScores(species);
+        AssertMicrobeRecomputedScores(fresh);
+
         cache.Clear();
 
         var recomputed = cache.GetPredationToolsRawScores(species);
-        AssertThat(recomputed.OxytoxyScore).IsNotEqual(initial.OxytoxyScore);
-        AssertThat(recomputed.SlimeJetScore).IsNotEqual(initial.SlimeJetScore);
-        AssertThat(recomputed.PullingCiliaModifier).IsNotEqual(initial.PullingCiliaModifier);
+        AssertDifferentBits(recomputed.OxytoxyScore, initial.OxytoxyScore);
+        AssertDifferentBits(recomputed.SlimeJetScore, initial.SlimeJetScore);
+        AssertDifferentBits(recomputed.PullingCiliaModifier, initial.PullingCiliaModifier);
         AssertMicrobeRecomputedScores(recomputed);
+        AssertRawBits(recomputed, fresh);
     }
 
     [TestCase]
@@ -40,7 +45,7 @@ public class SimulationCachePredationToolsRawScoresTests
         var cache = CreateCache();
         var species = CreateMicrobe(103);
         species.Organelles.Clear();
-        species.Organelles.Add(CreateOrganelle(SimulationParameters.Instance, "cytoplasm", new Hex(0, 0)));
+        species.Organelles.Add(CreateOrganelle("cytoplasm", new Hex(0, 0)));
         species.OnEdited();
         species.CellTypeSpecializationBonus = 2.0f;
 
@@ -95,13 +100,17 @@ public class SimulationCachePredationToolsRawScoresTests
         var cached = cache.GetPredationToolsRawScores(species);
         AssertMulticellularInitialScores(cached);
 
+        var fresh = CreateCache().GetPredationToolsRawScores(species);
+        AssertMulticellularRecomputedScores(fresh);
+
         cache.Clear();
 
         var recomputed = cache.GetPredationToolsRawScores(species);
-        AssertThat(recomputed.OxytoxyScore).IsNotEqual(initial.OxytoxyScore);
-        AssertThat(recomputed.SlimeJetScore).IsNotEqual(initial.SlimeJetScore);
-        AssertThat(recomputed.PullingCiliaModifier).IsNotEqual(initial.PullingCiliaModifier);
+        AssertDifferentBits(recomputed.OxytoxyScore, initial.OxytoxyScore);
+        AssertDifferentBits(recomputed.SlimeJetScore, initial.SlimeJetScore);
+        AssertDifferentBits(recomputed.PullingCiliaModifier, initial.PullingCiliaModifier);
         AssertMulticellularRecomputedScores(recomputed);
+        AssertRawBits(recomputed, fresh);
     }
 
     [TestCase]
@@ -145,14 +154,6 @@ public class SimulationCachePredationToolsRawScoresTests
         AssertThat(scores.SlimeJetScore).IsEqual(Constants.AUTO_EVO_SLIME_JET_SCORE * 4.0f);
     }
 
-    private static SimulationCache CreateCache()
-    {
-        return new SimulationCache(new WorldGenerationSettings
-        {
-            Seed = 1,
-        });
-    }
-
     private static MicrobeSpecies CreateMicrobe(uint id)
     {
         var simulationParameters = SimulationParameters.Instance;
@@ -162,7 +163,7 @@ public class SimulationCachePredationToolsRawScoresTests
             MembraneType = simulationParameters.GetMembrane("single"),
         };
 
-        AddPredationToolOrganelles(species.Organelles, simulationParameters);
+        AddPredationToolOrganelles(species.Organelles);
         species.OnEdited();
         species.CellTypeSpecializationBonus = 1.25f;
 
@@ -179,10 +180,9 @@ public class SimulationCachePredationToolsRawScoresTests
             MembraneType = simulationParameters.GetMembrane("single"),
         };
 
-        species.Organelles.Add(CreateOrganelle(simulationParameters, "cytoplasm", new Hex(0, 0)));
-        species.Organelles.Add(CreateToxinOrganelle(simulationParameters, new Hex(-4, 0), ToxinType.Oxytoxy));
-        species.Organelles.Add(CreateToxinOrganelle(simulationParameters, new Hex(4, 0),
-            ToxinType.OxygenMetabolismInhibitor));
+        species.Organelles.Add(CreateOrganelle("cytoplasm", new Hex(0, 0)));
+        species.Organelles.Add(CreateToxin(new Hex(-4, 0), ToxinType.Oxytoxy, 0.25f));
+        species.Organelles.Add(CreateToxin(new Hex(4, 0), ToxinType.OxygenMetabolismInhibitor, 0.25f));
         species.OnEdited();
         species.CellTypeSpecializationBonus = specializationBonus;
 
@@ -196,13 +196,13 @@ public class SimulationCachePredationToolsRawScoresTests
         {
             CellTypeName = "PredationTools",
         };
-        AddPredationToolOrganelles(contributingCellType.ModifiableOrganelles, simulationParameters);
+        AddPredationToolOrganelles(contributingCellType.ModifiableOrganelles);
 
         var supportingCellType = new CellType(simulationParameters.GetMembrane("single"))
         {
             CellTypeName = "Support",
         };
-        supportingCellType.ModifiableOrganelles.Add(CreateOrganelle(simulationParameters, "cytoplasm", new Hex(0, 0)));
+        supportingCellType.ModifiableOrganelles.Add(CreateOrganelle("cytoplasm", new Hex(0, 0)));
 
         var species = new MulticellularSpecies(id, "Characterization", "RawScoreMulticellular");
         species.ModifiableCellTypes.Add(contributingCellType);
@@ -244,10 +244,10 @@ public class SimulationCachePredationToolsRawScoresTests
         {
             CellTypeName = name,
         };
-        cellType.ModifiableOrganelles.Add(CreateOrganelle(simulationParameters, "cytoplasm", new Hex(0, 0)));
+        cellType.ModifiableOrganelles.Add(CreateOrganelle("cytoplasm", new Hex(0, 0)));
 
         foreach (var slimeJetPosition in slimeJetPositions)
-            cellType.ModifiableOrganelles.Add(CreateOrganelle(simulationParameters, "slimeJet", slimeJetPosition));
+            cellType.ModifiableOrganelles.Add(CreateOrganelle("slimeJet", slimeJetPosition));
 
         return cellType;
     }
@@ -258,50 +258,18 @@ public class SimulationCachePredationToolsRawScoresTests
         {
             CellTypeName = "Support",
         };
-        cellType.ModifiableOrganelles.Add(CreateOrganelle(simulationParameters, "cytoplasm", new Hex(0, 0)));
+        cellType.ModifiableOrganelles.Add(CreateOrganelle("cytoplasm", new Hex(0, 0)));
         return cellType;
     }
 
-    private static void AddPredationToolOrganelles(OrganelleLayout<OrganelleTemplate> organelles,
-        SimulationParameters simulationParameters)
+    private static void AddPredationToolOrganelles(OrganelleLayout<OrganelleTemplate> organelles)
     {
-        organelles.Add(CreateOrganelle(simulationParameters, "cytoplasm", new Hex(0, 0)));
-        organelles.Add(CreateOrganelle(simulationParameters, "pilus", new Hex(0, -4)));
-        organelles.Add(CreateOrganelle(simulationParameters, "slimeJet", new Hex(0, 4)));
-        organelles.Add(CreateUpgradedOrganelle(simulationParameters, "cilia", new Hex(4, 0),
+        organelles.Add(CreateOrganelle("cytoplasm", new Hex(0, 0)));
+        organelles.Add(CreateOrganelle("pilus", new Hex(0, -4)));
+        organelles.Add(CreateOrganelle("slimeJet", new Hex(0, 4)));
+        organelles.Add(CreateOrganelle("cilia", new Hex(4, 0),
             CiliaComponent.CILIA_PULL_UPGRADE_NAME));
-        organelles.Add(CreateToxinOrganelle(simulationParameters, new Hex(-4, 0), ToxinType.Oxytoxy));
-    }
-
-    private static OrganelleTemplate CreateOrganelle(SimulationParameters simulationParameters, string internalName,
-        Hex position)
-    {
-        return new OrganelleTemplate(simulationParameters.GetOrganelleType(internalName), position, 0);
-    }
-
-    private static OrganelleTemplate CreateUpgradedOrganelle(SimulationParameters simulationParameters,
-        string internalName, Hex position, string upgrade)
-    {
-        return new OrganelleTemplate(simulationParameters.GetOrganelleType(internalName), position, 0)
-        {
-            ModifiableUpgrades = new OrganelleUpgrades
-            {
-                ModifiableUnlockedFeatures = [upgrade],
-            },
-        };
-    }
-
-    private static OrganelleTemplate CreateToxinOrganelle(SimulationParameters simulationParameters, Hex position,
-        ToxinType toxinType)
-    {
-        return new OrganelleTemplate(simulationParameters.GetOrganelleType("oxytoxy"), position, 0)
-        {
-            ModifiableUpgrades = new OrganelleUpgrades
-            {
-                ModifiableUnlockedFeatures = [ToxinUpgradeNames.ToxinNameFromType(toxinType)],
-                CustomUpgradeData = new ToxinUpgrades(toxinType, 0.25f),
-            },
-        };
+        organelles.Add(CreateToxin(new Hex(-4, 0), ToxinType.Oxytoxy, 0.25f));
     }
 
     private static void AssertMicrobeOxygenInhibitorToxinScores(SimulationCache.PredationToolsRawScores scores,
@@ -326,69 +294,69 @@ public class SimulationCachePredationToolsRawScoresTests
 
     private static void AssertMicrobeInitialScores(SimulationCache.PredationToolsRawScores scores)
     {
-        AssertThat(scores.PilusScore).IsEqual(5000.0f);
-        AssertThat(scores.InjectisomeScore).IsEqual(0.0f);
-        AssertThat(scores.DefensivePilusScore).IsEqual(0.0f);
-        AssertThat(scores.DefensiveInjectisomeScore).IsEqual(0.0f);
-        AssertThat(scores.AverageToxicity).IsEqual(0.25f);
-        AssertThat(scores.OxytoxyScore).IsEqual(4334465.0f);
-        AssertThat(scores.CytotoxinScore).IsEqual(0.0f);
-        AssertThat(scores.MacrolideScore).IsEqual(0.0f);
-        AssertThat(scores.ChannelInhibitorScore).IsEqual(0.0f);
-        AssertThat(scores.OxygenMetabolismInhibitorScore).IsEqual(0.0f);
-        AssertThat(scores.SlimeJetScore).IsEqual(37.5f);
-        AssertThat(scores.MucocystsScore).IsEqual(0.0f);
-        AssertThat(scores.PullingCiliaModifier).IsEqual(2.25f);
+        AssertBits(scores.PilusScore, 5000.0f);
+        AssertBits(scores.InjectisomeScore, 0.0f);
+        AssertBits(scores.DefensivePilusScore, 0.0f);
+        AssertBits(scores.DefensiveInjectisomeScore, 0.0f);
+        AssertBits(scores.AverageToxicity, 0.25f);
+        AssertBits(scores.OxytoxyScore, 4334465.0f);
+        AssertBits(scores.CytotoxinScore, 0.0f);
+        AssertBits(scores.MacrolideScore, 0.0f);
+        AssertBits(scores.ChannelInhibitorScore, 0.0f);
+        AssertBits(scores.OxygenMetabolismInhibitorScore, 0.0f);
+        AssertBits(scores.SlimeJetScore, 37.5f);
+        AssertBits(scores.MucocystsScore, 0.0f);
+        AssertBits(scores.PullingCiliaModifier, 2.25f);
     }
 
     private static void AssertMicrobeRecomputedScores(SimulationCache.PredationToolsRawScores scores)
     {
-        AssertThat(scores.PilusScore).IsEqual(5000.0f);
-        AssertThat(scores.InjectisomeScore).IsEqual(0.0f);
-        AssertThat(scores.DefensivePilusScore).IsEqual(0.0f);
-        AssertThat(scores.DefensiveInjectisomeScore).IsEqual(0.0f);
-        AssertThat(scores.AverageToxicity).IsEqual(0.25f);
-        AssertThat(scores.OxytoxyScore).IsEqual(6935144.0f);
-        AssertThat(scores.CytotoxinScore).IsEqual(0.0f);
-        AssertThat(scores.MacrolideScore).IsEqual(0.0f);
-        AssertThat(scores.ChannelInhibitorScore).IsEqual(0.0f);
-        AssertThat(scores.OxygenMetabolismInhibitorScore).IsEqual(0.0f);
-        AssertThat(scores.SlimeJetScore).IsEqual(60.0f);
-        AssertThat(scores.MucocystsScore).IsEqual(0.0f);
-        AssertThat(scores.PullingCiliaModifier).IsEqual(3.6f);
+        AssertBits(scores.PilusScore, 5000.0f);
+        AssertBits(scores.InjectisomeScore, 0.0f);
+        AssertBits(scores.DefensivePilusScore, 0.0f);
+        AssertBits(scores.DefensiveInjectisomeScore, 0.0f);
+        AssertBits(scores.AverageToxicity, 0.25f);
+        AssertBits(scores.OxytoxyScore, 6935144.0f);
+        AssertBits(scores.CytotoxinScore, 0.0f);
+        AssertBits(scores.MacrolideScore, 0.0f);
+        AssertBits(scores.ChannelInhibitorScore, 0.0f);
+        AssertBits(scores.OxygenMetabolismInhibitorScore, 0.0f);
+        AssertBits(scores.SlimeJetScore, 60.0f);
+        AssertBits(scores.MucocystsScore, 0.0f);
+        AssertBits(scores.PullingCiliaModifier, 3.6f);
     }
 
     private static void AssertMulticellularInitialScores(SimulationCache.PredationToolsRawScores scores)
     {
-        AssertThat(scores.PilusScore).IsEqual(7071.068f);
-        AssertThat(scores.InjectisomeScore).IsEqual(0.0f);
-        AssertThat(scores.DefensivePilusScore).IsEqual(0.0f);
-        AssertThat(scores.DefensiveInjectisomeScore).IsEqual(0.0f);
-        AssertThat(scores.AverageToxicity).IsEqual(0.25f);
-        AssertThat(scores.OxytoxyScore).IsEqual(10922850.0f);
-        AssertThat(scores.CytotoxinScore).IsEqual(0.0f);
-        AssertThat(scores.MacrolideScore).IsEqual(0.0f);
-        AssertThat(scores.ChannelInhibitorScore).IsEqual(0.0f);
-        AssertThat(scores.OxygenMetabolismInhibitorScore).IsEqual(0.0f);
-        AssertThat(scores.SlimeJetScore).IsEqual(94.49999f);
-        AssertThat(scores.MucocystsScore).IsEqual(0.0f);
-        AssertThat(scores.PullingCiliaModifier).IsEqual(2.4198592f);
+        AssertBits(scores.PilusScore, 7071.068f);
+        AssertBits(scores.InjectisomeScore, 0.0f);
+        AssertBits(scores.DefensivePilusScore, 0.0f);
+        AssertBits(scores.DefensiveInjectisomeScore, 0.0f);
+        AssertBits(scores.AverageToxicity, 0.25f);
+        AssertBits(scores.OxytoxyScore, 10922850.0f);
+        AssertBits(scores.CytotoxinScore, 0.0f);
+        AssertBits(scores.MacrolideScore, 0.0f);
+        AssertBits(scores.ChannelInhibitorScore, 0.0f);
+        AssertBits(scores.OxygenMetabolismInhibitorScore, 0.0f);
+        AssertBits(scores.SlimeJetScore, 94.49999f);
+        AssertBits(scores.MucocystsScore, 0.0f);
+        AssertBits(scores.PullingCiliaModifier, 2.4198592f);
     }
 
     private static void AssertMulticellularRecomputedScores(SimulationCache.PredationToolsRawScores scores)
     {
-        AssertThat(scores.PilusScore).IsEqual(7071.068f);
-        AssertThat(scores.InjectisomeScore).IsEqual(0.0f);
-        AssertThat(scores.DefensivePilusScore).IsEqual(0.0f);
-        AssertThat(scores.DefensiveInjectisomeScore).IsEqual(0.0f);
-        AssertThat(scores.AverageToxicity).IsEqual(0.25f);
-        AssertThat(scores.OxytoxyScore).IsEqual(16384275.0f);
-        AssertThat(scores.CytotoxinScore).IsEqual(0.0f);
-        AssertThat(scores.MacrolideScore).IsEqual(0.0f);
-        AssertThat(scores.ChannelInhibitorScore).IsEqual(0.0f);
-        AssertThat(scores.OxygenMetabolismInhibitorScore).IsEqual(0.0f);
-        AssertThat(scores.SlimeJetScore).IsEqual(141.75f);
-        AssertThat(scores.MucocystsScore).IsEqual(0.0f);
-        AssertThat(scores.PullingCiliaModifier).IsEqual(2.7389653f);
+        AssertBits(scores.PilusScore, 7071.068f);
+        AssertBits(scores.InjectisomeScore, 0.0f);
+        AssertBits(scores.DefensivePilusScore, 0.0f);
+        AssertBits(scores.DefensiveInjectisomeScore, 0.0f);
+        AssertBits(scores.AverageToxicity, 0.25f);
+        AssertBits(scores.OxytoxyScore, 16384275.0f);
+        AssertBits(scores.CytotoxinScore, 0.0f);
+        AssertBits(scores.MacrolideScore, 0.0f);
+        AssertBits(scores.ChannelInhibitorScore, 0.0f);
+        AssertBits(scores.OxygenMetabolismInhibitorScore, 0.0f);
+        AssertBits(scores.SlimeJetScore, 141.75f);
+        AssertBits(scores.MucocystsScore, 0.0f);
+        AssertBits(scores.PullingCiliaModifier, 2.7389653f);
     }
 }

--- a/test/auto_evo.tests/SimulationCacheTestFixtures.cs
+++ b/test/auto_evo.tests/SimulationCacheTestFixtures.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using AutoEvo;
+using static GdUnit4.Assertions;
+
+/// <summary>
+///   Small, test-local building blocks for public SimulationCache observations.
+/// </summary>
+internal static class SimulationCacheTestFixtures
+{
+    internal static SimulationCache CreateCache()
+    {
+        return new SimulationCache(new WorldGenerationSettings { Seed = 1 });
+    }
+
+    internal static BiomeConditions CreateBiome()
+    {
+        return (BiomeConditions)SimulationParameters.Instance.GetBiome("aavolcanic_vent").Conditions.Clone();
+    }
+
+    internal static OrganelleTemplate CreateOrganelle(string name, Hex position, string? upgrade = null)
+    {
+        var organelle = new OrganelleTemplate(SimulationParameters.Instance.GetOrganelleType(name), position, 0);
+        if (upgrade != null)
+            organelle.ModifiableUpgrades = new OrganelleUpgrades { ModifiableUnlockedFeatures = [upgrade] };
+
+        return organelle;
+    }
+
+    internal static OrganelleTemplate CreateToxin(Hex position, ToxinType type, float toxicity = 0)
+    {
+        var organelle = CreateOrganelle("oxytoxy", position, ToxinUpgradeNames.ToxinNameFromType(type));
+        organelle.ModifiableUpgrades!.CustomUpgradeData = new ToxinUpgrades(type, toxicity);
+        return organelle;
+    }
+
+    internal static MicrobeSpecies CreateMicrobe(uint id, string epithet, string membrane,
+        params string[] organelles)
+    {
+        var species = new MicrobeSpecies(id, "Characterization", epithet)
+        {
+            IsBacteria = true,
+            MembraneType = SimulationParameters.Instance.GetMembrane(membrane),
+        };
+
+        for (var i = 0; i < organelles.Length; ++i)
+            species.Organelles.Add(CreateOrganelle(organelles[i], new Hex(i * 4, 0)));
+
+        species.OnEdited();
+        return species;
+    }
+
+    internal static CellType CreateCellType(string name, string membrane, params OrganelleTemplate[] organelles)
+    {
+        var cellType = new CellType(SimulationParameters.Instance.GetMembrane(membrane)) { CellTypeName = name };
+        foreach (var organelle in organelles)
+            cellType.ModifiableOrganelles.Add(organelle);
+
+        return cellType;
+    }
+
+    internal static MulticellularSpecies CreateMulticellular(uint id, string epithet,
+        params (CellType CellType, Hex Position)[] cells)
+    {
+        var species = new MulticellularSpecies(id, "Characterization", epithet);
+        foreach (var (cellType, position) in cells)
+        {
+            if (!species.ModifiableCellTypes.Contains(cellType))
+                species.ModifiableCellTypes.Add(cellType);
+
+            species.ModifiableGameplayCells.AddFast(new CellTemplate(cellType, position, 0),
+                new List<Hex>(), new List<Hex>());
+        }
+
+        species.OnEdited();
+        return species;
+    }
+
+    internal static void AssertBits(float actual, float expected)
+    {
+        AssertThat(BitConverter.SingleToInt32Bits(actual)).IsEqual(BitConverter.SingleToInt32Bits(expected));
+    }
+
+    internal static void AssertDifferentBits(float actual, float other)
+    {
+        AssertThat(BitConverter.SingleToInt32Bits(actual)).IsNotEqual(BitConverter.SingleToInt32Bits(other));
+    }
+
+    internal static void AssertPredationLifecycle(Species predator, Species prey, float expected,
+        BiomeConditions? biome = null)
+    {
+        var cache = CreateCache();
+        biome ??= CreateBiome();
+        AssertBits(cache.GetPredationScore(predator, prey, biome), expected);
+        AssertBits(cache.GetPredationScore(predator, prey, biome), expected);
+        cache.Clear();
+        AssertBits(cache.GetPredationScore(predator, prey, biome), expected);
+    }
+
+    internal static void AssertRawBits(SimulationCache.PredationToolsRawScores actual,
+        SimulationCache.PredationToolsRawScores expected)
+    {
+        AssertBits(actual.PilusScore, expected.PilusScore);
+        AssertBits(actual.InjectisomeScore, expected.InjectisomeScore);
+        AssertBits(actual.DefensivePilusScore, expected.DefensivePilusScore);
+        AssertBits(actual.DefensiveInjectisomeScore, expected.DefensiveInjectisomeScore);
+        AssertBits(actual.AverageToxicity, expected.AverageToxicity);
+        AssertBits(actual.OxytoxyScore, expected.OxytoxyScore);
+        AssertBits(actual.CytotoxinScore, expected.CytotoxinScore);
+        AssertBits(actual.MacrolideScore, expected.MacrolideScore);
+        AssertBits(actual.ChannelInhibitorScore, expected.ChannelInhibitorScore);
+        AssertBits(actual.OxygenMetabolismInhibitorScore, expected.OxygenMetabolismInhibitorScore);
+        AssertBits(actual.SlimeJetScore, expected.SlimeJetScore);
+        AssertBits(actual.MucocystsScore, expected.MucocystsScore);
+        AssertBits(actual.PullingCiliaModifier, expected.PullingCiliaModifier);
+    }
+}

--- a/test/auto_evo.tests/SimulationCacheTestFixtures.cs.uid
+++ b/test/auto_evo.tests/SimulationCacheTestFixtures.cs.uid
@@ -1,0 +1,1 @@
+uid://db4k7n5u1cg1b


### PR DESCRIPTION
**Brief Description of What This PR Does**

Strengthen the six original SimulationCache predation characterizations with bitwise cold, warm, and post-`Clear()` assertions, including fresh-cache oracles for raw-score invalidation.

Add small test-local fixture helpers and 30 matched-pair final-score baselines covering predation tool roles and all four Microbe/Multicellular pairings. Additional cases cover nested cache invalidation with new opponents, self-predation, and unsupported species. The changes are confined to tests.

**Related Issues**

No linked GitHub issue. 

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for predation scoring across offensive and defensive abilities, toxins, upgrades, toxicity changes, self-predation, and unsupported species.
  * Added validation for channel-inhibitor effects, including reduced movement funding, stationary consumption, and sprint escape speed.
  * Added checks for predation score caching, cache clearing, and bit-exact consistency after recalculation.
  * Expanded microbial and multicellular predator scenarios.
  * Consolidated shared test setup and assertion helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->