### PR TITLE
Optimize random take x algorithm

### DIFF
--- a/src/auto-evo/mutation_strategy/AddCellWithOrganelle.cs
+++ b/src/auto-evo/mutation_strategy/AddCellWithOrganelle.cs
@@ -85,8 +85,9 @@ public class AddCellWithOrganelle : IMutationStrategy<Species>
             mp < Constants.CELL_ADD_COST)
             return null;
 
-        var organelles = allOrganelles.OrderBy(_ => random.Next())
-            .Take(Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS);
+        var candidateCount = Math.Min(allOrganelles.Length, Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS);
+        Span<int> candidateIndices = stackalloc int[candidateCount];
+        SelectCandidateIndices(allOrganelles.Length, candidateIndices, random);
 
         // TODO: reuse this memory somehow
         var mutated = new List<Mutant>();
@@ -95,8 +96,10 @@ public class AddCellWithOrganelle : IMutationStrategy<Species>
         var workMemory2 = new List<Hex>();
         var workMemory3 = new HashSet<Hex>();
 
-        foreach (var organelle in organelles)
+        foreach (var i in candidateIndices)
         {
+            var organelle = allOrganelles[i];
+
             // Important to not accidentally add non-LAWK organelles in a LAWK game
             if (!organelle.LAWK && lawk)
                 continue;
@@ -129,13 +132,13 @@ public class AddCellWithOrganelle : IMutationStrategy<Species>
                 var smallestCellIndex = 0;
                 var newSpecies = baseMulticellularSpecies.Clone(true, false);
 
-                for (int i = 0; i < baseCellTypesCount; ++i)
+                for (int j = 0; j < baseCellTypesCount; ++j)
                 {
-                    if (baseCellTypes[i].BaseHexSize >= smallestCellSize)
+                    if (baseCellTypes[j].BaseHexSize >= smallestCellSize)
                         continue;
 
-                    smallestCellIndex = i;
-                    smallestCellSize = baseCellTypes[i].BaseHexSize;
+                    smallestCellIndex = j;
+                    smallestCellSize = baseCellTypes[j].BaseHexSize;
                 }
 
                 var templateCellType = baseMulticellularSpecies.ModifiableCellTypes[smallestCellIndex];

--- a/src/auto-evo/mutation_strategy/AddOrganelleAnywhere.cs
+++ b/src/auto-evo/mutation_strategy/AddOrganelleAnywhere.cs
@@ -86,14 +86,9 @@ public class AddOrganelleAnywhere : IMutationStrategy<Species>
         if (mp < Constants.ORGANELLE_CHEAPEST_COST)
             return null;
 
-        // TODO: would the following be more efficient?
-        // var organelles = allOrganelles.ToList();
-        // organelles.Shuffle(random);
-        // organelles.RemoveRange(Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS,
-        //     organelles.Count - Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS);
-
-        var organelles = allOrganelles.OrderBy(_ => random.Next())
-            .Take(Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS);
+        var candidateCount = Math.Min(allOrganelles.Length, Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS);
+        Span<int> candidateIndices = stackalloc int[candidateCount];
+        SelectCandidateIndices(allOrganelles.Length, candidateIndices, random);
 
         var mutated = new List<Mutant>();
 
@@ -102,8 +97,11 @@ public class AddOrganelleAnywhere : IMutationStrategy<Species>
         var workMemory2 = new List<Hex>();
         var workMemory3 = new HashSet<Hex>();
 
-        foreach (var organelle in organelles)
+        // Iterate randomly selected organelles
+        foreach (var i in candidateIndices)
         {
+            var organelle = allOrganelles[i];
+
             if (organelle.MPCost > mp)
                 continue;
 
@@ -125,8 +123,7 @@ public class AddOrganelleAnywhere : IMutationStrategy<Species>
 
             // In the rare case that adding the organelle fails, this can skip adding it to be tested as the species
             // is not any different
-            if (AddOrganelle(organelle, direction, newSpecies, workMemory1, workMemory2,
-                    workMemory3, random))
+            if (AddOrganelle(organelle, direction, newSpecies, workMemory1, workMemory2, workMemory3, random))
             {
                 mutated.Add(new Mutant(newSpecies, mp - organelle.MPCost));
             }

--- a/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
+++ b/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
@@ -214,9 +214,9 @@ public class RemoveOrganelle : IMutationStrategy<Species>
     /// </summary>
     private int SelectOrganelleIndices(IReadOnlyList<OrganelleTemplate> organelles, Span<int> candidates, Random random)
     {
-        int matchingCount = 0;
-        int selectedCount = 0;
-        int organelleCount = organelles.Count;
+        var matchingCount = 0;
+        var selectedCount = 0;
+        var organelleCount = organelles.Count;
         for (int i = 0; i < organelleCount; ++i)
         {
             if (!criteria(organelles[i].Definition))
@@ -230,15 +230,17 @@ public class RemoveOrganelle : IMutationStrategy<Species>
             }
 
             // Each matching organelle has the same chance of belonging to the bounded sample.
-            int replacement = random.Next(matchingCount);
+            var replacement = random.Next(matchingCount);
             if (replacement < candidates.Length)
+            {
                 candidates[replacement] = i;
+            }
         }
 
         // Reservoir sampling chooses a subset; shuffle it to also randomize the attempt order.
         for (int i = 0; i < selectedCount - 1; ++i)
         {
-            int swapIndex = i + random.Next(selectedCount - i);
+            var swapIndex = i + random.Next(selectedCount - i);
             (candidates[i], candidates[swapIndex]) = (candidates[swapIndex], candidates[i]);
         }
 

--- a/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
+++ b/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
@@ -66,15 +66,18 @@ public class RemoveOrganelle : IMutationStrategy<Species>
         if (baseSpecies.Organelles.Count <= 1)
             return null;
 
-        var organelles = baseSpecies.Organelles.Where(x => criteria(x.Definition))
-            .OrderBy(_ => random.Next()).Take(Constants.AUTO_EVO_ORGANELLE_REMOVE_ATTEMPTS);
+        var baseOrganelles = baseSpecies.Organelles.Organelles;
+        Span<int> candidateIndices = stackalloc int[Constants.AUTO_EVO_ORGANELLE_REMOVE_ATTEMPTS];
+        int candidateCount = SelectOrganelleIndices(baseOrganelles, candidateIndices, random);
 
         List<Mutant>? mutated = null;
 
         MutationWorkMemory? workMemory = null;
 
-        foreach (var organelle in organelles)
+        foreach (int candidateIndex in candidateIndices[..candidateCount])
         {
+            var organelle = baseOrganelles[candidateIndex];
+
             // The player cannot remove the nucleus, so Auto-Evo should not be able to either
             if (ReferenceEquals(organelle.Definition, Nucleus))
                 continue;
@@ -87,7 +90,6 @@ public class RemoveOrganelle : IMutationStrategy<Species>
             // Is this the best way to do this? Probably not, but this is how mutations.cs does is
             // and the other way outright did not work
             // This is now slightly improved - hhyyrylainen
-            var baseOrganelles = baseSpecies.Organelles.Organelles;
             var count = baseSpecies.Organelles.Count;
 
             for (var i = 0; i < count; ++i)
@@ -121,6 +123,7 @@ public class RemoveOrganelle : IMutationStrategy<Species>
         List<Mutant>? mutated = null;
 
         var cellTypeCount = baseSpecies.CellTypes.Count;
+        Span<int> candidateIndices = stackalloc int[Constants.AUTO_EVO_ORGANELLE_REMOVE_ATTEMPTS];
 
         for (var i = 0; i < cellTypeCount; ++i)
         {
@@ -128,13 +131,15 @@ public class RemoveOrganelle : IMutationStrategy<Species>
             if (baseCellType.Organelles.Count <= 1)
                 continue;
 
-            var organelles = baseCellType.Organelles.Where(x => criteria(x.Definition))
-                .OrderBy(_ => random.Next()).Take(Constants.AUTO_EVO_ORGANELLE_REMOVE_ATTEMPTS);
+            var baseOrganelles = baseCellType.ModifiableOrganelles.Organelles;
+            int candidateCount = SelectOrganelleIndices(baseOrganelles, candidateIndices, random);
 
             MutationWorkMemory? workMemory = null;
 
-            foreach (var organelle in organelles)
+            foreach (int candidateIndex in candidateIndices[..candidateCount])
             {
+                var organelle = baseOrganelles[candidateIndex];
+
                 // The player cannot remove the nucleus, so Auto-Evo should not be able to either
                 if (ReferenceEquals(organelle.Definition, Nucleus))
                     continue;
@@ -178,7 +183,6 @@ public class RemoveOrganelle : IMutationStrategy<Species>
 
                 // Clone the organelles for the targeted cell type, excluding the targeted organelle
                 // Is this the best way to do this?
-                var baseOrganelles = baseCellType.ModifiableOrganelles;
                 var organelleCount = baseCellType.Organelles.Count;
 
                 for (var j = 0; j < organelleCount; ++j)
@@ -202,5 +206,42 @@ public class RemoveOrganelle : IMutationStrategy<Species>
         }
 
         return mutated;
+    }
+
+    /// <summary>
+    ///   Samples matching organelles in one scan, then randomizes their attempt order. Only the returned number of
+    ///   entries in candidates is initialized.
+    /// </summary>
+    private int SelectOrganelleIndices(IReadOnlyList<OrganelleTemplate> organelles, Span<int> candidates, Random random)
+    {
+        int matchingCount = 0;
+        int selectedCount = 0;
+        int organelleCount = organelles.Count;
+        for (int i = 0; i < organelleCount; ++i)
+        {
+            if (!criteria(organelles[i].Definition))
+                continue;
+
+            ++matchingCount;
+            if (selectedCount < candidates.Length)
+            {
+                candidates[selectedCount++] = i;
+                continue;
+            }
+
+            // Each matching organelle has the same chance of belonging to the bounded sample.
+            int replacement = random.Next(matchingCount);
+            if (replacement < candidates.Length)
+                candidates[replacement] = i;
+        }
+
+        // Reservoir sampling chooses a subset; shuffle it to also randomize the attempt order.
+        for (int i = 0; i < selectedCount - 1; ++i)
+        {
+            int swapIndex = i + random.Next(selectedCount - i);
+            (candidates[i], candidates[swapIndex]) = (candidates[swapIndex], candidates[i]);
+        }
+
+        return selectedCount;
     }
 }

--- a/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
+++ b/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
@@ -209,9 +209,21 @@ public class RemoveOrganelle : IMutationStrategy<Species>
     }
 
     /// <summary>
-    ///   Samples matching organelles in one scan, then randomizes their attempt order. Only the returned number of
-    ///   entries in candidates is initialized.
+    ///   Uses reservoir sampling to select matching organelles, then shuffles the selected indices into attempt order.
     /// </summary>
+    /// <param name="organelles">The original organelle list, filtered using this strategy's criteria.</param>
+    /// <param name="candidates">The output buffer, whose length limits the number of selected indices.</param>
+    /// <param name="random">The random source used for reservoir replacement and shuffling.</param>
+    /// <returns>
+    ///   The number of valid entries at the start of <paramref name="candidates"/>. Each entry indexes the original
+    ///   organelle list; entries beyond the returned count may be uninitialized or left over from an earlier call.
+    /// </returns>
+    /// <remarks>
+    ///   <para>
+    ///     This only filters by criteria. Callers may skip protected organelles in the sample without replacing them,
+    ///     so the sample size limits attempts rather than successful removals.
+    ///   </para>
+    /// </remarks>
     private int SelectOrganelleIndices(IReadOnlyList<OrganelleTemplate> organelles, Span<int> candidates, Random random)
     {
         var matchingCount = 0;
@@ -222,6 +234,7 @@ public class RemoveOrganelle : IMutationStrategy<Species>
             if (!criteria(organelles[i].Definition))
                 continue;
 
+            // Count only matching organelles for sampling, but store their indices in the original list.
             ++matchingCount;
             if (selectedCount < candidates.Length)
             {
@@ -229,7 +242,10 @@ public class RemoveOrganelle : IMutationStrategy<Species>
                 continue;
             }
 
-            // Each matching organelle has the same chance of belonging to the bounded sample.
+            // With uniform draws, the m-th match enters a full k-slot reservoir with probability k/m.
+            // Each earlier match had selection probability k/(m - 1) and survives with probability (m - 1)/m,
+            // so its probability of remaining in the sample is also k/m.
+            // For example, with k = 2, the fifth match replaces a slot only on draws 0 or 1 out of [0, 5).
             var replacement = random.Next(matchingCount);
             if (replacement < candidates.Length)
             {
@@ -237,7 +253,8 @@ public class RemoveOrganelle : IMutationStrategy<Species>
             }
         }
 
-        // Reservoir sampling chooses a subset; shuffle it to also randomize the attempt order.
+        // Reservoir sampling chooses a uniform subset, not a uniform order. Use a Fisher-Yates shuffle for attempts.
+        // This is also needed when all matches fit in the buffer and would otherwise remain in source order.
         for (int i = 0; i < selectedCount - 1; ++i)
         {
             var swapIndex = i + random.Next(selectedCount - i);

--- a/src/auto-evo/mutations/CommonMutationFunctions.cs
+++ b/src/auto-evo/mutations/CommonMutationFunctions.cs
@@ -405,26 +405,41 @@ public static class CommonMutationFunctions
     }
 
     /// <summary>
-    ///   Draws a random sample without replacement using only the small, bounded set of selected indices.
-    ///   The output length must not exceed the candidate count and must be small enough for stack allocation.
+    ///   Fills the output with distinct indices from [0, candidateCount), in random selection order.
     /// </summary>
+    /// <param name="candidateCount">The number of available candidates. Must be non-negative.</param>
+    /// <param name="candidates">
+    ///   Receives the selected indices. Its length is the requested sample size and must not exceed
+    ///   <paramref name="candidateCount"/>. An empty span produces no output and consumes no random values.
+    /// </param>
+    /// <param name="random">The random source used to choose ranks among the remaining candidates.</param>
     /// <remarks>
     ///   <para>
-    ///     This algorithm takes O(k^2) time and uses O(k) additional stack space, where k is
-    ///     <paramref name="candidates"/>.Length. It avoids heap allocations and is intended for small samples.
-    ///     Consider using other algorithms when k is big.
+    ///     Each draw chooses a rank among the indices not yet selected, then maps that rank back to the original
+    ///     index range. With uniform random draws, every ordered sample of distinct indices is equally likely.
+    ///     The caller owns the output buffer; this method does not copy or modify the source collection.
+    ///   </para>
+    ///   <para>
+    ///     For k output indices, this takes O(k^2) time and O(k) temporary stack space, with no heap allocations
+    ///     by the sampling algorithm. Keep k small enough for the internal stack allocation, even when the output
+    ///     buffer itself is not on the stack. Use another algorithm for large samples.
     ///   </para>
     /// </remarks>
     internal static void SelectCandidateIndices(int candidateCount, Span<int> candidates, Random random)
     {
+        // At the start of each draw, selected[..i] is sorted for rank mapping, while candidates[..i] keeps draw order.
         Span<int> selected = stackalloc int[candidates.Length];
         for (int i = 0; i < candidates.Length; ++i)
         {
             var remaining = candidateCount - i;
+
+            // A single remaining index needs no random draw.
             var index = remaining == 1 ? 0 : random.Next(remaining);
             var insertion = 0;
 
-            // Convert a rank among the remaining candidates to an index in the original array.
+            // Skip previously selected indices to map the remaining rank to an original index.
+            // Example: from [0, 6), with sorted selections [1, 3], the remaining indices are [0, 2, 4, 5].
+            // Rank 2 maps to index 4: skipping 1 changes 2 to 3, then skipping 3 changes it to 4.
             while (insertion < i && selected[insertion] <= index)
             {
                 ++index;
@@ -432,9 +447,12 @@ public static class CommonMutationFunctions
             }
 
             candidates[i] = index;
+
+            // The final selection needs no sorted insertion because there is no next draw.
             if (i + 1 == candidates.Length)
                 break;
 
+            // Insert the new index in sorted order so the next draw can skip all previous selections.
             for (int j = i; j > insertion; --j)
             {
                 selected[j] = selected[j - 1];

--- a/src/auto-evo/mutations/CommonMutationFunctions.cs
+++ b/src/auto-evo/mutations/CommonMutationFunctions.cs
@@ -392,6 +392,39 @@ public static class CommonMutationFunctions
         return true;
     }
 
+    /// <summary>
+    ///   Draws a random sample without replacement using only the small, bounded set of selected indices.
+    ///   The output length must not exceed the candidate count and must be small enough for stack allocation.
+    /// </summary>
+    internal static void SelectCandidateIndices(int candidateCount, Span<int> candidates, Random random)
+    {
+        Span<int> selected = stackalloc int[candidates.Length];
+        for (int i = 0; i < candidates.Length; ++i)
+        {
+            var remaining = candidateCount - i;
+            var index = remaining == 1 ? 0 : random.Next(remaining);
+            var insertion = 0;
+
+            // Convert a rank among the remaining candidates to an index in the original array.
+            while (insertion < i && selected[insertion] <= index)
+            {
+                ++index;
+                ++insertion;
+            }
+
+            candidates[i] = index;
+            if (i + 1 == candidates.Length)
+                break;
+
+            for (int j = i; j > insertion; --j)
+            {
+                selected[j] = selected[j - 1];
+            }
+
+            selected[insertion] = index;
+        }
+    }
+
     private static bool TryAddNewCell(ref double mp, CellType newCellType, int mpCost, List<Hex> workMemory1,
         List<Hex> workMemory2, CellTemplate baseCell, Hex.HexSide hexSide, IReadOnlyHexWithData<CellTemplate> baseHex,
         IndividualHexLayout<CellTemplate> newCells)

--- a/src/auto-evo/mutations/CommonMutationFunctions.cs
+++ b/src/auto-evo/mutations/CommonMutationFunctions.cs
@@ -396,6 +396,13 @@ public static class CommonMutationFunctions
     ///   Draws a random sample without replacement using only the small, bounded set of selected indices.
     ///   The output length must not exceed the candidate count and must be small enough for stack allocation.
     /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     This algorithm takes O(k^2) time and uses O(k) additional stack space, where k is
+    ///     <paramref name="candidates"/>.Length. It avoids heap allocations and is intended for small samples.
+    ///     Consider using other algorithms when k is big.
+    ///   </para>
+    /// </remarks>
     internal static void SelectCandidateIndices(int candidateCount, Span<int> candidates, Random random)
     {
         Span<int> selected = stackalloc int[candidates.Length];

--- a/test/auto_evo.tests/RandomOrganelleRemovalTests.cs
+++ b/test/auto_evo.tests/RandomOrganelleRemovalTests.cs
@@ -13,9 +13,9 @@ using static GdUnit4.Assertions;
 [RequireGodotRuntime]
 public class RandomOrganelleRemovalTests
 {
-    private static OrganelleDefinition Cytoplasm => SimulationParameters.Instance.GetOrganelleType("cytoplasm");
+    private readonly OrganelleDefinition cytoplasm = SimulationParameters.Instance.GetOrganelleType("cytoplasm");
 
-    private static BiomeConditions Biome => SimulationParameters.Instance.GetBiome("aavolcanic_vent").Conditions;
+    private readonly BiomeConditions biome = SimulationParameters.Instance.GetBiome("aavolcanic_vent").Conditions;
 
     [TestCase(false)]
     [TestCase(true)]
@@ -31,7 +31,7 @@ public class RandomOrganelleRemovalTests
             var strategy = new RemoveOrganelle(candidates.Contains);
             foreach (int seed in new[] { 1, 71, 431 })
             {
-                var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), Biome);
+                var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), biome);
                 if (count == 0)
                 {
                     AssertThat(mutants).IsNull();
@@ -70,7 +70,7 @@ public class RandomOrganelleRemovalTests
         // Fixed seeds cover the resulting orders without depending on an algorithm's random-call sequence.
         for (int seed = 0; seed < 128; ++seed)
         {
-            var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), Biome);
+            var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), biome);
             AssertThat(mutants).IsNotNull();
             AssertThat(mutants!.Count).IsEqual(3);
             var removed = mutants.Select(m => definitions.Except(GetDefinitions(m.Species)).Single().InternalName)
