### PR TITLE
Optimise random mutation selection during species generation

### DIFF
--- a/src/auto-evo/mutations/CommonMutationFunctions.cs
+++ b/src/auto-evo/mutations/CommonMutationFunctions.cs
@@ -90,7 +90,7 @@ public static class CommonMutationFunctions
         while (mp > 0)
         {
             var mutation = mutationStrategy.MutationsOf(mutated, mp, true, random, forPatch.Biome)
-                ?.OrderBy(_ => random.Next()).FirstOrDefault();
+                .RandomOrDefault(random);
 
             if (mutation == null)
                 break;

--- a/test/auto_evo.tests/RandomMicrobeSpeciesTests.cs
+++ b/test/auto_evo.tests/RandomMicrobeSpeciesTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using AutoEvo;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+[TestSuite]
+[RequireGodotRuntime]
+public class RandomMicrobeSpeciesTests
+{
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(Constants.ORGANELLE_CHEAPEST_COST - 1)]
+    public void GenerateRandomMicrobeSpecies_InsufficientBudgetReturnsInitialSpecies(int mp)
+    {
+        var world = CreateWorld();
+        var original = new MicrobeSpecies(2, string.Empty, string.Empty);
+
+        var result = CommonMutationFunctions.GenerateRandomMicrobeSpecies(original, world.Map.CurrentPatch!,
+            new MutationWorkMemory(), new Random(42), mp);
+
+        AssertThat(result).IsSame(original);
+        AssertThat(result.Organelles.Count).IsEqual(1);
+        AssertThat(result.Organelles[0].Definition.InternalName).IsEqual("cytoplasm");
+        AssertThat(string.IsNullOrEmpty(result.Genus)).IsFalse();
+        AssertThat(string.IsNullOrEmpty(result.Epithet)).IsFalse();
+    }
+
+    [TestCase(42)]
+    [TestCase(123)]
+    [TestCase(456)]
+    public void GenerateRandomMicrobeSpecies_AppliesMutationsAndFinalisesSpecies(int seed)
+    {
+        var world = CreateWorld();
+        var original = new MicrobeSpecies(2, string.Empty, string.Empty);
+
+        var result = CommonMutationFunctions.GenerateRandomMicrobeSpecies(original, world.Map.CurrentPatch!,
+            new MutationWorkMemory(), new Random(seed));
+
+        AssertThat(result.ID).IsEqual(original.ID);
+        AssertThat(result.Organelles.Count).IsGreater(1);
+        AssertThat(original.Organelles.Count).IsEqual(1);
+        AssertThat(string.IsNullOrEmpty(result.Genus)).IsFalse();
+        AssertThat(string.IsNullOrEmpty(result.Epithet)).IsFalse();
+    }
+
+    [TestCase]
+    public void GenerateRandomMicrobeSpecies_EmptyCandidatesReturnsInitialSpecies()
+    {
+        var world = CreateWorld();
+        var patch = world.Map.CurrentPatch!;
+        var memory = new MutationWorkMemory();
+        var probe = new MicrobeSpecies(2, string.Empty, string.Empty);
+        GameWorld.SetInitialSpeciesProperties(probe, memory.WorkingMemory1, memory.WorkingMemory2);
+
+        // This seed samples organelles that cannot be added within the minimum budget.
+        var candidates = new AddOrganelleAnywhere(_ => true).MutationsOf(probe,
+            Constants.ORGANELLE_CHEAPEST_COST, true, new Random(0), patch.Biome);
+        AssertThat(candidates).IsNotNull();
+        AssertThat(candidates!.Count).IsEqual(0);
+
+        var original = new MicrobeSpecies(2, string.Empty, string.Empty);
+        var result = CommonMutationFunctions.GenerateRandomMicrobeSpecies(original, patch, memory,
+            new Random(0), Constants.ORGANELLE_CHEAPEST_COST);
+
+        AssertThat(result).IsSame(original);
+        AssertThat(result.Organelles.Count).IsEqual(1);
+        AssertThat(string.IsNullOrEmpty(result.Genus)).IsFalse();
+        AssertThat(string.IsNullOrEmpty(result.Epithet)).IsFalse();
+    }
+
+    private static GameWorld CreateWorld()
+    {
+        return new GameWorld(new WorldGenerationSettings
+        {
+            Seed = 0x5EED,
+            WorldSize = WorldGenerationSettings.WorldSizeEnum.Small,
+        });
+    }
+}

