### PR TITLE
Recognize godot-mono consistently in development scripts

### DIFF
--- a/Scripts/GodotExecutable.cs
+++ b/Scripts/GodotExecutable.cs
@@ -1,0 +1,25 @@
+﻿namespace Scripts;
+
+using System;
+using System.IO;
+using SharedBase.Utilities;
+
+/// <summary>
+///   Finds Godot in PATH, preferring the explicit mono executable name, and caches the result for this script run
+/// </summary>
+public static class GodotExecutable
+{
+    private static readonly Lazy<string?> ExecutablePath = new(() =>
+        ExecutableFinder.Which("godot-mono") ?? ExecutableFinder.Which("godot"));
+
+    /// <summary>
+    ///   The cached executable path, or null if neither supported name was found
+    /// </summary>
+    public static string? Path => ExecutablePath.Value;
+
+    /// <summary>
+    ///   The executable path for launching Godot when it is required
+    /// </summary>
+    public static string RequiredPath => Path ??
+        throw new FileNotFoundException("Could not find 'godot-mono' or 'godot' executable, make sure it is in PATH");
+}

--- a/Scripts/GodotExecutable.cs.uid
+++ b/Scripts/GodotExecutable.cs.uid
@@ -1,0 +1,1 @@
+uid://c2rbyhrha5njb