@@ -92,7 +92,7 @@ public class RandomOrganelleRemovalTests
             AddCellType(species, definitions.Take(counts[i]).ToArray());
 
         var strategy = new RemoveOrganelle(definitions.Contains);
-        var mutants = strategy.MutationsOf(species, 1000, false, new XoShiRo256starstar(71), Biome);
+        var mutants = strategy.MutationsOf(species, 1000, false, new XoShiRo256starstar(71), biome);
         AssertThat(mutants).IsNotNull();
         AssertThat(mutants!.Count).IsEqual(14);
         var mutationsPerType = new int[counts.Length];
@@ -129,7 +129,7 @@ public class RandomOrganelleRemovalTests
 
             for (int seed = 0; seed < 128; ++seed)
             {
-                var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), Biome);
+                var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), biome);
                 AssertThat(mutants).IsNotNull();
                 AssertThat(mutants!.Count is 9 or 10).IsTrue();
                 if (removableCount == 9)
@@ -161,7 +161,7 @@ public class RandomOrganelleRemovalTests
         var selected = new HashSet<OrganelleDefinition>();
         for (int seed = 0; seed < 128 && selected.Count < definitions.Length; ++seed)
         {
-            var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), Biome);
+            var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), biome);
             AssertThat(mutants).IsNotNull();
             foreach (var mutant in mutants!)
                 selected.Add(definitions.Except(GetDefinitions(mutant.Species)).Single());