--- a/test/auto_evo.tests/RandomMicrobeSpeciesTests.cs.uid
+++ b/test/auto_evo.tests/RandomMicrobeSpeciesTests.cs.uid
@@ -1,0 +1,1 @@
+uid://bckexubxvolrk

--- a/test/code_tests/General/Utils.Tests/ListUtilsTests.cs
+++ b/test/code_tests/General/Utils.Tests/ListUtilsTests.cs
@@ -1,0 +1,61 @@
+﻿namespace ThriveTest.General.Utils.Tests;
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+public class ListUtilsTests
+{
+    [Fact]
+    public void RandomOrDefault_NullOrEmptyListReturnsNullWithoutDrawingRandomness()
+    {
+        List<object>? missing = null;
+        var empty = new List<object>();
+        var random = new IndexRandom(0);
+
+        Assert.Null(missing.RandomOrDefault(random));
+        Assert.Null(empty.RandomOrDefault(random));
+        Assert.Equal(0, random.Calls);
+    }
+
+    [Fact]
+    public void RandomOrDefault_SingleItemReturnsThatInstance()
+    {
+        var item = new object();
+        var items = new List<object> { item };
+
+        Assert.Same(item, items.RandomOrDefault(new Random(42)));
+        Assert.Single(items);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void RandomOrDefault_EveryCandidateIsReachableWithoutChangingTheList(int index)
+    {
+        var items = new List<object> { new(), new(), new() };
+        var original = items.ToArray();
+        var random = new IndexRandom(index);
+
+        Assert.Same(original[index], items.RandomOrDefault(random));
+        Assert.Equal(original, items);
+        Assert.Equal(1, random.Calls);
+        Assert.Equal(items.Count, random.UpperBound);
+    }
+
+    private sealed class IndexRandom(int index) : Random
+    {
+        public int Calls { get; private set; }
+        public int UpperBound { get; private set; }
+
+        public override int Next(int minValue, int maxValue)
+        {
+            Assert.Equal(0, minValue);
+            Assert.InRange(index, minValue, maxValue - 1);
+            ++Calls;
+            UpperBound = maxValue;
+            return index;
+        }
+    }
+}

--- a/test/code_tests/General/Utils.Tests/ListUtilsTests.cs.uid
+++ b/test/code_tests/General/Utils.Tests/ListUtilsTests.cs.uid
@@ -1,0 +1,1 @@
+uid://dm3bdert4w3xr


### PR DESCRIPTION
**Brief Description of What This PR Does**

Use non-alloc `ListUtils.RandomOrDefault()` to replace `OrderBy()` when picking up one item, avoid list shuffle and memory allocation.

For selection alone, both variants reused identical candidate lists. After three warmup batches, 15 alternating batches of 200,000 selections gave median times of 89–95 ns before and 8.7–10.6 ns after across System.Random and XoShiRo256starstar. Average managed allocation fell from approximately 122 B per selection to 0 B. The baseline reused its key delegate, excluding delegate-creation overhead.

Whole GenerateRandomMicrobeSpecies measurements used three warmup batches and 15 alternating batches of 128 fresh, equal-seed inputs. Median time and managed allocation per generated species:

| RNG / MP budget | Time before → after | Allocation before → after |
| --- | --- | --- |
| System.Random / 300 | 40.92 → 42.50 µs | 62,718 → 65,476 B |
| System.Random / 200–499 | 47.08 → 46.89 µs | 62,718 → 65,476 B |
| XoShiRo256starstar / 300 | 43.15 → 42.50 µs | 64,941 → 63,489 B |
| XoShiRo256starstar / 200–499 | 42.97 → 42.09 µs | 64,941 → 63,489 B |


**Related Issues**

No linked issue.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [ ] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).
