### PR TITLE
Replace Linq in GetTotalNominalCapacity

### DIFF
--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -85,8 +85,14 @@ public static class MicrobeInternalCalculations
     public static float GetTotalNominalCapacity(IEnumerable<OrganelleTemplate> organelles,
         float totalSpecializationBonus)
     {
-        return organelles.Sum(o => GetNominalCapacityForOrganelle(o.Definition, o.Upgrades,
-            totalSpecializationBonus));
+        double capacity = 0;
+        foreach (var organelle in organelles)
+        {
+            capacity += GetNominalCapacityForOrganelle(organelle.Definition, organelle.Upgrades,
+                totalSpecializationBonus);
+        }
+
+        return (float)capacity;
     }
 
     public static Dictionary<Compound, float> GetTotalSpecificCapacity(IReadOnlyList<OrganelleTemplate> organelles,

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -85,14 +85,14 @@ public static class MicrobeInternalCalculations
     public static float GetTotalNominalCapacity(IEnumerable<OrganelleTemplate> organelles,
         float totalSpecializationBonus)
     {
-        double capacity = 0;
+        float capacity = 0;
         foreach (var organelle in organelles)
         {
             capacity += GetNominalCapacityForOrganelle(organelle.Definition, organelle.Upgrades,
                 totalSpecializationBonus);
         }
 
-        return (float)capacity;
+        return capacity;
     }
 
     public static Dictionary<Compound, float> GetTotalSpecificCapacity(IReadOnlyList<OrganelleTemplate> organelles,


### PR DESCRIPTION
**Brief Description of What This PR Does**

Replaces Linq usage in GetTotalNominalCapacity with a Foreach loop to improve performance.

Initial code contribution from [ChevyLevi](https://github.com/Revolutionary-Games/Thrive/commits?author=ChevyLevi).

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal capacity calculations were streamlined while preserving existing results and public functionality.
  * No user-facing features, workflows, or interfaces have changed.
  * Capacity reporting continues to behave as expected across supported scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->