@@ -170,15 +170,22 @@ public class RandomOrganelleRemovalTests
         AssertThat(selected.Count).IsEqual(definitions.Length);
     }
 
-    private static OrganelleDefinition[] GetCandidates()
+    private static IEnumerable<OrganelleDefinition> GetDefinitions(Species species, int cellType = 0)
+    {
+        return species is MicrobeSpecies microbe ?
+            microbe.Organelles.Select(o => o.Definition) :
+            ((MulticellularSpecies)species).CellTypes[cellType].Organelles.Select(o => o.Definition);
+    }
+
+    private OrganelleDefinition[] GetCandidates()
     {
         return SimulationParameters.Instance.GetAllOrganelles()
-            .Where(o => o.AutoEvoCanPlace && o.Hexes.Count == 1 && !ReferenceEquals(o, Cytoplasm) &&
+            .Where(o => o.AutoEvoCanPlace && o.Hexes.Count == 1 && !ReferenceEquals(o, cytoplasm) &&
                 !o.HasBindingFeature)
             .Take(12).ToArray();
     }
 
-    private static Species CreateSpecies(bool multicellular, OrganelleDefinition[] definitions)
+    private Species CreateSpecies(bool multicellular, OrganelleDefinition[] definitions)
     {
         if (multicellular)
         {
@@ -196,7 +203,7 @@ public class RandomOrganelleRemovalTests
         return microbe;
     }
 
-    private static void AddCellType(MulticellularSpecies species, OrganelleDefinition[] definitions)
+    private void AddCellType(MulticellularSpecies species, OrganelleDefinition[] definitions)
     {
         var cellType = new CellType(SimulationParameters.Instance.GetMembrane("single"))
         {
@@ -206,21 +213,14 @@ public class RandomOrganelleRemovalTests
         species.ModifiableCellTypes.Add(cellType);
     }
 
-    private static void FillOrganelles(OrganelleLayout<OrganelleTemplate> layout, OrganelleDefinition[] definitions)
+    private void FillOrganelles(OrganelleLayout<OrganelleTemplate> layout, OrganelleDefinition[] definitions)
     {
         // A cytoplasm backbone keeps the layout connected after any candidate is removed.
         for (int i = 0; i < Math.Max(2, definitions.Length); ++i)
         {
-            layout.Add(new OrganelleTemplate(Cytoplasm, new Hex(i, 0), 0));
+            layout.Add(new OrganelleTemplate(cytoplasm, new Hex(i, 0), 0));
             if (i < definitions.Length)
                 layout.Add(new OrganelleTemplate(definitions[i], new Hex(i, 1), 0));
         }
-    }
-
-    private static IEnumerable<OrganelleDefinition> GetDefinitions(Species species, int cellType = 0)
-    {
-        return species is MicrobeSpecies microbe ?
-            microbe.Organelles.Select(o => o.Definition) :
-            ((MulticellularSpecies)species).CellTypes[cellType].Organelles.Select(o => o.Definition);
     }
 }

--- a/test/auto_evo.tests/RandomOrganelleRemovalTests.cs
+++ b/test/auto_evo.tests/RandomOrganelleRemovalTests.cs
@@ -1,0 +1,225 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using AutoEvo;
+using GdUnit4;
+using Xoshiro.PRNG64;
+using static GdUnit4.Assertions;
+
+/// <summary>
+///   Checks filtered random removal through both species mutation paths.
+/// </summary>
+[TestSuite]
+[RequireGodotRuntime]
+public class RandomOrganelleRemovalTests
+{
+    private static OrganelleDefinition Cytoplasm => SimulationParameters.Instance.GetOrganelleType("cytoplasm");
+
+    private static BiomeConditions Biome => SimulationParameters.Instance.GetBiome("aavolcanic_vent").Conditions;
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void FilteredCandidatesRespectLimitAndMapToOriginalOrganelles(bool multicellular)
+    {
+        var definitions = GetCandidates();
+        AssertThat(definitions.Length).IsEqual(12);
+        var original = CreateSpecies(multicellular, definitions);
+
+        foreach (int count in new[] { 0, 1, 2, 9, 10, 11, 12 })
+        {
+            var candidates = definitions.Take(count).ToHashSet();
+            var strategy = new RemoveOrganelle(candidates.Contains);
+            foreach (int seed in new[] { 1, 71, 431 })
+            {
+                var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), Biome);
+                if (count == 0)
+                {
+                    AssertThat(mutants).IsNull();
+                    continue;
+                }
+
+                AssertThat(mutants).IsNotNull();
+                AssertThat(mutants!.Count).IsEqual(Math.Min(count, Constants.AUTO_EVO_ORGANELLE_REMOVE_ATTEMPTS));
+                var removed = mutants.Select(m => definitions.Except(GetDefinitions(m.Species)).Single()).ToArray();
+                AssertThat(removed.Distinct().Count()).IsEqual(removed.Length);
+                AssertThat(removed.All(candidates.Contains)).IsTrue();
+                foreach (var mutant in mutants)
+                {
+                    AssertThat(GetDefinitions(mutant.Species).Count()).IsEqual(definitions.Length * 2 - 1);
+                    double cost = Constants.ORGANELLE_REMOVE_COST *
+                        (multicellular ? Constants.MULTICELLULAR_EDITOR_COST_FACTOR : 1);
+                    AssertThat(mutant.MP).IsEqual(1000 - cost);
+                }
+            }
+        }
+
+        AssertThat(GetDefinitions(original).Count()).IsEqual(definitions.Length * 2);
+        AssertThat(definitions.Except(GetDefinitions(original)).Count()).IsEqual(0);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void AllThreeFilteredCandidatesCanAppearInEveryOrder(bool multicellular)
+    {
+        var definitions = GetCandidates().Take(3).ToArray();
+        var candidates = definitions.ToHashSet();
+        var strategy = new RemoveOrganelle(candidates.Contains);
+        var original = CreateSpecies(multicellular, definitions);
+        var orders = new HashSet<string>();
+
+        // Fixed seeds cover the resulting orders without depending on an algorithm's random-call sequence.
+        for (int seed = 0; seed < 128; ++seed)
+        {
+            var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), Biome);
+            AssertThat(mutants).IsNotNull();
+            AssertThat(mutants!.Count).IsEqual(3);
+            var removed = mutants.Select(m => definitions.Except(GetDefinitions(m.Species)).Single().InternalName)
+                .ToArray();
+            AssertThat(removed.Distinct().Count()).IsEqual(3);
+            orders.Add(string.Join(",", removed));
+        }
+
+        AssertThat(orders.Count).IsEqual(6);
+    }
+
+    [TestCase]
+    public void MulticellularTypesHaveIndependentLimitsAndReuseOnlyInitializedIndices()
+    {
+        var definitions = GetCandidates();
+        var counts = new[] { 12, 1, 0, 3 };
+        var species = (MulticellularSpecies)CreateSpecies(true, definitions);
+        for (int i = 1; i < counts.Length; ++i)
+            AddCellType(species, definitions.Take(counts[i]).ToArray());
+
+        var strategy = new RemoveOrganelle(definitions.Contains);
+        var mutants = strategy.MutationsOf(species, 1000, false, new XoShiRo256starstar(71), Biome);
+        AssertThat(mutants).IsNotNull();
+        AssertThat(mutants!.Count).IsEqual(14);
+        var mutationsPerType = new int[counts.Length];
+        foreach (var mutant in mutants)
+        {
+            var changedTypes = Enumerable.Range(0, counts.Length)
+                .Where(i => GetDefinitions(mutant.Species, i).Count() != GetDefinitions(species, i).Count()).ToArray();
+            AssertThat(changedTypes.Length).IsEqual(1);
+            ++mutationsPerType[changedTypes[0]];
+        }
+
+        for (int i = 0; i < counts.Length; ++i)
+            AssertThat(mutationsPerType[i]).IsEqual(Math.Min(counts[i], Constants.AUTO_EVO_ORGANELLE_REMOVE_ATTEMPTS));
+    }
+
+    [TestCase(false, false)]
+    [TestCase(true, false)]
+    [TestCase(true, true)]
+    public void ProtectedSelectedOrganellesAreSkippedWithoutReplacement(bool multicellular, bool binding)
+    {
+        var protectedOrganelle = SimulationParameters.Instance.GetOrganelleType(binding ? "bindingAgent" : "nucleus");
+        foreach (int removableCount in new[] { 9, 10 })
+        {
+            var definitions = GetCandidates().Take(removableCount).ToArray();
+            var original = CreateSpecies(multicellular, definitions);
+            var layout = original is MicrobeSpecies microbe ?
+                microbe.Organelles :
+                ((MulticellularSpecies)original).ModifiableCellTypes[0].ModifiableOrganelles;
+            layout.Add(new OrganelleTemplate(protectedOrganelle, new Hex(-10, 0), 0));
+            var candidates = definitions.Append(protectedOrganelle).ToHashSet();
+            var strategy = new RemoveOrganelle(candidates.Contains);
+            bool sawProtectedSelected = false;
+            bool sawProtectedNotSelected = false;
+
+            for (int seed = 0; seed < 128; ++seed)
+            {
+                var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), Biome);
+                AssertThat(mutants).IsNotNull();
+                AssertThat(mutants!.Count is 9 or 10).IsTrue();
+                if (removableCount == 9)
+                    AssertThat(mutants.Count).IsEqual(9);
+
+                sawProtectedSelected |= mutants.Count == 9;
+                sawProtectedNotSelected |= mutants.Count == 10;
+                foreach (var mutant in mutants)
+                    AssertThat(GetDefinitions(mutant.Species).Contains(protectedOrganelle)).IsTrue();
+
+                if (sawProtectedSelected && (removableCount == 9 || sawProtectedNotSelected))
+                    break;
+            }
+
+            AssertThat(sawProtectedSelected).IsTrue();
+            if (removableCount == 10)
+                AssertThat(sawProtectedNotSelected).IsTrue();
+        }
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void EveryFilteredCandidateCanBeSelectedAboveLimit(bool multicellular)
+    {
+        var definitions = GetCandidates();
+        var candidates = definitions.ToHashSet();
+        var strategy = new RemoveOrganelle(candidates.Contains);
+        var original = CreateSpecies(multicellular, definitions);
+        var selected = new HashSet<OrganelleDefinition>();
+        for (int seed = 0; seed < 128 && selected.Count < definitions.Length; ++seed)
+        {
+            var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), Biome);
+            AssertThat(mutants).IsNotNull();
+            foreach (var mutant in mutants!)
+                selected.Add(definitions.Except(GetDefinitions(mutant.Species)).Single());
+        }
+
+        AssertThat(selected.Count).IsEqual(definitions.Length);
+    }
+
+    private static OrganelleDefinition[] GetCandidates()
+    {
+        return SimulationParameters.Instance.GetAllOrganelles()
+            .Where(o => o.AutoEvoCanPlace && o.Hexes.Count == 1 && o != Cytoplasm && !o.HasBindingFeature)
+            .Take(12).ToArray();
+    }
+
+    private static Species CreateSpecies(bool multicellular, OrganelleDefinition[] definitions)
+    {
+        if (multicellular)
+        {
+            var species = new MulticellularSpecies(1, "Test", "RandomRemoval");
+            AddCellType(species, definitions);
+            return species;
+        }
+
+        var microbe = new MicrobeSpecies(1, "Test", "RandomRemoval")
+        {
+            IsBacteria = false,
+            MembraneType = SimulationParameters.Instance.GetMembrane("single"),
+        };
+        FillOrganelles(microbe.Organelles, definitions);
+        return microbe;
+    }
+
+    private static void AddCellType(MulticellularSpecies species, OrganelleDefinition[] definitions)
+    {
+        var cellType = new CellType(SimulationParameters.Instance.GetMembrane("single"))
+        {
+            CellTypeName = $"Type{species.CellTypes.Count}",
+        };
+        FillOrganelles(cellType.ModifiableOrganelles, definitions);
+        species.ModifiableCellTypes.Add(cellType);
+    }
+
+    private static void FillOrganelles(OrganelleLayout<OrganelleTemplate> layout, OrganelleDefinition[] definitions)
+    {
+        // A cytoplasm backbone keeps the layout connected after any candidate is removed.
+        for (int i = 0; i < Math.Max(2, definitions.Length); ++i)
+        {
+            layout.Add(new OrganelleTemplate(Cytoplasm, new Hex(i, 0), 0));
+            if (i < definitions.Length)
+                layout.Add(new OrganelleTemplate(definitions[i], new Hex(i, 1), 0));
+        }
+    }
+
+    private static IEnumerable<OrganelleDefinition> GetDefinitions(Species species, int cellType = 0)
+    {
+        return species is MicrobeSpecies microbe ?
+            microbe.Organelles.Select(o => o.Definition) :
+            ((MulticellularSpecies)species).CellTypes[cellType].Organelles.Select(o => o.Definition);
+    }
+}

