### PR TITLE
Fix disconnected macroscopic compatibility test fixture

### DIFF
--- a/test/auto_evo.tests/MacroscopicSpeciesCompatibilityTests.cs
+++ b/test/auto_evo.tests/MacroscopicSpeciesCompatibilityTests.cs
@@ -306,7 +306,7 @@ public class MacroscopicSpeciesCompatibilityTests
         microbe.Organelles.Add(new OrganelleTemplate(simulationParameters.GetOrganelleType("nucleus"),
             new Hex(0, 0), 0));
         microbe.Organelles.Add(new OrganelleTemplate(simulationParameters.GetOrganelleType("cytoplasm"),
-            new Hex(3, 0), 0));
+            new Hex(2, 0), 0));
         microbe.OnEdited();
     }
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Move the cytoplasm in `MacroscopicSpeciesCompatibilityTests` from `(3, 0)` to `(2, 0)` so it touches the nucleus. The disconnected fixture makes the high-quality multicellular layout algorithm retry until its 10-second timeout during test setup. With a connected fixture, the conversion completes without that fallback. All existing compatibility assertions are preserved.

**Related Issues**

No linked issue. 
**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't
      break existing features:
      https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist
      (this is important as to not waste the time of Thrive team
      members reviewing this PR). This includes **gameplay** testing by the PR author.
- [x] Initial code review passed (this and further items should not be checked by the PR author)
- [x] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the
      [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish on this PR without errors, if
there are automatically detected style issues they should be fixed by
the PR author. Merging must follow our
[styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an automated compatibility test to use the corrected cytoplasm placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->