### PR TITLE
Fixed mass budding creating action history for other reproduction modes

### DIFF
--- a/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
+++ b/src/multicellular_stage/editor/CellBodyPlanEditorComponent.GUI.cs
@@ -68,6 +68,11 @@ public partial class CellBodyPlanEditorComponent
 
     public void OnMassBuddingCellCountChanged(float count)
     {
+        // The slider is refreshed whenever the body plan changes, including when a cell is placed or removed.
+        // We want to suppress action history creation while another reproduction method is active.
+        if (ReproductionMethod != MulticellularReproductionMethod.MassBudding)
+            return;
+
         var newCellCount = (int)count;
 
         if (newCellCount == DesiredMassBuddingCellCount)


### PR DESCRIPTION
when placing a cell, which caused undo / redo history problems in freebuild

Seems to not cause any weirdness when swapping to mass budding or back. So this was surprisingly simple fix.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->
Placing a cell in freebuild couldn't be undone with a single undo press and redoing 2 cells failed for some reason.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the mass budding cell count slider from creating unnecessary history entries when another reproduction method is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->