### PR TITLE
Fixed placing stuff after using a history-resetting action in multicellular (or microbe stage)

### DIFF
--- a/src/general/mutation_points/CellTypeEditsFacade.cs
+++ b/src/general/mutation_points/CellTypeEditsFacade.cs
@@ -288,18 +288,32 @@ public class CellTypeEditsFacade : EditsFacadeBase, IReadOnlyCellTypeDefinition,
                 // Then match to the original microbe organelles
                 original = originalCell.Organelles.GetByExactElementRootPosition(organelleRemoveActionData.Location);
 
+                if (original != null &&
+                    (!ReferenceEquals(original.Definition, organelleRemoveActionData.RemovedHex.Definition) ||
+                        removedOrganelles.Contains(original)))
+                {
+                    // This is either an organelle of a different type at the same position or an organelle that was
+                    // already removed by a history-resetting new-cell action. Neither can be the target of this
+                    // remove action.
+                    original = null;
+                }
+
                 if (original != null)
                 {
-                    if (!ReferenceEquals(original.Definition, organelleRemoveActionData.RemovedHex.Definition))
-                        GD.PrintErr("Found unrelated organelle at exact position of removed organelle");
-
                     // Don't want the old instance to show up any more
                     removedOrganelles.Add(original);
                 }
             }
 
             if (original == null)
+            {
+                // Removing cytoplasm before placing an organelle is only used to describe a replacement for
+                // mutation-point calculations. A reset can already have removed that cytoplasm from the facade.
+                if (organelleRemoveActionData.GotReplaced)
+                    return true;
+
                 throw new InvalidOperationException("Could not find the organelle a remove operation is related to");
+            }
 
             // We already removed the original, so there's nothing more to do
 

--- a/src/microbe_stage/editor/EditorActionHistory.cs
+++ b/src/microbe_stage/editor/EditorActionHistory.cs
@@ -9,6 +9,7 @@ using SharedBase.Archive;
 /// <summary>
 ///   Holds the action history for the editor.
 /// </summary>
+/// <typeparam name="TAction">Type of action in the history</typeparam>
 /// <remarks>
 ///   <para>
 ///     Is capable of MP calculation.
@@ -245,7 +246,7 @@ public class EditorActionHistory<TAction> : ActionHistory<TAction>
     }
 
     /// <summary>
-    ///   Returns all actions since the last time a history resetting action was done
+    ///   Returns all actions since the last time a history-resetting action was done
     /// </summary>
     private List<EditorCombinableActionData> GetActionHistorySinceLastHistoryResettingAction()
     {
@@ -253,6 +254,6 @@ public class EditorActionHistory<TAction> : ActionHistory<TAction>
         var lastHistoryResetActionIndex = relevantActions.FindLastIndex(d => d.ResetsHistory);
         return lastHistoryResetActionIndex == -1 ?
             relevantActions :
-            Actions.Skip(lastHistoryResetActionIndex).SelectMany(p => p.Data).ToList();
+            relevantActions.Skip(lastHistoryResetActionIndex).ToList();
     }
 }

