### PR TITLE
Optimised RemoveOrganelle to use a faster placement check

### DIFF
--- a/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
+++ b/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
@@ -138,6 +138,8 @@ public class RemoveOrganelle : IMutationStrategy<Species>
 
         var cellTypeCount = baseSpecies.CellTypes.Count;
 
+        MutationWorkMemory? workMemory = null;
+
         for (var i = 0; i < cellTypeCount; ++i)
         {
             var baseCellType = baseSpecies.ModifiableCellTypes[i];
@@ -147,7 +149,10 @@ public class RemoveOrganelle : IMutationStrategy<Species>
             var organelles = baseCellType.Organelles.Where(x => criteria(x.Definition))
                 .OrderBy(_ => random.Next()).Take(Constants.AUTO_EVO_ORGANELLE_REMOVE_ATTEMPTS);
 
-            MutationWorkMemory? workMemory = null;
+            workMemory ??= new MutationWorkMemory();
+
+            var occupied = workMemory.WorkingMemory3;
+            occupied.Clear();
 
             foreach (var organelle in organelles)
             {
@@ -163,8 +168,6 @@ public class RemoveOrganelle : IMutationStrategy<Species>
                 var newSpecies = baseSpecies.Clone(false, false);
                 var newCellType = newSpecies.ModifiableCellTypes[i];
                 var newCellTypeOrganelles = newCellType.ModifiableOrganelles;
-
-                workMemory ??= new MutationWorkMemory();
 
                 // Clone organelles for the cell types not currently targeted
                 for (var j = 0; j < cellTypeCount; ++j)
@@ -185,10 +188,21 @@ public class RemoveOrganelle : IMutationStrategy<Species>
                         if (ReferenceEquals(parentOrganelle, organelle))
                             continue;
 
-                        // Copy the organelle
-                        var copiedOrganelle = parentOrganelle.Clone();
-                        clonedCellType.ModifiableOrganelles.AddIfPossible(copiedOrganelle,
-                            workMemory.WorkingMemory1, workMemory.WorkingMemory2);
+                        var definition = parentOrganelle.Definition;
+                        var position = parentOrganelle.Position;
+                        var orientation = parentOrganelle.Orientation;
+
+                        if (!clonedCellType.ModifiableOrganelles.IsOrganellePositionFree(definition, position.Q,
+                                position.R, orientation, occupied, out _))
+                        {
+                            continue;
+                        }
+
+                        var rotated = definition.GetRotatedHexes(orientation);
+                        for (var r = 0; r < rotated.Count; ++r)
+                            occupied.Add(rotated[r] + position);
+
+                        clonedCellType.ModifiableOrganelles.AddAutoEvoAttemptOrganelle(parentOrganelle.Clone());
                     }
                 }
 
@@ -204,10 +218,21 @@ public class RemoveOrganelle : IMutationStrategy<Species>
                     if (ReferenceEquals(parentOrganelle, organelle))
                         continue;
 
-                    // Copy the organelle
-                    var newOrganelle = parentOrganelle.Clone();
-                    newCellTypeOrganelles.AddIfPossible(newOrganelle, workMemory.WorkingMemory1,
-                        workMemory.WorkingMemory2);
+                    var definition = parentOrganelle.Definition;
+                    var position = parentOrganelle.Position;
+                    var orientation = parentOrganelle.Orientation;
+
+                    if (!newCellTypeOrganelles.IsOrganellePositionFree(definition, position.Q, position.R,
+                            orientation, occupied, out _))
+                    {
+                        continue;
+                    }
+
+                    var rotated = definition.GetRotatedHexes(orientation);
+                    for (var r = 0; r < rotated.Count; ++r)
+                        occupied.Add(rotated[r] + position);
+
+                    newCellTypeOrganelles.AddAutoEvoAttemptOrganelle(parentOrganelle.Clone());
                 }
 
                 AttachIslandHexes(newCellTypeOrganelles, workMemory);

--- a/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
+++ b/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
@@ -177,6 +177,8 @@ public class RemoveOrganelle : IMutationStrategy<Species>
                     if (ReferenceEquals(clonedCellType, newCellType))
                         continue;
 
+                    occupied.Clear();
+
                     var parentCellTypeOrganelles =
                         baseSpecies.ModifiableCellTypes[j].ModifiableOrganelles;
                     var copyOrganelleCount = parentCellTypeOrganelles.Count;
@@ -210,6 +212,8 @@ public class RemoveOrganelle : IMutationStrategy<Species>
                 // Is this the best way to do this?
                 var baseOrganelles = baseCellType.ModifiableOrganelles;
                 var organelleCount = baseCellType.Organelles.Count;
+
+                occupied.Clear();
 
                 for (var j = 0; j < organelleCount; ++j)
                 {

--- a/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
+++ b/src/auto-evo/mutation_strategy/RemoveOrganelle.cs
@@ -90,6 +90,9 @@ public class RemoveOrganelle : IMutationStrategy<Species>
             var baseOrganelles = baseSpecies.Organelles.Organelles;
             var count = baseSpecies.Organelles.Count;
 
+            var occupied = workMemory.WorkingMemory3;
+            occupied.Clear();
+
             for (var i = 0; i < count; ++i)
             {
                 var parentOrganelle = baseOrganelles[i];
@@ -97,10 +100,23 @@ public class RemoveOrganelle : IMutationStrategy<Species>
                 if (ReferenceEquals(parentOrganelle, organelle))
                     continue;
 
-                // Copy the organelle
-                var newOrganelle = parentOrganelle.Clone();
-                newSpecies.Organelles.AddIfPossible(newOrganelle, workMemory.WorkingMemory1,
-                    workMemory.WorkingMemory2);
+                var definition = parentOrganelle.Definition;
+                var position = parentOrganelle.Position;
+                var orientation = parentOrganelle.Orientation;
+
+                // Same decision as CanPlace: skipped only if it overlaps an organelle copied earlier, which means the
+                // parent layout was already invalid
+                if (!newSpecies.Organelles.IsOrganellePositionFree(definition, position.Q, position.R, orientation,
+                        occupied, out _))
+                {
+                    continue;
+                }
+
+                var rotated = definition.GetRotatedHexes(orientation);
+                for (var j = 0; j < rotated.Count; ++j)
+                    occupied.Add(rotated[j] + position);
+
+                newSpecies.Organelles.AddAutoEvoAttemptOrganelle(parentOrganelle.Clone());
             }
 
             AttachIslandHexes(newSpecies.Organelles, workMemory);


### PR DESCRIPTION
This replaces `AddIfPossible` in `RemoveOrganelle` with a custom placement check.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented overlapping organelles from being added during evolutionary mutations.
  - Improved placement validation so copied organelles are added only when their occupied space is free.
  - Applied consistent placement checks for both multicellular and microbial cell types.
  - Ensured organelle placement is evaluated independently for each cell type and layout, improving the reliability and consistency of evolutionary changes.
  - Skipped invalid organelle copies rather than forcing them into occupied spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->