--- a/Scripts/GodotProjectCompiler.cs
+++ b/Scripts/GodotProjectCompiler.cs
@@ -76,7 +76,7 @@ public class GodotProjectCompiler
 
     private async Task RunGodot(CancellationToken cancellationToken)
     {
-        var startInfo = new ProcessStartInfo("godot");
+        var startInfo = new ProcessStartInfo(GodotExecutable.RequiredPath);
         startInfo.ArgumentList.Add(PackageTool.GODOT_HEADLESS_FLAG);
         startInfo.ArgumentList.Add("--build-solutions");
 

--- a/Scripts/GodotProjectValidMaker.cs
+++ b/Scripts/GodotProjectValidMaker.cs
@@ -34,7 +34,7 @@ public class GodotProjectAssetImporter
 
     private async Task RunGodot(CancellationToken cancellationToken)
     {
-        var startInfo = new ProcessStartInfo("godot");
+        var startInfo = new ProcessStartInfo(GodotExecutable.RequiredPath);
         startInfo.ArgumentList.Add(PackageTool.GODOT_HEADLESS_FLAG);
         startInfo.ArgumentList.Add("--import");
 

--- a/Scripts/NativeLibs.cs
+++ b/Scripts/NativeLibs.cs
@@ -1537,7 +1537,7 @@ public class NativeLibs
 
         Directory.CreateDirectory(temporaryFolder);
 
-        var startInfo = new ProcessStartInfo("godot")
+        var startInfo = new ProcessStartInfo(GodotExecutable.RequiredPath)
         {
             WorkingDirectory = temporaryFolder,
         };

--- a/Scripts/PackageTool.cs
+++ b/Scripts/PackageTool.cs
@@ -189,12 +189,13 @@ public class PackageTool : PackageToolBase<Program.PackageOptions>
         if (checkedGodot)
             return true;
 
-        var godot = ExecutableFinder.Which("godot");
+        var godot = GodotExecutable.Path;
 
         if (godot == null)
         {
             ExecutableFinder.PrintPathInfo(Console.Out);
-            ColourConsole.WriteErrorLine("Godot not found in PATH with name \"godot\" please make it available");
+            ColourConsole.WriteErrorLine(
+                "Godot not found in PATH with name \"godot-mono\" or \"godot\" please make it available");
             return false;
         }
 
@@ -398,7 +399,7 @@ public class PackageTool : PackageToolBase<Program.PackageOptions>
 
         var targetFile = Path.Join(folder, "Thrive" + ThriveProperties.GodotTargetExtension(platform));
 
-        var startInfo = new ProcessStartInfo("godot");
+        var startInfo = new ProcessStartInfo(GodotExecutable.RequiredPath);
         startInfo.ArgumentList.Add(GODOT_HEADLESS_FLAG);
         startInfo.ArgumentList.Add("--export-release");
         startInfo.ArgumentList.Add(target);

--- a/Scripts/Program.cs
+++ b/Scripts/Program.cs
@@ -96,13 +96,14 @@ public class Program
     {
         CommandLineHelpers.HandleDefaultOptions(options);
 
-        var godot = ExecutableFinder.Which("godot");
+        var godot = GodotExecutable.Path;
 
         if (options.Godot is not false)
         {
             if (string.IsNullOrEmpty(godot))
             {
-                ColourConsole.WriteErrorLine("Could not find 'godot' executable, make sure it is in PATH");
+                ColourConsole.WriteErrorLine(
+                    "Could not find 'godot-mono' or 'godot' executable, make sure it is in PATH");
                 return 2;
             }
 
@@ -400,7 +401,7 @@ public class Program
 
         using var combined = CancellationTokenSource.CreateLinkedTokenSource(tokenSource.Token, timeout.Token);
 
-        var startInfo = new ProcessStartInfo("godot");
+        var startInfo = new ProcessStartInfo(GodotExecutable.RequiredPath);
         startInfo.ArgumentList.Add(PackageTool.GODOT_HEADLESS_FLAG);
         startInfo.ArgumentList.Add("--editor");
         startInfo.ArgumentList.Add("--quit-after");

--- a/doc/setup_instructions.md
+++ b/doc/setup_instructions.md
@@ -353,7 +353,7 @@ should be used. The command line tools can be installed with
 `xcode-select --install`. Homebrew is again recommended to get the
 other tools on mac, like cmake (`brew install cmake`).
 
-For the gdextension to be compiled, `godot` must be available in PATH
+For the gdextension to be compiled, `godot-mono` or `godot` must be available in PATH
 to generate the required binding files. And when compiling outside the
 container Python and other [Godot build
 dependencies](https://docs.godotengine.org/en/stable/contributing/development/compiling/index.html#toc-devel-compiling)
@@ -479,9 +479,10 @@ Optional downloads
 
 In addition to the following optional downloads you need to have Godot
 in your PATH for the scripts to find it. To do this create a link /
-rename the Godot editor executable to just `godot` or `godot.exe` if
-you are on Windows. Then you need to either add the folder where that
-executable is to your system PATH or move the executable (along with
+rename the Godot editor executable to `godot-mono` or `godot` (with `.exe` on
+Windows). The scripts prefer `godot-mono` when both names are available.
+Then you need to either add the folder where that executable is to your
+system PATH or move the executable (along with
 the other Godot resources it needs, i.e. the entire `GodotSharp`
 folder) to a path that is already in PATH.
 
@@ -776,8 +777,8 @@ apply.
 
 There is a provided script `dotnet run --project Scripts -- package`
 which helps with bundling the game up for releases. This relies on
-`godot` (or `godot.exe`) being the name of the Godot editor that is
-the current version and it being in PATH.
+`godot-mono` or `godot` (with `.exe` on Windows) being the name of the Godot
+editor that is the current version and it being in PATH.
 
 To set this up basically create a new folder that you add to PATH (Windows 
 registry, `.bashrc` or `.zshrc` for Linux/Mac) and create a copy or 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Development scripts currently reject a Godot .NET installation named `godot-mono`, and several launches still hardcode `godot` even after availability checks.

Add a shared cached resolver that prefers `godot-mono`, falls back to `godot`, and is used by all script lookups and launches (native API generation, packaging, tests, compilation and imports). Cache misses too, retain the existing version/.NET checks, and update setup instructions and missing-executable messages.

**Related Issues**

Closes #7047

**Review follow-up**

Handle missing Godot in `godot-test-import` as an allowed skip: warn and return 0 instead of throwing before process startup. Reproduced the previous unhandled exception, then verified five fresh-process cases on macOS ARM64: neither executable (warning, exit 0), mono-only, godot-only, both (mono preferred), and launched Godot returning nonzero (existing exit 1 retained). Launch arguments are unchanged. Scripts build passed with zero warnings/errors; focused file checks and `git diff --check` passed. The setup instructions now also state explicitly that a `godot` executable must point to the Godot .NET (Mono) editor, not the regular build. Earlier native/gameplay validation below was on commit `03b040f`; this follow-up changes the test-import missing-executable path and clarifies that requirement.

**Testing**

- `dotnet build Scripts`: passed with zero warnings/errors on Ubuntu 24.04 ARM64, .NET SDK 10.0.401; baseline also passed.
- Focused file checks passed:
  ```sh
  dotnet run --project Scripts -- check files --include Scripts/GodotExecutable.cs Scripts/Program.cs Scripts/PackageTool.cs Scripts/NativeLibs.cs Scripts/GodotProjectCompiler.cs Scripts/GodotProjectValidMaker.cs doc/setup_instructions.md
  git diff --check
  ```
- `dotnet run --project Scripts -- check cleanupcode --include Scripts/GodotExecutable.cs Scripts/Program.cs Scripts/PackageTool.cs Scripts/NativeLibs.cs Scripts/GodotProjectCompiler.cs Scripts/GodotProjectValidMaker.cs`: passed, no formatting changes.
- `dotnet run --project Scripts -- check inspectcode --include Scripts/GodotExecutable.cs Scripts/Program.cs Scripts/PackageTool.cs Scripts/NativeLibs.cs Scripts/GodotProjectCompiler.cs Scripts/GodotProjectValidMaker.cs`: passed, no inspection problems.
- `dotnet run --project Scripts -- check compile localization steam-build rewrite`: passed after installing `gettext`; compilation finished without warnings and the checkout stayed clean.
- Local external harness referencing the actual Scripts project (not a new repository test framework): mono-only, godot-only, both, neither; 100 concurrent cached reads after removing PATH; cached misses; missing-executable error; repeated version checks; wrong-version and non-.NET rejection. All passed, including a repeat with spaces and a literal semicolon in the executable directory. Executable recorders also exercised the actual compile/import/test-import/export launch methods and confirmed the preferred path and arguments. These dispatch checks are not real game import/export tests.
- Real official Godot 4.7.2 .NET, Linux ARM64: unmodified `dotnet run --project Scripts -- native Build Install` fails to find Godot when only `godot-mono` exists. The patch validates the version, generates both API files and configures CMake, then hits the existing ARM `-march=sandybridge` compiler error. Unmodified scripts with a `godot` symlink reach the same compiler error.

- Ubuntu 24.04 x86-64 under emulation: baseline mono-only failure reproduced again. Running the same patched Scripts assembly with `dotnet /opt/patched-scripts/Scripts.dll native Build Install` passed (exit 0) with only `godot-mono` available: real Godot API generation, CMake configuration, full Debug and RelWithDebInfo compilation/linking, and installation. Both installed extension links resolve to valid x86-64 ELF libraries. This uses official Godot 4.7.2 .NET and Clang 18.1.3.

**Validation limits / review status**

The initial full `check` invocation stopped at a missing `msgmerge` tool (also with the baseline). After installing `gettext`, the remaining compile/localization/steam-build/rewrite checks passed; focused file, cleanup and inspection checks had already passed. Windows and Arch/pacman validation and loading a save from an older release have not been performed. The Linux environments are Ubuntu containers on a Mac host. Native macOS playtesting is described below.

DevCenter build, format_test, jetbrains and CLA checks passed at the original head `03b040f`; fresh checks are pending for the review follow-up. Codacy remains action-required for maintainer adjudication as described below. The contribution is ready for review; independent functionality confirmation and maintainer reviews remain outstanding.

**Codacy findings**

Codacy flags four `ProcessStartInfo(GodotExecutable.RequiredPath)` calls as command injection. I traced each through `ProcessRunHelpers`: these developer scripts resolve only the fixed names `godot-mono`/`godot` from the caller's documented PATH, pass the filename separately from `ArgumentList`, and launch directly without a command shell (.NET 10 defaults `UseShellExecute` to false). The previous bare `godot` launches already trusted that same PATH. No game/remote input is introduced into the executable selection. My static assessment is that these are not actionable command-injection findings; the check remains visible for maintainer adjudication. No suppression or code workaround has been added.

**macOS playtest**

The PR source was built on Apple Silicon with official Godot 4.7.2 .NET and downloaded Mac native libraries. The C# build passed with zero warnings/errors, asset import completed, and the native libraries initialized successfully. The contributor played this separate PR build, created a save, relaunched, loaded the save and confirmed that controls and gameplay worked. The contributor clarified that an earlier reported crash was separate; its captured log did not establish a cause. This is contributor-reported gameplay validation, not independent reviewer confirmation.

**AI disclosure**

This is an AI-authored patch (OpenAI Codex), including the validation harness and PR text, prepared at the contributor's request. The contributor personally performed the gameplay check described above.

**Progress Checklist**

Note: before starting this checklist the PR should be marked as non-draft.

- [x] PR author has checked that this PR works as intended and doesn't break existing features: https://wiki.revolutionarygamesstudio.com/wiki/Testing_Checklist (including gameplay testing).
- [ ] Initial code review passed (this and further items should not be checked by the PR author)
- [ ] Functionality is confirmed working by another person (see above checklist link)
- [ ] Final code review is passed and code conforms to the [styleguide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md).

Before merging all CI jobs should finish without errors. Merging must follow the [Git style guide](https://github.com/Revolutionary-Games/Thrive/blob/master/doc/style_guide.md#git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic detection of `godot-mono` or `godot` from the system PATH, preferring `godot-mono` when available.

- **Bug Fixes**
  - Project compilation, testing, API generation, imports, and packaging now use the detected Godot executable consistently.
  - Improved error messages when no supported Godot executable is found.
  - Asset imports are skipped gracefully when no supported Godot executable is available.

- **Documentation**
  - Updated setup instructions to document supported executable names, including the Windows `.exe` format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
