### PR TITLE
Made the single step cell move attempts bounded

### DIFF
--- a/src/multicellular_stage/MulticellularLayoutHelpers.cs
+++ b/src/multicellular_stage/MulticellularLayoutHelpers.cs
@@ -599,9 +599,13 @@ public static class MulticellularLayoutHelpers
 
                     if (moveOnlyOneStepAtATime)
                     {
-                        // Increase step size until it results in a difference
-                        while (true)
+                        // The direction can be zero when the item is already at its target. In that case rounding
+                        // the position never produces a different hex, so keep this bounded and let the fallback
+                        // below restore the item and try again on the next layout pass.
+                        const int maxMovementAttempts = 100;
+                        for (int movementAttempt = 0; movementAttempt < maxMovementAttempts; ++movementAttempt)
                         {
+                            // Increase step size until it results in a difference.
                             var newPositionRaw = itemPos + shift * effectiveMoveDistance;
                             var newPosition = new Hex((int)Math.Round(newPositionRaw.X),
                                 (int)Math.Round(newPositionRaw.Y));


### PR DESCRIPTION
**Brief Description of What This PR Does**

this should prevent an infinite loop in very rare cases

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented layout movement from retrying indefinitely when cells cannot be moved closer together.
  * Cells that remain stationary are restored and retried during a later layout pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->