--- a/test/auto_evo.tests/RandomOrganelleRemovalTests.cs
+++ b/test/auto_evo.tests/RandomOrganelleRemovalTests.cs
@@ -173,7 +173,8 @@ public class RandomOrganelleRemovalTests
     private static OrganelleDefinition[] GetCandidates()
     {
         return SimulationParameters.Instance.GetAllOrganelles()
-            .Where(o => o.AutoEvoCanPlace && o.Hexes.Count == 1 && o != Cytoplasm && !o.HasBindingFeature)
+            .Where(o => o.AutoEvoCanPlace && o.Hexes.Count == 1 && !ReferenceEquals(o, Cytoplasm) &&
+                !o.HasBindingFeature)
             .Take(12).ToArray();
     }
 

--- a/test/auto_evo.tests/RandomOrganelleRemovalTests.cs.uid
+++ b/test/auto_evo.tests/RandomOrganelleRemovalTests.cs.uid
@@ -1,0 +1,1 @@
+uid://dpx4rn7j5sa2

--- a/test/auto_evo.tests/RandomOrganelleSelectionTests.cs
+++ b/test/auto_evo.tests/RandomOrganelleSelectionTests.cs
@@ -90,7 +90,8 @@ public class RandomOrganelleSelectionTests
                     new SelectionRandom([first, second]), Biome);
                 AssertThat(mutants).IsNotNull();
                 AssertThat(mutants!.Count).IsEqual(3);
