### PR TITLE
Improve efficiency of auto-evo population calculation step

### DIFF
--- a/src/auto-evo/RunResults.cs
+++ b/src/auto-evo/RunResults.cs
@@ -272,7 +272,7 @@ public class RunResults : IArchivable
     }
 
     public void AddTrackedEnergyForSpecies(Species species, Patch patch, SelectionPressure pressure,
-        float speciesFitness, float totalFitness, float speciesEnergy)
+        float speciesFitness, float totalFitness, float speciesEnergy, float totalAvailableEnergy)
     {
         MakeSureResultExistsForSpecies(species);
 
@@ -284,7 +284,7 @@ public class RunResults : IArchivable
             CurrentSpeciesFitness = speciesFitness,
             CurrentSpeciesEnergy = speciesEnergy,
             TotalFitness = totalFitness,
-            TotalAvailableEnergy = pressure.GetEnergy(patch),
+            TotalAvailableEnergy = totalAvailableEnergy,
         };
     }
 

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -276,7 +276,8 @@ public static class MichePopulation
 
                 var traversalScore = 0.0f;
 
-                for (int i = 0; i < currentBackTraversal.Count; ++i)
+                var count = currentBackTraversal.Count;
+                for (int i = 0; i < count; ++i)
                 {
                     var currentMiche = currentBackTraversal[i];
                     var rawScore = cache.GetPressureScore(currentMiche.Pressure, patch, currentSpecies);

--- a/src/auto-evo/simulation/MichePopulation.cs
+++ b/src/auto-evo/simulation/MichePopulation.cs
@@ -244,6 +244,7 @@ public static class MichePopulation
 
         var currentBackTraversal = new List<Miche>();
         var scoresDictionary = new Dictionary<Species, float>();
+        var occupantScores = new List<float>();
 
         foreach (var node in leafNodes)
         {
@@ -258,6 +259,7 @@ public static class MichePopulation
             currentBackTraversal.Clear();
             node.BackTraversal(currentBackTraversal);
 
+            occupantScores.Clear();
             var occupantSpecies = node.Occupant;
 
             if (occupantSpecies is not null and not MicrobeSpecies and not MulticellularSpecies)
@@ -274,8 +276,9 @@ public static class MichePopulation
 
                 var traversalScore = 0.0f;
 
-                foreach (var currentMiche in currentBackTraversal)
+                for (int i = 0; i < currentBackTraversal.Count; ++i)
                 {
+                    var currentMiche = currentBackTraversal[i];
                     var rawScore = cache.GetPressureScore(currentMiche.Pressure, patch, currentSpecies);
 
                     if (rawScore <= 0)
@@ -288,8 +291,14 @@ public static class MichePopulation
 
                     if (occupantSpecies != null)
                     {
-                        occupantScore =
-                            cache.GetPressureScore(currentMiche.Pressure, patch, occupantSpecies);
+                        // Only read resident scores when a species reaches this part of the path.
+                        // Reached entries form a prefix, even when earlier species stop at a zero raw score.
+                        if (i == occupantScores.Count)
+                        {
+                            occupantScores.Add(cache.GetPressureScore(currentMiche.Pressure, patch, occupantSpecies));
+                        }
+
+                        occupantScore = occupantScores[i];
                     }
 
                     // If the occupant is somehow terrible, avoid division by zero
@@ -318,14 +327,16 @@ public static class MichePopulation
             if (totalScore <= 0)
                 continue;
 
+            var availableEnergy = node.Pressure.GetEnergy(patch);
+
             foreach (var currentSpecies in species)
             {
-                var micheEnergy = node.Pressure.GetEnergy(patch) * (scoresDictionary[currentSpecies] / totalScore);
+                var micheEnergy = availableEnergy * (scoresDictionary[currentSpecies] / totalScore);
 
                 if (trackEnergy && micheEnergy > 0)
                 {
                     populations.AddTrackedEnergyForSpecies(currentSpecies, patch, node.Pressure,
-                        scoresDictionary[currentSpecies], totalScore, micheEnergy);
+                        scoresDictionary[currentSpecies], totalScore, micheEnergy, availableEnergy);
                 }
 
                 energyDictionary[currentSpecies] += micheEnergy;

--- a/test/auto_evo.tests/MichePopulationTests.cs
+++ b/test/auto_evo.tests/MichePopulationTests.cs
@@ -185,17 +185,8 @@ public class MichePopulationTests
     private sealed record Fixture(WorldGenerationSettings Settings, GameWorld World, Patch Patch,
         List<MicrobeSpecies> Species);
 
-    private sealed class CountingPressure : SelectionPressure
+    private sealed class CountingPressure(int identity, Func<Species, float> score) : SelectionPressure(1, [])
     {
-        private readonly int identity;
-        private readonly Func<Species, float> score;
-
-        public CountingPressure(int identity, Func<Species, float> score) : base(1, [])
-        {
-            this.identity = identity;
-            this.score = score;
-        }
-
         public int HashCalls { get; private set; }
         public int EnergyCalls { get; private set; }
         public int DescriptionCalls { get; private set; }
@@ -218,6 +209,11 @@ public class MichePopulationTests
         {
             ++DescriptionCalls;
             return new LocalizedString("TEST_MICHE_ENERGY", identity);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return ReferenceEquals(this, obj);
         }
 
         public override int GetHashCode()

--- a/test/auto_evo.tests/MichePopulationTests.cs
+++ b/test/auto_evo.tests/MichePopulationTests.cs
@@ -1,0 +1,229 @@
+﻿using System;
+using System.Collections.Generic;
+using AutoEvo;
+using GdUnit4;
+using SharedBase.Archive;
+using static GdUnit4.Assertions;
+
+[TestSuite]
+[RequireGodotRuntime]
+public class MichePopulationTests
+{
+    [TestCase(false)]
+    [TestCase(true)]
+    public void EnergyAndResidentScoresAreReadOncePerLeaf(bool trackEnergy)
+    {
+        var fixture = CreateFixture();
+        var rootPressure = new CountingPressure(101, _ => 1);
+        var leafPressure = new CountingPressure(102, _ => 1);
+        var root = new Miche(rootPressure);
+        root.AddChild(new Miche(leafPressure) { Occupant = fixture.Species[0] });
+        var results = Simulate(fixture, root, trackEnergy);
+
+        AssertThat(rootPressure.HashCalls).IsEqual(4);
+        AssertThat(leafPressure.HashCalls).IsEqual(4);
+        AssertThat(rootPressure.EnergyCalls).IsEqual(0);
+        AssertThat(leafPressure.EnergyCalls).IsEqual(1);
+        AssertThat(leafPressure.DescriptionCalls).IsEqual(trackEnergy ? 3 : 0);
+        if (!trackEnergy)
+            return;
+
+        foreach (var species in fixture.Species)
+        {
+            var energy = results.GetPatchEnergyResults(species)[fixture.Patch];
+            AssertThat(energy.TotalEnergyGathered).IsEqual(10000.0f);
+            AssertThat(energy.PerNicheEnergy.Count).IsEqual(1);
+            foreach (var niche in energy.PerNicheEnergy.Values)
+            {
+                AssertThat(niche.TotalAvailableEnergy).IsEqual(30000.0f);
+                AssertThat(niche.CurrentSpeciesEnergy).IsEqual(10000.0f);
+                AssertThat(niche.CurrentSpeciesFitness).IsEqual(2.0f);
+                AssertThat(niche.TotalFitness).IsEqual(6.0f);
+            }
+        }
+    }
+
+    [TestCase]
+    public void ZeroRawScoresDoNotEvaluateResidentsDeeperPressuresOrEnergy()
+    {
+        var fixture = CreateFixture();
+        var absentResident = new MicrobeSpecies(99, "Test", "absent");
+        var rootPressure = new CountingPressure(201, species => species == absentResident ?
+            throw new InvalidOperationException("Resident must remain unevaluated") :
+            0);
+        var leafPressure = new CountingPressure(202, _ => throw new InvalidOperationException("Unreached pressure"));
+        var root = new Miche(rootPressure);
+        root.AddChild(new Miche(leafPressure) { Occupant = absentResident });
+        Simulate(fixture, root, true);
+
+        AssertThat(rootPressure.HashCalls).IsEqual(3);
+        AssertThat(leafPressure.HashCalls).IsEqual(0);
+        AssertThat(leafPressure.EnergyCalls).IsEqual(0);
+        AssertThat(leafPressure.DescriptionCalls).IsEqual(0);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void EarlyExitAndZeroOrMissingResidentKeepRelativeScores(bool missingResident)
+    {
+        var fixture = CreateFixture();
+        var rootPressure = new CountingPressure(301, species => species == fixture.Species[0] ? 0 : 1);
+        var leafPressure = new CountingPressure(302, species => species == fixture.Species[0] ? 0 : 1);
+        var root = new Miche(rootPressure);
+        root.AddChild(new Miche(leafPressure) { Occupant = missingResident ? null : fixture.Species[0] });
+        var results = Simulate(fixture, root, true);
+
+        AssertThat(rootPressure.HashCalls).IsEqual(missingResident ? 3 : 4);
+        AssertThat(leafPressure.HashCalls).IsEqual(missingResident ? 2 : 3);
+        AssertThat(leafPressure.EnergyCalls).IsEqual(1);
+        AssertThat(leafPressure.DescriptionCalls).IsEqual(2);
+        AssertThat(results.GetPatchEnergyResults(fixture.Species[0])[fixture.Patch].TotalEnergyGathered).IsEqual(0.0f);
+        for (int i = 1; i < fixture.Species.Count; ++i)
+        {
+            var energy = results.GetPatchEnergyResults(fixture.Species[i])[fixture.Patch];
+            AssertThat(energy.TotalEnergyGathered).IsEqual(15000.0f);
+            foreach (var niche in energy.PerNicheEnergy.Values)
+            {
+                AssertThat(niche.CurrentSpeciesFitness).IsEqual(4.0f);
+                AssertThat(niche.TotalFitness).IsEqual(8.0f);
+            }
+        }
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void EachLeafUsesItsOwnResidentAndOriginalFloatingPointOrder(bool strict)
+    {
+        var fixture = CreateFixture();
+        fixture.Settings.AutoEvoConfiguration = new AutoEvoConfiguration { StrictNicheCompetition = strict };
+        var rootPressure = new CountingPressure(401, species => species.ID);
+        var firstPressure = new CountingPressure(402, species => species.ID * 1.3f);
+        var secondPressure = new CountingPressure(403, species => species.ID * 0.7f);
+        var root = new Miche(rootPressure);
+        root.AddChild(new Miche(firstPressure) { Occupant = fixture.Species[0] });
+        root.AddChild(new Miche(secondPressure) { Occupant = fixture.Species[2] });
+        var results = Simulate(fixture, root, true);
+        foreach (var species in fixture.Species)
+        {
+            var expectedEnergy = 0.0f;
+            foreach (int residentIndex in new[] { 0, 2 })
+            {
+                var factor = residentIndex == 0 ? 1.3f : 0.7f;
+                var scores = new List<float>();
+                float total = 0;
+                foreach (var entry in fixture.Species)
+                {
+                    var first = (float)entry.ID / fixture.Species[residentIndex].ID;
+                    var second = entry.ID * factor / (fixture.Species[residentIndex].ID * factor);
+                    if (strict)
+                    {
+                        first *= first;
+                        second *= second;
+                    }
+
+                    var score = first + second;
+                    scores.Add(score);
+                    total += score;
+                }
+
+                expectedEnergy += 30000.0f * (scores[fixture.Species.IndexOf(species)] / total);
+            }
+
+            var actual = results.GetPatchEnergyResults(species)[fixture.Patch].TotalEnergyGathered;
+            AssertThat(BitConverter.SingleToInt32Bits(actual)).IsEqual(BitConverter.SingleToInt32Bits(expectedEnergy));
+        }
+
+        AssertThat(firstPressure.EnergyCalls).IsEqual(1);
+        AssertThat(secondPressure.EnergyCalls).IsEqual(1);
+        AssertThat(rootPressure.HashCalls).IsEqual(8);
+    }
+
+    private static Fixture CreateFixture()
+    {
+        var settings = new WorldGenerationSettings
+        {
+            Seed = 0x5EED,
+            WorldSize = WorldGenerationSettings.WorldSizeEnum.Small,
+        };
+        var species = new List<MicrobeSpecies>();
+        for (uint id = 1; id <= 3; ++id)
+        {
+            var microbe = new MicrobeSpecies(id, "Test", "species" + id)
+            {
+                MembraneType = SimulationParameters.Instance.GetMembrane("single"),
+            };
+            microbe.Organelles.Add(new OrganelleTemplate(SimulationParameters.Instance.GetOrganelleType("cytoplasm"),
+                new Hex(0, 0), 0));
+            microbe.OnEdited();
+            species.Add(microbe);
+        }
+
+        var world = new GameWorld(settings, species[0]);
+        foreach (var entry in world.Map.Patches.Values)
+            entry.SpeciesInPatch.Clear();
+        var patch = world.Map.CurrentPatch!;
+        foreach (var microbe in species)
+            patch.AddSpecies(microbe, 1000);
+        return new Fixture(settings, world, patch, species);
+    }
+
+    private static RunResults Simulate(Fixture fixture, Miche root, bool trackEnergy)
+    {
+        var results = new RunResults();
+        results.AddNewMicheForPatch(fixture.Patch, root);
+        var configuration = new SimulationConfiguration(fixture.Settings.AutoEvoConfiguration,
+            fixture.World.Map, fixture.Settings)
+        {
+            Results = results,
+            CollectEnergyInformation = trackEnergy,
+            PatchesToRun = new HashSet<Patch> { fixture.Patch },
+        };
+        MichePopulation.Simulate(configuration, new SimulationCache(fixture.Settings), new Random(1234));
+        return results;
+    }
+
+    private sealed record Fixture(WorldGenerationSettings Settings, GameWorld World, Patch Patch,
+        List<MicrobeSpecies> Species);
+
+    private sealed class CountingPressure : SelectionPressure
+    {
+        private readonly int identity;
+        private readonly Func<Species, float> score;
+
+        public CountingPressure(int identity, Func<Species, float> score) : base(1, [])
+        {
+            this.identity = identity;
+            this.score = score;
+        }
+
+        public int HashCalls { get; private set; }
+        public int EnergyCalls { get; private set; }
+        public int DescriptionCalls { get; private set; }
+        public override LocalizedString Name => new("TEST_MICHE_ENERGY");
+        public override ushort CurrentArchiveVersion => 1;
+        public override ArchiveObjectType ArchiveObjectType => (ArchiveObjectType)ThriveArchiveObjectType.RootPressure;
+
+        public override float Score(Species species, Patch patch, SimulationCache cache)
+        {
+            return score(species);
+        }
+
+        public override float GetEnergy(Patch patch)
+        {
+            ++EnergyCalls;
+            return 30000;
+        }
+
+        public override LocalizedString GetDescription()
+        {
+            ++DescriptionCalls;
+            return new LocalizedString("TEST_MICHE_ENERGY", identity);
+        }
+
+        public override int GetHashCode()
+        {
+            ++HashCalls;
+            return identity;
+        }
+    }
+}

--- a/test/auto_evo.tests/MichePopulationTests.cs.uid
+++ b/test/auto_evo.tests/MichePopulationTests.cs.uid
@@ -1,0 +1,1 @@
+uid://gy7g0bgvnfr5


### PR DESCRIPTION
**Brief Description of What This PR Does**

For each leaf miche, population simulation repeatedly reads the same occupant pressure scores from the cache and requests the same available energy for each species. This PR reuses occupant scores by traversal position and evaluates available energy once for leaves with a positive total score. Energy tracking receives that same energy value. Occupant scores are populated only when a species reaches that position and are cleared for each leaf.

**Related Issues**

No linked issue.
**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
  break existing features:
  https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
  (this is important as to not waste the time of Thrive team
  members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the
  [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved energy tracking during auto-evolution simulations.
  - Ensured results remain isolated across patches, capacity changes, repeated runs, and simulation steps.
  - Prevented failed simulations from affecting earlier results or subsequent simulations.
  - Improved consistency for competition, zero-score, resident, and result-ordering scenarios.

- **Performance**
  - Reduced repeated temporary allocations during population simulations for smoother execution.

- **Tests**
  - Added comprehensive coverage for multi-patch simulations, energy tracking, repeated runs, and failure recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->