--- a/test/code_tests/MicrobeStage.Tests/EditorActionTests.cs
+++ b/test/code_tests/MicrobeStage.Tests/EditorActionTests.cs
@@ -1,39 +1,11 @@
 ﻿namespace ThriveTest.MicrobeStage;
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using Godot;
 using Xunit;
 
 public class EditorActionTests
 {
-    [Fact]
-    public void EditorAction_HistoryResetKeepsActionsAfterResetWhenPreviousActionIsCombined()
-    {
-        var history = new EditorActionHistory<EditorAction>();
-
-        history.AddAction(new CombinedEditorAction(
-            new SingleEditorAction<RigidityActionData>(_ => { }, _ => { }, new RigidityActionData(0.2f, 0.1f)),
-            new SingleEditorAction<RigidityActionData>(_ => { }, _ => { }, new RigidityActionData(0.3f, 0.2f))));
-
-        var newCell = new NewMicrobeActionData(new OrganelleLayout<OrganelleTemplate>(), new MembraneType(), 0,
-            Colors.White, null, null);
-        history.AddAction(new SingleEditorAction<NewMicrobeActionData>(_ => { }, _ => { }, newCell));
-
-        var placement = new OrganellePlacementActionData(
-            new OrganelleTemplate(new OrganelleDefinition { Hexes = [new Hex(0, 0)] }, new Hex(0, 0), 0),
-            new Hex(0, 0), 0);
-        history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, placement));
-
-        var performedData = new List<EditorCombinableActionData>();
-        history.GetPerformedActionData(performedData);
-
-        Assert.Collection(performedData,
-            item => Assert.Same(newCell, item),
-            item => Assert.Same(placement, item));
-    }
-
     [Fact]
     public void EditorAction_SubsequentRigidityChangesCombine()
     {

--- a/test/code_tests/MicrobeStage.Tests/EditorActionTests.cs
+++ b/test/code_tests/MicrobeStage.Tests/EditorActionTests.cs
@@ -1,11 +1,39 @@
 ﻿namespace ThriveTest.MicrobeStage;
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using Godot;
 using Xunit;
 
 public class EditorActionTests
 {
+    [Fact]
+    public void EditorAction_HistoryResetKeepsActionsAfterResetWhenPreviousActionIsCombined()
+    {
+        var history = new EditorActionHistory<EditorAction>();
+
+        history.AddAction(new CombinedEditorAction(
+            new SingleEditorAction<RigidityActionData>(_ => { }, _ => { }, new RigidityActionData(0.2f, 0.1f)),
+            new SingleEditorAction<RigidityActionData>(_ => { }, _ => { }, new RigidityActionData(0.3f, 0.2f))));
+
+        var newCell = new NewMicrobeActionData(new OrganelleLayout<OrganelleTemplate>(), new MembraneType(), 0,
+            Colors.White, null, null);
+        history.AddAction(new SingleEditorAction<NewMicrobeActionData>(_ => { }, _ => { }, newCell));
+
+        var placement = new OrganellePlacementActionData(
+            new OrganelleTemplate(new OrganelleDefinition { Hexes = [new Hex(0, 0)] }, new Hex(0, 0), 0),
+            new Hex(0, 0), 0);
+        history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, placement));
+
+        var performedData = new List<EditorCombinableActionData>();
+        history.GetPerformedActionData(performedData);
+
+        Assert.Collection(performedData,
+            item => Assert.Same(newCell, item),
+            item => Assert.Same(placement, item));
+    }
+
     [Fact]
     public void EditorAction_SubsequentRigidityChangesCombine()
     {

--- a/test/microbe_stage.tests/MicrobeEditorTests.cs
+++ b/test/microbe_stage.tests/MicrobeEditorTests.cs
@@ -17,10 +17,14 @@ public class MicrobeEditorTests
         var oldPlacement2 = new OrganellePlacementActionData(
             new OrganelleTemplate(new OrganelleDefinition { Hexes = [new Hex(0, 0)] }, new Hex(1, 0), 0),
             new Hex(1, 0), 0);
+        var oldPlacement3 = new OrganellePlacementActionData(
+            new OrganelleTemplate(new OrganelleDefinition { Hexes = [new Hex(0, 0)] }, new Hex(2, 0), 0),
+            new Hex(2, 0), 0);
 
         history.AddAction(new CombinedEditorAction(
             new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, oldPlacement1),
-            new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, oldPlacement2)));
+            new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, oldPlacement2),
+            new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, oldPlacement3)));
 
         var newCell = new NewMicrobeActionData(new OrganelleLayout<OrganelleTemplate>(), new MembraneType(), 0,
             Colors.White, null, null);