-                var names = mutants.Select(m => ((MicrobeSpecies)m.Species).Organelles[1].Definition.InternalName);
+                var names = mutants.Select(m => ((MicrobeSpecies)m.Species).Organelles[1].Definition.InternalName)
+                    .ToArray();
                 AssertThat(names.Distinct().Count()).IsEqual(3);
                 AssertThat(orders.Add(string.Join(",", names))).IsTrue();
             }
@@ -136,7 +137,7 @@ public class RandomOrganelleSelectionTests
         // Use a separate dense list to describe an order selecting every expensive candidate, but not cytoplasm.
         var remaining = SimulationParameters.Instance.GetAllOrganelles().Where(candidates.Contains).ToList();
         var ranks = new List<int>();
-        foreach (var candidate in remaining.Where(o => o != Cytoplasm).ToArray())
+        foreach (var candidate in remaining.Where(o => !ReferenceEquals(o, Cytoplasm)).ToArray())
         {
             int index = remaining.IndexOf(candidate);
             ranks.Add(index);
@@ -168,7 +169,7 @@ public class RandomOrganelleSelectionTests
                 AssertThat(mutants).IsNotNull();
                 AssertThat(mutants!.Count).IsEqual(3);
                 var names = mutants.Select(m => ((MulticellularSpecies)m.Species)
-                    .CellTypes[1].Organelles.Last().Definition.InternalName);
+                    .CellTypes[1].Organelles.Last().Definition.InternalName).ToArray();
                 AssertThat(names.Distinct().Count()).IsEqual(3);
                 AssertThat(orders.Add(string.Join(",", names))).IsTrue();
             }
@@ -181,7 +182,7 @@ public class RandomOrganelleSelectionTests
     public void AddCellCandidatesRespectAttemptLimitWithoutDuplicates()
     {
         // Each candidate creates one new cell type, making selected candidates observable in the variants.
-        var definitions = GetAddableDefinitions().Where(o => o != Cytoplasm).ToArray();
+        var definitions = GetAddableDefinitions().Where(o => !ReferenceEquals(o, Cytoplasm)).ToArray();
         foreach (int count in new[] { 0, 1, 2, 14, 15, 16, definitions.Length })
         {
             var candidates = definitions.Take(count).ToHashSet();

--- a/test/auto_evo.tests/RandomOrganelleSelectionTests.cs
+++ b/test/auto_evo.tests/RandomOrganelleSelectionTests.cs
@@ -13,15 +13,15 @@ using static GdUnit4.Assertions;
 [RequireGodotRuntime]
 public class RandomOrganelleSelectionTests
 {
-    private static OrganelleDefinition Cytoplasm => SimulationParameters.Instance.GetOrganelleType("cytoplasm");
+    private readonly OrganelleDefinition cytoplasm = SimulationParameters.Instance.GetOrganelleType("cytoplasm");
 
-    private static BiomeConditions Biome => SimulationParameters.Instance.GetBiome("aavolcanic_vent").Conditions;
+    private readonly BiomeConditions biome = SimulationParameters.Instance.GetBiome("aavolcanic_vent").Conditions;
 
     [TestCase]
     public void EmptyAddCandidatesDoNotConsumeRandom()
     {
         var random = new RecordingRandom();
-        var mutants = new AddOrganelleAnywhere(_ => false).MutationsOf(CreateMicrobe(), 1000, false, random, Biome);
+        var mutants = new AddOrganelleAnywhere(_ => false).MutationsOf(CreateMicrobe(), 1000, false, random, biome);
 
         AssertThat(mutants).IsNotNull();
         AssertThat(mutants!.Count).IsEqual(0);
@@ -35,9 +35,9 @@ public class RandomOrganelleSelectionTests
         var random = new RecordingRandom();
 
         AssertThat(strategy.MutationsOf(CreateMicrobe(), 0, false,
-            random, Biome)).IsNull();
+            random, biome)).IsNull();
         AssertThat(strategy.MutationsOf(new MulticellularSpecies(2, "Test", "Multicellular"),
-            1000, false, random, Biome)).IsNull();
+            1000, false, random, biome)).IsNull();
         AssertThat(random.Calls.Count).IsEqual(0);
     }
 
@@ -47,7 +47,7 @@ public class RandomOrganelleSelectionTests
         var random = new RecordingRandom();
         var mutants = new AddOrganelleAnywhere(o => o.InternalName == "nucleus")
             .MutationsOf(CreateMicrobe(), Constants.ORGANELLE_CHEAPEST_COST,
-                false, random, Biome);
+                false, random, biome);
 
         AssertThat(mutants).IsNotNull();
         AssertThat(mutants!.Count).IsEqual(0);
@@ -61,11 +61,11 @@ public class RandomOrganelleSelectionTests
         var original = CreateMicrobe();
         var random = new RecordingRandom();
         var mutants = new AddOrganelleAnywhere(o => o.InternalName == "cytoplasm")
-            .MutationsOf(original, 1000, false, random, Biome);
+            .MutationsOf(original, 1000, false, random, biome);
 
         AssertThat(mutants).IsNotNull();
         AssertThat(mutants!.Count).IsEqual(1);
-        AssertThat(mutants[0].MP).IsEqual(1000.0 - Cytoplasm.MPCost);
+        AssertThat(mutants[0].MP).IsEqual(1000.0 - cytoplasm.MPCost);
         AssertThat(original.Organelles.Count).IsEqual(1);
         var mutant = (MicrobeSpecies)mutants[0].Species;
         AssertThat(mutant.Organelles.Count).IsEqual(2);
@@ -87,7 +87,7 @@ public class RandomOrganelleSelectionTests
             for (int second = 0; second < 2; ++second)
             {
                 var mutants = strategy.MutationsOf(CreateMicrobe(), 1000, false,
-                    new SelectionRandom([first, second]), Biome);
+                    new SelectionRandom([first, second]), biome);
                 AssertThat(mutants).IsNotNull();
                 AssertThat(mutants!.Count).IsEqual(3);
                 var names = mutants.Select(m => ((MicrobeSpecies)m.Species).Organelles[1].Definition.InternalName)
@@ -114,7 +114,7 @@ public class RandomOrganelleSelectionTests
             foreach (int seed in new[] { 1, 71, 431 })
             {
                 var mutants = strategy.MutationsOf(original, 1000, false,
-                    new XoShiRo256starstar(seed), Biome);
+                    new XoShiRo256starstar(seed), biome);
                 AssertThat(mutants).IsNotNull();
                 AssertThat(mutants!.Count).IsEqual(Math.Min(count, Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS));
                 var added = mutants.Select(m => ((MicrobeSpecies)m.Species).Organelles[1].Definition).ToArray();
@@ -132,12 +132,12 @@ public class RandomOrganelleSelectionTests
             .Where(o => o.MPCost > Constants.ORGANELLE_CHEAPEST_COST)
             .Take(Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS).ToHashSet();
         AssertThat(candidates.Count).IsEqual(Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS);
-        candidates.Add(Cytoplasm);
+        candidates.Add(cytoplasm);
 
         // Use a separate dense list to describe an order selecting every expensive candidate, but not cytoplasm.
         var remaining = SimulationParameters.Instance.GetAllOrganelles().Where(candidates.Contains).ToList();
         var ranks = new List<int>();
-        foreach (var candidate in remaining.Where(o => !ReferenceEquals(o, Cytoplasm)).ToArray())
+        foreach (var candidate in remaining.Where(o => !ReferenceEquals(o, cytoplasm)).ToArray())
         {
             int index = remaining.IndexOf(candidate);
             ranks.Add(index);
@@ -146,7 +146,7 @@ public class RandomOrganelleSelectionTests
 
         var mutants = new AddOrganelleAnywhere(candidates.Contains).MutationsOf(CreateMicrobe(),
             Constants.ORGANELLE_CHEAPEST_COST, false, new SelectionRandom(ranks.ToArray()),
-            Biome);
+            biome);
 
         AssertThat(mutants).IsNotNull();
         AssertThat(mutants!.Count).IsEqual(0);
@@ -165,7 +165,7 @@ public class RandomOrganelleSelectionTests
             for (int second = 0; second < 2; ++second)
             {
                 var mutants = strategy.MutationsOf(CreateMulticellular(), 1000, false,
-                    new SelectionRandom([first, second]), Biome);
+                    new SelectionRandom([first, second]), biome);
                 AssertThat(mutants).IsNotNull();
                 AssertThat(mutants!.Count).IsEqual(3);
                 var names = mutants.Select(m => ((MulticellularSpecies)m.Species)
@@ -182,7 +182,7 @@ public class RandomOrganelleSelectionTests
     public void AddCellCandidatesRespectAttemptLimitWithoutDuplicates()
     {
         // Each candidate creates one new cell type, making selected candidates observable in the variants.
-        var definitions = GetAddableDefinitions().Where(o => !ReferenceEquals(o, Cytoplasm)).ToArray();
+        var definitions = GetAddableDefinitions().Where(o => !ReferenceEquals(o, cytoplasm)).ToArray();
         foreach (int count in new[] { 0, 1, 2, 14, 15, 16, definitions.Length })
         {
             var candidates = definitions.Take(count).ToHashSet();
@@ -191,7 +191,7 @@ public class RandomOrganelleSelectionTests
 
             foreach (int seed in new[] { 1, 71, 431 })
             {
-                var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), Biome);
+                var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), biome);
                 AssertThat(mutants).IsNotNull();
                 AssertThat(mutants!.Count).IsEqual(Math.Min(count, Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS));
                 var added = mutants.Select(m => ((MulticellularSpecies)m.Species)
@@ -214,7 +214,7 @@ public class RandomOrganelleSelectionTests
             !o.IsIncompatibleWithMembrane(membrane)).ToArray();
     }
 