@@ -33,6 +37,7 @@ public class MicrobeEditorTests
 
         AssertThat(history.HexPlacedThisSession<OrganelleTemplate, CellType>(oldPlacement1.PlacedHex)).IsFalse();
         AssertThat(history.HexPlacedThisSession<OrganelleTemplate, CellType>(oldPlacement2.PlacedHex)).IsFalse();
+        AssertThat(history.HexPlacedThisSession<OrganelleTemplate, CellType>(oldPlacement3.PlacedHex)).IsFalse();
         AssertThat(history.HexPlacedThisSession<OrganelleTemplate, CellType>(newPlacement.PlacedHex)).IsTrue();
     }
 }

--- a/test/microbe_stage.tests/MicrobeEditorTests.cs
+++ b/test/microbe_stage.tests/MicrobeEditorTests.cs
@@ -1,0 +1,38 @@
+﻿using GdUnit4;
+using Godot;
+using static GdUnit4.Assertions;
+
+[TestSuite]
+[RequireGodotRuntime]
+public class MicrobeEditorTests
+{
+    [TestCase]
+    public void EditorAction_HistoryResetKeepsActionsAfterResetWhenPreviousActionIsCombined()
+    {
+        var history = new EditorActionHistory<EditorAction>();
+
+        var oldPlacement1 = new OrganellePlacementActionData(
+            new OrganelleTemplate(new OrganelleDefinition { Hexes = [new Hex(0, 0)] }, new Hex(0, 0), 0),
+            new Hex(0, 0), 0);
+        var oldPlacement2 = new OrganellePlacementActionData(
+            new OrganelleTemplate(new OrganelleDefinition { Hexes = [new Hex(0, 0)] }, new Hex(1, 0), 0),
+            new Hex(1, 0), 0);
+
+        history.AddAction(new CombinedEditorAction(
+            new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, oldPlacement1),
+            new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, oldPlacement2)));
+
+        var newCell = new NewMicrobeActionData(new OrganelleLayout<OrganelleTemplate>(), new MembraneType(), 0,
+            Colors.White, null, null);
+        history.AddAction(new SingleEditorAction<NewMicrobeActionData>(_ => { }, _ => { }, newCell));
+
+        var newPlacement = new OrganellePlacementActionData(
+            new OrganelleTemplate(new OrganelleDefinition { Hexes = [new Hex(0, 0)] }, new Hex(0, 0), 0),
+            new Hex(0, 0), 0);
+        history.AddAction(new SingleEditorAction<OrganellePlacementActionData>(_ => { }, _ => { }, newPlacement));
+
+        AssertThat(history.HexPlacedThisSession<OrganelleTemplate, CellType>(oldPlacement1.PlacedHex)).IsFalse();
+        AssertThat(history.HexPlacedThisSession<OrganelleTemplate, CellType>(oldPlacement2.PlacedHex)).IsFalse();
+        AssertThat(history.HexPlacedThisSession<OrganelleTemplate, CellType>(newPlacement.PlacedHex)).IsTrue();
+    }
+}

--- a/test/microbe_stage.tests/MicrobeEditorTests.cs.uid
+++ b/test/microbe_stage.tests/MicrobeEditorTests.cs.uid
@@ -1,0 +1,1 @@
+uid://0h4342yknnbx


### PR DESCRIPTION
**Brief Description of What This PR Does**

Turns out that the new cell button was majorly untested since the rework to the cell facades so there was a pretty big bug with it.

This should fix those problems. At least the test save I got can now place an organelle there were there was an error before.

**Related Issues**

<!-- List all issues this PR closes here with the closes syntax: 
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
If this is not related to an issue, it should be described in more detail why this PR is needed here instead.
-->

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the 
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Organelle removal now prevents mismatched or already-removed targets from being processed.
  - Replacement-removal actions complete successfully when their target is already absent.
  - Editor action history now preserves only actions made after the latest history reset, improving session-based placement tracking.

- **Tests**
  - Added coverage for editor history resets involving combined actions and organelle placements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->