-    private static MicrobeSpecies CreateMicrobe()
+    private MicrobeSpecies CreateMicrobe()
     {
         var species = new MicrobeSpecies(1, "Test", "RandomSelection")
         {
@@ -222,20 +222,20 @@ public class RandomOrganelleSelectionTests
             MembraneType = SimulationParameters.Instance.GetMembrane("single"),
         };
 
-        species.Organelles.Add(new OrganelleTemplate(Cytoplasm, new Hex(0, 0), 0));
+        species.Organelles.Add(new OrganelleTemplate(cytoplasm, new Hex(0, 0), 0));
         species.OnEdited();
 
         return species;
     }
 
-    private static MulticellularSpecies CreateMulticellular()
+    private MulticellularSpecies CreateMulticellular()
     {
         var species = new MulticellularSpecies(1, "Test", "RandomCellSelection");
         var cellType = new CellType(SimulationParameters.Instance.GetMembrane("single"))
         {
             CellTypeName = "Original",
         };
-        cellType.ModifiableOrganelles.Add(new OrganelleTemplate(Cytoplasm, new Hex(0, 0), 0));
+        cellType.ModifiableOrganelles.Add(new OrganelleTemplate(cytoplasm, new Hex(0, 0), 0));
         species.ModifiableCellTypes.Add(cellType);
         species.ModifiableGameplayCells.AddFast(new CellTemplate(cellType, new Hex(0, 0), 0), [], []);
         return species;

--- a/test/auto_evo.tests/RandomOrganelleSelectionTests.cs
+++ b/test/auto_evo.tests/RandomOrganelleSelectionTests.cs
@@ -1,0 +1,288 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using AutoEvo;
+using GdUnit4;
+using Xoshiro.PRNG64;
+using static GdUnit4.Assertions;
+
+/// <summary>
+///   Checks random candidate sampling when adding organelles and cells.
+/// </summary>
+[TestSuite]
+[RequireGodotRuntime]
+public class RandomOrganelleSelectionTests
+{
+    private static OrganelleDefinition Cytoplasm => SimulationParameters.Instance.GetOrganelleType("cytoplasm");
+
+    private static BiomeConditions Biome => SimulationParameters.Instance.GetBiome("aavolcanic_vent").Conditions;
+
+    [TestCase]
+    public void EmptyAddCandidatesDoNotConsumeRandom()
+    {
+        var random = new RecordingRandom();
+        var mutants = new AddOrganelleAnywhere(_ => false).MutationsOf(CreateMicrobe(), 1000, false, random, Biome);
+
+        AssertThat(mutants).IsNotNull();
+        AssertThat(mutants!.Count).IsEqual(0);
+        AssertThat(random.Calls.Count).IsEqual(0);
+    }
+
+    [TestCase]
+    public void AddEntryGuardsDoNotConsumeRandom()
+    {
+        var strategy = new AddOrganelleAnywhere(o => o.InternalName == "cytoplasm");
+        var random = new RecordingRandom();
+
+        AssertThat(strategy.MutationsOf(CreateMicrobe(), 0, false,
+            random, Biome)).IsNull();
+        AssertThat(strategy.MutationsOf(new MulticellularSpecies(2, "Test", "Multicellular"),
+            1000, false, random, Biome)).IsNull();
+        AssertThat(random.Calls.Count).IsEqual(0);
+    }
+
+    [TestCase]
+    public void RejectedSingleAddCandidateDoesNotNeedRandomSelection()
+    {
+        var random = new RecordingRandom();
+        var mutants = new AddOrganelleAnywhere(o => o.InternalName == "nucleus")
+            .MutationsOf(CreateMicrobe(), Constants.ORGANELLE_CHEAPEST_COST,
+                false, random, Biome);
+
+        AssertThat(mutants).IsNotNull();
+        AssertThat(mutants!.Count).IsEqual(0);
+        AssertThat(random.KeyCount).IsEqual(0);
+        AssertThat(random.SideCount).IsEqual(0);
+    }
+
+    [TestCase]
+    public void SingleAddCandidateOnlyConsumesPlacementRandom()
+    {
+        var original = CreateMicrobe();
+        var random = new RecordingRandom();
+        var mutants = new AddOrganelleAnywhere(o => o.InternalName == "cytoplasm")
+            .MutationsOf(original, 1000, false, random, Biome);
+
+        AssertThat(mutants).IsNotNull();
+        AssertThat(mutants!.Count).IsEqual(1);
+        AssertThat(mutants[0].MP).IsEqual(1000.0 - Cytoplasm.MPCost);
+        AssertThat(original.Organelles.Count).IsEqual(1);
+        var mutant = (MicrobeSpecies)mutants[0].Species;
+        AssertThat(mutant.Organelles.Count).IsEqual(2);
+        AssertThat(mutant.Organelles[1].Position).IsEqual(new Hex(0, 1));
+        AssertThat(mutant.Organelles[1].Orientation).IsEqual(0);
+        AssertThat(random.KeyCount).IsEqual(1);
+        AssertThat(random.SideCount).IsEqual(1);
+    }
+
+    [TestCase]
+    public void AddCandidatesCoverEveryOrderForThreeCandidates()
+    {
+        var strategy = new AddOrganelleAnywhere(o =>
+            o.InternalName is "cytoplasm" or "flagellum" or "rusticyanin");
+        var orders = new HashSet<string>();
+
+        for (int first = 0; first < 3; ++first)
+        {
+            for (int second = 0; second < 2; ++second)
+            {
+                var mutants = strategy.MutationsOf(CreateMicrobe(), 1000, false,
+                    new SelectionRandom([first, second]), Biome);
+                AssertThat(mutants).IsNotNull();
+                AssertThat(mutants!.Count).IsEqual(3);
+                var names = mutants.Select(m => ((MicrobeSpecies)m.Species).Organelles[1].Definition.InternalName);
+                AssertThat(names.Distinct().Count()).IsEqual(3);
+                AssertThat(orders.Add(string.Join(",", names))).IsTrue();
+            }
+        }
+
+        AssertThat(orders.Count).IsEqual(6);
+    }
+
+    [TestCase]
+    public void AddCandidatesRespectAttemptLimitWithoutDuplicates()
+    {
+        var definitions = GetAddableDefinitions();
+        foreach (int count in new[] { 0, 1, 2, 14, 15, 16, definitions.Length })
+        {
+            var candidates = definitions.Take(count).ToHashSet();
+            var strategy = new AddOrganelleAnywhere(candidates.Contains);
+            var original = CreateMicrobe();
+            original.IsBacteria = false;
+
+            foreach (int seed in new[] { 1, 71, 431 })
+            {
+                var mutants = strategy.MutationsOf(original, 1000, false,
+                    new XoShiRo256starstar(seed), Biome);
+                AssertThat(mutants).IsNotNull();
+                AssertThat(mutants!.Count).IsEqual(Math.Min(count, Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS));
+                var added = mutants.Select(m => ((MicrobeSpecies)m.Species).Organelles[1].Definition).ToArray();
+                AssertThat(added.Distinct().Count()).IsEqual(added.Length);
+                AssertThat(added.All(candidates.Contains)).IsTrue();
+                AssertThat(original.Organelles.Count).IsEqual(1);
+            }
+        }
+    }
+
+    [TestCase]
+    public void RejectedCandidatesAreNotReplacedWithUnselectedCandidates()
+    {
+        var candidates = GetAddableDefinitions()
+            .Where(o => o.MPCost > Constants.ORGANELLE_CHEAPEST_COST)
+            .Take(Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS).ToHashSet();
+        AssertThat(candidates.Count).IsEqual(Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS);
+        candidates.Add(Cytoplasm);
+
+        // Use a separate dense list to describe an order selecting every expensive candidate, but not cytoplasm.
+        var remaining = SimulationParameters.Instance.GetAllOrganelles().Where(candidates.Contains).ToList();
+        var ranks = new List<int>();
+        foreach (var candidate in remaining.Where(o => o != Cytoplasm).ToArray())
+        {
+            int index = remaining.IndexOf(candidate);
+            ranks.Add(index);
+            remaining.RemoveAt(index);
+        }
+
+        var mutants = new AddOrganelleAnywhere(candidates.Contains).MutationsOf(CreateMicrobe(),
+            Constants.ORGANELLE_CHEAPEST_COST, false, new SelectionRandom(ranks.ToArray()),
+            Biome);
+
+        AssertThat(mutants).IsNotNull();
+        AssertThat(mutants!.Count).IsEqual(0);
+    }
+
+    [TestCase]
+    public void AddCellCandidatesCoverEveryOrderForThreeCandidates()
+    {
+        var strategy = new AddCellWithOrganelle(o =>
+                o.InternalName is "metabolosome" or "flagellum" or "rusticyanin",
+            CommonMutationFunctions.Direction.Front);
+        var orders = new HashSet<string>();
+
+        for (int first = 0; first < 3; ++first)
+        {
+            for (int second = 0; second < 2; ++second)
+            {
+                var mutants = strategy.MutationsOf(CreateMulticellular(), 1000, false,
+                    new SelectionRandom([first, second]), Biome);
+                AssertThat(mutants).IsNotNull();
+                AssertThat(mutants!.Count).IsEqual(3);
+                var names = mutants.Select(m => ((MulticellularSpecies)m.Species)
+                    .CellTypes[1].Organelles.Last().Definition.InternalName);
+                AssertThat(names.Distinct().Count()).IsEqual(3);
+                AssertThat(orders.Add(string.Join(",", names))).IsTrue();
+            }
+        }
+
+        AssertThat(orders.Count).IsEqual(6);
+    }
+
+    [TestCase]
+    public void AddCellCandidatesRespectAttemptLimitWithoutDuplicates()
+    {
+        // Each candidate creates one new cell type, making selected candidates observable in the variants.
+        var definitions = GetAddableDefinitions().Where(o => o != Cytoplasm).ToArray();
+        foreach (int count in new[] { 0, 1, 2, 14, 15, 16, definitions.Length })
+        {
+            var candidates = definitions.Take(count).ToHashSet();
+            var strategy = new AddCellWithOrganelle(candidates.Contains, CommonMutationFunctions.Direction.Front);
+            var original = CreateMulticellular();
+
+            foreach (int seed in new[] { 1, 71, 431 })
+            {
+                var mutants = strategy.MutationsOf(original, 1000, false, new XoShiRo256starstar(seed), Biome);
+                AssertThat(mutants).IsNotNull();
+                AssertThat(mutants!.Count).IsEqual(Math.Min(count, Constants.AUTO_EVO_ORGANELLE_ADD_ATTEMPTS));
+                var added = mutants.Select(m => ((MulticellularSpecies)m.Species)
+                    .CellTypes[1].Organelles.Last().Definition).ToArray();
+                AssertThat(added.Distinct().Count()).IsEqual(added.Length);
+                AssertThat(added.All(candidates.Contains)).IsTrue();
+                AssertThat(original.CellTypes.Count).IsEqual(1);
+                AssertThat(original.CellTypes[0].Organelles.Count).IsEqual(1);
+                AssertThat(original.EditorCells.Count).IsEqual(1);
+            }
+        }
+    }
+
+    private static OrganelleDefinition[] GetAddableDefinitions()
+    {
+        var membrane = SimulationParameters.Instance.GetMembrane("single");
+        return SimulationParameters.Instance.GetAllOrganelles().Where(o => o.AutoEvoCanPlace &&
+            o.EditorButtonGroup != OrganelleDefinition.OrganelleGroup.Multicellular &&
+            o.EditorButtonGroup != OrganelleDefinition.OrganelleGroup.Macroscopic &&
+            !o.IsIncompatibleWithMembrane(membrane)).ToArray();
+    }
+
+    private static MicrobeSpecies CreateMicrobe()
+    {
+        var species = new MicrobeSpecies(1, "Test", "RandomSelection")
+        {
+            IsBacteria = true,
+            MembraneType = SimulationParameters.Instance.GetMembrane("single"),
+        };
+
+        species.Organelles.Add(new OrganelleTemplate(Cytoplasm, new Hex(0, 0), 0));
+        species.OnEdited();
+
+        return species;
+    }
+
+    private static MulticellularSpecies CreateMulticellular()
+    {
+        var species = new MulticellularSpecies(1, "Test", "RandomCellSelection");
+        var cellType = new CellType(SimulationParameters.Instance.GetMembrane("single"))
+        {
+            CellTypeName = "Original",
+        };
+        cellType.ModifiableOrganelles.Add(new OrganelleTemplate(Cytoplasm, new Hex(0, 0), 0));
+        species.ModifiableCellTypes.Add(cellType);
+        species.ModifiableGameplayCells.AddFast(new CellTemplate(cellType, new Hex(0, 0), 0), [], []);
+        return species;
+    }
+
+    private sealed class SelectionRandom(int[]? ranks = null) : Random
+    {
+        private int nextRank;
+
+        public override int Next()
+        {
+            return 0;
+        }
+
+        public override int Next(int maxValue)
+        {
+            int result = ranks != null && nextRank < ranks.Length ? ranks[nextRank++] : 0;
+            if (result < 0 || result >= maxValue)
+                throw new InvalidOperationException("Unexpected selection bound");
+
+            return result;
+        }
+    }
+
+    private sealed class RecordingRandom : Random
+    {
+        private readonly Random source = new XoShiRo256starstar(431);
+
+        public List<string> Calls { get; } = new();
+
+        public int KeyCount { get; private set; }
+
+        public int SideCount { get; private set; }
+
+        public override int Next()
+        {
+            int result = source.Next();
+            ++KeyCount;
+            Calls.Add($"Next:{result}");
+            return result;
+        }
+
+        public override int Next(int maxValue)
+        {
+            int result = source.Next(maxValue);
+            ++SideCount;
+            Calls.Add($"Next({maxValue}):{result}");
+            return result;
+        }
+    }
+}

--- a/test/auto_evo.tests/RandomOrganelleSelectionTests.cs.uid
+++ b/test/auto_evo.tests/RandomOrganelleSelectionTests.cs.uid
@@ -1,0 +1,1 @@
+uid://rg3612sp7hvd


### PR DESCRIPTION
**Brief Description of What This PR Does**

In current codebase, there are some places where we need to take k items from a given list with random sequence. Currently we are doing this by copy and shuffle the whole list in LINQ, which is not very efficient. 

This PR implement an algorithm, which would generate a `Span` containing k indices, then iterate the indices to access k items from the list. 

The algorithm takes O(k^2) time and uses O(k) additional stack space.

Since k is usually small (<15) in those cases, even the time complexity is not that optimal, the execution time is still much better than the current one. However ,in other situation where k is big or we don't have a fixed k, we might need other Algorithms.

**Related Issues**

No related issue.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved randomness and consistency when adding or removing organelles during automatic evolution.
  * Ensured protected or unsuitable organelles are skipped correctly without duplicate selections.
  * Preserved independent selection limits across multicellular cell types.
  * Maintained correct behavior when candidates are rejected or when fewer candidates are available.

* **Tests**
  * Added comprehensive coverage for organelle selection order, attempt limits, filtering, protected organelles, rejected candidates, and preservation of existing species data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->